### PR TITLE
Modernize release pipeline: nfpm + dry-run + webhook host allowlist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,7 +509,14 @@ jobs:
       - name: Upload assembled artifacts (dry-run inspectable)
         uses: actions/upload-artifact@v4
         with:
-          name: release-bundle-${{ github.ref_name }}
+          # Slashes in branch names (e.g. chore/...) aren't valid in artifact
+          # names, so fall back to the run_id when triggered off a non-tag.
+          name: >-
+            release-bundle-${{
+              github.ref_type == 'tag'
+                && github.ref_name
+                || format('dryrun-{0}', github.run_id)
+            }}
           path: dist/
           retention-days: 14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,10 +172,23 @@ jobs:
 
       - name: Create release packages (.tar.gz + .deb + .rpm via nfpm)
         env:
-          VERSION: ${{ github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          SHORT_SHA: ${{ github.sha }}
           ARCH: ${{ matrix.arch }}
         run: |
-          PKG_VERSION=$(echo "${VERSION#v}" | sed 's/-dirty$//;s/-[0-9]*-g[0-9a-f]*$//')
+          # On tag: VERSION = "v0.66.34"; PKG_VERSION = "0.66.34".
+          # On dispatch from a branch (REF_TYPE=branch): VERSION = "0.0.0-dryrun-<sha7>",
+          # because branch names like "chore/release-pipeline-modernize" contain
+          # slashes that would otherwise leak into archive/.deb/.rpm filenames.
+          if [ "${REF_TYPE}" = "tag" ]; then
+            VERSION="${REF_NAME}"
+            PKG_VERSION=$(echo "${VERSION#v}" | sed 's/-dirty$//;s/-[0-9]*-g[0-9a-f]*$//')
+          else
+            VERSION="0.0.0-dryrun-${SHORT_SHA:0:7}"
+            PKG_VERSION="${VERSION}"
+          fi
+          echo "Using VERSION=${VERSION} PKG_VERSION=${PKG_VERSION}"
           mkdir -p release
 
           # .tar.gz: prebuilt binary in a versioned directory
@@ -294,10 +307,18 @@ jobs:
 
       - name: Create release packages
         env:
-          VERSION: ${{ github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          SHORT_SHA: ${{ github.sha }}
           ARCH: ${{ matrix.arch }}
         run: |
-          PKG_VERSION=$(echo "${VERSION#v}" | sed 's/-dirty$//;s/-[0-9]*-g[0-9a-f]*$//')
+          if [ "${REF_TYPE}" = "tag" ]; then
+            VERSION="${REF_NAME}"
+            PKG_VERSION=$(echo "${VERSION#v}" | sed 's/-dirty$//;s/-[0-9]*-g[0-9a-f]*$//')
+          else
+            VERSION="0.0.0-dryrun-${SHORT_SHA:0:7}"
+            PKG_VERSION="${VERSION}"
+          fi
 
           # Create .tar.gz package
           mkdir -p release/niac-${VERSION}-darwin-${ARCH}
@@ -390,9 +411,16 @@ jobs:
 
       - name: Create Windows distribution
         env:
-          VERSION: ${{ github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          SHORT_SHA: ${{ github.sha }}
         run: |
-          PKG_VERSION=$(echo "${VERSION#v}" | sed 's/-dirty$//;s/-[0-9]*-g[0-9a-f]*$//')
+          if [ "${REF_TYPE}" = "tag" ]; then
+            VERSION="${REF_NAME}"
+            PKG_VERSION=$(echo "${VERSION#v}" | sed 's/-dirty$//;s/-[0-9]*-g[0-9a-f]*$//')
+          else
+            PKG_VERSION="0.0.0-dryrun-${SHORT_SHA:0:7}"
+          fi
           PKG_NAME="niac-${PKG_VERSION}-windows-amd64"
           mkdir -p "release/${PKG_NAME}"
           cp dist/niac-windows-amd64.exe "release/${PKG_NAME}/niac.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build artifacts and exit (skip publishing the GitHub release)"
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -162,66 +167,36 @@ jobs:
           fi
           echo "NiAC binary smoke test passed"
 
-      - name: Create release packages
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.3
+
+      - name: Create release packages (.tar.gz + .deb + .rpm via nfpm)
         env:
           VERSION: ${{ github.ref_name }}
           ARCH: ${{ matrix.arch }}
         run: |
           PKG_VERSION=$(echo "${VERSION#v}" | sed 's/-dirty$//;s/-[0-9]*-g[0-9a-f]*$//')
+          mkdir -p release
 
-          # Create .tar.gz package
-          mkdir -p release/niac-${VERSION}-linux-${ARCH}
-          cp dist/niac-linux-${ARCH} release/niac-${VERSION}-linux-${ARCH}/niac
-          chmod +x release/niac-${VERSION}-linux-${ARCH}/*
-          cd release
-          tar -czvf niac-${VERSION}-linux-${ARCH}.tar.gz niac-${VERSION}-linux-${ARCH}
-          cd ..
+          # .tar.gz: prebuilt binary in a versioned directory
+          mkdir -p "release/niac-${VERSION}-linux-${ARCH}"
+          cp "dist/niac-linux-${ARCH}" "release/niac-${VERSION}-linux-${ARCH}/niac"
+          chmod +x "release/niac-${VERSION}-linux-${ARCH}"/*
+          tar -C release -czvf "release/niac-${VERSION}-linux-${ARCH}.tar.gz" "niac-${VERSION}-linux-${ARCH}"
+          rm -rf "release/niac-${VERSION}-linux-${ARCH}"
 
-          # Create .deb package
-          DEB_DIR="dist/deb"
-          mkdir -p $DEB_DIR/DEBIAN
-          mkdir -p $DEB_DIR/usr/bin
-          mkdir -p $DEB_DIR/usr/lib/systemd/system
-          mkdir -p $DEB_DIR/var/lib/niac
-          mkdir -p $DEB_DIR/var/log/niac
+          # .deb + .rpm: render .nfpm.yaml with envsubst, hand to nfpm. nfpm is
+          # pure Go, so cross-arch RPMs work the same as cross-arch DEBs — no
+          # rpmbuild/rpmrc/platform-macros plumbing needed.
+          export NIAC_VERSION="${PKG_VERSION}"
+          export NIAC_ARCH="${ARCH}"
+          export NIAC_BINARY="./dist/niac-linux-${ARCH}"
+          envsubst < .nfpm.yaml > nfpm.rendered.yaml
 
-          cp dist/niac-linux-${ARCH} $DEB_DIR/usr/bin/niac
-          chmod 755 $DEB_DIR/usr/bin/niac
-          cp deploy/systemd/niac.service $DEB_DIR/usr/lib/systemd/system/
-
-          sed "s/__VERSION__/${PKG_VERSION}/;s/__ARCHITECTURE__/${ARCH}/" \
-            deploy/deb/control > $DEB_DIR/DEBIAN/control
-
-          cp deploy/deb/postinst $DEB_DIR/DEBIAN/
-          cp deploy/deb/prerm $DEB_DIR/DEBIAN/
-          cp deploy/deb/postrm $DEB_DIR/DEBIAN/
-          chmod 755 $DEB_DIR/DEBIAN/postinst $DEB_DIR/DEBIAN/prerm $DEB_DIR/DEBIAN/postrm
-
-          dpkg-deb --build $DEB_DIR release/niac_${PKG_VERSION}_${ARCH}.deb
-
-          # Create .rpm package (amd64 only — Ubuntu's `rpm` package can't
-          # cross-build for aarch64 without the missing rpmrc/platform
-          # entries, and patching them in is fragile. The .deb + .tar.gz
-          # cover arm64 deployments; revisit if/when an arm64 RPM target
-          # actually has consumers).
-          if [ "${ARCH}" = "amd64" ]; then
-            RPM_ARCH="x86_64"
-
-            # Copy binary to repo root for rpmbuild (spec expects %{_repo_root}/niac)
-            cp dist/niac-linux-${ARCH} niac
-
-            sed "s/__VERSION__/${PKG_VERSION}/;s/__ARCHITECTURE__/${RPM_ARCH}/" \
-              deploy/rpm/niac.spec > niac.spec
-
-            rpmbuild --target "${RPM_ARCH}" \
-              --define "_repo_root $(pwd)" \
-              --define "_topdir $(pwd)/rpmbuild" \
-              --define "_rpmdir $(pwd)/release" \
-              -bb niac.spec
-
-            # Move RPM from arch subdirectory to release/
-            mv release/${RPM_ARCH}/*.rpm release/ || true
-          fi
+          nfpm pkg --config nfpm.rendered.yaml --packager deb \
+            --target "release/niac_${PKG_VERSION}_${ARCH}.deb"
+          nfpm pkg --config nfpm.rendered.yaml --packager rpm \
+            --target "release/niac-${PKG_VERSION}-1.${ARCH}.rpm"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -503,7 +478,15 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Upload assembled artifacts (dry-run inspectable)
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bundle-${{ github.ref_name }}
+          path: dist/
+          retention-days: 14
+
       - name: Create Release
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         uses: softprops/action-gh-release@v2
         with:
           body: |

--- a/.nfpm.yaml
+++ b/.nfpm.yaml
@@ -1,0 +1,95 @@
+# nfpm packaging config for NiAC (.deb + .rpm).
+#
+# nfpm replaces the prior dpkg-deb + rpmbuild + niac.spec setup. It produces
+# both formats from a single config and supports cross-arch trivially because
+# the implementation is pure Go (no rpmbuild platform/macros files needed).
+#
+# Build inputs are passed via environment variables so the same file works for
+# both linux/amd64 and linux/arm64 from the release workflow:
+#   NIAC_VERSION  - version string with leading 'v' stripped (e.g. "0.66.34")
+#   NIAC_ARCH     - "amd64" or "arm64"
+#   NIAC_BINARY   - path to the prebuilt binary (e.g. dist/niac-linux-arm64)
+#
+# Usage:
+#   nfpm pkg --config .nfpm.yaml --packager deb --target out.deb
+#   nfpm pkg --config .nfpm.yaml --packager rpm --target out.rpm
+name: niac
+version: ${NIAC_VERSION}
+arch: ${NIAC_ARCH}
+platform: linux
+section: net
+priority: optional
+maintainer: Kris Armstrong <kris@mustardseednetworks.com>
+description: |
+  NiAC - Network Infrastructure Agent Cluster
+  .
+  NiAC is a network device simulator supporting SNMP agent simulation,
+  device template management, walk file capture and replay, multi-device
+  orchestration, packet capture/traffic generation, and a WebUI for
+  configuration management.
+vendor: Mustard Seed Networks
+homepage: https://github.com/krisarmstrong/niac-go
+license: Proprietary
+
+# Per-format dependency lists. Names differ between Debian and RPM ecosystems.
+overrides:
+  deb:
+    depends:
+      - libpcap0.8 | libpcap0.8t64
+      - systemd
+      - libcap2-bin
+  rpm:
+    depends:
+      - libpcap
+      - systemd
+      - libcap
+
+contents:
+  - src: ${NIAC_BINARY}
+    dst: /usr/bin/niac
+    file_info:
+      mode: 0755
+  - src: ./deploy/systemd/niac.service
+    dst: /usr/lib/systemd/system/niac.service
+    file_info:
+      mode: 0644
+  # Built-in YAML templates (top-level + per-category subdirs)
+  - src: ./cmd/niac/templates/*.yaml
+    dst: /var/lib/niac/templates/
+  - src: ./examples/combinations/*.yaml
+    dst: /var/lib/niac/templates/combinations/
+  - src: ./examples/layer2/*.yaml
+    dst: /var/lib/niac/templates/layer2/
+  - src: ./examples/network/*.yaml
+    dst: /var/lib/niac/templates/network/
+  - src: ./examples/services/*.yaml
+    dst: /var/lib/niac/templates/services/
+  - src: ./examples/snmp/*.yaml
+    dst: /var/lib/niac/templates/snmp/
+  - src: ./examples/vendors/*.yaml
+    dst: /var/lib/niac/templates/vendors/
+  # Owner-only data + log dirs that the maintainer scripts populate
+  - dst: /etc/niac
+    type: dir
+    file_info:
+      mode: 0750
+      owner: niac
+      group: niac
+  - dst: /var/lib/niac
+    type: dir
+    file_info:
+      mode: 0750
+      owner: niac
+      group: niac
+  - dst: /var/log/niac
+    type: dir
+    file_info:
+      mode: 0750
+      owner: niac
+      group: niac
+
+scripts:
+  preinstall: ./deploy/nfpm/preinstall.sh
+  postinstall: ./deploy/nfpm/postinstall.sh
+  preremove: ./deploy/nfpm/preremove.sh
+  postremove: ./deploy/nfpm/postremove.sh

--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -15,9 +15,10 @@ import (
 )
 
 type daemonOptions struct {
-	listen      string
-	token       string
-	storagePath string
+	listen              string
+	token               string
+	storagePath         string
+	webhookAllowedHosts []string
 }
 
 func addDaemonCommand(root *cobra.Command, info versionInfo) {
@@ -51,6 +52,9 @@ The web UI will be available at http://localhost:8080`,
 		StringVar(&options.token, "token", "", "Bearer token for API authentication (RECOMMENDED for network-exposed instances)")
 	daemonCmd.Flags().
 		StringVar(&options.storagePath, "storage", "~/.niac/niac.db", "Path to run history database (use 'disabled' to disable)")
+	daemonCmd.Flags().
+		StringSliceVar(&options.webhookAllowedHosts, "webhook-allowed-host", nil,
+			"Hostname allowed as alert webhook destination (repeatable; if any are set, all webhook URLs must match exactly). When unset, the existing private-IP/blocked-hostname filter is used.")
 
 	root.AddCommand(daemonCmd)
 }
@@ -71,13 +75,14 @@ func runDaemon(options *daemonOptions, info versionInfo) error {
 
 	// Create daemon instance
 	d, err := daemon.NewDaemon(daemon.Config{
-		ListenAddr:  options.listen,
-		Token:       options.token,
-		StoragePath: options.storagePath,
-		Version:     info.version,
-		Commit:      info.commit,
-		BuildTime:   info.date,
-		UIBuildHash: info.uiBuildHash,
+		ListenAddr:          options.listen,
+		Token:               options.token,
+		StoragePath:         options.storagePath,
+		Version:             info.version,
+		Commit:              info.commit,
+		BuildTime:           info.date,
+		UIBuildHash:         info.uiBuildHash,
+		WebhookAllowedHosts: options.webhookAllowedHosts,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create daemon: %w", err)

--- a/deploy/nfpm/postinstall.sh
+++ b/deploy/nfpm/postinstall.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Post-install: set raw-socket capabilities, configure firewall (best-effort),
+# reload systemd, and (re)start the niac service. Runs after both fresh
+# installs and upgrades.
+set -e
+
+BINARY=/usr/bin/niac
+
+# Set capabilities for raw socket access (required for packet capture).
+if command -v setcap >/dev/null 2>&1; then
+    setcap 'cap_net_raw,cap_net_admin=+ep' "$BINARY" || \
+        echo "warning: could not set capabilities on $BINARY"
+fi
+
+# ufw (Debian/Ubuntu) — open the WebUI port if ufw is active.
+if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+    ufw allow 8080/tcp comment 'NiAC WebUI HTTP' >/dev/null 2>&1 || true
+fi
+
+# firewalld (RHEL/Fedora) — same idea.
+if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+    firewall-cmd --permanent --add-port=8080/tcp >/dev/null 2>&1 || true
+    firewall-cmd --reload >/dev/null 2>&1 || true
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+    systemctl enable niac.service >/dev/null 2>&1 || true
+    if systemctl is-active --quiet niac.service 2>/dev/null; then
+        systemctl restart niac.service || true
+    else
+        systemctl start niac.service || true
+    fi
+fi
+
+cat <<'EOF'
+
+==========================================
+  NiAC installed successfully
+==========================================
+
+Web interface: http://localhost:8080
+
+Commands:
+  View logs:  journalctl -u niac -f
+  Restart:    sudo systemctl restart niac
+  Status:     sudo systemctl status niac
+  Stop:       sudo systemctl stop niac
+
+EOF
+
+exit 0

--- a/deploy/nfpm/postremove.sh
+++ b/deploy/nfpm/postremove.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Post-remove: clean up firewall rules + the service user on a *complete*
+# uninstall (not on upgrade). Detection is per-format:
+#   deb -> $1 == "purge"
+#   rpm -> $1 == "0"   (number of remaining instances)
+set -e
+
+is_purge=0
+case "$1" in
+    purge)
+        is_purge=1
+        ;;
+    0)
+        is_purge=1
+        ;;
+esac
+
+if [ "$is_purge" -eq 1 ]; then
+    if command -v ufw >/dev/null 2>&1; then
+        ufw delete allow 8080/tcp >/dev/null 2>&1 || true
+    fi
+    if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+        firewall-cmd --permanent --remove-port=8080/tcp >/dev/null 2>&1 || true
+        firewall-cmd --reload >/dev/null 2>&1 || true
+    fi
+
+    if getent passwd niac >/dev/null 2>&1; then
+        userdel niac >/dev/null 2>&1 || true
+    fi
+    if getent group niac >/dev/null 2>&1; then
+        groupdel niac >/dev/null 2>&1 || true
+    fi
+
+    rm -rf /etc/niac /var/lib/niac /var/log/niac
+fi
+
+exit 0

--- a/deploy/nfpm/preinstall.sh
+++ b/deploy/nfpm/preinstall.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Pre-install: ensure the niac service user and group exist before files are
+# unpacked, so the directory ownership entries in the package can resolve.
+set -e
+
+if ! getent group niac >/dev/null 2>&1; then
+    groupadd --system niac
+fi
+
+if ! getent passwd niac >/dev/null 2>&1; then
+    useradd --system \
+        --gid niac \
+        --home-dir /var/lib/niac \
+        --no-create-home \
+        --shell /usr/sbin/nologin \
+        --comment "NiAC Network Device Simulator" \
+        niac
+fi
+
+exit 0

--- a/deploy/nfpm/preremove.sh
+++ b/deploy/nfpm/preremove.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Pre-remove: stop and disable the systemd service. Runs both on uninstall and
+# before an upgrade swaps the binary, which is fine — postinstall restarts.
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+    if systemctl is-active --quiet niac.service 2>/dev/null; then
+        systemctl stop niac.service || true
+    fi
+    if systemctl is-enabled --quiet niac.service 2>/dev/null; then
+        systemctl disable niac.service || true
+    fi
+fi
+
+exit 0

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 )
@@ -157,13 +158,24 @@ func (s *Server) postAlertWebhook(webhookURL string, body []byte) {
 
 	// Inline SSRF barrier at the dispatch site. validateWebhookURLSSRF above
 	// performs the same checks, but CodeQL's go/request-forgery query needs
-	// to see the IP rejection pattern directly at the http.Client.Do call.
+	// to see the host check directly at the http.Client.Do call.
 	host := parsedURL.Hostname()
 	if host == "" {
 		s.logger.Error("Alert webhook URL has empty host")
 		return
 	}
-	if ip := net.ParseIP(host); ip != nil {
+	// Admin-side hostname allowlist. When configured, only exact hostname
+	// matches are accepted — this is the canonical CodeQL barrier for
+	// go/request-forgery and lets a deployment opt out of accepting
+	// arbitrary user-supplied webhook destinations entirely.
+	if allowed := s.cfg.WebhookAllowedHosts; len(allowed) > 0 {
+		if !slices.Contains(allowed, host) {
+			s.logger.Error("Alert webhook host not in allowlist", "host", host)
+			return
+		}
+	} else if ip := net.ParseIP(host); ip != nil {
+		// No allowlist configured — fall back to the IP-class filter so a
+		// raw-IP literal can't reach private/loopback/link-local space.
 		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
 			ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
 			ip.IsInterfaceLocalMulticast() || ip.IsMulticast() {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -163,8 +163,14 @@ type ServerConfig struct {
 	UIBuildHash string
 	Topology    Topology
 	Alert       AlertConfig
-	ApplyConfig func(*config.Config) error
-	Replay      ReplayManager
+	// WebhookAllowedHosts is an admin-side allowlist of hostnames that the
+	// alert webhook is permitted to dispatch to. Empty = no allowlist (the
+	// existing private-IP / blocked-hostname filters in
+	// validateWebhookURLSSRF still apply). Non-empty = strict allowlist:
+	// the parsed URL's hostname must match one of these exactly.
+	WebhookAllowedHosts []string
+	ApplyConfig         func(*config.Config) error
+	Replay              ReplayManager
 }
 
 // SimulationRequest represents a request to start a simulation.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -42,6 +42,10 @@ type Config struct {
 	Commit      string
 	BuildTime   string
 	UIBuildHash string
+	// WebhookAllowedHosts restricts the alert webhook destination to an
+	// admin-managed set of hostnames. Empty = no allowlist (the existing
+	// private-IP / blocked-hostname filters still apply).
+	WebhookAllowedHosts []string
 }
 
 // Daemon manages the NIAC simulation lifecycle.
@@ -99,13 +103,14 @@ func NewDaemon(cfg Config) (*Daemon, error) {
 func (d *Daemon) Start() error {
 	// Create API server
 	serverCfg := api.ServerConfig{
-		Addr:        d.cfg.ListenAddr,
-		Token:       d.cfg.Token,
-		Version:     d.cfg.Version,
-		Commit:      d.cfg.Commit,
-		BuildTime:   d.cfg.BuildTime,
-		UIBuildHash: d.cfg.UIBuildHash,
-		Storage:     d.storage,
+		Addr:                d.cfg.ListenAddr,
+		Token:               d.cfg.Token,
+		Version:             d.cfg.Version,
+		Commit:              d.cfg.Commit,
+		BuildTime:           d.cfg.BuildTime,
+		UIBuildHash:         d.cfg.UIBuildHash,
+		Storage:             d.storage,
+		WebhookAllowedHosts: d.cfg.WebhookAllowedHosts,
 		// Stack, Config, etc. will be nil until simulation starts
 	}
 


### PR DESCRIPTION
Follow-up to PR #483 / v0.66.34. Addresses three of the five "best practice" gaps from that release post-mortem:

## 1. Replace `dpkg-deb` + `rpmbuild` with `nfpm` (commit `c114c3b`)

The v0.66.27..v0.66.34 chain of release-pipeline fixes was almost entirely about Ubuntu's `rpm` package failing to cross-build aarch64 — missing rpmrc entries, missing `/usr/lib/rpm/platform/aarch64-linux/macros`, apt sources getting mangled. v0.66.34 ended up skipping the arm64 .rpm entirely.

`nfpm` is pure Go and produces `.deb` + `.rpm` for any arch from a single config. Confirmed locally: arm64 .deb + arm64 .rpm (Architecture: aarch64) both build cleanly from the same `.nfpm.yaml`.

- `.nfpm.yaml` — single config covering templates, systemd unit, owner-only data dirs, per-format deps; envsubst injects ${NIAC_VERSION}/${NIAC_ARCH}/${NIAC_BINARY} at workflow time
- `deploy/nfpm/{pre,post}{install,remove}.sh` — consolidated maintainer scripts (deb `$1 == purge` and rpm `$1 == 0` detected at runtime)

`deploy/deb/control` + `deploy/rpm/niac.spec` are now unused by the workflow but kept on disk for reference; cleanup is a separate PR.

## 2. `workflow_dispatch` dry-run mode (commit `c114c3b`)

`release.yml` now has a `workflow_dispatch.inputs.dry_run` toggle (default true) that builds + signs every artifact and uploads them as a workflow artifact (`release-bundle-<ref>`) but does not publish a GitHub release. Lets us iterate on the pipeline without burning tag numbers like v0.66.27..33 did.

## 3. `--webhook-allowed-host` admin allowlist (commit `420afcb`)

`postAlertWebhook` now consults a `cfg.WebhookAllowedHosts` allowlist (settable via the new `--webhook-allowed-host` daemon flag, repeatable). When set, only exact hostname matches dispatch — that is the canonical CodeQL barrier for `go/request-forgery`, so deployments that opt in get a real allowlist rather than relying on the runtime IP-class filter.

When unset (default, preserves existing behavior), the inline `net.ParseIP` IsLoopback/IsPrivate/etc. filter still rejects raw-IP literals.

This lets us reverse the `won't-fix` dismissal on CodeQL alert #18 once a deployment ships with the allowlist set; tracked in #484.

## Test plan
- [x] Local smoke build: `nfpm pkg --packager rpm` produces arm64 RPM with `Architecture: aarch64`, correct deps (`libpcap`, `systemd`, `libcap`), templates installed
- [x] Local smoke build: `nfpm pkg --packager deb` produces arm64 DEB with correct deps (`libpcap0.8 | libpcap0.8t64`)
- [x] `go build ./... && golangci-lint` clean for the webhook allowlist change
- [x] `go test ./internal/api/... ./internal/daemon/... ./cmd/niac/...` passes
- [ ] Trigger `release.yml` via `workflow_dispatch` (dry_run=true) on this branch and confirm all 5 platform jobs + Publish job succeed and a `release-bundle-*` artifact is uploaded
- [ ] After PR merge, tag a fresh version (next would be v0.66.35) and confirm the tag-triggered run publishes a real GitHub release

Closes nothing yet (#484 will close once a deployment uses the allowlist and #18 reopens-and-resolves on its own); related to the v0.66.27..34 release post-mortem.