### PR TITLE
chore(deps): bump toolchain to go1.25.10 for stdlib CVE fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/krisarmstrong/niac-go
 
 go 1.25.6
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
PR #505's CI run flagged two stdlib vulns reachable from our code under go1.25.9:

- **GO-2026-4971**: net.Dial / LookupPort panic on Windows-NUL byte (called from internal/ipc/client.go, internal/api/server.go, internal/ipc/socket.go, internal/protocols/snmp/traps.go)
- **GO-2026-4918**: HTTP/2 transport infinite loop on bad SETTINGS_MAX_FRAME_SIZE (called from internal/api/alerts.go's webhook poster)

Both fixed in go1.25.10. No source changes — just the toolchain bump.