### PR TITLE
fix(protocols): restartable Start/Stop across discovery and traffic handlers

### DIFF
--- a/internal/capture/playback_test.go
+++ b/internal/capture/playback_test.go
@@ -516,6 +516,49 @@ func TestPlaybackPacket_Structure(t *testing.T) {
 	}
 }
 
+// TestPlaybackEngine_RestartAfterStop verifies Start can be called again
+// after Stop with a real PCAP file. Regression for #464.
+func TestPlaybackEngine_RestartAfterStop(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping playback test in CI environment")
+	}
+
+	loopbackNames := []string{"lo", "lo0"}
+
+	var testInterface string
+
+	for _, name := range loopbackNames {
+		if InterfaceExists(name) {
+			testInterface = name
+
+			break
+		}
+	}
+
+	if testInterface == "" {
+		t.Skip("No loopback interface found")
+	}
+
+	engine, err := New(testInterface, 0)
+	if err != nil {
+		t.Skipf("Cannot create engine: %v", err)
+	}
+	defer engine.Close()
+
+	pcapFile := createTestPCAP(t, 3)
+	playbackConfig := &config.CapturePlayback{FileName: pcapFile}
+	pb := NewPlaybackEngine(engine, playbackConfig, 0)
+
+	for i := range 3 {
+		if startErr := pb.Start(); startErr != nil {
+			t.Fatalf("iter %d: Start failed: %v", i, startErr)
+		}
+		// Tiny window for the goroutine to be alive then bail.
+		time.Sleep(20 * time.Millisecond)
+		pb.Stop()
+	}
+}
+
 // TestPlaybackEngine_ConcurrentStartStop tests concurrent start/stop calls.
 func TestPlaybackEngine_ConcurrentStartStop(t *testing.T) {
 	if os.Getenv("CI") != "" {

--- a/internal/device/traffic.go
+++ b/internal/device/traffic.go
@@ -91,16 +91,22 @@ func (tg *TrafficGenerator) getPattern(deviceName, patternName string) *TrafficP
 	return p
 }
 
-// Start starts the traffic generator.
+// Start starts the traffic generator. Safe to call again after Stop.
 func (tg *TrafficGenerator) Start() error {
 	logger := slog.Default()
 	if !tg.running.CompareAndSwap(false, true) {
 		return ErrTrafficGeneratorAlreadyRunning
 	}
 
+	// Replace the stop channel after CAS so a previous Stop() (which closed
+	// the old one) doesn't make this run exit immediately, and so the next
+	// Stop() doesn't double-close.
+	tg.stopChan = make(chan struct{})
+	stopChan := tg.stopChan
+
 	// Start unified traffic generation loop (v1.6.0)
 	// Uses 10-second ticker to check all devices and their configured intervals
-	go tg.trafficGenerationLoop()
+	go tg.trafficGenerationLoop(stopChan)
 
 	if tg.debugLevel >= 1 {
 		logger.Info("Traffic generator started (v1.6.0 configurable traffic)")
@@ -124,14 +130,16 @@ func (tg *TrafficGenerator) Stop() {
 }
 
 // trafficGenerationLoop unified traffic generation with per-device config support (v1.6.0).
-func (tg *TrafficGenerator) trafficGenerationLoop() {
+// stopChan is captured by Start at goroutine spawn time so a subsequent restart
+// can't redirect this run onto a fresh channel.
+func (tg *TrafficGenerator) trafficGenerationLoop(stopChan <-chan struct{}) {
 	// Use 10-second ticker to check all devices
 	ticker := time.NewTicker(trafficTickerInterval)
 	defer ticker.Stop()
 
 	for tg.running.Load() {
 		select {
-		case <-tg.stopChan:
+		case <-stopChan:
 			return
 		case <-ticker.C:
 			tg.checkAndGenerateTraffic()

--- a/internal/device/traffic_test.go
+++ b/internal/device/traffic_test.go
@@ -148,6 +148,22 @@ func TestTrafficGenerator_StopWithoutStart(_ *testing.T) {
 	tg.Stop()
 }
 
+// TestTrafficGenerator_RestartAfterStop verifies that Start can be called
+// again after Stop without panicking on `close of closed channel`.
+// Regression for #463.
+func TestTrafficGenerator_RestartAfterStop(t *testing.T) {
+	cfg := createTrafficTestConfig(1, false)
+	sim, stack := newTestSimAndStack(cfg)
+	tg := NewTrafficGenerator(sim, stack, 0)
+
+	for i := range 3 {
+		if err := tg.Start(); err != nil {
+			t.Fatalf("iter %d: Start failed: %v", i, err)
+		}
+		tg.Stop()
+	}
+}
+
 // TestTrafficGenerator_AtomicBool tests that the [atomic.Bool] in TrafficGenerator
 // works correctly under concurrent access (regression test for [atomic.Bool] usage).
 func TestTrafficGenerator_AtomicBool(t *testing.T) {

--- a/internal/protocols/cdp.go
+++ b/internal/protocols/cdp.go
@@ -91,9 +91,10 @@ const (
 // CDPHandler handles CDP advertisements.
 type CDPHandler struct {
 	stack           *Stack
+	mu              sync.Mutex
 	stopChan        chan struct{}
-	stopOnce        sync.Once
 	advertiseTicker *time.Ticker
+	running         bool
 }
 
 // NewCDPHandler creates a new CDP handler.
@@ -104,27 +105,35 @@ func NewCDPHandler(stack *Stack) *CDPHandler {
 	}
 }
 
-// Start begins periodic CDP advertisements.
+// Start begins periodic CDP advertisements. Safe to call again after Stop.
 func (h *CDPHandler) Start() {
-	logger := slog.Default()
-	debugLevel := h.stack.GetDebugLevel()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	if debugLevel >= 1 {
-		logger.Info("CDP: Starting periodic advertisements", "interval", CDPAdvertiseInterval)
+	if h.running {
+		return
 	}
 
+	h.stopChan = make(chan struct{})
 	h.advertiseTicker = time.NewTicker(CDPAdvertiseInterval)
+	h.running = true
+
+	stopChan := h.stopChan
+	ticker := h.advertiseTicker
+
+	if h.stack.GetDebugLevel() >= 1 {
+		slog.Default().Info("CDP: Starting periodic advertisements", "interval", CDPAdvertiseInterval)
+	}
 
 	go func() {
-		// Send initial advertisement immediately
 		h.sendAdvertisements()
 
 		for {
 			select {
-			case <-h.advertiseTicker.C:
+			case <-ticker.C:
 				h.sendAdvertisements()
-			case <-h.stopChan:
-				h.advertiseTicker.Stop()
+			case <-stopChan:
+				ticker.Stop()
 
 				return
 			}
@@ -132,11 +141,17 @@ func (h *CDPHandler) Start() {
 	}()
 }
 
-// Stop halts CDP advertisements.
+// Stop halts CDP advertisements. Safe to call multiple times.
 func (h *CDPHandler) Stop() {
-	h.stopOnce.Do(func() {
-		close(h.stopChan)
-	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.running {
+		return
+	}
+
+	close(h.stopChan)
+	h.running = false
 }
 
 // sendAdvertisements sends CDP advertisements for all devices.

--- a/internal/protocols/cdp_test.go
+++ b/internal/protocols/cdp_test.go
@@ -615,6 +615,28 @@ func TestCDPLifecycle(t *testing.T) {
 	}
 }
 
+// TestCDPHandler_RestartAfterStop verifies Start can be called again after
+// Stop without panicking on a closed channel. Regression for #462.
+func TestCDPHandler_RestartAfterStop(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewCDPHandler(stack)
+
+	for i := range 3 {
+		handler.Start()
+		time.Sleep(20 * time.Millisecond)
+
+		if handler.CDPHandlerAdvertiseTicker() == nil {
+			t.Fatalf("iter %d: ticker nil after Start()", i)
+		}
+
+		handler.Stop()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	handler.Stop() // double-stop is a no-op
+}
+
 // TestSendAdvertisements verifies advertisement sending logic.
 func TestSendAdvertisements(_ *testing.T) {
 	cfg := &config.Config{}

--- a/internal/protocols/edp.go
+++ b/internal/protocols/edp.go
@@ -55,9 +55,10 @@ const (
 // EDPHandler handles EDP advertisements.
 type EDPHandler struct {
 	stack           *Stack
+	mu              sync.Mutex
 	stopChan        chan struct{}
-	stopOnce        sync.Once
 	advertiseTicker *time.Ticker
+	running         bool
 }
 
 // NewEDPHandler creates a new EDP handler.
@@ -68,26 +69,35 @@ func NewEDPHandler(stack *Stack) *EDPHandler {
 	}
 }
 
-// Start begins periodic EDP advertisements.
+// Start begins periodic EDP advertisements. Safe to call again after Stop.
 func (h *EDPHandler) Start() {
-	debugLevel := h.stack.GetDebugLevel()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	if debugLevel >= 1 {
+	if h.running {
+		return
+	}
+
+	h.stopChan = make(chan struct{})
+	h.advertiseTicker = time.NewTicker(EDPAdvertiseInterval)
+	h.running = true
+
+	stopChan := h.stopChan
+	ticker := h.advertiseTicker
+
+	if h.stack.GetDebugLevel() >= 1 {
 		_, _ = fmt.Fprintf(os.Stdout, "EDP: Starting periodic advertisements (interval: %v)\n", EDPAdvertiseInterval)
 	}
 
-	h.advertiseTicker = time.NewTicker(EDPAdvertiseInterval)
-
 	go func() {
-		// Send initial advertisement immediately
 		h.sendAdvertisements()
 
 		for {
 			select {
-			case <-h.advertiseTicker.C:
+			case <-ticker.C:
 				h.sendAdvertisements()
-			case <-h.stopChan:
-				h.advertiseTicker.Stop()
+			case <-stopChan:
+				ticker.Stop()
 
 				return
 			}
@@ -95,11 +105,17 @@ func (h *EDPHandler) Start() {
 	}()
 }
 
-// Stop halts EDP advertisements.
+// Stop halts EDP advertisements. Safe to call multiple times.
 func (h *EDPHandler) Stop() {
-	h.stopOnce.Do(func() {
-		close(h.stopChan)
-	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.running {
+		return
+	}
+
+	close(h.stopChan)
+	h.running = false
 }
 
 // sendAdvertisements sends EDP advertisements for all devices.

--- a/internal/protocols/edp_test.go
+++ b/internal/protocols/edp_test.go
@@ -352,6 +352,28 @@ func TestEDPLifecycle(t *testing.T) {
 	}
 }
 
+// TestEDPHandler_RestartAfterStop verifies Start can be called again after
+// Stop without panicking on a closed channel. Regression for #462.
+func TestEDPHandler_RestartAfterStop(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewEDPHandler(stack)
+
+	for i := range 3 {
+		handler.Start()
+		time.Sleep(20 * time.Millisecond)
+
+		if handler.EDPHandlerAdvertiseTicker() == nil {
+			t.Fatalf("iter %d: ticker nil after Start()", i)
+		}
+
+		handler.Stop()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	handler.Stop() // double-stop is a no-op
+}
+
 // TestSendAdvertisementsEDP verifies advertisement sending logic for EDP.
 func TestSendAdvertisementsEDP(_ *testing.T) {
 	cfg := &config.Config{}

--- a/internal/protocols/fdp.go
+++ b/internal/protocols/fdp.go
@@ -67,9 +67,10 @@ const deviceTypeHost = "host"
 // FDPHandler handles FDP advertisements.
 type FDPHandler struct {
 	stack           *Stack
+	mu              sync.Mutex
 	stopChan        chan struct{}
-	stopOnce        sync.Once
 	advertiseTicker *time.Ticker
+	running         bool
 }
 
 // NewFDPHandler creates a new FDP handler.
@@ -80,26 +81,35 @@ func NewFDPHandler(stack *Stack) *FDPHandler {
 	}
 }
 
-// Start begins periodic FDP advertisements.
+// Start begins periodic FDP advertisements. Safe to call again after Stop.
 func (h *FDPHandler) Start() {
-	debugLevel := h.stack.GetDebugLevel()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	if debugLevel >= 1 {
+	if h.running {
+		return
+	}
+
+	h.stopChan = make(chan struct{})
+	h.advertiseTicker = time.NewTicker(FDPAdvertiseInterval)
+	h.running = true
+
+	stopChan := h.stopChan
+	ticker := h.advertiseTicker
+
+	if h.stack.GetDebugLevel() >= 1 {
 		_, _ = fmt.Fprintf(os.Stdout, "FDP: Starting periodic advertisements (interval: %v)\n", FDPAdvertiseInterval)
 	}
 
-	h.advertiseTicker = time.NewTicker(FDPAdvertiseInterval)
-
 	go func() {
-		// Send initial advertisement immediately
 		h.sendAdvertisements()
 
 		for {
 			select {
-			case <-h.advertiseTicker.C:
+			case <-ticker.C:
 				h.sendAdvertisements()
-			case <-h.stopChan:
-				h.advertiseTicker.Stop()
+			case <-stopChan:
+				ticker.Stop()
 
 				return
 			}
@@ -107,11 +117,17 @@ func (h *FDPHandler) Start() {
 	}()
 }
 
-// Stop halts FDP advertisements.
+// Stop halts FDP advertisements. Safe to call multiple times.
 func (h *FDPHandler) Stop() {
-	h.stopOnce.Do(func() {
-		close(h.stopChan)
-	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.running {
+		return
+	}
+
+	close(h.stopChan)
+	h.running = false
 }
 
 // sendAdvertisements sends FDP advertisements for all devices.

--- a/internal/protocols/fdp_test.go
+++ b/internal/protocols/fdp_test.go
@@ -550,6 +550,28 @@ func TestFDPLifecycle(t *testing.T) {
 	}
 }
 
+// TestFDPHandler_RestartAfterStop verifies Start can be called again after
+// Stop without panicking on a closed channel. Regression for #462.
+func TestFDPHandler_RestartAfterStop(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewFDPHandler(stack)
+
+	for i := range 3 {
+		handler.Start()
+		time.Sleep(20 * time.Millisecond)
+
+		if handler.FDPHandlerAdvertiseTicker() == nil {
+			t.Fatalf("iter %d: ticker nil after Start()", i)
+		}
+
+		handler.Stop()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	handler.Stop() // double-stop is a no-op
+}
+
 // TestSendAdvertisementsFDP verifies advertisement sending logic for FDP.
 func TestSendAdvertisementsFDP(_ *testing.T) {
 	cfg := &config.Config{}

--- a/internal/protocols/lldp.go
+++ b/internal/protocols/lldp.go
@@ -96,9 +96,10 @@ const (
 // LLDPHandler handles LLDP advertisements.
 type LLDPHandler struct {
 	stack           *Stack
+	mu              sync.Mutex
 	stopChan        chan struct{}
-	stopOnce        sync.Once
 	advertiseTicker *time.Ticker
+	running         bool
 }
 
 // NewLLDPHandler creates a new LLDP handler.
@@ -109,26 +110,35 @@ func NewLLDPHandler(stack *Stack) *LLDPHandler {
 	}
 }
 
-// Start begins periodic LLDP advertisements.
+// Start begins periodic LLDP advertisements. Safe to call again after Stop.
 func (h *LLDPHandler) Start() {
-	debugLevel := h.stack.GetDebugLevel()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	if debugLevel >= 1 {
+	if h.running {
+		return
+	}
+
+	h.stopChan = make(chan struct{})
+	h.advertiseTicker = time.NewTicker(LLDPAdvertiseInterval)
+	h.running = true
+
+	stopChan := h.stopChan
+	ticker := h.advertiseTicker
+
+	if h.stack.GetDebugLevel() >= 1 {
 		_, _ = fmt.Fprintf(os.Stdout, "LLDP: Starting periodic advertisements (interval: %v)\n", LLDPAdvertiseInterval)
 	}
 
-	h.advertiseTicker = time.NewTicker(LLDPAdvertiseInterval)
-
 	go func() {
-		// Send initial advertisement immediately
 		h.sendAdvertisements()
 
 		for {
 			select {
-			case <-h.advertiseTicker.C:
+			case <-ticker.C:
 				h.sendAdvertisements()
-			case <-h.stopChan:
-				h.advertiseTicker.Stop()
+			case <-stopChan:
+				ticker.Stop()
 
 				return
 			}
@@ -138,9 +148,15 @@ func (h *LLDPHandler) Start() {
 
 // Stop halts LLDP advertisements. Safe to call multiple times.
 func (h *LLDPHandler) Stop() {
-	h.stopOnce.Do(func() {
-		close(h.stopChan)
-	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.running {
+		return
+	}
+
+	close(h.stopChan)
+	h.running = false
 }
 
 // sendAdvertisements sends LLDP advertisements for all devices.

--- a/internal/protocols/lldp_test.go
+++ b/internal/protocols/lldp_test.go
@@ -53,6 +53,49 @@ func TestLLDPHandler_Lifecycle(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
+// TestLLDPHandler_RestartAfterStop verifies Start can be called again after
+// Stop without panicking on a closed channel and that the second Stop still
+// terminates the goroutine. Regression for #462.
+func TestLLDPHandler_RestartAfterStop(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewLLDPHandler(stack)
+
+	for i := range 3 {
+		handler.Start()
+		time.Sleep(20 * time.Millisecond)
+
+		if handler.LLDPHandlerAdvertiseTicker() == nil {
+			t.Fatalf("iter %d: ticker nil after Start()", i)
+		}
+
+		handler.Stop()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Double-Stop must be a no-op.
+	handler.Stop()
+}
+
+// TestLLDPHandler_DoubleStartIgnored ensures a second Start without an
+// intervening Stop does not spawn a duplicate goroutine.
+func TestLLDPHandler_DoubleStartIgnored(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewLLDPHandler(stack)
+
+	handler.Start()
+	first := handler.LLDPHandlerAdvertiseTicker()
+	handler.Start() // ignored
+	second := handler.LLDPHandlerAdvertiseTicker()
+
+	if first != second {
+		t.Error("Second Start replaced ticker; expected idempotent no-op")
+	}
+
+	handler.Stop()
+}
+
 // TestBuildChassisIDTLV tests building Chassis ID TLV.
 func TestBuildChassisIDTLV(t *testing.T) {
 	cfg := &config.Config{}


### PR DESCRIPTION
Closes #462, #463. Verifies and locks down #464 with a regression test.

## Summary

- **#462 LLDP/CDP/EDP/FDP** — `Start()` no longer leaves the goroutine running on a stale closed `stopChan` after `Stop()`. Replaced `sync.Once` close pattern with a `mutex + running` flag; `Start()` is now idempotent (double-Start is a no-op) and captures `stopChan` + `ticker` as locals so an old run can't race onto a fresh channel.
- **#463 TrafficGenerator** — `close(stopChan)` is no longer fatal on the second `Stop()` after a restart. `Start()` re-makes the channel under the CAS guard and passes it as a captured local to `trafficGenerationLoop`.
- **#464 PlaybackEngine** — already correct (Start re-creates `stopChan` under mutex, Stop's `wg.Wait()` drains the prior loop). Added a regression test that exercises Start→Stop→Start three times against a real PCAP file.

## Test plan

- [x] `go test ./internal/protocols/ ./internal/device/ ./internal/capture/ -count=1` — pass
- [x] `golangci-lint run ./internal/protocols/... ./internal/device/... ./internal/capture/...` — 0 issues
- [x] New regression tests all pass