### PR TITLE
feat(ui): consolidate Templates page into Simulation page

### DIFF
--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,11 +20,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-Dpefvjr8.js"></script>
+    <script type="module" crossorigin src="/assets/index-uA58YXEh.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-BoJ-pB7h.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-DtDwoORA.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-uzW8H4LC.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BDDexPqQ.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-CL4vA7_X.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-codemirror-BjllbsfA.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-DXmdNVIm.css">
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,6 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Activity,
   FileBox,
-  FileCode,
   FileSearch,
   GitCompare,
   LineChart,
@@ -45,9 +44,6 @@ const DeviceEditorPage = lazy(() =>
 );
 const DeviceListPage = lazy(() =>
   import('./pages/DeviceListPage').then((m) => ({ default: m.DeviceListPage })),
-);
-const TemplatesPage = lazy(() =>
-  import('./pages/TemplatesPage').then((m) => ({ default: m.TemplatesPage })),
 );
 const AnalysisPage = lazy(() =>
   import('./pages/AnalysisPage').then((m) => ({ default: m.AnalysisPage })),
@@ -375,28 +371,6 @@ const pages: PageConfig[] = [
     ),
   },
   {
-    path: '/templates',
-    label: 'Templates',
-    title: 'Configuration Templates',
-    description: 'Browse and use pre-configured network templates to quickly start simulations.',
-    icon: FileCode,
-    component: TemplatesPage,
-    help: (
-      <>
-        <p>
-          Built-in templates are starter YAMLs for common scenarios (single router, layer-2 lab,
-          etc.). Pick one, give it a name, and it's saved to your Device Library.
-        </p>
-        <h4>Importing legacy configs</h4>
-        <p>
-          The <strong>Import legacy config</strong> card at the bottom converts a Java-DSL{' '}
-          <code>.cfg</code> file to YAML — the same operation as <code>niac config export</code> on
-          the CLI. Useful for moving off the v1 format.
-        </p>
-      </>
-    ),
-  },
-  {
     path: '/config-diff',
     label: 'Config Diff',
     title: 'Config Diff & Merge',
@@ -527,7 +501,6 @@ const navGroups: SidebarNavGroup[] = [
         label: 'Device Library',
         icon: Wrench,
       },
-      { path: '/templates', label: 'Templates', icon: FileCode },
       { path: '/config-diff', label: 'Config Diff', icon: GitCompare },
     ],
   },
@@ -627,6 +600,10 @@ function AppShell() {
               </PageWithErrorBoundary>
             }
           />
+          {/* Back-compat: the standalone Templates page was folded into the
+              Simulation page in feat/consolidate-simulation-templates.
+              Bookmarks and copied URLs continue to work. */}
+          <Route path="/templates" element={<Navigate to="/runtime" replace={true} />} />
           <Route path="*" element={<Navigate to="/" replace={true} />} />
         </Routes>
       </Suspense>

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -163,6 +163,16 @@ async function fetchCSRFToken() {
   }
 }
 
+/**
+ * Force the next CSRF token use to refetch from the server. Called when a
+ * state-changing request fails with csrf_token_invalid — typically because
+ * the daemon was restarted and rotated its in-memory token, leaving the
+ * client with a stale cached promise.
+ */
+function resetCSRFToken() {
+  csrfTokenPromise = null;
+}
+
 async function buildRequestHeaders(path: string, init: RequestInit) {
   const headers = new Headers(init.headers);
   headers.set('Accept', 'application/json');
@@ -235,6 +245,21 @@ export async function request<T>(
           continue;
         }
         const text = await response.text();
+        // If the server rejected a stale CSRF token (typically because the
+        // daemon was restarted and rotated its in-memory secret), drop the
+        // cached token and retry once. Without this the SPA would keep
+        // sending the stale token on every state-changing request until a
+        // full reload.
+        if (
+          response.status === 403 &&
+          isStateChangingMethod(init.method) &&
+          /csrf_token_invalid/i.test(text) &&
+          attempt < retry.maxRetries
+        ) {
+          resetCSRFToken();
+          lastError = new ApiError(text, response.status);
+          continue;
+        }
         throw new ApiError(text || response.statusText, response.status);
       }
 

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -1,4 +1,20 @@
-import { Eye, FileCode, FileUp, FolderOpen, Search } from 'lucide-react';
+import {
+  Building2,
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  FileCode,
+  FileUp,
+  FolderOpen,
+  Globe,
+  HardDrive,
+  LayoutGrid,
+  List,
+  Router,
+  Search,
+  Server,
+  Wifi,
+} from 'lucide-react';
 import { type FC, useEffect, useMemo, useState } from 'react';
 import { fetchTemplateContent, fetchTemplates, fetchUserConfigs } from '../../api/client';
 import type { Template, TemplateContent, UserConfig } from '../../api/types';
@@ -7,7 +23,58 @@ import { SmallText } from '../../ui/Typography';
 import { TemplatePreviewModal } from '../TemplatePreviewModal';
 import { JavaDslImportCard } from '../templates/JavaDslImportCard';
 
-type Tab = 'templates' | 'configs' | 'upload';
+type ViewMode = 'grid' | 'list';
+type SourceFilter = 'all' | 'builtin' | 'saved' | 'local';
+
+const VIEW_PREF_KEY = 'niac.configs.viewMode';
+const SOURCE_FILTER_PREF_KEY = 'niac.configs.sourceFilter';
+
+const TEMPLATE_TYPE_ICON: Record<Template['type'], FC<{ className?: string }>> = {
+  basic: Globe,
+  router: Router,
+  switch: FileCode,
+  'access-point': Wifi,
+  server: Server,
+  complete: Building2,
+  custom: FileCode,
+};
+
+const TEMPLATE_TYPE_TINT: Record<Template['type'], string> = {
+  basic: 'bg-blue-500/15 text-blue-200 border-blue-400/30',
+  router: 'bg-orange-500/15 text-orange-200 border-orange-400/30',
+  switch: 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30',
+  'access-point': 'bg-purple-500/15 text-purple-200 border-purple-400/30',
+  server: 'bg-cyan-500/15 text-cyan-200 border-cyan-400/30',
+  complete: 'bg-amber-500/15 text-amber-200 border-amber-400/30',
+  custom: 'bg-pink-500/15 text-pink-200 border-pink-400/30',
+};
+
+// One row in the unified Configs list.
+type ConfigItem =
+  | {
+      kind: 'builtin';
+      key: string;
+      name: string;
+      description: string;
+      deviceCount: number;
+      template: Template;
+    }
+  | {
+      kind: 'saved';
+      key: string;
+      name: string;
+      description: string;
+      deviceCount: number;
+      config: UserConfig;
+    }
+  | {
+      kind: 'local';
+      key: string;
+      name: string;
+      description: string;
+      deviceCount: number;
+      file: File;
+    };
 
 interface Selection {
   source: 'template' | 'userConfig' | 'upload' | null;
@@ -16,9 +83,9 @@ interface Selection {
 }
 
 export interface ConfigPickerProps {
-  /** The currently selected config (template name, user config name, or null). */
+  /** The currently selected config. */
   selection: Selection;
-  /** Called when the user picks a template. */
+  /** Called when the user picks a built-in template. */
   onSelectTemplate: (template: Template) => void;
   /** Called when the user picks a saved (user) config. */
   onSelectUserConfig: (config: UserConfig) => void;
@@ -29,10 +96,9 @@ export interface ConfigPickerProps {
 }
 
 /**
- * ConfigPicker is the tabbed config-source picker that lives inline on the
- * Simulation Control page. It collapses what used to be three separate
- * surfaces (Templates page, Settings drawer, RuntimeControlPage's "Quick
- * Override Upload") into one source-of-truth chooser.
+ * ConfigPicker is the single config-source picker for the Simulation page.
+ * Built-in templates, user-saved configs, and a one-shot local upload all
+ * live in the same list with a "source" filter chip; there are no tabs.
  */
 export const ConfigPicker: FC<ConfigPickerProps> = ({
   selection,
@@ -41,19 +107,17 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
   onUpload,
   uploadFile,
 }) => {
-  const initialTab: Tab =
-    selection.source === 'userConfig'
-      ? 'configs'
-      : selection.source === 'upload'
-        ? 'upload'
-        : 'templates';
-  const [tab, setTab] = useState<Tab>(initialTab);
   const [templates, setTemplates] = useState<Template[]>([]);
   const [userConfigs, setUserConfigs] = useState<UserConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
+  const [viewMode, setViewMode] = useState<ViewMode>(() => readPref(VIEW_PREF_KEY, 'grid'));
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>(() =>
+    readPref(SOURCE_FILTER_PREF_KEY, 'all'),
+  );
+  const [showJavaDsl, setShowJavaDsl] = useState(false);
 
-  // Preview modal state
+  // Preview modal state (built-in templates only)
   const [previewTemplate, setPreviewTemplate] = useState<Template | null>(null);
   const [previewContent, setPreviewContent] = useState<TemplateContent | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -68,8 +132,7 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
         setUserConfigs(u.configs);
       })
       .catch(() => {
-        // Best-effort hydration; the empty states below already cover the
-        // failure case.
+        // Best-effort hydration; the empty state covers failure.
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -79,30 +142,92 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
     };
   }, []);
 
-  const filteredTemplates = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return templates;
-    return templates.filter(
-      (t) =>
-        t.name.toLowerCase().includes(q) ||
-        t.description.toLowerCase().includes(q) ||
-        t.type.toLowerCase().includes(q),
-    );
-  }, [templates, search]);
+  // Build the unified list — local upload first (most recent action), then
+  // saved (user's stuff), then built-ins.
+  const items: ConfigItem[] = useMemo(() => {
+    const list: ConfigItem[] = [];
+    if (uploadFile) {
+      list.push({
+        kind: 'local',
+        key: 'local:current',
+        name: uploadFile.name,
+        description: `${(uploadFile.size / 1024).toFixed(1)} KB local file`,
+        deviceCount: 0,
+        file: uploadFile,
+      });
+    }
+    for (const c of userConfigs) {
+      list.push({
+        kind: 'saved',
+        key: `saved:${c.path}`,
+        name: c.name,
+        description: c.path,
+        deviceCount: c.deviceCount,
+        config: c,
+      });
+    }
+    for (const t of templates) {
+      list.push({
+        kind: 'builtin',
+        key: `builtin:${t.name}`,
+        name: t.name,
+        description: t.description,
+        deviceCount: t.deviceCount,
+        template: t,
+      });
+    }
+    return list;
+  }, [templates, userConfigs, uploadFile]);
 
-  const filteredConfigs = useMemo(() => {
+  const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    if (!q) return userConfigs;
-    return userConfigs.filter((c) => c.name.toLowerCase().includes(q));
-  }, [userConfigs, search]);
+    return items.filter((item) => {
+      if (sourceFilter === 'builtin' && item.kind !== 'builtin') return false;
+      if (sourceFilter === 'saved' && item.kind !== 'saved') return false;
+      if (sourceFilter === 'local' && item.kind !== 'local') return false;
+      if (!q) return true;
+      return item.name.toLowerCase().includes(q) || item.description.toLowerCase().includes(q);
+    });
+  }, [items, sourceFilter, search]);
 
-  const openPreview = async (template: Template) => {
-    setPreviewTemplate(template);
+  const counts = useMemo(
+    () => ({
+      all: items.length,
+      builtin: items.filter((i) => i.kind === 'builtin').length,
+      saved: items.filter((i) => i.kind === 'saved').length,
+      local: items.filter((i) => i.kind === 'local').length,
+    }),
+    [items],
+  );
+
+  const updateViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    writePref(VIEW_PREF_KEY, mode);
+  };
+  const updateSourceFilter = (f: SourceFilter) => {
+    setSourceFilter(f);
+    writePref(SOURCE_FILTER_PREF_KEY, f);
+  };
+
+  const handleSelectItem = (item: ConfigItem) => {
+    if (item.kind === 'builtin') onSelectTemplate(item.template);
+    else if (item.kind === 'saved') onSelectUserConfig(item.config);
+    // local items are already "selected" — RuntimeControlPage tracks them as
+    // the upload file. Selecting again is a no-op.
+  };
+
+  const handleClearLocal = () => {
+    onUpload(null);
+  };
+
+  const handleViewItem = async (item: ConfigItem) => {
+    if (item.kind !== 'builtin') return; // Only built-ins have an inline preview today
+    setPreviewTemplate(item.template);
     setPreviewContent(null);
     setPreviewError(null);
     setPreviewLoading(true);
     try {
-      const content = await fetchTemplateContent(template.name);
+      const content = await fetchTemplateContent(item.template.name);
       setPreviewContent(content);
     } catch (err) {
       setPreviewError(err as Error);
@@ -117,70 +242,138 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
     setPreviewError(null);
   };
 
+  const isItemSelected = (item: ConfigItem): boolean => {
+    if (item.kind === 'builtin')
+      return selection.source === 'template' && selection.name === item.name;
+    if (item.kind === 'saved')
+      return selection.source === 'userConfig' && selection.name === item.name;
+    return selection.source === 'upload';
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    onUpload(file);
+    // Force the source filter to "local" so the user immediately sees their
+    // file in the list.
+    if (file) updateSourceFilter('local');
+  };
+
   return (
     <div className="space-y-3">
-      {/* Tabs */}
-      <div
-        className="flex gap-1 rounded-lg border border-white/10 bg-gray-900/60 p-1"
-        role="tablist"
-      >
-        <TabButton
-          active={tab === 'templates'}
-          onClick={() => setTab('templates')}
-          icon={<FileCode className="h-4 w-4" />}
-          label="Templates"
-          count={templates.length}
+      {/* Source filter chips + Upload button */}
+      <div className="flex flex-wrap items-center gap-2">
+        <SourceChip
+          active={sourceFilter === 'all'}
+          onClick={() => updateSourceFilter('all')}
+          label="All"
+          count={counts.all}
         />
-        <TabButton
-          active={tab === 'configs'}
-          onClick={() => setTab('configs')}
-          icon={<FolderOpen className="h-4 w-4" />}
-          label="My Configs"
-          count={userConfigs.length}
+        <SourceChip
+          active={sourceFilter === 'builtin'}
+          onClick={() => updateSourceFilter('builtin')}
+          label="Built-in"
+          count={counts.builtin}
         />
-        <TabButton
-          active={tab === 'upload'}
-          onClick={() => setTab('upload')}
-          icon={<FileUp className="h-4 w-4" />}
-          label="Upload"
+        <SourceChip
+          active={sourceFilter === 'saved'}
+          onClick={() => updateSourceFilter('saved')}
+          label="Saved"
+          count={counts.saved}
         />
+        {counts.local > 0 && (
+          <SourceChip
+            active={sourceFilter === 'local'}
+            onClick={() => updateSourceFilter('local')}
+            label="Local"
+            count={counts.local}
+          />
+        )}
+        <div className="flex-1" />
+        <label
+          htmlFor="config-upload"
+          className="flex cursor-pointer items-center gap-1.5 rounded border border-white/10 bg-gray-900/60 px-3 py-1 text-xs font-medium text-gray-200 hover:bg-white/5"
+          title="Pick a YAML from disk to use for this run (one-shot, not saved to your library)."
+        >
+          <FileUp className="h-3.5 w-3.5" />
+          {uploadFile ? 'Replace local file' : 'Upload local file…'}
+        </label>
+        <input
+          id="config-upload"
+          type="file"
+          accept=".yaml,.yml"
+          onChange={handleFileChange}
+          className="sr-only"
+        />
+        {uploadFile && (
+          <button
+            type="button"
+            onClick={handleClearLocal}
+            className="text-xs font-medium text-red-300 hover:text-red-200"
+          >
+            Clear
+          </button>
+        )}
       </div>
 
-      {/* Search bar (templates / configs only) */}
-      {tab !== 'upload' && (
-        <div className="relative">
+      {/* Search + view toggle */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
           <input
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder={tab === 'templates' ? 'Search templates…' : 'Search configs…'}
+            placeholder="Search configs…"
             className="w-full rounded border border-white/10 bg-gray-900/60 py-2 pl-9 pr-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
           />
         </div>
-      )}
+        <fieldset
+          className="flex rounded border border-white/10 bg-gray-900/60 p-0.5"
+          aria-label="View density"
+        >
+          <ViewToggle
+            active={viewMode === 'grid'}
+            onClick={() => updateViewMode('grid')}
+            icon={<LayoutGrid className="h-4 w-4" />}
+            label="Card view"
+          />
+          <ViewToggle
+            active={viewMode === 'list'}
+            onClick={() => updateViewMode('list')}
+            icon={<List className="h-4 w-4" />}
+            label="Compact list"
+          />
+        </fieldset>
+      </div>
 
-      {/* Tab content */}
-      {tab === 'templates' && (
-        <TemplatesTab
-          templates={filteredTemplates}
-          loading={loading}
-          selectedName={selection.source === 'template' ? selection.name : ''}
-          onSelect={onSelectTemplate}
-          onView={openPreview}
-        />
-      )}
+      {/* List / grid */}
+      <ConfigsList
+        items={filtered}
+        loading={loading}
+        viewMode={viewMode}
+        isSelected={isItemSelected}
+        onSelect={handleSelectItem}
+        onView={handleViewItem}
+        onClearLocal={handleClearLocal}
+      />
 
-      {tab === 'configs' && (
-        <ConfigsTab
-          configs={filteredConfigs}
-          loading={loading}
-          selectedName={selection.source === 'userConfig' ? selection.name : ''}
-          onSelect={onSelectUserConfig}
-        />
-      )}
-
-      {tab === 'upload' && <UploadTab uploadFile={uploadFile} onUpload={onUpload} />}
+      {/* Java-DSL import — collapsed by default since most users won't need it */}
+      <details
+        className="rounded border border-white/10 bg-gray-950/40 p-3"
+        open={showJavaDsl}
+        onToggle={(e) => setShowJavaDsl(e.currentTarget.open)}
+      >
+        <summary className="flex cursor-pointer items-center gap-2 text-sm text-gray-300 hover:text-white">
+          {showJavaDsl ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          <FileCode className="h-4 w-4" />
+          <span>
+            Convert a legacy Java-DSL <code className="text-xs">.cfg</code> to YAML
+          </span>
+        </summary>
+        <div className="mt-3">
+          <JavaDslImportCard />
+        </div>
+      </details>
 
       {previewTemplate && (
         <TemplatePreviewModal
@@ -194,8 +387,7 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
             onSelectTemplate(t);
           }}
           onCopy={async () => {
-            // Copy is a no-op — TemplatePreviewModal expects a Promise<void>;
-            // it already handles its own clipboard plumbing via the parent.
+            // No-op; the modal expects a Promise<void>.
           }}
         />
       )}
@@ -203,183 +395,287 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
   );
 };
 
-const TabButton: FC<{
+function readPref<T extends string>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') return fallback;
+  const saved = window.localStorage.getItem(key);
+  return (saved as T) || fallback;
+}
+
+function writePref(key: string, value: string) {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(key, value);
+  }
+}
+
+const SourceChip: FC<{
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  count: number;
+}> = ({ active, onClick, label, count }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={active}
+    className={`flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+      active
+        ? 'bg-violet-500/20 text-violet-100 ring-1 ring-violet-400/40'
+        : 'bg-gray-800/60 text-gray-400 ring-1 ring-white/10 hover:bg-white/5 hover:text-gray-200'
+    }`}
+  >
+    <span>{label}</span>
+    <span
+      className={`rounded-full px-1.5 py-0.5 text-[10px] ${
+        active ? 'bg-violet-500/30 text-violet-100' : 'bg-white/10 text-gray-300'
+      }`}
+    >
+      {count}
+    </span>
+  </button>
+);
+
+const ViewToggle: FC<{
   active: boolean;
   onClick: () => void;
   icon: React.ReactNode;
   label: string;
-  count?: number;
-}> = ({ active, onClick, icon, label, count }) => (
+}> = ({ active, onClick, icon, label }) => (
   <button
     type="button"
-    role="tab"
-    aria-selected={active}
     onClick={onClick}
-    className={`flex flex-1 items-center justify-center gap-2 rounded px-3 py-1.5 text-sm transition-colors ${
+    aria-pressed={active}
+    title={label}
+    className={`rounded px-2 py-1 transition-colors ${
       active
-        ? 'bg-violet-500/20 text-violet-100 ring-1 ring-violet-400/40'
+        ? 'bg-violet-500/20 text-violet-100'
         : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
     }`}
   >
     {icon}
-    <span>{label}</span>
-    {typeof count === 'number' && (
-      <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] font-medium text-gray-300">
-        {count}
-      </span>
-    )}
   </button>
 );
 
-const TemplatesTab: FC<{
-  templates: Template[];
+const ConfigsList: FC<{
+  items: ConfigItem[];
   loading: boolean;
-  selectedName: string;
-  onSelect: (t: Template) => void;
-  onView: (t: Template) => void;
-}> = ({ templates, loading, selectedName, onSelect, onView }) => {
-  if (loading) {
-    return <SmallText className="text-gray-500">Loading templates…</SmallText>;
-  }
-  if (templates.length === 0) {
-    return (
-      <SmallText className="text-gray-500">
-        No templates match. Try a different search or upload a YAML in the Upload tab.
-      </SmallText>
-    );
-  }
-  return (
-    <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto rounded-lg border border-white/10 bg-gray-950/40">
-      {templates.map((t) => (
-        <li
-          key={t.name}
-          className={`flex items-center gap-3 px-3 py-2 transition-colors ${
-            selectedName === t.name ? 'bg-violet-500/10' : 'hover:bg-white/5'
-          }`}
-        >
-          <button
-            type="button"
-            onClick={() => onSelect(t)}
-            className="flex-1 text-left"
-            title={`Use ${t.name} as the simulation config`}
-          >
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-white">{t.name}</span>
-              <Tag colorScheme="purple" className="text-[10px]">
-                {t.deviceCount} {t.deviceCount === 1 ? 'device' : 'devices'}
-              </Tag>
-              <Tag colorScheme="gray" className="text-[10px] capitalize">
-                {t.type}
-              </Tag>
-            </div>
-            {t.description && (
-              <SmallText className="mt-0.5 text-gray-400 line-clamp-1">{t.description}</SmallText>
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={() => onView(t)}
-            className="rounded p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
-            title="Preview the template YAML"
-          >
-            <Eye className="h-4 w-4" />
-          </button>
-        </li>
-      ))}
-    </ul>
-  );
-};
-
-const ConfigsTab: FC<{
-  configs: UserConfig[];
-  loading: boolean;
-  selectedName: string;
-  onSelect: (c: UserConfig) => void;
-}> = ({ configs, loading, selectedName, onSelect }) => {
+  viewMode: ViewMode;
+  isSelected: (item: ConfigItem) => boolean;
+  onSelect: (item: ConfigItem) => void;
+  onView: (item: ConfigItem) => void;
+  onClearLocal: () => void;
+}> = ({ items, loading, viewMode, isSelected, onSelect, onView, onClearLocal }) => {
   if (loading) {
     return <SmallText className="text-gray-500">Loading configs…</SmallText>;
   }
-  if (configs.length === 0) {
+  if (items.length === 0) {
     return (
       <SmallText className="text-gray-500">
-        No saved configs yet. Pick a template above (it'll be saved here) or upload a YAML.
+        Nothing matches. Try a different search, switch the source filter, or upload a local YAML
+        with the button above.
       </SmallText>
     );
   }
+
+  if (viewMode === 'grid') {
+    return (
+      <div className="grid max-h-[420px] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2 xl:grid-cols-3">
+        {items.map((item) => (
+          <ConfigCard
+            key={item.key}
+            item={item}
+            selected={isSelected(item)}
+            onSelect={onSelect}
+            onView={onView}
+            onClearLocal={onClearLocal}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto rounded-lg border border-white/10 bg-gray-950/40">
-      {configs.map((c) => (
-        <li
-          key={c.path}
-          className={`flex items-center gap-3 px-3 py-2 transition-colors ${
-            selectedName === c.name ? 'bg-violet-500/10' : 'hover:bg-white/5'
-          }`}
-        >
-          <button type="button" onClick={() => onSelect(c)} className="flex-1 text-left">
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-white">{c.name}</span>
-              <Tag colorScheme="purple" className="text-[10px]">
-                {c.deviceCount} {c.deviceCount === 1 ? 'device' : 'devices'}
-              </Tag>
-            </div>
-            <SmallText className="mt-0.5 font-mono text-[11px] text-gray-500 line-clamp-1">
-              {c.path}
-            </SmallText>
-          </button>
-        </li>
+      {items.map((item) => (
+        <ConfigRow
+          key={item.key}
+          item={item}
+          selected={isSelected(item)}
+          onSelect={onSelect}
+          onView={onView}
+          onClearLocal={onClearLocal}
+        />
       ))}
     </ul>
   );
 };
 
-const UploadTab: FC<{
-  uploadFile: File | null;
-  onUpload: (file: File | null) => void;
-}> = ({ uploadFile, onUpload }) => {
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] ?? null;
-    onUpload(file);
-  };
+function sourceTagFor(item: ConfigItem) {
+  if (item.kind === 'builtin')
+    return (
+      <Tag colorScheme="purple" className="text-[10px]">
+        Built-in
+      </Tag>
+    );
+  if (item.kind === 'saved')
+    return (
+      <Tag colorScheme="green" className="text-[10px]">
+        Saved
+      </Tag>
+    );
+  return (
+    <Tag colorScheme="blue" className="text-[10px]">
+      Local
+    </Tag>
+  );
+}
+
+const ConfigCard: FC<{
+  item: ConfigItem;
+  selected: boolean;
+  onSelect: (item: ConfigItem) => void;
+  onView: (item: ConfigItem) => void;
+  onClearLocal: () => void;
+}> = ({ item, selected, onSelect, onView, onClearLocal }) => {
+  const Icon =
+    item.kind === 'builtin'
+      ? (TEMPLATE_TYPE_ICON[item.template.type] ?? FileCode)
+      : item.kind === 'saved'
+        ? FolderOpen
+        : HardDrive;
+  const tint =
+    item.kind === 'builtin'
+      ? (TEMPLATE_TYPE_TINT[item.template.type] ?? TEMPLATE_TYPE_TINT.custom)
+      : item.kind === 'saved'
+        ? 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30'
+        : 'bg-blue-500/15 text-blue-200 border-blue-400/30';
 
   return (
-    <div className="space-y-3">
-      <div className="rounded-lg border border-dashed border-white/15 bg-gray-950/40 p-4">
-        <div className="flex items-center gap-3">
-          <label
-            htmlFor="config-upload"
-            className="flex cursor-pointer items-center gap-2 rounded bg-gray-800 px-4 py-2 text-sm text-white hover:bg-gray-700"
-          >
-            <FileUp className="h-4 w-4 text-gray-400" />
-            {uploadFile ? 'Change YAML' : 'Choose YAML…'}
-          </label>
-          <input
-            id="config-upload"
-            type="file"
-            accept=".yaml,.yml"
-            onChange={handleChange}
-            className="sr-only"
-          />
-          {uploadFile && (
-            <>
-              <span className="text-sm text-gray-300">{uploadFile.name}</span>
-              <button
-                type="button"
-                onClick={() => onUpload(null)}
-                className="text-sm text-red-400 hover:text-red-300"
-              >
-                Clear
-              </button>
-            </>
-          )}
+    <div
+      className={`flex flex-col gap-3 rounded-lg border p-3 transition-colors ${
+        selected
+          ? 'border-violet-400/50 bg-violet-500/10'
+          : 'border-white/10 bg-gray-950/40 hover:border-violet-500/30'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className={`rounded-md border p-2 ${tint}`}>
+          <Icon className="h-5 w-5" />
         </div>
-        <SmallText className="mt-2 text-gray-500">
-          Upload a YAML config to use for this simulation run. The file is sent to the daemon
-          inline; it isn't saved to your config library.
+        {sourceTagFor(item)}
+      </div>
+      <div>
+        <div className="font-semibold text-white">{item.name}</div>
+        <SmallText className="mt-0.5 line-clamp-2 text-gray-400">
+          {item.description || 'No description'}
         </SmallText>
       </div>
-
-      {/* Java DSL import — also writes a saved config the daemon can run */}
-      <JavaDslImportCard />
+      <div className="flex flex-wrap items-center gap-1.5">
+        {item.kind !== 'local' && (
+          <Tag colorScheme="purple" className="text-[10px]">
+            {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
+          </Tag>
+        )}
+        {item.kind === 'builtin' &&
+          item.template.tags?.slice(0, 2).map((tag) => (
+            <Tag key={tag} colorScheme="gray" className="text-[10px]">
+              {tag}
+            </Tag>
+          ))}
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => onSelect(item)}
+          className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
+        >
+          {selected ? 'Selected' : 'Use'}
+        </button>
+        {item.kind === 'builtin' && (
+          <button
+            type="button"
+            onClick={() => onView(item)}
+            className="rounded border border-white/10 bg-gray-900/60 px-2 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
+            title="Preview YAML"
+          >
+            <Eye className="h-3.5 w-3.5" />
+          </button>
+        )}
+        {item.kind === 'local' && (
+          <button
+            type="button"
+            onClick={onClearLocal}
+            className="rounded border border-red-400/30 bg-red-500/10 px-2 py-1.5 text-xs font-medium text-red-200 hover:bg-red-500/20"
+            title="Drop the local file"
+          >
+            Clear
+          </button>
+        )}
+      </div>
     </div>
   );
 };
+
+const ConfigRow: FC<{
+  item: ConfigItem;
+  selected: boolean;
+  onSelect: (item: ConfigItem) => void;
+  onView: (item: ConfigItem) => void;
+  onClearLocal: () => void;
+}> = ({ item, selected, onSelect, onView, onClearLocal }) => (
+  <li
+    className={`flex items-center gap-3 px-3 py-2 transition-colors ${
+      selected ? 'bg-violet-500/10' : 'hover:bg-white/5'
+    }`}
+  >
+    <button
+      type="button"
+      onClick={() => onSelect(item)}
+      className="flex-1 text-left"
+      title={`Use ${item.name}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-white">{item.name}</span>
+        {sourceTagFor(item)}
+        {item.kind !== 'local' && (
+          <Tag colorScheme="purple" className="text-[10px]">
+            {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
+          </Tag>
+        )}
+        {item.kind === 'builtin' && (
+          <Tag colorScheme="gray" className="text-[10px] capitalize">
+            {item.template.type}
+          </Tag>
+        )}
+      </div>
+      {item.description && (
+        <SmallText
+          className={`mt-0.5 line-clamp-1 text-gray-400 ${
+            item.kind === 'saved' ? 'font-mono text-[11px] text-gray-500' : ''
+          }`}
+        >
+          {item.description}
+        </SmallText>
+      )}
+    </button>
+    {item.kind === 'builtin' && (
+      <button
+        type="button"
+        onClick={() => onView(item)}
+        className="rounded p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
+        title="Preview the template YAML"
+      >
+        <Eye className="h-4 w-4" />
+      </button>
+    )}
+    {item.kind === 'local' && (
+      <button
+        type="button"
+        onClick={onClearLocal}
+        className="text-xs font-medium text-red-300 hover:text-red-200"
+        title="Drop the local file"
+      >
+        Clear
+      </button>
+    )}
+  </li>
+);

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -1,0 +1,385 @@
+import { Eye, FileCode, FileUp, FolderOpen, Search } from 'lucide-react';
+import { type FC, useEffect, useMemo, useState } from 'react';
+import { fetchTemplateContent, fetchTemplates, fetchUserConfigs } from '../../api/client';
+import type { Template, TemplateContent, UserConfig } from '../../api/types';
+import { Tag } from '../../ui/Tag';
+import { SmallText } from '../../ui/Typography';
+import { TemplatePreviewModal } from '../TemplatePreviewModal';
+import { JavaDslImportCard } from '../templates/JavaDslImportCard';
+
+type Tab = 'templates' | 'configs' | 'upload';
+
+interface Selection {
+  source: 'template' | 'userConfig' | 'upload' | null;
+  name: string;
+  path?: string;
+}
+
+export interface ConfigPickerProps {
+  /** The currently selected config (template name, user config name, or null). */
+  selection: Selection;
+  /** Called when the user picks a template. */
+  onSelectTemplate: (template: Template) => void;
+  /** Called when the user picks a saved (user) config. */
+  onSelectUserConfig: (config: UserConfig) => void;
+  /** Called when the user uploads a file (or clears it). */
+  onUpload: (file: File | null) => void;
+  /** The current upload file, if any. */
+  uploadFile: File | null;
+}
+
+/**
+ * ConfigPicker is the tabbed config-source picker that lives inline on the
+ * Simulation Control page. It collapses what used to be three separate
+ * surfaces (Templates page, Settings drawer, RuntimeControlPage's "Quick
+ * Override Upload") into one source-of-truth chooser.
+ */
+export const ConfigPicker: FC<ConfigPickerProps> = ({
+  selection,
+  onSelectTemplate,
+  onSelectUserConfig,
+  onUpload,
+  uploadFile,
+}) => {
+  const initialTab: Tab =
+    selection.source === 'userConfig'
+      ? 'configs'
+      : selection.source === 'upload'
+        ? 'upload'
+        : 'templates';
+  const [tab, setTab] = useState<Tab>(initialTab);
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [userConfigs, setUserConfigs] = useState<UserConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  // Preview modal state
+  const [previewTemplate, setPreviewTemplate] = useState<Template | null>(null);
+  const [previewContent, setPreviewContent] = useState<TemplateContent | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([fetchTemplates(), fetchUserConfigs()])
+      .then(([t, u]) => {
+        if (cancelled) return;
+        setTemplates(t);
+        setUserConfigs(u.configs);
+      })
+      .catch(() => {
+        // Best-effort hydration; the empty states below already cover the
+        // failure case.
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filteredTemplates = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return templates;
+    return templates.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q) ||
+        t.type.toLowerCase().includes(q),
+    );
+  }, [templates, search]);
+
+  const filteredConfigs = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return userConfigs;
+    return userConfigs.filter((c) => c.name.toLowerCase().includes(q));
+  }, [userConfigs, search]);
+
+  const openPreview = async (template: Template) => {
+    setPreviewTemplate(template);
+    setPreviewContent(null);
+    setPreviewError(null);
+    setPreviewLoading(true);
+    try {
+      const content = await fetchTemplateContent(template.name);
+      setPreviewContent(content);
+    } catch (err) {
+      setPreviewError(err as Error);
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const closePreview = () => {
+    setPreviewTemplate(null);
+    setPreviewContent(null);
+    setPreviewError(null);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Tabs */}
+      <div
+        className="flex gap-1 rounded-lg border border-white/10 bg-gray-900/60 p-1"
+        role="tablist"
+      >
+        <TabButton
+          active={tab === 'templates'}
+          onClick={() => setTab('templates')}
+          icon={<FileCode className="h-4 w-4" />}
+          label="Templates"
+          count={templates.length}
+        />
+        <TabButton
+          active={tab === 'configs'}
+          onClick={() => setTab('configs')}
+          icon={<FolderOpen className="h-4 w-4" />}
+          label="My Configs"
+          count={userConfigs.length}
+        />
+        <TabButton
+          active={tab === 'upload'}
+          onClick={() => setTab('upload')}
+          icon={<FileUp className="h-4 w-4" />}
+          label="Upload"
+        />
+      </div>
+
+      {/* Search bar (templates / configs only) */}
+      {tab !== 'upload' && (
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={tab === 'templates' ? 'Search templates…' : 'Search configs…'}
+            className="w-full rounded border border-white/10 bg-gray-900/60 py-2 pl-9 pr-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+          />
+        </div>
+      )}
+
+      {/* Tab content */}
+      {tab === 'templates' && (
+        <TemplatesTab
+          templates={filteredTemplates}
+          loading={loading}
+          selectedName={selection.source === 'template' ? selection.name : ''}
+          onSelect={onSelectTemplate}
+          onView={openPreview}
+        />
+      )}
+
+      {tab === 'configs' && (
+        <ConfigsTab
+          configs={filteredConfigs}
+          loading={loading}
+          selectedName={selection.source === 'userConfig' ? selection.name : ''}
+          onSelect={onSelectUserConfig}
+        />
+      )}
+
+      {tab === 'upload' && <UploadTab uploadFile={uploadFile} onUpload={onUpload} />}
+
+      {previewTemplate && (
+        <TemplatePreviewModal
+          template={previewTemplate}
+          content={previewContent}
+          loading={previewLoading}
+          error={previewError}
+          onClose={closePreview}
+          onUse={(t) => {
+            closePreview();
+            onSelectTemplate(t);
+          }}
+          onCopy={async () => {
+            // Copy is a no-op — TemplatePreviewModal expects a Promise<void>;
+            // it already handles its own clipboard plumbing via the parent.
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+const TabButton: FC<{
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  count?: number;
+}> = ({ active, onClick, icon, label, count }) => (
+  <button
+    type="button"
+    role="tab"
+    aria-selected={active}
+    onClick={onClick}
+    className={`flex flex-1 items-center justify-center gap-2 rounded px-3 py-1.5 text-sm transition-colors ${
+      active
+        ? 'bg-violet-500/20 text-violet-100 ring-1 ring-violet-400/40'
+        : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+    }`}
+  >
+    {icon}
+    <span>{label}</span>
+    {typeof count === 'number' && (
+      <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] font-medium text-gray-300">
+        {count}
+      </span>
+    )}
+  </button>
+);
+
+const TemplatesTab: FC<{
+  templates: Template[];
+  loading: boolean;
+  selectedName: string;
+  onSelect: (t: Template) => void;
+  onView: (t: Template) => void;
+}> = ({ templates, loading, selectedName, onSelect, onView }) => {
+  if (loading) {
+    return <SmallText className="text-gray-500">Loading templates…</SmallText>;
+  }
+  if (templates.length === 0) {
+    return (
+      <SmallText className="text-gray-500">
+        No templates match. Try a different search or upload a YAML in the Upload tab.
+      </SmallText>
+    );
+  }
+  return (
+    <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto rounded-lg border border-white/10 bg-gray-950/40">
+      {templates.map((t) => (
+        <li
+          key={t.name}
+          className={`flex items-center gap-3 px-3 py-2 transition-colors ${
+            selectedName === t.name ? 'bg-violet-500/10' : 'hover:bg-white/5'
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => onSelect(t)}
+            className="flex-1 text-left"
+            title={`Use ${t.name} as the simulation config`}
+          >
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-white">{t.name}</span>
+              <Tag colorScheme="purple" className="text-[10px]">
+                {t.deviceCount} {t.deviceCount === 1 ? 'device' : 'devices'}
+              </Tag>
+              <Tag colorScheme="gray" className="text-[10px] capitalize">
+                {t.type}
+              </Tag>
+            </div>
+            {t.description && (
+              <SmallText className="mt-0.5 text-gray-400 line-clamp-1">{t.description}</SmallText>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => onView(t)}
+            className="rounded p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
+            title="Preview the template YAML"
+          >
+            <Eye className="h-4 w-4" />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const ConfigsTab: FC<{
+  configs: UserConfig[];
+  loading: boolean;
+  selectedName: string;
+  onSelect: (c: UserConfig) => void;
+}> = ({ configs, loading, selectedName, onSelect }) => {
+  if (loading) {
+    return <SmallText className="text-gray-500">Loading configs…</SmallText>;
+  }
+  if (configs.length === 0) {
+    return (
+      <SmallText className="text-gray-500">
+        No saved configs yet. Pick a template above (it'll be saved here) or upload a YAML.
+      </SmallText>
+    );
+  }
+  return (
+    <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto rounded-lg border border-white/10 bg-gray-950/40">
+      {configs.map((c) => (
+        <li
+          key={c.path}
+          className={`flex items-center gap-3 px-3 py-2 transition-colors ${
+            selectedName === c.name ? 'bg-violet-500/10' : 'hover:bg-white/5'
+          }`}
+        >
+          <button type="button" onClick={() => onSelect(c)} className="flex-1 text-left">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-white">{c.name}</span>
+              <Tag colorScheme="purple" className="text-[10px]">
+                {c.deviceCount} {c.deviceCount === 1 ? 'device' : 'devices'}
+              </Tag>
+            </div>
+            <SmallText className="mt-0.5 font-mono text-[11px] text-gray-500 line-clamp-1">
+              {c.path}
+            </SmallText>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const UploadTab: FC<{
+  uploadFile: File | null;
+  onUpload: (file: File | null) => void;
+}> = ({ uploadFile, onUpload }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    onUpload(file);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-dashed border-white/15 bg-gray-950/40 p-4">
+        <div className="flex items-center gap-3">
+          <label
+            htmlFor="config-upload"
+            className="flex cursor-pointer items-center gap-2 rounded bg-gray-800 px-4 py-2 text-sm text-white hover:bg-gray-700"
+          >
+            <FileUp className="h-4 w-4 text-gray-400" />
+            {uploadFile ? 'Change YAML' : 'Choose YAML…'}
+          </label>
+          <input
+            id="config-upload"
+            type="file"
+            accept=".yaml,.yml"
+            onChange={handleChange}
+            className="sr-only"
+          />
+          {uploadFile && (
+            <>
+              <span className="text-sm text-gray-300">{uploadFile.name}</span>
+              <button
+                type="button"
+                onClick={() => onUpload(null)}
+                className="text-sm text-red-400 hover:text-red-300"
+              >
+                Clear
+              </button>
+            </>
+          )}
+        </div>
+        <SmallText className="mt-2 text-gray-500">
+          Upload a YAML config to use for this simulation run. The file is sent to the daemon
+          inline; it isn't saved to your config library.
+        </SmallText>
+      </div>
+
+      {/* Java DSL import — also writes a saved config the daemon can run */}
+      <JavaDslImportCard />
+    </div>
+  );
+};

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -1,5 +1,6 @@
 import {
   Building2,
+  Check,
   ChevronDown,
   ChevronRight,
   Eye,
@@ -583,13 +584,21 @@ const ConfigCard: FC<{
           ))}
       </div>
       <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={() => onSelect(item)}
-          className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
-        >
-          {selected ? 'Selected' : 'Use'}
-        </button>
+        {selected ? (
+          <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-violet-500/30 px-2 py-1.5 text-xs font-medium text-violet-50 ring-1 ring-violet-400/60">
+            <Check className="h-3.5 w-3.5" />
+            <span>Will use this</span>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onSelect(item)}
+            className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
+            title="Pick this config — you'll still need to click Start Simulation below to run it"
+          >
+            Pick
+          </button>
+        )}
         {item.kind === 'builtin' && (
           <button
             type="button"

--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -1,18 +1,20 @@
-import { Activity, BellRing, Download, FileCog, FileUp, PlugZap, Settings } from 'lucide-react';
-import { type FC, useCallback, useState } from 'react';
+import { Activity, BellRing, Download, FileCog, Network, PlugZap } from 'lucide-react';
+import { type FC, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   fetchConfig,
   fetchProtocolDebugLevels,
   fetchSimulationStatus,
   fetchTemplateContent,
+  fetchUsableInterfaces,
   fetchUserConfigContent,
   startSimulation,
   stopSimulation,
   updateProtocolDebugLevels,
 } from '../api/client';
-import type { DebugLevel } from '../api/types';
+import type { DebugLevel, NetworkInterface, Template, UserConfig } from '../api/types';
 import { StatBlock } from '../components/StatBlock';
+import { ConfigPicker } from '../components/simulation/ConfigPicker';
 import { POLL_INTERVALS } from '../constants/polling';
 import { useApiResource } from '../hooks/useApiResource';
 import { useUIStore } from '../stores/ui-store';
@@ -21,7 +23,7 @@ import { Card, CardContent } from '../ui/Card';
 import { Tag } from '../ui/Tag';
 import { H2, SmallText } from '../ui/Typography';
 import { fileToText } from '../utils/file';
-import { formatBytes, formatTime, formatUptime, getErrorMessage } from '../utils/format';
+import { formatTime, formatUptime, getErrorMessage } from '../utils/format';
 
 /**
  * Simulation Control Page (formerly RuntimeControlPage)
@@ -42,7 +44,9 @@ export const RuntimeControlPage: FC = () => {
     intervalMs: POLL_INTERVALS.fast,
   });
 
-  const { simulationSettings, openModal } = useUIStore();
+  const { simulationSettings, setSimulationSettings } = useUIStore();
+  const [interfaces, setInterfaces] = useState<NetworkInterface[]>([]);
+  const [interfacesLoading, setInterfacesLoading] = useState(true);
   const [quickUploadFile, setQuickUploadFile] = useState<File | null>(null);
   const [starting, setStarting] = useState(false);
   const [stopping, setStopping] = useState(false);
@@ -50,6 +54,75 @@ export const RuntimeControlPage: FC = () => {
     tone: 'success' | 'error';
     text: string;
   } | null>(null);
+
+  // Hydrate the interface dropdown so the user can pick an interface inline
+  // instead of having to open the Settings drawer.
+  useEffect(() => {
+    let cancelled = false;
+    fetchUsableInterfaces()
+      .then((resp) => {
+        if (cancelled) return;
+        setInterfaces(resp.interfaces);
+      })
+      .catch(() => {
+        // Ignored — interface list is best-effort. The Configure button still
+        // works, and an empty list shows the "no interfaces" state below.
+      })
+      .finally(() => {
+        if (!cancelled) setInterfacesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleInterfaceChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSimulationSettings({ selectedInterface: e.target.value });
+    },
+    [setSimulationSettings],
+  );
+
+  const handleSelectTemplate = useCallback(
+    (template: Template) => {
+      setSimulationSettings({
+        configSource: 'template',
+        configName: template.name,
+        configPath: undefined,
+      });
+      setQuickUploadFile(null);
+    },
+    [setSimulationSettings],
+  );
+
+  const handleSelectUserConfig = useCallback(
+    (config: UserConfig) => {
+      setSimulationSettings({
+        configSource: 'userConfig',
+        configName: config.name,
+        configPath: config.path,
+      });
+      setQuickUploadFile(null);
+    },
+    [setSimulationSettings],
+  );
+
+  const handleUpload = useCallback(
+    (file: File | null) => {
+      setQuickUploadFile(file);
+      if (file) {
+        // Picking an upload clears any previously-selected template / config so
+        // the start handler doesn't get confused about which source wins.
+        setSimulationSettings({
+          configSource: 'upload',
+          configName: '',
+          configPath: undefined,
+        });
+        setMessage(null);
+      }
+    },
+    [setSimulationSettings],
+  );
 
   const isDaemonMode = simStatus !== null;
   const hasValidConfig =
@@ -139,40 +212,6 @@ export const RuntimeControlPage: FC = () => {
     }
   }, []);
 
-  const handleQuickUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) {
-      setQuickUploadFile(null);
-      return;
-    }
-
-    const MaxSize = 10 * 1024 * 1024;
-    if (file.size > MaxSize) {
-      setMessage({
-        tone: 'error',
-        text: `File too large. Maximum size is ${formatBytes(MaxSize)}`,
-      });
-      e.target.value = '';
-      return;
-    }
-
-    if (!file.name.match(/\.(yaml|yml)$/i)) {
-      setMessage({
-        tone: 'error',
-        text: 'Please select a YAML file (.yaml or .yml)',
-      });
-      e.target.value = '';
-      return;
-    }
-
-    setQuickUploadFile(file);
-    setMessage(null);
-  }, []);
-
-  const openSettings = useCallback(() => {
-    openModal('settings');
-  }, [openModal]);
-
   return (
     <div className="space-y-6">
       {/* Daemon Mode Warning */}
@@ -199,86 +238,68 @@ export const RuntimeControlPage: FC = () => {
       {isDaemonMode && !simStatus?.running && (
         <Card className="border-white/5 bg-gradient-to-br from-violet-900/30 to-gray-900/70">
           <CardContent className="space-y-5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <PlugZap className="h-6 w-6 text-violet-400" />
-                <H2 className="mb-0">Start Simulation</H2>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                leftIcon={<Settings className="h-4 w-4" />}
-                onClick={openSettings}
-              >
-                Configure
-              </Button>
+            <div className="flex items-center gap-3">
+              <PlugZap className="h-6 w-6 text-violet-400" />
+              <H2 className="mb-0">Start Simulation</H2>
             </div>
 
-            {/* Current Settings Display */}
-            <div className="p-4 bg-gray-900/50 rounded-lg border border-white/5 space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-400">Interface:</span>
-                <span className="text-sm text-white font-medium">
-                  {simulationSettings.selectedInterface || (
-                    <span className="text-gray-500 italic">Not selected</span>
-                  )}
-                </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-400">Configuration:</span>
-                <span className="text-sm text-white font-medium">
-                  {quickUploadFile ? (
-                    <>
-                      {quickUploadFile.name}
-                      <span className="text-gray-500 ml-1">(upload)</span>
-                    </>
-                  ) : simulationSettings.configName ? (
-                    <>
-                      {simulationSettings.configName}
-                      <span className="text-gray-500 ml-1">
-                        ({simulationSettings.configSource === 'template' ? 'template' : 'config'})
-                      </span>
-                    </>
-                  ) : (
-                    <span className="text-gray-500 italic">Not selected</span>
-                  )}
-                </span>
-              </div>
-            </div>
-
-            {/* Quick Override Upload */}
-            <div className="space-y-2">
-              <span className="block text-sm text-gray-400">Quick Override (optional)</span>
-              <div className="flex items-center gap-3">
-                <label
-                  htmlFor="quick-upload"
-                  className="flex items-center gap-2 px-4 py-2 bg-gray-800 hover:bg-gray-700 border border-white/10 rounded-lg cursor-pointer transition-colors"
+            {/* Step 1: interface */}
+            <div className="space-y-1">
+              <label htmlFor="rc-interface" className="text-sm font-medium text-gray-300">
+                1. Network Interface
+              </label>
+              <div className="relative">
+                <Network className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                <select
+                  id="rc-interface"
+                  value={simulationSettings.selectedInterface}
+                  onChange={handleInterfaceChange}
+                  disabled={interfacesLoading || interfaces.length === 0}
+                  title="Pick the host interface the daemon should bind to. Loopback (lo0/lo) is safest for local testing."
+                  className="w-full rounded border border-white/10 bg-gray-800 py-2 pl-10 pr-3 text-sm text-white focus:border-violet-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                  <FileUp className="h-4 w-4 text-gray-400" />
-                  <span className="text-sm text-white">
-                    {quickUploadFile ? 'Change File' : 'Browse...'}
-                  </span>
-                </label>
-                <input
-                  id="quick-upload"
-                  type="file"
-                  accept=".yaml,.yml"
-                  onChange={handleQuickUpload}
-                  className="sr-only"
-                />
-                {quickUploadFile && (
-                  <button
-                    type="button"
-                    onClick={() => setQuickUploadFile(null)}
-                    className="text-sm text-red-400 hover:text-red-300"
-                  >
-                    Clear
-                  </button>
+                  {interfacesLoading && <option value="">Loading interfaces…</option>}
+                  {!interfacesLoading && interfaces.length === 0 && (
+                    <option value="">No usable interfaces detected</option>
+                  )}
+                  {!interfacesLoading && interfaces.length > 0 && (
+                    <option value="">Select interface…</option>
+                  )}
+                  {interfaces.map((iface) => (
+                    <option key={iface.name} value={iface.name}>
+                      {iface.name}
+                      {iface.addresses.length > 0 ? ` (${iface.addresses[0]})` : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* Step 2: config */}
+            <div className="space-y-2">
+              <div className="flex items-baseline justify-between">
+                <span className="text-sm font-medium text-gray-300">2. Configuration</span>
+                {simulationSettings.configName || quickUploadFile ? (
+                  <SmallText className="text-emerald-300">
+                    {quickUploadFile
+                      ? `${quickUploadFile.name} (upload)`
+                      : `${simulationSettings.configName} (${simulationSettings.configSource === 'template' ? 'template' : 'config'})`}
+                  </SmallText>
+                ) : (
+                  <SmallText className="text-gray-500 italic">Nothing selected</SmallText>
                 )}
               </div>
-              <SmallText className="text-gray-500">
-                Upload a config to use instead of the saved configuration.
-              </SmallText>
+              <ConfigPicker
+                selection={{
+                  source: quickUploadFile ? 'upload' : (simulationSettings.configSource ?? null),
+                  name: quickUploadFile ? quickUploadFile.name : simulationSettings.configName,
+                  path: simulationSettings.configPath,
+                }}
+                onSelectTemplate={handleSelectTemplate}
+                onSelectUserConfig={handleSelectUserConfig}
+                onUpload={handleUpload}
+                uploadFile={quickUploadFile}
+              />
             </div>
 
             {/* Messages */}

--- a/ui/src/pages/templates/useTemplates.ts
+++ b/ui/src/pages/templates/useTemplates.ts
@@ -1,7 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { applyTemplate, fetchTemplateContent, fetchTemplates } from '../../api/client';
 import type { Template, TemplateContent } from '../../api/types';
 import { useApiResource } from '../../hooks/useApiResource';
+import { useUIStore } from '../../stores/ui-store';
 import { copyToClipboard } from '../../utils/file';
 import { getErrorMessage } from '../../utils/format';
 
@@ -44,6 +46,8 @@ export interface UseTemplatesReturn {
 }
 
 export function useTemplates(): UseTemplatesReturn {
+  const navigate = useNavigate();
+  const { setSimulationSettings } = useUIStore();
   const {
     data: templates,
     loading: templatesLoading,
@@ -131,13 +135,25 @@ export function useTemplates(): UseTemplatesReturn {
           newConfigName: configName || undefined,
         });
 
-        setMessage({
-          type: 'success',
-          text: response.message || `Configuration created at ${response.configPath}`,
+        // Pre-select the new config in the simulation drawer so the user can
+        // jump straight from "I picked a template" to "start it" without
+        // re-discovering it under My Configs.
+        const savedName = configName || `${template.name}-config`;
+        setSimulationSettings({
+          configSource: 'userConfig',
+          configName: savedName,
+          configPath: response.configPath,
         });
 
-        // Close the preview modal if open
+        setMessage({
+          type: 'success',
+          text: `${response.message || `Configuration "${savedName}" created`} — go to Simulation to start it.`,
+        });
+
+        // Close the preview modal if open and route the user to the
+        // Simulation page where they can pick an interface and hit Start.
         setSelectedTemplate(null);
+        navigate('/runtime');
       } catch (err) {
         setMessage({
           type: 'error',
@@ -145,7 +161,7 @@ export function useTemplates(): UseTemplatesReturn {
         });
       }
     },
-    [showUseTemplateModal],
+    [showUseTemplateModal, navigate, setSimulationSettings],
   );
 
   // Handle closing the preview modal


### PR DESCRIPTION
Replaces the standalone Templates page + Settings drawer + Quick Override Upload card with a single tabbed ConfigPicker on the Simulation Control page.

## What changed

- New `components/simulation/ConfigPicker.tsx` with three tabs: **Templates**, **My Configs**, **Upload** (file picker + JavaDslImportCard).
- RuntimeControlPage hosts the picker inline. Interface dropdown is also inline. The 'Configure' button is gone.
- Sidebar Configuration group: Live Devices, Device Library, Config Diff (Templates removed).
- `/templates` redirects to `/runtime` so old bookmarks keep working.
- Template **Use** seeds simulationSettings + routes to /runtime — fixes the 'blank page after Use' confusion.
- Request layer now refetches the CSRF token and retries when the server returns `csrf_token_invalid` (typically on daemon restart).

## Test plan
- [x] biome / tsc / vitest clean (65/65)
- [x] `npm run build` — clean, embedded into binary
- [x] Manually verified: open Simulation page → tabs render → pick `router` template → interface dropdown lets you pick lo0 → Start works (no CSRF flake)