### PR TITLE
docs: surface matrix + config coverage audit + kitchen-sink FDB

### DIFF
--- a/docs/CONFIG_COVERAGE.md
+++ b/docs/CONFIG_COVERAGE.md
@@ -1,0 +1,93 @@
+# Config coverage audit
+
+Generated 2026-05-06 against `examples/` (45 YAML files). Companion to
+[SURFACE_MATRIX.md](./SURFACE_MATRIX.md).
+
+## Method
+
+Each file scanned for substring tokens that map to schema features, then
+features aggregated. Source: `internal/config/config.go` struct types
+cross-referenced against `internal/protocols/*.go` implementations.
+
+## Feature → coverage
+
+| Feature                  | Covered by                                     |
+|--------------------------|------------------------------------------------|
+| ARP                      | most configs (implicit in any device with ips) |
+| CDP                      | layer2/cdp-only.yaml, layer2/all-discovery-protocols.yaml, vendors/cisco-network.yaml, complete-kitchen-sink.yaml, … |
+| LLDP                     | layer2/lldp-only.yaml, layer2/all-discovery-protocols.yaml, multi-vendor configs |
+| EDP                      | layer2/edp-only.yaml, layer2/all-discovery-protocols.yaml |
+| FDP                      | layer2/fdp-only.yaml, layer2/all-discovery-protocols.yaml |
+| STP                      | layer2/stp-bridge.yaml, vendors/dell-network.yaml, complete-kitchen-sink.yaml |
+| DHCPv4                   | dhcp/dhcpv4-{simple,advanced}.yaml, network/dual-stack.yaml |
+| DHCPv6                   | dhcp/dhcpv4-advanced.yaml (mixed), network/dhcpv6-config.yaml, network/dual-stack.yaml |
+| DNS                      | services/dns-server.yaml, complete-kitchen-sink.yaml |
+| HTTP                     | services/http-server.yaml, complete-kitchen-sink.yaml |
+| FTP                      | services/ftp-server.yaml, complete-kitchen-sink.yaml |
+| NetBIOS                  | services/netbios-server.yaml, complete-kitchen-sink.yaml |
+| ICMP                     | network/icmp-config.yaml, complete-kitchen-sink.yaml |
+| ICMPv6                   | network/icmpv6-config.yaml, complete-kitchen-sink.yaml |
+| IPv6 (dual / single)     | network/ipv6-only.yaml, network/dual-stack.yaml |
+| iperf3                   | traffic-generation.yaml, complete-kitchen-sink.yaml |
+| Traffic gen (announce/ping/random) | traffic-generation.yaml |
+| OS fingerprint           | health-check-network.yaml |
+| Fault injection          | fault-injection.yaml, snmp/snmp-complete-network.yaml |
+| SNMP agent               | snmp/snmp-agent-basic.yaml, snmp/snmp-multiple-communities.yaml, vendors/* |
+| SNMP traps               | snmp/snmp-traps-all.yaml |
+| **SNMP FDB injection**   | **complete-kitchen-sink.yaml (added 2026-05-06)** |
+| Capture playback         | complete-kitchen-sink.yaml |
+| VLANs / trunks           | topology/* + complete-kitchen-sink.yaml |
+| Vendor-flavored          | vendors/{cisco,arista,juniper,aruba,extreme,foundry,dell,fortinet,paloalto,meraki,multi-vendor-campus}.yaml |
+
+## Walks
+
+`examples/device_walks_sanitized/` ships **575 walk files** across 15
+vendor folders (3com, arista, aruba, brocade, cisco, dell, extreme,
+fortinet, hp, hpe, huawei, juniper, meraki, mikrotik, plus `misc`).
+Each major vendor folder has multiple model-specific walks suitable for
+SNMP agent simulation.
+
+`mapping.json` maps walk filenames to the original device metadata
+(model, sysDescr, etc.).
+
+The kitchen-sink config exercises walks from cisco, extreme, brocade,
+and misc; the `enterprise-campus-walks.yaml` config does broader
+multi-vendor walk coverage.
+
+## What changed in this audit
+
+Before: 21 of 25 feature-tokens covered by the kitchen-sink (FDB,
+non-OID-walk-warnings, and a couple false positives).
+
+After: kitchen-sink now also exercises `dot1d_fdb_table` and
+`dot1q_fdb_table` (SNMP bridge MIB FDB injection). The remaining
+"missing" tokens from my heuristic scan are false positives — see
+SURFACE_MATRIX for the actual schema.
+
+## Known behavior nuance
+
+`capture_playbacks:` declared in a config file auto-starts on the legacy
+CLI path (`niac <iface> <cfg>`). On the daemon path, playback is on-demand:
+the YAML field is parsed but the playback engine has to be started
+explicitly via `POST /api/v1/replay`. This is by design — daemon mode is
+intended for interactive control — but may surprise users coming from
+the CLI flow. Document in the daemon section of CONTRIBUTING.md if it
+keeps tripping people up.
+
+## Smoke verification (2026-05-06)
+
+Daemon + kitchen-sink end-to-end:
+
+```text
+✓ POST /api/v1/simulation         → 9 devices loaded on lo0
+✓ GET  /api/v1/devices            → 9
+✓ GET  /api/v1/topology           → nodes + links populated
+✓ GET  /api/v1/stats              → packets_sent: 32, packets_received: 51
+✓ GET  /api/v1/neighbors          → CDP discovery firing (cisco→brocade visible)
+✓ POST /api/v1/walk/validate      → parsed cisco-c3850 walk, found 66 advisory issues
+✓ DELETE /api/v1/simulation       → clean stop
+```
+
+Walk validator's 66 "issues" on `niac-cisco-c3850-48p.walk` are all
+advisory (severity: info, mostly "string value not quoted" — a stylistic
+recommendation). Walks load and serve correctly.

--- a/docs/SURFACE_MATRIX.md
+++ b/docs/SURFACE_MATRIX.md
@@ -1,0 +1,210 @@
+# NIAC surface matrix — CLI / TUI / WebUI / API
+
+Generated 2026-05-06 against `main` @ v0.66.36. This is the source of truth
+for "which interface exposes which feature" and is the input to the
+WebUI-parity follow-up.
+
+## Frontend coverage at a glance
+
+| Feature area                       | CLI          | TUI          | WebUI        | API          |
+|------------------------------------|:------------:|:------------:|:------------:|:------------:|
+| Run a simulation (legacy positional) | ✅ `niac <iface> <cfg>` | n/a          | n/a          | n/a          |
+| Run a simulation (cobra subcommand)| ✅ `niac run`  | ✅ `niac interactive` | ✅ via `/runtime` | ✅ `/api/v1/simulation` (POST), `/api/v1/runtime` (GET) |
+| Daemon mode (web UI host)          | ✅ `niac daemon` | n/a       | (this **is** the daemon) | n/a |
+| List interfaces                    | ✅ `--list-interfaces` | ✅ stats panel | ✅ via `/runtime` | ✅ `/api/v1/interfaces` |
+| Live device list                   | ❌           | ✅ device pane | ✅ `/devices` | ✅ `/api/v1/devices` |
+| Device editor                      | ❌           | ✅ device_config.go | ✅ `/device-config/:hostname` | ✅ `/api/v1/config/devices/` |
+| Topology view                      | ❌           | ✅ topology_view.go | ✅ `/topology` | ✅ `/api/v1/topology` |
+| Topology export (graphviz/json)    | ❌           | ❌           | ✅ `/topology` (export button) | ✅ `/api/v1/topology/export` |
+| Live stats                         | ✅ stdout stats ticker | ✅ stats.go | ✅ `/` dashboard + SSE | ✅ `/api/v1/stats`, `/api/v1/stream/stats` |
+| Live packet inspector              | ❌           | ✅ hexdump.go | ✅ `/packets` (SSE) | ✅ `/api/v1/stream/packets` |
+| Live log tail                      | ✅ `--log-file` + `tail -f` | ✅ logs.go | ✅ `/debug` (SSE) | ✅ `/api/v1/stream/logs` |
+| PCAP playback                      | ✅ legacy `--pcap-file` | ✅ pcap_replay.go | ✅ `/analysis` | ✅ `/api/v1/replay` (under `/runtime`) |
+| PCAP analyze                       | ✅ `niac analyze-pcap` | ❌ | ✅ `/pcap-analyzer` | ✅ `/api/v1/pcap/` |
+| SNMP walk validation               | ✅ `niac analyze-walk` | ✅ snmp_walk.go + validation_panel.go | ❌ **gap (page)** | ✅ `/api/v1/walk/validate` |
+| Walk auto-fix                      | ✅ `niac analyze-walk --fix` | ✅ TUI | ❌ **gap (page)** | ✅ `/api/v1/walk/fix` |
+| Run history (storage-backed)       | ❌           | ✅ history.go | ✅ via dashboard | ✅ `/api/v1/history` |
+| Templates: list                    | ❌           | ✅ template_browser.go | ✅ `/templates` | ✅ `/api/v1/templates` |
+| Templates: get one                 | ❌           | ✅ TUI       | ✅ `/templates`  | ✅ `/api/v1/templates/{name}` |
+| User configs CRUD                  | ❌           | ❌           | ✅ devices/config-builder | ✅ `/api/v1/configs[/{name}]` |
+| Config diff                        | ✅ `niac config diff` | ✅ config_diff.go | ✅ `/config-diff` | ❌ (client-side) |
+| Config merge                       | ✅ `niac config merge` | ❌ | ❌ **gap** | ❌ **gap** |
+| Config export (Java DSL → YAML)    | ✅ `niac config export` | ❌ | ❌ **gap** | ❌ **gap** |
+| Config init (template scaffold)    | ✅ `niac init` | ❌ | (close enough via Templates page) | ❌ |
+| Config generate (interactive Q&A)  | ✅ `niac generate` | ✅ device_config.go | ✅ `/device-config/new` | ❌ (client-side) |
+| Error / fault injection            | ✅ `niac inject` (`list`, `clear`) | ✅ error_injection.go | ✅ `/traffic` (Traffic Injection) | ✅ `/api/v1/errors` |
+| Neighbor discovery view            | ✅ `niac neighbors`, `niac neighbors watch` | ❌ **gap** | ❌ **gap** (in topology?) | ✅ `/api/v1/neighbors` |
+| Live monitor (TUI-lite over SSH)   | ✅ `niac monitor` | n/a       | (dashboard equivalent) | ✅ via streams |
+| Service control (Windows)          | ✅ `niac service {install,uninstall,start,stop,status}` | ❌ | ❌ | ❌ |
+| Shell completion                   | ✅ `niac completion {bash,zsh,fish,powershell}` | n/a | n/a       | n/a       |
+| Man page                           | ✅ `niac man` | n/a          | n/a          | n/a       |
+| Dump (config dump)                 | ✅ `niac dump` | ❌           | ❌ **gap** | ❌ **gap** |
+| Logs subcmd (`logs`, `logs tail`)  | ✅           | ✅           | ✅           | ✅           |
+| Alert config (admin)               | ❌ (config file only) | ✅ alert_config.go | ❌ **gap (page exists, not wired?)** | (via runtime config update) |
+| Webhook host allowlist             | ✅ `--webhook-allowed-host` (daemon flag) | n/a       | n/a       | n/a       |
+| Health endpoint                    | n/a       | n/a       | n/a       | ✅ `/__version` (no auth) |
+| Prometheus metrics                 | n/a       | n/a       | n/a       | ✅ `/metrics` |
+| CSRF token                         | n/a       | n/a       | n/a       | ✅ `/api/v1/csrf-token` |
+| Files browse / serve               | n/a       | n/a       | (via templates) | ✅ `/api/v1/files` |
+| Schema introspection               | n/a       | n/a       | (used by DeviceEditor) | ✅ `/api/v1/config/schema` |
+
+Legend: ✅ supported · ❌ missing · **gap** = WebUI is meant to have this and doesn't (priority follow-up).
+
+## Per-interface inventories
+
+### CLI (cobra subcommands + legacy positional mode)
+
+```
+niac                          # legacy: <interface> <config> with all the --debug-* flags
+niac run <iface> <cfg>        # cobra alias for the same
+niac interactive <iface> <cfg># launches the TUI
+
+niac daemon                   # web UI host (--listen, --token, --webhook-allowed-host, --storage)
+niac monitor                  # remote-stats TUI-lite that talks to a running daemon
+
+niac analyze-pcap <pcap>      # parse a PCAP and dump structured info
+niac analyze-walk <walkfile>  # validate a walk file (--fix to auto-repair)
+
+niac config export <in> <out> # Java DSL → YAML
+niac config diff <a> <b>      # YAML diff
+niac config merge <base> <overlay> <out>
+
+niac init [out.yaml]          # scaffold a starter config
+niac generate [out.yaml]      # interactive Q&A
+
+niac inject <device> <error-type> <value>
+niac inject list
+niac inject clear
+
+niac neighbors                # one-shot
+niac neighbors watch          # live
+
+niac dump                     # dump runtime config
+niac logs
+niac logs tail
+niac man
+niac completion {bash,zsh,fish,powershell}
+niac service ...              # Windows only
+```
+
+### TUI screens (`internal/interactive/`)
+
+| File                     | Screen / responsibility                                  |
+|--------------------------|----------------------------------------------------------|
+| `interactive.go`         | Top-level loop, screen routing, status bar                |
+| `stats.go`               | Live counters per device + protocol                       |
+| `device_config.go`       | Edit a device in-place                                    |
+| `topology_view.go`       | ASCII topology                                            |
+| `template_browser.go`    | List + preview built-in templates                         |
+| `pcap_replay.go`         | PCAP playback control                                     |
+| `snmp_walk.go`           | Walk file viewer / validator                              |
+| `validation_panel.go`    | Show walk-validation issues + fixes                       |
+| `hexdump.go`             | Live packet hex view                                      |
+| `logs.go`                | Live log tail                                             |
+| `error_injection.go`     | Set/clear faults                                          |
+| `alert_config.go`        | Threshold + webhook URL editor                            |
+| `config_diff.go`         | YAML diff viewer                                          |
+| `history.go`             | Past run history (from storage.db)                        |
+| `search.go`              | Cross-screen find                                         |
+| `export.go`              | Topology / report export                                  |
+| `keyboard.go`, `handlers.go`, `display_utils.go`, `helpers_test.go`, `types.go` | infrastructure |
+
+### WebUI pages (`ui/src/pages/`, routed in `ui/src/App.tsx`)
+
+| Route                          | Page                       | Purpose                                          |
+|--------------------------------|----------------------------|--------------------------------------------------|
+| `/`                            | DashboardPage              | live stats, recent runs                          |
+| `/runtime`                     | RuntimeControlPage         | start/stop simulation, choose interface + config |
+| `/devices`                     | DevicesPage / DeviceListPage | live device table                              |
+| `/device-config`               | DeviceEditorPage           | full device editor                              |
+| `/device-config/new`           | DeviceEditorPage (new mode)| create device                                    |
+| `/device-config/:hostname`     | DeviceEditorPage (edit)    | edit device                                      |
+| `/topology`                    | TopologyPage               | interactive graph + export                      |
+| `/analysis`                    | AnalysisPage               | replay control                                   |
+| `/automation`                  | AutomationPage             | alerts & workflows (beta)                        |
+| `/traffic`                     | TrafficInjectionPage       | error / fault injection                          |
+| `/debug`                       | DebugConsolePage           | log tail, raw API console                        |
+| `/packets`                     | PacketInspectorPage        | live packet stream                              |
+| `/templates`                   | TemplatesPage              | template browser                                 |
+| `/config-diff`                 | ConfigDiffPage             | YAML diff                                        |
+| `/pcap-analyzer`               | PcapAnalyzerPage           | upload + analyze a PCAP                          |
+
+### API endpoints (`internal/api/routes.go`)
+
+```
+/__version                               # health (no auth)
+/metrics                                 # prometheus
+
+/api/v1/csrf-token
+/api/v1/version
+/api/v1/stats
+/api/v1/devices
+/api/v1/history
+/api/v1/interfaces
+/api/v1/runtime                         # POST start, DELETE stop, GET status
+/api/v1/topology                        # GET tree
+/api/v1/topology/export                 # GET ?format=graphviz|json
+/api/v1/config/schema                   # JSON schema (powers DeviceEditor)
+/api/v1/config/devices                  # CRUD on the running config
+/api/v1/config/devices/{name}           # CRUD per device
+/api/v1/configs                         # named user configs CRUD
+/api/v1/configs/{name}
+/api/v1/templates                       # built-in template list
+/api/v1/templates/{name}
+/api/v1/files                           # file browse (sandboxed)
+/api/v1/pcap/                           # pcap analyzer
+/api/v1/errors                          # error/fault injection
+/api/v1/neighbors                       # neighbor table
+
+/api/v1/replay                          # PCAP replay control (under runtime)
+/api/v1/capture/filter                  # BPF filter for live packets
+
+/api/v1/stream/logs                     # SSE
+/api/v1/stream/packets                  # SSE
+/api/v1/stream/stats                    # SSE
+/api/v1/stream/status                   # SSE
+```
+
+## Protocol coverage (config schema → runtime)
+
+Generated from `internal/config/config.go` (struct types) cross-referenced
+against `internal/protocols/*.go` (implementations). All present and
+implemented:
+
+ARP · CDP · DHCP (v4) · DHCPv6 · DNS · EDP · FDP · FTP · HTTP · ICMP ·
+ICMPv6 · IP (v4 / v6) · iperf3 · LLDP · NetBIOS · OS-fingerprint ·
+SNMP (agent + walks + traps) · STP · TCP · UDP · plus traffic
+generation (ARP announce, periodic ping, random traffic).
+
+## Identified gaps (priority for follow-up PR)
+
+These are real WebUI / API gaps where the CLI exposes something the WebUI
+doesn't:
+
+1. **SNMP walk validation + auto-fix** — API exists
+   (`POST /api/v1/walk/{validate,fix}`), but no WebUI page consumes it.
+   _Suggested:_ a "Validate Walk" button in the device editor + a
+   standalone `/walk` page.
+2. **Config merge** — only in CLI. _Suggested:_ `POST /api/v1/config/merge`
+   plus a "Merge into base" action in `/config-diff`.
+3. **Config export (Java DSL → YAML)** — only in CLI. _Suggested:_
+   `POST /api/v1/config/import?format=java-dsl` + a "Import Java DSL"
+   button on the templates page.
+4. **`niac dump`** — runtime config dump in CLI; nothing in WebUI.
+   _Suggested:_ `GET /api/v1/runtime/dump` + a "Dump current config"
+   button on the runtime page.
+5. **Alert config (admin-side)** — TUI has a full editor; WebUI's
+   automation page exists but doesn't appear to wire it. _Suggested:_
+   `PUT /api/v1/alerts/config` + an alert editor on `/automation`.
+   (The data path already lives in `internal/api/alerts.go`.)
+6. **Neighbor watch view** — CLI has it, WebUI doesn't surface it
+   distinctly from the topology view. _Suggested:_ a `Neighbors` panel
+   on the dashboard or a dedicated `/neighbors` page.
+
+These are the "WebUI behind CLI" items called out in the original ask.
+
+## Coverage of features by example config
+
+See [examples/README.md] (existing) for the per-file purpose summary. The
+audit of "which examples cover which features" is in
+[CONFIG_COVERAGE.md](./CONFIG_COVERAGE.md) (next file).

--- a/examples/complete-kitchen-sink.yaml
+++ b/examples/complete-kitchen-sink.yaml
@@ -126,6 +126,14 @@ devices:
       community_includes:
         - community: "private"
           walk_file: "device_walks_sanitized/cisco/niac-cisco-c9300-48p.walk"
+      # Bridge MIB FDB table injection — exercised so an snmpwalk against the
+      # dot1dTpFdbTable / dot1qTpFdbTable returns synthesized entries.
+      dot1d_fdb_table:
+        port: 1
+        vlan: 1
+      dot1q_fdb_table:
+        port: 1
+        vlan: 10
 
     # HTTP Server Configuration
     http:


### PR DESCRIPTION
Phase 1 deliverable for the CLI/TUI/WebUI validation ask.

## What landed

- **docs/SURFACE_MATRIX.md** — feature × interface table cross-referencing every capability against CLI / TUI / WebUI / API. Includes per-interface inventories (cobra subcommand list, TUI screens, WebUI routes, full API endpoint list).
- **docs/CONFIG_COVERAGE.md** — which example configs exercise which protocols, plus walk-file inventory (575 walks across 15 vendors).
- **examples/complete-kitchen-sink.yaml** — added `dot1d_fdb_table` + `dot1q_fdb_table` (SNMP bridge MIB FDB injection — the only real schema feature the existing kitchen-sink wasn't exercising).

## End-to-end smoke (already verified locally)

```
✓ POST /api/v1/simulation         → 9 devices on lo0 from kitchen-sink
✓ GET  /api/v1/devices            → 9
✓ GET  /api/v1/topology           → nodes + links populated
✓ GET  /api/v1/stats              → 32 sent, 51 received (real wire traffic)
✓ GET  /api/v1/neighbors          → CDP discovery firing
✓ POST /api/v1/walk/validate      → cisco-c3850 walk parsed, 66 advisory issues
✓ DELETE /api/v1/simulation       → clean stop
```

## Identified WebUI gaps (priority for Phase 2 PR)

These are the "WebUI is behind CLI" items the user asked about:

1. **Walk validation page** — API endpoints `POST /api/v1/walk/{validate,fix}` already exist; no WebUI page consumes them.
2. **Config merge** — only in CLI (`niac config merge`).
3. **Java DSL → YAML import** — only in CLI (`niac config export`).
4. **Runtime config dump** — only in CLI (`niac dump`).
5. **Alert config editor** — TUI has it; the WebUI's `/automation` page doesn't appear to wire `internal/api/alerts.go`.
6. **Dedicated neighbors view** — CLI has `niac neighbors watch`; WebUI surfaces neighbors only inside the topology graph.

## Behavior nuance worth a doc note

`capture_playbacks:` in a YAML config auto-starts on the legacy CLI path but is on-demand-only on the daemon path (must call `POST /api/v1/replay`). Documented in CONFIG_COVERAGE.md.

## Test plan
- [x] `niac --dry-run lo0 examples/complete-kitchen-sink.yaml` → "Configuration is valid"
- [x] Daemon end-to-end with kitchen-sink → 9 devices, neighbors firing, stats counters incrementing
- [x] `POST /api/v1/walk/validate` against a real walk file → structured response with per-line issues
- [ ] Phase 2 PR to close the 6 WebUI gaps above (separate effort)