### PR TITLE
fix: older defect backlog (#406, #409, #415)

### DIFF
--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -105,6 +105,7 @@ func runDaemon(options *daemonOptions, info versionInfo) error {
 	// Wait for interrupt signal
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 	<-sigChan
 
 	logging.Infof("\nShutting down daemon...")

--- a/cmd/niac/root.go
+++ b/cmd/niac/root.go
@@ -189,6 +189,11 @@ and network discovery without physical hardware.`,
 	// SECURITY FIX #101: Deprecate --api-token flag in favor of environment variable
 	rootCmd.PersistentFlags().
 		StringVar(&services.apiToken, "api-token", "", "Bearer token required for API/Web UI access (DEPRECATED: use NIAC_API_TOKEN env var)")
+	if err := rootCmd.PersistentFlags().MarkDeprecated("api-token",
+		"the value lands in /proc/<pid>/cmdline and `ps`. Set NIAC_API_TOKEN in the environment instead."); err != nil {
+		// MarkDeprecated only fails for an unknown flag name, which is a programming error.
+		panic(fmt.Errorf("mark --api-token deprecated: %w", err))
+	}
 	rootCmd.PersistentFlags().
 		StringVar(&services.metricsListen, "metrics-listen", "", "Expose Prometheus metrics on this address (defaults to --api-listen)")
 	rootCmd.PersistentFlags().

--- a/internal/api/devices.go
+++ b/internal/api/devices.go
@@ -617,7 +617,7 @@ func (s *Server) handleDeviceUpdate(w http.ResponseWriter, r *http.Request, host
 		return
 	}
 
-	newCfg := *cfg
+	newCfg := *deepCopyConfig(cfg)
 
 	if req.RawYAML != "" {
 		updatedDevice, parseErr := updateDeviceFromYAML(req.RawYAML, hostname)
@@ -667,7 +667,7 @@ func (s *Server) handleDeviceDelete(w http.ResponseWriter, r *http.Request, host
 	}
 
 	// Find and remove device
-	newCfg := *cfg
+	newCfg := *deepCopyConfig(cfg)
 	found := false
 
 	newDevices := make([]config.Device, 0, len(cfg.Devices)-1)
@@ -777,7 +777,7 @@ func (s *Server) handleDeviceClone(w http.ResponseWriter, r *http.Request, hostn
 	clonedDevice := cloneDevice(sourceDevice, req.NewHostname, req.NewIP, req.NewMAC)
 
 	// Add to config and save
-	newCfg := *cfg
+	newCfg := *deepCopyConfig(cfg)
 	newCfg.Devices = append(newCfg.Devices, *clonedDevice)
 
 	err = s.saveConfig(&newCfg)


### PR DESCRIPTION
Three small fixes from the older defect backlog (#403–#424):

- **#406 shallow config copy** — `internal/api/devices.go` had three `newCfg := *cfg` shallow copies (update / delete / clone paths) that aliased the Devices slice and pointer fields. Switched to `*deepCopyConfig(cfg)` so concurrent readers see a stable view.
- **#409 `--api-token` deprecation** — flag description already said DEPRECATED; now actually `MarkDeprecated` so cobra surfaces the warning at runtime. NIAC_API_TOKEN env var remains the recommended replacement.
- **#415 signal cleanup** — added `defer signal.Stop(sigChan)` in `cmd_daemon.go`, matching what logs/monitor/neighbors already do.

The remaining items in the #403–#424 range were verified already fixed in main; closing them with verification comments.