### PR TITLE
fix: low-priority hardening sweep (cmd, capture, ICMP, CSP, YAML, clipboard)

### DIFF
--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -62,21 +62,27 @@ The web UI will be available at http://localhost:8080`,
 func runDaemon(options *daemonOptions, info versionInfo) error {
 	logging.InitColors(true)
 
+	// Resolve token through resolveAPIToken so NIAC_API_TOKEN env wins over
+	// the (deprecated) --token flag and the deprecation warning prints once
+	// at startup. Without this, the daemon binary kept accepting the flag
+	// while inject/replay paths quietly preferred env, splitting behavior.
+	token := resolveAPIToken(options.token)
+
 	logging.Infof("Starting NIAC Daemon v%s", info.version)
 	logging.Infof("Web UI will be available at http://localhost%s", options.listen)
-	if options.token != "" {
+	if token != "" {
 		logging.Infof("API authentication enabled")
 	} else {
 		logging.Warningf(
 			"SECURITY: No API token set. Anyone with network access can control simulations.",
 		)
-		logging.Warningf("         Use --token for production or network-exposed deployments.")
+		logging.Warningf("         Use NIAC_API_TOKEN env var for production or network-exposed deployments.")
 	}
 
 	// Create daemon instance
 	d, err := daemon.NewDaemon(daemon.Config{
 		ListenAddr:          options.listen,
-		Token:               options.token,
+		Token:               token,
 		StoragePath:         options.storagePath,
 		Version:             info.version,
 		Commit:              info.commit,

--- a/cmd/niac/cmd_service_windows.go
+++ b/cmd/niac/cmd_service_windows.go
@@ -64,10 +64,23 @@ func (p *niacProgram) run() {
 
 	logging.InitColors(false)
 
+	listen := os.Getenv("NIAC_LISTEN")
+	if listen == "" {
+		listen = ":8080"
+	}
+
+	storagePath := os.Getenv("NIAC_STORAGE_PATH")
+	if storagePath == "" {
+		storagePath = "~/.niac/niac.db"
+	}
+	if expanded, err := expandUserHome(storagePath); err == nil {
+		storagePath = expanded
+	}
+
 	d, err := daemon.NewDaemon(daemon.Config{
-		ListenAddr:  ":8080",
-		Token:       "",
-		StoragePath: "~/.niac/niac.db",
+		ListenAddr:  listen,
+		Token:       resolveAPIToken(""),
+		StoragePath: storagePath,
 		Version:     p.info.version,
 		Commit:      p.info.commit,
 		BuildTime:   p.info.date,
@@ -172,32 +185,61 @@ func addServiceCommand(root *cobra.Command, _ *serviceOptions) {
 	root.AddCommand(serviceCmd)
 }
 
-func getServiceConfig() *service.Config {
-	execPath, _ := os.Executable()
+func getServiceConfig() (*service.Config, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve executable path: %w", err)
+	}
 	return &service.Config{
 		Name:        windowsServiceName,
 		DisplayName: windowsDisplayName,
 		Description: windowsDescription,
 		Arguments:   []string{"service", "run"},
 		Executable:  execPath,
+	}, nil
+}
+
+// expandUserHome replaces a leading "~" in path with the current user's home
+// directory. Used for the Windows service storage path config which historically
+// hardcoded "~/.niac/niac.db" and never expanded the tilde.
+func expandUserHome(path string) (string, error) {
+	if len(path) == 0 || path[0] != '~' {
+		return path, nil
 	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path, err
+	}
+	return home + path[1:], nil
+}
+
+// newServiceFor creates a kardianos service.Service for the given program,
+// surfacing the os.Executable lookup failure rather than silently swallowing it.
+func newServiceFor(prg *niacProgram) (service.Service, error) {
+	cfg, err := getServiceConfig()
+	if err != nil {
+		return nil, err
+	}
+	svc, err := service.New(prg, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service: %w", err)
+	}
+	return svc, nil
 }
 
 func runWindowsService(info versionInfo) error {
-	prg := &niacProgram{info: info}
-	svc, err := service.New(prg, getServiceConfig())
+	svc, err := newServiceFor(&niacProgram{info: info})
 	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
+		return err
 	}
 
 	return svc.Run()
 }
 
 func installWindowsService() error {
-	prg := &niacProgram{}
-	svc, err := service.New(prg, getServiceConfig())
+	svc, err := newServiceFor(&niacProgram{})
 	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
+		return err
 	}
 
 	if err := svc.Install(); err != nil {
@@ -216,10 +258,9 @@ func installWindowsService() error {
 }
 
 func uninstallWindowsService() error {
-	prg := &niacProgram{}
-	svc, err := service.New(prg, getServiceConfig())
+	svc, err := newServiceFor(&niacProgram{})
 	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
+		return err
 	}
 
 	// Stop service first if running
@@ -234,10 +275,9 @@ func uninstallWindowsService() error {
 }
 
 func controlWindowsService(action string) error {
-	prg := &niacProgram{}
-	svc, err := service.New(prg, getServiceConfig())
+	svc, err := newServiceFor(&niacProgram{})
 	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
+		return err
 	}
 
 	switch action {
@@ -256,10 +296,9 @@ func controlWindowsService(action string) error {
 }
 
 func showWindowsServiceStatus() error {
-	prg := &niacProgram{}
-	svc, err := service.New(prg, getServiceConfig())
+	svc, err := newServiceFor(&niacProgram{})
 	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
+		return err
 	}
 
 	status, err := svc.Status()

--- a/cmd/niac/completion.go
+++ b/cmd/niac/completion.go
@@ -51,20 +51,21 @@ func addCompletionCommand(root *cobra.Command) {
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		Run:                   runCompletion,
+		RunE:                  runCompletion,
 	}
 	root.AddCommand(completionCmd)
 }
 
-func runCompletion(cmd *cobra.Command, args []string) {
+func runCompletion(cmd *cobra.Command, args []string) error {
 	switch args[0] {
 	case "bash":
-		_ = cmd.Root().GenBashCompletion(os.Stdout)
+		return cmd.Root().GenBashCompletion(os.Stdout)
 	case "zsh":
-		_ = cmd.Root().GenZshCompletion(os.Stdout)
+		return cmd.Root().GenZshCompletion(os.Stdout)
 	case "fish":
-		_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+		return cmd.Root().GenFishCompletion(os.Stdout, true)
 	case "powershell":
-		_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 	}
+	return nil
 }

--- a/cmd/niac/man.go
+++ b/cmd/niac/man.go
@@ -10,26 +10,34 @@ import (
 )
 
 func addManCommand(root *cobra.Command, info versionInfo) {
+	var outputDir string
+
 	manCmd := &cobra.Command{
 		Use:    "man",
 		Short:  "Generate man pages",
 		Long:   `Generate Unix man pages for NIAC commands.`,
 		Hidden: true, // Hidden from help, mainly for maintainers
-		Example: `  # Generate man pages to docs/man/
+		Example: `  # Generate man pages to ./docs/man/ (default)
   niac man
+
+  # Generate to a specific directory
+  niac man --output /tmp/niac-man
 
   # Install man pages (requires sudo)
   sudo cp docs/man/* /usr/local/share/man/man1/
   sudo mandb`,
-		Run: func(_ *cobra.Command, _ []string) {
-			runMan(root, info)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runMan(root, info, outputDir)
 		},
 	}
+
+	manCmd.Flags().StringVarP(&outputDir, "output", "o", "docs/man",
+		"output directory (relative paths resolve against the current working directory)")
 
 	root.AddCommand(manCmd)
 }
 
-func runMan(root *cobra.Command, info versionInfo) {
+func runMan(root *cobra.Command, info versionInfo, outputDir string) error {
 	header := new(doc.GenManHeader)
 	header.Title = "NIAC"
 	header.Section = "1"
@@ -38,21 +46,17 @@ func runMan(root *cobra.Command, info versionInfo) {
 	now := time.Now()
 	header.Date = &now
 
-	manDir := "docs/man"
-	err := os.MkdirAll(manDir, 0o750)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating man directory: %v\n", err)
-		os.Exit(1)
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		return fmt.Errorf("create man directory: %w", err)
 	}
 
-	err = doc.GenManTree(root, header, manDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error generating man pages: %v\n", err)
-		os.Exit(1)
+	if err := doc.GenManTree(root, header, outputDir); err != nil {
+		return fmt.Errorf("generate man pages: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "Man pages generated in %s/\n", manDir)
+	fmt.Fprintf(os.Stdout, "Man pages generated in %s/\n", outputDir)
 	fmt.Fprintln(os.Stdout, "\nTo install:")
-	fmt.Fprintln(os.Stdout, "  sudo cp docs/man/* /usr/local/share/man/man1/")
+	fmt.Fprintf(os.Stdout, "  sudo cp %s/* /usr/local/share/man/man1/\n", outputDir)
 	fmt.Fprintln(os.Stdout, "  sudo mandb")
+	return nil
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -77,11 +77,16 @@ func addSecurityHeaders(w http.ResponseWriter, r *http.Request) {
 	// Enable XSS protection (legacy, but still useful for older browsers)
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 
-	// Content Security Policy - restrict resource loading
-	// Note: fonts.googleapis.com and fonts.gstatic.com allowed for Google Fonts
+	// Content Security Policy - restrict resource loading.
+	// Note: fonts.googleapis.com and fonts.gstatic.com are allowed for Google Fonts.
+	// script-src no longer permits 'unsafe-inline'; the only inline handler we
+	// had (a font loader onload) was removed from index.html. style-src still
+	// allows 'unsafe-inline' because Tailwind v4 emits inline <style> blocks
+	// during HMR and a few first-paint utility rules; revisiting requires a
+	// nonced build pipeline (tracked separately).
 	w.Header().Set("Content-Security-Policy",
 		"default-src 'self'; "+
-			"script-src 'self' 'unsafe-inline'; "+
+			"script-src 'self'; "+
 			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
 			"img-src 'self' data:; "+
 			"font-src 'self' https://fonts.gstatic.com; "+

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -8,19 +8,18 @@
     <!-- Preconnect to Google Fonts for faster loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Load fonts asynchronously with display=swap to prevent render blocking -->
+    <!--
+      Load fonts with display=swap so the page renders the moment the bundle
+      is ready, even if Google Fonts is slow. We used to use the
+      media="print" / onload="this.media='all'" trick for non-blocking
+      delivery, but the inline onload required script-src 'unsafe-inline'
+      in our CSP. The font CSS itself is small and gzipped, so a normal
+      stylesheet link is the right tradeoff for a stricter CSP.
+    -->
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      media="print"
-      onload="this.media='all'"
     />
-    <noscript>
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      />
-    </noscript>
     <script type="module" crossorigin src="/assets/index-Dpefvjr8.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-BoJ-pB7h.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-DtDwoORA.js">

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -2,6 +2,7 @@
 package capture
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -128,19 +129,33 @@ func (e *Engine) ReadPacket(buffer []byte) ([]byte, error) {
 }
 
 // StartCapture starts capturing packets and calls handler for each packet.
+// Blocks until the underlying handle is closed (e.g. via Engine.Close).
 func (e *Engine) StartCapture(handler func(gopacket.Packet)) error {
+	return e.StartCaptureContext(context.Background(), handler)
+}
+
+// StartCaptureContext is the cancellable form of StartCapture. When ctx is
+// cancelled, the loop exits at the next packet boundary or after captureTimeoutMs
+// of idle time (because pcap.Handle was opened with that timeout).
+func (e *Engine) StartCaptureContext(ctx context.Context, handler func(gopacket.Packet)) error {
 	packetSource := gopacket.NewPacketSource(e.handle, e.handle.LinkType())
 
 	if e.debugLevel >= 1 {
-		logger := slog.Default()
-		logger.Info("Started packet capture", "interface", e.interfaceName)
+		slog.Default().Info("Started packet capture", "interface", e.interfaceName)
 	}
 
-	for packet := range packetSource.Packets() {
-		handler(packet)
+	packets := packetSource.Packets()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case packet, ok := <-packets:
+			if !ok {
+				return nil
+			}
+			handler(packet)
+		}
 	}
-
-	return nil
 }
 
 // SetFilter sets a BPF filter on the capture.

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -1596,9 +1596,25 @@ func (p *Parser) formatMAC(mac string) string {
 		mac[0:2], mac[2:4], mac[4:6], mac[6:8], mac[8:10], mac[10:12])
 }
 
+// MaxYAMLConfigSize caps in-memory YAML config size at 16 MiB. The check
+// guards against pathological alias-bomb / billion-laughs payloads that would
+// otherwise be expanded by yaml.Unmarshal. Real configs in our corpus top out
+// well under 1 MiB.
+const MaxYAMLConfigSize = 16 * 1024 * 1024
+
 // LoadYAMLConfig loads a YAML config file into Go config structure.
 func LoadYAMLConfig(filename string) (*Config, error) {
-	data, err := os.ReadFile(filepath.Clean(filename))
+	clean := filepath.Clean(filename)
+	info, err := os.Stat(clean)
+	if err != nil {
+		return nil, fmt.Errorf("error accessing YAML file: %w", err)
+	}
+	if info.Size() > MaxYAMLConfigSize {
+		return nil, fmt.Errorf(
+			"YAML config too large: %d bytes (max %d)", info.Size(), MaxYAMLConfigSize)
+	}
+
+	data, err := os.ReadFile(clean)
 	if err != nil {
 		return nil, fmt.Errorf("error reading YAML file: %w", err)
 	}
@@ -1608,6 +1624,11 @@ func LoadYAMLConfig(filename string) (*Config, error) {
 
 // LoadYAMLConfigFromBytes converts in-memory YAML data into a Go config structure.
 func LoadYAMLConfigFromBytes(data []byte) (*Config, error) {
+	if len(data) > MaxYAMLConfigSize {
+		return nil, fmt.Errorf(
+			"YAML config too large: %d bytes (max %d)", len(data), MaxYAMLConfigSize)
+	}
+
 	var config Config
 	err := yaml.Unmarshal(data, &config)
 	if err != nil {

--- a/internal/device/traffic.go
+++ b/internal/device/traffic.go
@@ -139,6 +139,22 @@ func (tg *TrafficGenerator) trafficGenerationLoop() {
 	}
 }
 
+// sleepInterruptible sleeps for d, returning false if Stop closes stopChan
+// before the timer fires. Callers should treat false as "exit your loop now".
+func (tg *TrafficGenerator) sleepInterruptible(d time.Duration) bool {
+	if d <= 0 {
+		return tg.running.Load()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-tg.stopChan:
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
 // checkAndGenerateTraffic checks each device's config and generates traffic if intervals have elapsed.
 func (tg *TrafficGenerator) checkAndGenerateTraffic() {
 	devices := tg.simulator.GetAllDevices()
@@ -324,8 +340,12 @@ func (tg *TrafficGenerator) generateRandomTrafficForDevice(
 			}
 		}
 
-		// Small delay between packets
-		time.Sleep(time.Duration(simRand.IntN(maxRandomDelayMs)) * time.Millisecond)
+		// Inter-packet jitter is interruptible so Stop() doesn't block waiting for
+		// up to maxRandomDelayMs before this loop yields.
+		delay := time.Duration(simRand.IntN(maxRandomDelayMs)) * time.Millisecond
+		if !tg.sleepInterruptible(delay) {
+			return
+		}
 	}
 
 	if tg.debugLevel >= debugLevelVerbose {

--- a/internal/protocols/icmp.go
+++ b/internal/protocols/icmp.go
@@ -32,6 +32,9 @@ const (
 	icmpRAEntrySize       = 8  // Router entry size (2 words * 4 bytes)
 	icmpOrigDatagramBytes = 8  // First 8 bytes of original datagram in error messages (RFC 792)
 	icmpTimestampReplyLen = 56 // Timestamp reply message size
+	// icmpUnreachableMaxOrig caps the original-datagram echo in ICMP error
+	// messages: max IPv4 header (60 bytes) + 8 bytes of payload (RFC 792).
+	icmpUnreachableMaxOrig = 68
 )
 
 // ICMPHandler handles ICMP packets (ping, etc.)
@@ -560,10 +563,10 @@ func (h *ICMPHandler) SendICMPUnreachable(
 		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeDestinationUnreachable, code),
 	}
 
-	// Include original IP header + 8 bytes of data
+	// Include original IP header + 8 bytes of data per RFC 792 §3.2.
 	payload := originalPacket
-	if len(payload) > icmpTimestampReplyLen {
-		payload = payload[:icmpTimestampReplyLen]
+	if len(payload) > icmpUnreachableMaxOrig {
+		payload = payload[:icmpUnreachableMaxOrig]
 	}
 
 	// Serialize

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,19 +8,18 @@
     <!-- Preconnect to Google Fonts for faster loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Load fonts asynchronously with display=swap to prevent render blocking -->
+    <!--
+      Load fonts with display=swap so the page renders the moment the bundle
+      is ready, even if Google Fonts is slow. We used to use the
+      media="print" / onload="this.media='all'" trick for non-blocking
+      delivery, but the inline onload required script-src 'unsafe-inline'
+      in our CSP. The font CSS itself is small and gzipped, so a normal
+      stylesheet link is the right tradeoff for a stricter CSP.
+    -->
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      media="print"
-      onload="this.media='all'"
     />
-    <noscript>
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      />
-    </noscript>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, Check, ChevronDown, ChevronRight, Copy, Terminal } from 'lucide-react';
 import { type FC, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { LogEntry, LogLevel } from '../api/types';
+import { copyToClipboard } from '../utils/file';
 
 /**
  * LogViewer Component
@@ -148,17 +149,8 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
   const copyLog = useCallback(async () => {
     const fullLog = `[${log.timestamp}] [${log.level}] [${log.protocol}] ${log.message}${log.details ? `\n${formatDetails(log.details)}` : ''}`;
     try {
-      await navigator.clipboard.writeText(fullLog);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback for older browsers
-      const textArea = document.createElement('textarea');
-      textArea.value = fullLog;
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textArea);
+      await copyToClipboard(fullLog);
+    } finally {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }

--- a/ui/src/components/config/MergeControls.tsx
+++ b/ui/src/components/config/MergeControls.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent } from '../../ui/Card';
 import { ConfirmModal } from '../../ui/ConfirmModal';
 import { Tag } from '../../ui/Tag';
 import { H2, SmallText } from '../../ui/Typography';
+import { copyToClipboard } from '../../utils/file';
 import type { DiffBlock, MergeDecision } from './DiffViewer';
 import { YamlViewer } from './YamlEditor';
 
@@ -313,17 +314,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
   const lineCount = useMemo(() => content.split('\n').length, [content]);
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(content);
-    } catch {
-      // Fallback for older browsers
-      const textarea = document.createElement('textarea');
-      textarea.value = content;
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-    }
+    await copyToClipboard(content);
   }, [content]);
 
   return (

--- a/ui/src/pages/templates/useTemplates.ts
+++ b/ui/src/pages/templates/useTemplates.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { applyTemplate, fetchTemplateContent, fetchTemplates } from '../../api/client';
 import type { Template, TemplateContent } from '../../api/types';
 import { useApiResource } from '../../hooks/useApiResource';
+import { copyToClipboard } from '../../utils/file';
 import { getErrorMessage } from '../../utils/format';
 
 export interface StatusMessage {
@@ -160,28 +161,11 @@ export function useTemplates(): UseTemplatesReturn {
       return;
     }
 
-    try {
-      await navigator.clipboard.writeText(templateContent.content);
-      setMessage({
-        type: 'success',
-        text: 'Template content copied to clipboard',
-      });
-    } catch {
-      // Fallback for older browsers
-      const textarea = document.createElement('textarea');
-      textarea.value = templateContent.content;
-      document.body.appendChild(textarea);
-      textarea.select();
-      try {
-        document.execCommand('copy');
-      } finally {
-        document.body.removeChild(textarea);
-      }
-      setMessage({
-        type: 'success',
-        text: 'Template content copied to clipboard',
-      });
-    }
+    await copyToClipboard(templateContent.content);
+    setMessage({
+      type: 'success',
+      text: 'Template content copied to clipboard',
+    });
   }, [templateContent]);
 
   return {


### PR DESCRIPTION
Bundles the low-priority hardening backlog. Each commit closes a distinct issue cluster.

## Commits

1. **`fix(cmd)`** — completion uses RunE; man takes `--output`; cmd_daemon routes `--token` through resolveAPIToken; Windows service reads NIAC_LISTEN/NIAC_API_TOKEN/NIAC_STORAGE_PATH (with tilde expansion) and surfaces os.Executable errors via newServiceFor; capture has StartCaptureContext for cancellable loops; traffic generator's inter-packet jitter is interruptible; ICMP Destination Unreachable uses a dedicated 68-byte constant per RFC 792 §3.2.

2. **`fix(api)`** — script-src drops `'unsafe-inline'`; index.html loads fonts as a normal link (no inline onload); converter caps YAML at 16 MiB (`MaxYAMLConfigSize`); LogViewer/MergeControls/useTemplates dedupe clipboard fallback through `copyToClipboard`.

## Closes

#441, #442, #444, #445, #447, #448, #449, #450 (residuals), #454 (execCommand).

Already-fixed issues (#439, #440, #443, #451, #452, #453) closed separately with verification comments.

## Test plan
- [x] go build ./... clean
- [x] go test on protocols, device, capture, logging, converter, cmd/niac — pass
- [x] golangci-lint on touched packages — 0 issues
- [x] npm run build — clean (no inline onload in built HTML)
- [x] npm test — 65/65 pass