### PR TITLE
feat(api,templates): front-matter metadata + clearer built-in template names

### DIFF
--- a/cmd/niac/templates/ap.yaml
+++ b/cmd/niac/templates/ap.yaml
@@ -1,5 +1,7 @@
-# Access Point Template
-# Enterprise Wi-Fi AP with controller integration
+# Display: Wi-Fi Access Point
+# Description: Enterprise AP persona advertising itself via LLDP and answering SNMP for radio/SSID OIDs. Useful when validating wireless management tooling that expects to discover thin APs talking to a controller.
+# Type: access-point
+# Tags: wireless, snmp, lldp
 
 devices:
   - name: wifi-ap-01

--- a/cmd/niac/templates/complete.yaml
+++ b/cmd/niac/templates/complete.yaml
@@ -1,5 +1,7 @@
-# Complete Network Simulation
-# Multi-device network with router, switch, AP, server
+# Display: Small Office Network (4 devices)
+# Description: A complete small-office topology in one config — one router, one switch, one Wi-Fi AP, one application server. Discovery (LLDP/CDP) wires them together so tools see a realistic four-device LAN.
+# Type: complete
+# Tags: lan, snmp, lldp, server
 
 devices:
   - name: core-router

--- a/cmd/niac/templates/iot.yaml
+++ b/cmd/niac/templates/iot.yaml
@@ -1,5 +1,7 @@
-# IoT Device Template
-# Lightweight IoT sensor with basic protocols
+# Display: IoT Sensor
+# Description: Lightweight IoT endpoint — answers ARP and ICMP, no SNMP, no fancy stack. Realistic shape for camera/sensor-class devices you'd find on a building network.
+# Type: basic
+# Tags: iot, minimal
 
 devices:
   - name: iot-sensor-01

--- a/cmd/niac/templates/minimal.yaml
+++ b/cmd/niac/templates/minimal.yaml
@@ -1,5 +1,7 @@
-# Minimal NIAC Configuration
-# Single device with basic protocols
+# Display: Minimal Router
+# Description: Smallest useful starter — one router persona answering ARP and ICMP. Boot it on a loopback to confirm the daemon works end-to-end before trying anything more elaborate.
+# Type: router
+# Tags: starter, smoke-test
 
 devices:
   - name: device-01

--- a/cmd/niac/templates/router.yaml
+++ b/cmd/niac/templates/router.yaml
@@ -1,5 +1,7 @@
-# Router Template
-# Enterprise router with full protocol support
+# Display: Core Router (full stack)
+# Description: One router with the full protocol set — ARP, ICMP, LLDP, CDP, SNMP v2c, plus a couple of test IP addresses. A reasonable single-device baseline for tooling that expects to see a "real" L3 box on the wire.
+# Type: router
+# Tags: l3, snmp, lldp, cdp
 
 devices:
   - name: core-router-01

--- a/cmd/niac/templates/server.yaml
+++ b/cmd/niac/templates/server.yaml
@@ -1,5 +1,7 @@
-# Server Template
-# Multi-service server (DHCP, DNS, HTTP)
+# Display: Application Server (DHCP/DNS/HTTP)
+# Description: Three-server persona — DHCP server handing out leases, DNS server resolving a small zone, and an HTTP server with a couple of endpoints. The shape monitoring tools expect from a multi-service host.
+# Type: server
+# Tags: dhcp, dns, http
 
 devices:
   - name: server-01

--- a/cmd/niac/templates/switch.yaml
+++ b/cmd/niac/templates/switch.yaml
@@ -1,5 +1,7 @@
-# Switch Template
-# Layer 2/3 switch with STP and VLAN support
+# Display: L2/L3 Switch
+# Description: Single switch persona with STP, VLAN tagging, LLDP and CDP. Good for sanity-checking spanning-tree and discovery tooling against a simulated bridge.
+# Type: switch
+# Tags: stp, vlan, lldp, cdp
 
 devices:
   - name: access-switch-01

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -25,8 +25,15 @@ const (
 )
 
 // Template represents a configuration template.
+//
+// Name is the stable filename-derived identifier ("minimal", "router")
+// used by the /api/v1/templates/{name} and /api/v1/templates/use APIs.
+// DisplayName is the human-readable label optionally provided via the
+// front-matter "# Display: ..." line; clients should prefer it for UI
+// rendering and fall back to Name when absent.
 type Template struct {
 	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName,omitempty"`
 	Description string   `json:"description"`
 	DeviceCount int      `json:"deviceCount"`
 	Type        string   `json:"type"`
@@ -158,32 +165,111 @@ func scanTemplateDir(baseDir string) ([]Template, error) {
 }
 
 // parseTemplateFile extracts template metadata from a file.
+//
+// Templates can opt-in to a small front-matter block at the very top of
+// the YAML for richer UI metadata. The parser walks consecutive comment
+// lines and recognises:
+//
+//	# Display: Enterprise Router
+//	# Description: A full enterprise router persona with LLDP, CDP, SNMP, ...
+//
+// When present these win over the legacy "first non-empty comment line"
+// heuristic. The keys are case-insensitive and the rest of the file is
+// untouched.
 func parseTemplateFile(path string, _ fs.FileInfo) Template {
 	// Extract name from filename without extension
 	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 
-	// Try to extract description from first comment line
-	description := extractDescription(path)
+	meta := extractFrontMatter(path)
+
+	displayName := meta["display"]
+
+	description := meta["description"]
 	if description == "" {
-		description = name + " configuration template"
+		// Fall back to the legacy first-comment heuristic for templates
+		// that haven't been migrated yet.
+		description = extractDescription(path)
+	}
+	if description == "" {
+		base := displayName
+		if base == "" {
+			base = name
+		}
+		description = base + " configuration template"
 	}
 
 	// Count devices in the YAML file
 	deviceCount := countDevicesInFile(path)
 
-	// Determine type from filename and content
-	templateType := determineTemplateType(path, name)
+	// Determine type: front-matter wins, otherwise infer from name+path.
+	templateType := strings.ToLower(strings.TrimSpace(meta["type"]))
+	if templateType == "" {
+		templateType = determineTemplateType(path, name)
+	}
 
-	// Generate tags from path components
-	tags := generateTags(path)
+	// Tags: front-matter "tags:" comma-separated wins, otherwise infer.
+	tags := splitTags(meta["tags"])
+	if len(tags) == 0 {
+		tags = generateTags(path)
+	}
 
 	return Template{
 		Name:        name,
+		DisplayName: displayName,
 		Description: description,
 		DeviceCount: deviceCount,
 		Type:        templateType,
 		Tags:        tags,
 	}
+}
+
+// splitTags parses a comma-separated tags string into a slice. Empty tags
+// are skipped and whitespace is trimmed.
+func splitTags(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// extractFrontMatter pulls "# Key: Value" lines from the top of a YAML
+// file into a map. Stops at the first non-comment, non-blank line. Keys
+// are lowercased; values are trimmed.
+func extractFrontMatter(path string) map[string]string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	meta := make(map[string]string)
+	for line := range strings.SplitSeq(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		comment, isComment := strings.CutPrefix(trimmed, "#")
+		if !isComment {
+			break
+		}
+		comment = strings.TrimSpace(comment)
+		key, value, ok := strings.Cut(comment, ":")
+		if !ok {
+			continue
+		}
+		k := strings.ToLower(strings.TrimSpace(key))
+		v := strings.TrimSpace(value)
+		if k != "" && v != "" {
+			meta[k] = v
+		}
+	}
+	return meta
 }
 
 // countDevicesInFile counts the number of devices defined in a YAML config.

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -244,7 +244,10 @@ func splitTags(raw string) []string {
 // file into a map. Stops at the first non-comment, non-blank line. Keys
 // are lowercased; values are trimmed.
 func extractFrontMatter(path string) map[string]string {
-	data, err := os.ReadFile(path)
+	// filepath.Clean keeps gosec G304 quiet — callers walk a
+	// server-owned templates directory, but cleaning is cheap and
+	// satisfies the linter without a //nolint exception.
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil
 	}

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,12 +20,11 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-uA58YXEh.js"></script>
+    <script type="module" crossorigin src="/assets/index-BZFh-aIk.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-BoJ-pB7h.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-DtDwoORA.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-CL4vA7_X.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-codemirror-BjllbsfA.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DXmdNVIm.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-uzW8H4LC.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-BtchU08s.css">
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/api/template-types.ts
+++ b/ui/src/api/template-types.ts
@@ -4,7 +4,10 @@
  */
 
 export interface Template {
+  /** Filename-derived identifier — pass this to /templates/{name} and /templates/use. */
   name: string;
+  /** Optional human-readable label from the template's "# Display: ..." front-matter. */
+  displayName?: string;
   description: string;
   deviceCount: number;
   type: 'basic' | 'router' | 'switch' | 'access-point' | 'server' | 'complete' | 'custom';

--- a/ui/src/components/TemplateCard.tsx
+++ b/ui/src/components/TemplateCard.tsx
@@ -51,7 +51,12 @@ export const TemplateCard: FC<TemplateCardProps> = memo(({ template, onView, onU
 
         {/* Template info */}
         <div className="space-y-1">
-          <h3 className="font-semibold text-white text-lg">{template.name}</h3>
+          <h3 className="font-semibold text-white text-lg">
+            {template.displayName || template.name}
+          </h3>
+          {template.displayName && (
+            <SmallText className="text-gray-500 font-mono text-[10px]">{template.name}</SmallText>
+          )}
           <SmallText className="text-gray-400 line-clamp-2">
             {template.description || 'No description available'}
           </SmallText>

--- a/ui/src/pages/templates/useTemplates.ts
+++ b/ui/src/pages/templates/useTemplates.ts
@@ -77,6 +77,7 @@ export function useTemplates(): UseTemplatesReturn {
     return templates.filter(
       (template) =>
         template.name.toLowerCase().includes(query) ||
+        template.displayName?.toLowerCase().includes(query) ||
         template.description?.toLowerCase().includes(query) ||
         template.type.toLowerCase().includes(query) ||
         template.tags?.some((tag) => tag.toLowerCase().includes(query)),


### PR DESCRIPTION
PR E of the A-E UX polish series.

## Problem

Built-in template names like `minimal`, `router`, `switch` were terse and the one-line descriptions didn't say what makes each useful. Users couldn't tell why they'd pick one over another.

## Solution

Templates can now opt-in to a tiny YAML front-matter block:

```yaml
# Display: Core Router (full stack)
# Description: One router with the full protocol set — ARP, ICMP, LLDP, CDP, SNMP v2c …
# Type: router
# Tags: l3, snmp, lldp, cdp

devices:
  - name: core-router-01
    …
```

`parseTemplateFile` reads consecutive `# Key: Value` comment lines into a metadata map; front-matter wins over the legacy first-line description heuristic. Templates without front-matter keep working.

`Template` struct gains `DisplayName` as a separate field — `Name` stays as the filename-derived identifier because the lookup APIs (`/api/v1/templates/{name}` and `/api/v1/templates/use`) key off it. Renaming `Name` would have been an API break.

UI: TemplateCard renders `displayName || name` with the raw name shown underneath in mono so the lookup key is still visible. Search now also matches against displayName.

## Migration

Rewrote the 7 cmd/niac/templates/ built-ins with proper front-matter. The 45 examples/ templates retain their existing one-line descriptions and can be migrated incrementally in follow-ups.

## Test plan
- [x] go build clean
- [x] tsc clean
- [x] biome clean
- [x] vitest 65/65
- [x] Local daemon serves new display names correctly via /api/v1/templates