### PR TITLE
fix(ui): context value identity + Modal focus trap

### DIFF
--- a/ui/src/contexts/DeviceListContext.tsx
+++ b/ui/src/contexts/DeviceListContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type FC, type ReactNode, useContext } from 'react';
+import { createContext, type FC, type ReactNode, useContext, useMemo } from 'react';
 import type { Device } from '../api/types';
 
 interface DeviceListContextValue {
@@ -45,16 +45,28 @@ export const DeviceListProvider: FC<DeviceListProviderProps> = ({
   getDeviceProtocols,
   children,
 }) => {
-  const value: DeviceListContextValue = {
-    devices,
-    selectedDevices,
-    onSelectDevice,
-    onSelectAll,
-    onEdit,
-    onClone,
-    onDelete,
-    getDeviceProtocols,
-  };
+  const value = useMemo<DeviceListContextValue>(
+    () => ({
+      devices,
+      selectedDevices,
+      onSelectDevice,
+      onSelectAll,
+      onEdit,
+      onClone,
+      onDelete,
+      getDeviceProtocols,
+    }),
+    [
+      devices,
+      selectedDevices,
+      onSelectDevice,
+      onSelectAll,
+      onEdit,
+      onClone,
+      onDelete,
+      getDeviceProtocols,
+    ],
+  );
 
   return <DeviceListContext.Provider value={value}>{children}</DeviceListContext.Provider>;
 };

--- a/ui/src/hooks/useApiResource.ts
+++ b/ui/src/hooks/useApiResource.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface Options<T> {
   intervalMs?: number;
@@ -67,5 +67,12 @@ export function useApiResource<T>(
 
   const refetch = useCallback(() => run(), [run]);
 
-  return { data, loading, error, refetch } as const;
+  // Stable identity across renders so callers that pass this object as a
+  // useMemo / useEffect dependency don't invalidate every render. Without
+  // the wrapper a fresh `{ data, loading, error, refetch }` literal would
+  // be allocated each render even when the underlying values were equal.
+  return useMemo(
+    () => ({ data, loading, error, refetch }) as const,
+    [data, loading, error, refetch],
+  );
 }

--- a/ui/src/ui/Modal.tsx
+++ b/ui/src/ui/Modal.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react';
-import { type FC, type KeyboardEvent, type ReactNode, useCallback, useEffect } from 'react';
+import { type FC, type KeyboardEvent, type ReactNode, useEffect } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
 
@@ -34,34 +35,28 @@ export const Modal: FC<ModalProps> = ({
   closeOnEscape = true,
   className = '',
 }) => {
-  // Handle escape key
-  const handleKeyDown = useCallback(
-    (e: globalThis.KeyboardEvent) => {
-      if (closeOnEscape && e.key === 'Escape') {
-        onClose();
-      }
-    },
-    [closeOnEscape, onClose],
-  );
+  // Trap Tab/Shift+Tab focus inside the dialog and route Escape through onClose.
+  const containerRef = useFocusTrap<HTMLDivElement>({
+    isActive: isOpen,
+    onEscape: closeOnEscape ? onClose : undefined,
+  });
 
   useEffect(() => {
     if (isOpen) {
-      document.addEventListener('keydown', handleKeyDown);
       // Prevent body scroll when modal is open
       document.body.style.overflow = 'hidden';
     }
     return () => {
-      document.removeEventListener('keydown', handleKeyDown);
       document.body.style.overflow = '';
     };
-  }, [isOpen, handleKeyDown]);
+  }, [isOpen]);
 
   if (!isOpen) {
     return null;
   }
 
   const handleContentKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    // Prevent escape from bubbling if handled
+    // Prevent escape from bubbling if handled by the focus-trap hook
     if (e.key === 'Escape') {
       e.stopPropagation();
     }
@@ -80,6 +75,7 @@ export const Modal: FC<ModalProps> = ({
         <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
       )}
       <div
+        ref={containerRef}
         className={`mx-4 w-full ${sizeClasses[size]} rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl ${className}`}
         role="dialog"
         aria-modal="true"


### PR DESCRIPTION
Two medium-priority UI fixes from the audit backlog.

Closes #471 and the Modal-focus part of #438.

## #471 — context value churn
- `useApiResource` now wraps its return in `useMemo` so identity is stable across renders when the four fields haven't changed. Previously a fresh literal allocated each render forced `AppContext.useMemo` to invalidate every poll tick.
- `DeviceListContext` provider value is now `useMemo`'d.

## #438 — Modal lacked focus trap
- Wired the existing `useFocusTrap` hook (already used by `SettingsDrawer`) into `Modal`. Tab/Shift+Tab now stay inside the dialog; focus is restored on close.

The other #438 subitems were verified already fixed in main and noted in the second commit body.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 65/65 pass