### PR TITLE
fix(protocols): handle odd-length input in CalculateIPChecksum

### DIFF
--- a/internal/protocols/packet.go
+++ b/internal/protocols/packet.go
@@ -210,8 +210,16 @@ func BuildEthernetHeader(dst, src net.HardwareAddr, etherType uint16) []byte {
 // CalculateIPChecksum calculates IP header checksum.
 func CalculateIPChecksum(header []byte) uint16 {
 	sum := uint32(0)
-	for i := 0; i < len(header); i += 2 {
+	// Walk pairs of bytes. An odd-length header would panic the previous
+	// loop on the trailing byte (binary.BigEndian.Uint16 reads 2 bytes);
+	// per RFC 1071 a lone trailing octet is promoted to the high byte of
+	// a notional 16-bit word padded with zeros.
+	n := len(header) &^ 1
+	for i := 0; i < n; i += 2 {
 		sum += uint32(binary.BigEndian.Uint16(header[i:]))
+	}
+	if len(header)%2 == 1 {
+		sum += uint32(header[len(header)-1]) << 8
 	}
 	// Add carry
 	for sum > checksumWordMask {


### PR DESCRIPTION
Fixes krisarmstrong/niac-go#476.

## Problem

`CalculateIPChecksum` ran `binary.BigEndian.Uint16(header[i:])` with `i += 2` without checking parity. An odd-length input (reachable on the uploaded-pcap path and caught by `recoverMiddleware` but abort the scan) panicked with `slice bounds out of range` on the trailing byte.

## Fix

Per RFC 1071, a lone trailing octet contributes as the high byte of a padded 16-bit word. Mask the upper bound to the even boundary, walk pairs, then add `header[last] << 8` when the length is odd. Wrap-add-carry is unchanged.

## Test

`go build ./internal/protocols/...` clean; `gofmt` clean.