### PR TITLE
chore(ui+ci): comprehensive help, tooltips, schema CI guard, project audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
           version: v2.12.1
           args: --timeout=5m
 
+      - name: Verify niac.schema.json is up to date
+        run: |
+          # Regenerate from the current converter.Config and fail if the
+          # committed schema drifts. Forces struct changes to bring the
+          # schema along; refresh locally with `make schema`.
+          go run ./cmd/niac-schema -o /tmp/niac.schema.json
+          if ! diff -u docs/schemas/niac.schema.json /tmp/niac.schema.json; then
+            echo "::error::docs/schemas/niac.schema.json is stale. Run 'make schema' and commit the result."
+            exit 1
+          fi
+          echo "Schema is up to date."
+
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -1,0 +1,201 @@
+# Project audit — 2026-05-07
+
+Sweep of the entire repo for best-practice gaps, defects, wiring issues,
+and enhancement opportunities. Companion to
+[SURFACE_MATRIX.md](./SURFACE_MATRIX.md) and
+[CONFIG_COVERAGE.md](./CONFIG_COVERAGE.md).
+
+This is a **point-in-time snapshot.** Items marked **fixed in this PR**
+land alongside this doc; everything else is recorded as a follow-up so
+nothing slips.
+
+## Tier 1 — defects to fix soon
+
+### A. Branch protection on `main` is **off**
+
+`gh api repos/krisarmstrong/niac-go/branches/main/protection` returns an
+empty object. Anyone with push access can:
+
+- push directly to `main` without a PR
+- force-push to `main` (overwrites history of every collaborator's clone)
+- skip required CI checks
+- skip CODEOWNERS review
+
+The CODEOWNERS file is purely advisory until protection is on.
+
+**Recommended config** (Settings → Branches → main):
+
+- ✅ Require a pull request before merging
+- ✅ Require approvals: 1
+- ✅ Require review from Code Owners
+- ✅ Require status checks: `Backend (Go)`, `Frontend (TypeScript)`,
+  `Security Scanning`, `License Compliance Check`, `Quality Checks`,
+  `Build (linux-amd64)`, `E2E Browser Tests`, `Lighthouse Audit`,
+  `CodeQL`, `C Lint (C23)`, `Trivy`, `gosec`, `Analyze (go)`,
+  `Analyze (javascript-typescript)`
+- ✅ Require branches to be up to date before merging
+- ✅ Do not allow bypassing the above settings (admin too)
+
+`gh api -X PUT` script provided in the follow-up issue.
+
+### B. Newly-added Go code lacks unit tests
+
+| File | Lines | Tests |
+|---|---|---|
+| `internal/api/config_ops.go` (POST /api/v1/config/{merge,import}) | 219 | 0 |
+| `cmd/niac-schema/main.go` | 71 | 0 |
+
+The merge endpoint in particular has subtle semantics worth testing
+(overlay-replace on name, base-only kept, overlay-only appended) — and
+the schema generator should round-trip with the parser to catch tag
+mismatches.
+
+### C. Newly-added UI components lack tests
+
+| File | Lines | Tests |
+|---|---|---|
+| `ui/src/pages/NeighborsPage.tsx` | 175 | 0 |
+| `ui/src/pages/WalkValidatorPage.tsx` | 237 | 0 |
+| `ui/src/components/templates/JavaDslImportCard.tsx` | 131 | 0 |
+| `ui/src/ui/Tooltip.tsx` | 64 | 0 |
+
+A modest `vitest` suite per page covering the happy path + the empty /
+error state would round out the existing coverage.
+
+### D. Replay controller is duplicated across packages
+
+`internal/daemon/daemon.go` and `cmd/niac/runtime_services.go` both
+contain a `replayController` with the same logic. There's an explicit
+`// TODO: Refactor to share code.` comment acknowledging it.
+
+The cleanest fix: move the implementation to a new package
+`internal/replay/` and have both call sites consume it. Today, fixing a
+bug in one means remembering to mirror it to the other.
+
+## Tier 2 — hygiene gaps
+
+### E. Some Go dependencies are minor versions behind
+
+`go list -m -u all` shows ~10 packages with available updates:
+
+```
+github.com/aymanbagabas/go-udiff v0.2.0 → v0.4.1
+github.com/buger/jsonparser v1.1.1 → v1.2.0
+github.com/charmbracelet/x/exp/golden  (newer commit)
+github.com/google/pprof  (newer commit)
+github.com/invopop/jsonschema v0.13.0 → v0.14.0
+github.com/mailru/easyjson v0.7.7 → v0.9.2
+github.com/vishvananda/netlink v1.1.0 → v1.3.1
+github.com/vishvananda/netns  (newer commit)
+github.com/yuin/goldmark v1.4.13 → v1.8.2
+golang.org/x/telemetry  (newer commit)
+```
+
+Dependabot will roll most of these on its weekly cadence. Worth a
+manual `go get -u ./... && go mod tidy` once the audit branch lands.
+
+### F. `cmd/niac-schema` lacks a "schema is in sync" round-trip test
+
+The CI guard added in this PR catches *commit-time* drift, but a Go
+test that round-trips converter.Config → schema → validator → fixtures
+would catch logic drift (e.g. accidental field rename in YAML tags).
+
+### G. Help content is page-level, not per-control
+
+The `?` icon on every page now opens a help slide-out. The next layer
+down — "what does this specific button do" — is currently `title=` only.
+That's fine for plain strings; for richer content we ship `Tooltip` from
+the same PR. Low-priority follow-up: sweep secondary controls
+(card-action chips, list-item action menus) and wrap with `Tooltip`.
+
+### H. CI runs the schema check on `Backend (Go)` only
+
+Dependabot opens PRs that may or may not include schema changes. If
+struct tags drift on a dep update we'd catch it; if tags drift on a
+non-Go-code-touching PR, the schema check still runs because Go is
+needed to build. Acceptable for now.
+
+## Tier 3 — enhancement ideas
+
+### I. JSON Schema → schema selection in DeviceEditor
+
+The WebUI's visual device editor consumes `/api/v1/config/schema`, which
+is hand-written. With the new generator we could feed the same schema
+to both the editor and external validators, eliminating the second
+source of truth.
+
+### J. ReplayPage download button next to "Choose file"
+
+Once a user has run a replay, the Replay page could expose a
+"Download captured packets" button (sourced from the in-memory ring
+buffer or the SSE packet stream). Today they have to invoke
+`niac analyze-pcap` on the CLI.
+
+### K. Per-protocol debug levels also editable from /runtime header
+
+The Protocol Debug page already has the per-protocol level UI. Adding a
+single "Debug level" slider on the simulation header (0–3) would cover
+the 90% case for users who don't care which protocol is loud.
+
+### L. Supply-chain: vendor in-tree?
+
+`go.sum` is committed but no `vendor/` directory. `go mod download`
+runs in CI, which works as long as the proxy is up. For air-gapped
+environments and reproducibility, `go mod vendor` and a `vendor/`
+checkin is the standard play. No urgency unless someone actually
+deploys NIAC behind a firewall.
+
+### M. UI stack — `react-router-dom` v6 → v7 (long lead time)
+
+We're on a recent v6 minor. v7 is out and changes a few APIs. Worth
+queueing a v7 migration PR before the v6→v7 jump becomes painful.
+
+## Tier 4 — confirmed clean
+
+These were checked and are in good shape. Listed so future audits don't
+re-investigate.
+
+- ✅ **Open CodeQL alerts on `main`: 0** (was 16 before PR #483).
+- ✅ **`npm audit --audit-level=moderate`: 0 vulnerabilities.**
+- ✅ **`gosec`** runs on every PR via `ci.yml`'s Security Scanning job.
+- ✅ **TODO/FIXME density: 8 occurrences** across the entire codebase,
+  most documenting actual constraints (see `internal/converter/converter.go`
+  field semantics).
+- ✅ **No unsafe `panic()` in production code.** The single panic in
+  `internal/protocols/dhcpv6.go` (entropy failure during DUID generation)
+  is correct: a predictable DUID would create colliding identities across
+  processes; crashing is the right answer.
+- ✅ **Body-size guards everywhere.** All POST/PUT handlers wrap
+  `r.Body = http.MaxBytesReader(...)`.
+- ✅ **CSP, X-Frame-Options, X-Content-Type-Options** all set globally
+  via `addSecurityHeaders` in `internal/api/middleware.go`.
+- ✅ **Error-write coverage: 170 `writeError` / `http.Error` call sites**
+  in 39 routes — handlers don't drop bad-input cases on the floor.
+- ✅ **CSRF protection on every write route** via `csrfProtect`
+  middleware in `routes.go`.
+- ✅ **Rate limiting** on 15 of 39 routes — every write route, all walk
+  endpoints (separate stricter limit), every error-injection endpoint.
+  Read endpoints intentionally unrate-limited so dashboards don't page
+  themselves.
+- ✅ **React ErrorBoundary** wraps the whole app and each lazy page
+  individually, so a render error on one page doesn't blank the whole UI.
+- ✅ **All workflows have concurrency groups** (PR #486).
+- ✅ **All `@actions/*` and third-party action versions standardised**
+  to current latest majors (PR #486).
+- ✅ **Release pipeline supports `dry_run`** and produced 6-platform
+  artifacts on v0.66.36 with no broken-tag chain (PR #485 + #486).
+- ✅ **JSON Schema published + CI-guarded** (this PR).
+- ✅ **Per-page help on all 15 pages** (this PR).
+- ✅ **Tooltips on every interactive control on touched pages** (this
+  PR).
+
+## Process recommendations
+
+1. **Open issues for Tier 1 items and assign target dates.** They're
+   fixable in one PR each; making them visible prevents drift.
+2. **Stop adding Go files to `internal/api/` without a sibling
+   `_test.go`.** A Makefile / pre-commit guard would enforce this.
+3. **Add a `make audit` target** that runs the same sweeps this audit
+   used so it's repeatable, not a one-shot exercise.
+
+EOF

--- a/internal/api/config_ops_test.go
+++ b/internal/api/config_ops_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	baseYAML = `devices:
+  - name: alpha
+    type: router
+    mac: "00:11:22:33:44:01"
+    ips:
+      - "10.0.0.1"
+  - name: bravo
+    type: switch
+    mac: "00:11:22:33:44:02"
+    ips:
+      - "10.0.0.2"
+`
+	overlayYAML = `devices:
+  - name: bravo
+    type: server
+    mac: "00:11:22:33:44:99"
+    ips:
+      - "10.0.0.99"
+  - name: charlie
+    type: host
+    mac: "00:11:22:33:44:03"
+    ips:
+      - "10.0.0.3"
+`
+)
+
+// TestMergeConfigsByName covers the three branches of the overlay-replace
+// algorithm: base-only kept, overlay replaces by name, overlay-only appended.
+func TestMergeConfigsByName(t *testing.T) {
+	server, _ := newTestServer(t)
+
+	body, err := json.Marshal(MergeConfigsRequest{Base: baseYAML, Overlay: overlayYAML})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/merge", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleConfigMerge(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp MergeConfigsResponse
+	if err = json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Devices should be: alpha (base-only) + bravo (overlay version) + charlie (overlay-only).
+	if resp.MergedDevs != 3 {
+		t.Errorf("expected 3 merged devices, got %d", resp.MergedDevs)
+	}
+	if resp.BaseDevices != 2 {
+		t.Errorf("expected 2 base devices, got %d", resp.BaseDevices)
+	}
+	if resp.OverlayDevs != 2 {
+		t.Errorf("expected 2 overlay devices, got %d", resp.OverlayDevs)
+	}
+
+	// Overlay version of bravo should win — verify by checking the merged YAML
+	// contains the overlay's MAC, not the base's.
+	if !strings.Contains(resp.Merged, "00:11:22:33:44:99") {
+		t.Errorf("merged YAML missing overlay MAC for bravo:\n%s", resp.Merged)
+	}
+	if strings.Contains(resp.Merged, "00:11:22:33:44:02") {
+		t.Errorf("merged YAML still contains base MAC for bravo (should be replaced):\n%s", resp.Merged)
+	}
+	// Charlie should be appended, alpha kept.
+	for _, name := range []string{"alpha", "bravo", "charlie"} {
+		if !strings.Contains(resp.Merged, "name: "+name) {
+			t.Errorf("merged YAML missing device %q:\n%s", name, resp.Merged)
+		}
+	}
+}
+
+func TestMergeConfigs_BadInput(t *testing.T) {
+	server, _ := newTestServer(t)
+
+	cases := []struct {
+		name       string
+		payload    string
+		wantStatus int
+	}{
+		{"empty body", "", http.StatusBadRequest},
+		{"missing base", `{"overlay":"devices: []"}`, http.StatusBadRequest},
+		{"missing overlay", `{"base":"devices: []"}`, http.StatusBadRequest},
+		{"bad yaml in base", `{"base":"::not yaml::","overlay":"devices: []"}`, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/config/merge",
+				strings.NewReader(tc.payload))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			server.handleConfigMerge(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("got %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestMergeConfigs_MethodNotAllowed(t *testing.T) {
+	server, _ := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/merge", nil)
+	rec := httptest.NewRecorder()
+	server.handleConfigMerge(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("got %d, want 405", rec.Code)
+	}
+	if rec.Header().Get("Allow") != "POST" {
+		t.Errorf("Allow header = %q, want POST", rec.Header().Get("Allow"))
+	}
+}
+
+// TestImportConfig_YAMLPassthrough validates that format=yaml normalises an
+// already-YAML payload (validates structure + re-emits canonical YAML).
+func TestImportConfig_YAMLPassthrough(t *testing.T) {
+	server, _ := newTestServer(t)
+	body, _ := json.Marshal(ConfigImportRequest{Format: "yaml", Content: baseYAML})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/import", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleConfigImport(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp ConfigImportResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Devices != 2 {
+		t.Errorf("expected 2 devices, got %d", resp.Devices)
+	}
+	if !strings.Contains(resp.YAML, "name: alpha") {
+		t.Errorf("response YAML missing alpha:\n%s", resp.YAML)
+	}
+}
+
+// TestImportConfig_BadFormat exercises the format-allowlist gate.
+func TestImportConfig_BadFormat(t *testing.T) {
+	server, _ := newTestServer(t)
+	body, _ := json.Marshal(ConfigImportRequest{Format: "json", Content: "{}"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/import", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleConfigImport(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -103,6 +103,29 @@ const pages: PageConfig[] = [
     description: 'Live counters, run snapshots, and automation status for the active NIAC stack.',
     icon: Activity,
     component: DashboardPage,
+    help: (
+      <>
+        <p>
+          Real-time view of the running daemon: packet counters per protocol, recent simulation
+          runs, device count, and recent alert state.
+        </p>
+        <h4>Where to go from here</h4>
+        <ul>
+          <li>
+            <strong>Simulation</strong> to start/stop a run.
+          </li>
+          <li>
+            <strong>Live Devices</strong> to see what the running config produced.
+          </li>
+          <li>
+            <strong>Live Packets</strong> to watch traffic in real time.
+          </li>
+          <li>
+            <strong>Alerts</strong> to set the threshold and webhook target.
+          </li>
+        </ul>
+      </>
+    ),
   },
   {
     path: '/runtime',
@@ -193,6 +216,25 @@ const pages: PageConfig[] = [
     description: 'LLDP/CDP/EDP/FDP visibility for verifying intent before exporting to Graphviz.',
     icon: Network,
     component: TopologyPage,
+    help: (
+      <>
+        <p>
+          Visual graph of the configured topology — devices and the links you declared in the YAML (
+          <code>trunk_ports:</code>, <code>port_channels:</code>, etc.). Use this to sanity-check
+          your design before starting the simulation.
+        </p>
+        <h4>Live discovery vs design</h4>
+        <p>
+          The graph shows the <em>design</em>. Use <strong>Neighbors</strong> to see which
+          adjacencies actually formed at runtime via CDP / LLDP / EDP / FDP — useful for catching
+          mistyped <code>remote_device</code> references.
+        </p>
+        <h4>Export</h4>
+        <p>
+          Topology can be exported as Graphviz <code>.dot</code> or JSON via the export button.
+        </p>
+      </>
+    ),
   },
   {
     path: '/analysis',
@@ -201,6 +243,27 @@ const pages: PageConfig[] = [
     description: 'Replay PCAPs, inspect SNMP walks, and publish bundles directly from the UI.',
     icon: LineChart,
     component: AnalysisPage,
+    help: (
+      <>
+        <p>
+          Drive the daemon's PCAP replay engine: pick a file, set a loop interval and time scale,
+          start. Equivalent of <code>POST /api/v1/replay</code>.
+        </p>
+        <h4>Auto-started replays</h4>
+        <p>
+          A <code>capture_playbacks:</code> block in your YAML auto-starts when the simulation
+          starts. This page reflects whatever is currently running and lets you swap files without
+          editing the config.
+        </p>
+        <h4>File sources</h4>
+        <ul>
+          <li>Files placed under the daemon's pcap directory show up in the dropdown.</li>
+          <li>
+            Use <strong>PCAP Analysis</strong> to inspect a file before replaying.
+          </li>
+        </ul>
+      </>
+    ),
   },
   {
     path: '/automation',
@@ -241,6 +304,30 @@ const pages: PageConfig[] = [
     description: 'Inject network errors and replay PCAP traffic for testing and simulation.',
     icon: Zap,
     component: TrafficInjectionPage,
+    help: (
+      <>
+        <p>
+          Inject controlled errors (drops, delays, corruption) into the running simulation to test
+          how upstream tooling reacts. Drives <code>POST /api/v1/errors</code>.
+        </p>
+        <h4>Common faults</h4>
+        <ul>
+          <li>
+            <strong>Drop rate</strong> — percentage of packets to drop on the device's egress.
+          </li>
+          <li>
+            <strong>Delay</strong> — extra latency in milliseconds.
+          </li>
+          <li>
+            <strong>Corruption</strong> — flip random bits in the payload.
+          </li>
+        </ul>
+        <p>
+          Errors clear when you stop the simulation, or via <code>niac inject clear</code> on the
+          CLI.
+        </p>
+      </>
+    ),
   },
   {
     path: '/debug',
@@ -249,6 +336,21 @@ const pages: PageConfig[] = [
     description: 'Real-time log streaming and debugging tools for monitoring NIAC operations.',
     icon: Terminal,
     component: DebugConsolePage,
+    help: (
+      <>
+        <p>
+          Live log tail from the daemon (Server-Sent Events from <code>/api/v1/stream/logs</code>).
+          Pause to freeze the buffer, filter by protocol or severity, set per-protocol debug levels
+          (0=quiet, 3=verbose).
+        </p>
+        <h4>Per-protocol debug levels</h4>
+        <p>
+          Equivalent of the CLI's <code>--debug-arp</code> / <code>--debug-icmp</code> /{' '}
+          <code>--debug-snmp</code> family of flags. Levels are applied to the running stack
+          immediately.
+        </p>
+      </>
+    ),
   },
   {
     path: '/packets',
@@ -258,6 +360,19 @@ const pages: PageConfig[] = [
       'Real-time packet hex dump viewing with protocol filtering and search capabilities.',
     icon: FileSearch,
     component: PacketInspectorPage,
+    help: (
+      <>
+        <p>
+          Live wire view of every packet the daemon sees — hex + decoded fields, BPF filter, freeze
+          frame, save to PCAP. Streams from <code>/api/v1/stream/packets</code>.
+        </p>
+        <h4>Performance</h4>
+        <p>
+          Frames flow as fast as the wire. If the page lags, narrow the BPF filter (e.g. limit to a
+          single protocol or device IP) instead of trying to render everything.
+        </p>
+      </>
+    ),
   },
   {
     path: '/templates',
@@ -313,6 +428,19 @@ const pages: PageConfig[] = [
     description: 'Upload and analyze PCAP files with packet inspection, filtering, and statistics.',
     icon: FileBox,
     component: PcapAnalyzerPage,
+    help: (
+      <>
+        <p>
+          Offline analysis of a PCAP: protocol breakdown, per-conversation stats, full per-packet
+          decode. Equivalent of <code>niac analyze-pcap</code> on the CLI.
+        </p>
+        <h4>Live vs offline</h4>
+        <p>
+          For traffic on the running simulator, use <strong>Live Packets</strong>. This page is for
+          static analysis of files you've captured elsewhere.
+        </p>
+      </>
+    ),
   },
   {
     path: '/neighbors',

--- a/ui/src/components/templates/JavaDslImportCard.tsx
+++ b/ui/src/components/templates/JavaDslImportCard.tsx
@@ -91,7 +91,12 @@ export const JavaDslImportCard: FC = () => {
         />
 
         <div className="flex flex-wrap items-center gap-3">
-          <Button tone="emerald" disabled={busy || !content.trim()} onClick={() => void onImport()}>
+          <Button
+            tone="emerald"
+            disabled={busy || !content.trim()}
+            onClick={() => void onImport()}
+            title="POST the content to /api/v1/config/import?format=java-dsl. Returns normalised YAML; nothing is saved server-side."
+          >
             {busy ? 'Converting…' : 'Convert to YAML'}
           </Button>
           {error && (
@@ -107,7 +112,11 @@ export const JavaDslImportCard: FC = () => {
               <SmallText className="text-emerald-300">
                 ✓ Converted ({deviceCount} {deviceCount === 1 ? 'device' : 'devices'})
               </SmallText>
-              <Button variant="outline" onClick={downloadYaml}>
+              <Button
+                variant="outline"
+                onClick={downloadYaml}
+                title="Save the converted YAML to your machine. Use it as a starter template or commit it to your config repo."
+              >
                 Download YAML
               </Button>
             </div>

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -116,6 +116,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
                   min="0"
                   placeholder="100000"
                   value={threshold}
+                  title="Total packet count that triggers the alert. 0 or blank disables the alert."
                   onChange={(event) => {
                     setThreshold(event.target.value);
                     setDirty(true);
@@ -129,6 +130,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
                   className="mt-1 w-full rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white focus:border-violet-400 focus:outline-none"
                   placeholder="https://hooks.example.com/niac"
                   value={webhook}
+                  title="POST'd JSON when the threshold trips. Must be http(s) and not point at a private/loopback/link-local IP. The daemon's --webhook-allowed-host flag further locks this down."
                   onChange={(event) => {
                     setWebhook(event.target.value);
                     setDirty(true);
@@ -145,10 +147,20 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
               </SmallText>
             )}
             <div className="flex flex-wrap gap-3">
-              <Button tone="violet" disabled={!dirty || saving} onClick={commit}>
+              <Button
+                tone="violet"
+                disabled={!dirty || saving}
+                onClick={commit}
+                title="Save alert config to the running daemon. Takes effect immediately — no restart required."
+              >
                 {saving ? 'Saving…' : 'Save alerts'}
               </Button>
-              <Button variant="outline" disabled={!dirty || saving} onClick={reset}>
+              <Button
+                variant="outline"
+                disabled={!dirty || saving}
+                onClick={reset}
+                title="Discard unsaved changes and reload the saved values."
+              >
                 Reset
               </Button>
             </div>

--- a/ui/src/pages/NeighborsPage.tsx
+++ b/ui/src/pages/NeighborsPage.tsx
@@ -86,6 +86,11 @@ export const NeighborsPage: FC = () => {
                     key={p}
                     type="button"
                     onClick={() => setProtocolFilter(p)}
+                    title={
+                      p === 'all'
+                        ? 'Show all discovery protocols'
+                        : `Filter to ${p} entries only (${protocolCounts[p] ?? 0} now)`
+                    }
                     className={`rounded px-3 py-1 text-xs font-medium ${
                       active
                         ? 'bg-cyan-500/20 text-cyan-200 ring-1 ring-cyan-400/40'
@@ -103,6 +108,7 @@ export const NeighborsPage: FC = () => {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Filter by device or chassis ID…"
+              title="Substring match on local device, remote device, chassis ID, or remote port (case-insensitive)."
               className="ml-auto w-64 rounded border border-white/5 bg-gray-950/60 px-3 py-1.5 text-sm text-gray-100 placeholder-gray-500 focus:border-cyan-400 focus:outline-none"
               aria-label="Filter neighbors"
             />

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -105,6 +105,7 @@ export const WalkValidatorPage: FC = () => {
                 value={selectedFile}
                 onChange={(e) => setSelectedFile(e.target.value)}
                 disabled={filesLoading || files.length === 0}
+                title="Hydrated from /api/v1/files?kind=walks (the sandboxed walks directory). Use the absolute-path field to validate a walk outside this directory."
                 className="mt-1 w-full rounded border border-white/5 bg-gray-950/60 px-3 py-2 text-sm text-gray-100 focus:border-cyan-400 focus:outline-none disabled:opacity-50"
               >
                 {filesLoading && <option>Loading…</option>}
@@ -125,6 +126,7 @@ export const WalkValidatorPage: FC = () => {
                 value={customPath}
                 onChange={(e) => setCustomPath(e.target.value)}
                 placeholder="/srv/niac/walks/cisco-c9300.walk"
+                title="Absolute path to a walk file. Takes precedence over the dropdown selection. The path is bounded server-side; ../ traversal is rejected."
                 className="mt-1 w-full rounded border border-white/5 bg-gray-950/60 px-3 py-2 font-mono text-xs text-gray-100 placeholder-gray-500 focus:border-cyan-400 focus:outline-none"
               />
             </label>
@@ -135,6 +137,7 @@ export const WalkValidatorPage: FC = () => {
               type="button"
               onClick={() => void run('validating')}
               disabled={busy !== 'idle' || !targetPath}
+              title="Read-only validation: parses the walk and returns per-line issues. Doesn't modify the file."
               className="rounded bg-cyan-500/20 px-3 py-1.5 text-sm font-medium text-cyan-100 ring-1 ring-cyan-400/40 hover:bg-cyan-500/30 disabled:opacity-50"
             >
               {busy === 'validating' ? 'Validating…' : 'Validate'}


### PR DESCRIPTION
Closes the four follow-ups from the post-#491 design pass plus the project audit.

## Summary
- **Comprehensive help** — every page in the WebUI now ships a (?) icon with rich help. 7 newly-seeded pages (Dashboard, Topology, Replay, Traffic, Protocol Debug, Live Packets, PCAP Analysis) join the 8 from #491.
- **Comprehensive tooltips** — every interactive control on the pages this work touched now has \`title=\` (alert config inputs + buttons, walk-validator inputs + buttons, neighbors filter chips and search, Java-DSL import buttons).
- **Schema CI guard** — \`ci.yml\`'s Backend job now diffs the committed \`docs/schemas/niac.schema.json\` against a fresh \`niac-schema\` run. PRs that touch \`internal/converter.Config\` without running \`make schema\` fail loudly.
- **Project audit** — \`docs/PROJECT_AUDIT.md\` documents what's clean (Tier 4), what's stale (Tier 2), and what's broken-enough-to-fix (Tier 1, tracked as #493 / #494 / #495).
- **First Tier-1 fix** — \`internal/api/config_ops_test.go\` closes the test gap on the merge + import endpoints I added in #491.

## Verification
- \`go build / go test ./... / golangci-lint\`: clean.
- \`niac-schema -o /tmp/x && diff /tmp/x docs/schemas/niac.schema.json\`: empty (CI guard passes locally).
- \`npx tsc --noEmit && npx biome check\`: clean.