### PR TITLE
fix(ci): split Trivy scan from upload so SARIF always uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,10 @@ jobs:
       - name: Run Trivy vulnerability scanner
         # Trivy moved to v-prefixed tags between 0.35 and 0.36; the bare
         # version no longer resolves.
+        # exit-code is 0 here so the SARIF always gets written; we still
+        # surface findings as a separate step that fails CI when the SARIF
+        # contains CRITICAL/HIGH entries.
+        id: trivy
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
@@ -189,13 +193,25 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
-          exit-code: '1'
+          exit-code: '0'
 
       - name: Upload Trivy results
+        if: always() && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
         with:
           sarif_file: trivy-results.sarif
+
+      - name: Fail on CRITICAL/HIGH findings
+        # Reads the SARIF Trivy just produced and fails CI if any CRITICAL or
+        # HIGH-severity result is present. We do this in a separate step so
+        # the SARIF is always uploaded for security tab visibility.
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        run: |
+          if jq -e '.runs[].results[] | select(.level=="error" or .properties.security_severity == "high" or .properties.security_severity == "critical")' trivy-results.sarif >/dev/null; then
+            echo "::error::Trivy found CRITICAL or HIGH severity issues — see Security tab."
+            jq '.runs[].results[] | {ruleId, level, severity: .properties.security_severity, message: .message.text}' trivy-results.sarif
+            exit 1
+          fi
 
   # ===========================================================================
   # C Lint (C23 Standard - NOT C++)


### PR DESCRIPTION
Recent CI runs failed at 'Upload Trivy results' with 'Path does not exist: trivy-results.sarif'. Root cause: Trivy with exit-code: 1 short-circuits the SARIF write under some cache paths, then the upload step has nothing to point at.

Restructure:
1. Trivy with exit-code: 0 so SARIF always writes.
2. Upload gated on hashFiles() so a truly-missing file is a soft skip.
3. Separate jq-based 'Fail on CRITICAL/HIGH findings' step preserves gate semantics.

Closes the CI red on PR #498 / main.