### PR TITLE
chore(ci): ignore major bumps for ui build toolchain in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
         patterns: ["*"]
 
   # npm packages for the embedded React/Vite UI
+  #
+  # Major bumps for the build toolchain (TypeScript, Vite, jsdom, etc.) are
+  # out of scope for dependabot — they're tied to project policy in CLAUDE.md
+  # (e.g. TypeScript pinned to 5.9.x) and tend to need code changes. We
+  # ignore them here so the weekly batch only ships safe minor / patch
+  # updates; major upgrades happen in dedicated, hand-driven PRs.
   - package-ecosystem: npm
     directory: /ui
     schedule:
@@ -38,3 +44,16 @@ updates:
     groups:
       ui-deps:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "rollup-plugin-visualizer"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "lucide-react"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot's weekly batch keeps proposing toolchain majors (TS, Vite, jsdom, etc.) that collide with project policy:

- typescript pinned to 5.9.x by CLAUDE.md ("NO EXCEPTIONS")
- vite, @vitejs/plugin-react, jsdom, rollup-plugin-visualizer, lucide-react majors typically need code changes

Add ignore rules so the auto-batch only contains safe minor/patch updates. Major upgrades will go through dedicated, manually-reviewed PRs.

This unblocks the weekly cadence — safe bumps continue to land, risky majors stop creating noise PRs (e.g. closed #487, #503).