### PR TITLE
fix(api): parseARPLayer guards against non-IPv4 ARP protocol addresses

### DIFF
--- a/internal/api/pcap.go
+++ b/internal/api/pcap.go
@@ -601,20 +601,29 @@ func parseARPLayer(packet gopacket.Packet, pkt *PcapPacket) {
 	}
 
 	pkt.Protocol = "ARP"
-	pkt.SourceIP = fmt.Sprintf(
-		"%d.%d.%d.%d",
-		arp.SourceProtAddress[0],
-		arp.SourceProtAddress[1],
-		arp.SourceProtAddress[2],
-		arp.SourceProtAddress[3],
-	)
-	pkt.DestIP = fmt.Sprintf(
-		"%d.%d.%d.%d",
-		arp.DstProtAddress[0],
-		arp.DstProtAddress[1],
-		arp.DstProtAddress[2],
-		arp.DstProtAddress[3],
-	)
+	// Guard against ARP-over-IPv6 and truncated ARP frames: addresses
+	// shorter than 4 bytes would have panicked the parse goroutine
+	// (recoverMiddleware caught it, but it still aborted analysis of
+	// the uploaded capture). Fall back to empty IPs for unsupported
+	// ProtAddressSize so the higher-level parser can skip the packet.
+	if len(arp.SourceProtAddress) >= 4 {
+		pkt.SourceIP = fmt.Sprintf(
+			"%d.%d.%d.%d",
+			arp.SourceProtAddress[0],
+			arp.SourceProtAddress[1],
+			arp.SourceProtAddress[2],
+			arp.SourceProtAddress[3],
+		)
+	}
+	if len(arp.DstProtAddress) >= 4 {
+		pkt.DestIP = fmt.Sprintf(
+			"%d.%d.%d.%d",
+			arp.DstProtAddress[0],
+			arp.DstProtAddress[1],
+			arp.DstProtAddress[2],
+			arp.DstProtAddress[3],
+		)
+	}
 
 	opStr := "Unknown"
 	switch arp.Operation {


### PR DESCRIPTION
Fixes krisarmstrong/niac-go#465.

## Problem

`parseARPLayer` indexed `arp.SourceProtAddress[0..3]` and `arp.DstProtAddress[0..3]` without checking `ProtAddressSize`. A PCAP upload containing ARP-over-IPv6 or a truncated ARP frame caused `index out of range`; `recoverMiddleware` caught it, but the recover aborted analysis of the upload.

## Fix

Per issue: guard both accesses with `len(...) >= 4` and leave `pkt.SourceIP` / `pkt.DestIP` empty when the address is not IPv4-sized, so the higher-level parser can continue processing the rest of the capture.

## Test

`go build ./internal/api/...` passes locally.