### PR TITLE
fix(ui): use react-router navigate() instead of window.location

### DIFF
--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -1,5 +1,6 @@
 import { Activity, BellRing, Download, FileCog, FileUp, PlugZap, Settings } from 'lucide-react';
 import { type FC, useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   fetchConfig,
   fetchProtocolDebugLevels,
@@ -35,6 +36,7 @@ import { formatBytes, formatTime, formatUptime, getErrorMessage } from '../utils
  * - Link to Settings for configuration management
  */
 export const RuntimeControlPage: FC = () => {
+  const navigate = useNavigate();
   const [refetchTrigger, setRefetchTrigger] = useState(0);
   const { data: simStatus } = useApiResource(fetchSimulationStatus, [refetchTrigger], {
     intervalMs: POLL_INTERVALS.fast,
@@ -364,9 +366,7 @@ export const RuntimeControlPage: FC = () => {
               <Button
                 variant="ghost"
                 leftIcon={<FileCog className="h-4 w-4" />}
-                onClick={() => {
-                  window.location.href = '/devices';
-                }}
+                onClick={() => navigate('/devices')}
               >
                 View Devices
               </Button>


### PR DESCRIPTION
Closes #470. Replaces the only remaining `window.location.href` SPA escape (RuntimeControlPage 'View Devices' button) with `useNavigate()`. The two other call sites flagged in #470 (ErrorBoundary recovery reload, useEventSource origin read) and the MergeControls clear-all path were already correct in main.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `npm test` — 65/65 pass