### PR TITLE
feat(api): wire stack packet observer to SSE hub for live Packet Capture

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -166,4 +166,15 @@ func (s *Server) startBackgroundTasks() {
 	// Start SSE hub for real-time streaming
 	go s.sseHub.Run()
 	s.logger.Info("[SSE] Server-Sent Events hub started")
+
+	// Log tee into the SSE hub is intentionally deferred. Wiring
+	// slog.SetDefault(NewSSELogHandler(...)) here caused the hub's
+	// Run loop to deadlock on certain code paths because the hub's
+	// own slog calls (registerClient logs "Client connected") fed
+	// back into the tee → Broadcast → log → tee → … The fix needs a
+	// reentrancy guard or an explicit "internal" channel that bypasses
+	// the SSE pipeline. Tracked separately. For now the Protocol Debug
+	// Console page will only show the device-CRUD log line until that
+	// lands; the rest of the stack's slog calls don't reach the UI.
+	_ = NewSSELogHandler
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -364,6 +364,15 @@ func (s *Server) UpdateSimulation(
 	s.cfg.Interface = iface
 	s.cfg.Replay = replay
 	s.cfg.Topology = BuildTopology(cfg)
+
+	// Wire the stack's packet stream into the SSE hub so the
+	// /api/v1/stream/packets subscribers actually see frames.
+	// Previously the hub had BroadcastPacket defined but it was never
+	// called, leaving the Packet Capture page perpetually empty even
+	// while a simulation was clearly handling traffic.
+	if stack != nil && s.sseHub != nil {
+		stack.AddPacketObserver(&sseHubPacketObserver{hub: s.sseHub})
+	}
 }
 
 // ClearSimulation clears simulation components (for daemon mode).

--- a/internal/api/sse_log_handler.go
+++ b/internal/api/sse_log_handler.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+// sseLogHandler is a slog.Handler that tees every record through the
+// upstream handler AND broadcasts it on the SSE logs stream so the
+// Protocol Debug Console page sees daemon logs in real time.
+//
+// The stack used to emit lots of fmt.Fprintf(os.Stdout, ...) lines that
+// are invisible to slog — those won't appear here. Migrating those to
+// slog is a separate cleanup. For now this captures everything that
+// already routes through slog.Default (which is most of the new code).
+type sseLogHandler struct {
+	hub  *SSEHub
+	next slog.Handler
+}
+
+// NewSSELogHandler wraps the given handler. The wrapper forwards every
+// record to next AND to hub.BroadcastLog. A nil hub falls through to
+// next so callers can install the wrapper unconditionally.
+func NewSSELogHandler(hub *SSEHub, next slog.Handler) slog.Handler {
+	if next == nil {
+		next = slog.Default().Handler()
+	}
+	return &sseLogHandler{hub: hub, next: next}
+}
+
+func (h *sseLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *sseLogHandler) Handle(ctx context.Context, rec slog.Record) error {
+	// Tee to the SSE hub first so a downstream handler error doesn't
+	// silently drop the broadcast.
+	if h.hub != nil {
+		h.hub.BroadcastLog(levelString(rec.Level), formatRecord(rec))
+	}
+	return h.next.Handle(ctx, rec)
+}
+
+func (h *sseLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &sseLogHandler{hub: h.hub, next: h.next.WithAttrs(attrs)}
+}
+
+func (h *sseLogHandler) WithGroup(name string) slog.Handler {
+	return &sseLogHandler{hub: h.hub, next: h.next.WithGroup(name)}
+}
+
+func levelString(l slog.Level) string {
+	switch {
+	case l >= slog.LevelError:
+		return "error"
+	case l >= slog.LevelWarn:
+		return "warn"
+	case l >= slog.LevelInfo:
+		return "info"
+	default:
+		return "debug"
+	}
+}
+
+// formatRecord builds a "<msg> key1=v1 key2=v2" string from the record.
+// Matches the shape the Debug Console UI already renders.
+func formatRecord(rec slog.Record) string {
+	if rec.NumAttrs() == 0 {
+		return rec.Message
+	}
+	var b strings.Builder
+	b.WriteString(rec.Message)
+	rec.Attrs(func(a slog.Attr) bool {
+		b.WriteByte(' ')
+		b.WriteString(a.Key)
+		b.WriteByte('=')
+		b.WriteString(a.Value.String())
+		return true
+	})
+	return b.String()
+}

--- a/internal/api/sse_packet_observer.go
+++ b/internal/api/sse_packet_observer.go
@@ -1,0 +1,174 @@
+package api
+
+// SSE packet observer: bridges the protocol stack's PacketObserver
+// hook into the SSE hub so /api/v1/stream/packets subscribers see live
+// frames. Previously the hub had BroadcastPacket defined but it was
+// never called, leaving Packet Capture perpetually empty even while a
+// simulation was clearly handling traffic.
+
+import (
+	"encoding/hex"
+	"strconv"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/krisarmstrong/niac-go/internal/protocols"
+)
+
+// sseHubPacketObserver implements protocols.PacketObserver and forwards
+// each packet event onto the SSE hub's packets stream.
+//
+// The hub's Broadcast is non-blocking (drops on full channel) so a slow
+// SSE consumer can never back-pressure the protocol stack. Observers
+// must be cheap; this one does a thin gopacket pass and a hex encode
+// of the truncated raw bytes.
+type sseHubPacketObserver struct {
+	hub *SSEHub
+}
+
+// sseMaxRawPacketBytes caps how many bytes of the raw frame we ship in
+// each event. The UI hex-viewer can render the full Ethernet MTU but
+// at high packet rates we'd flood the SSE buffer. 256 bytes covers
+// most useful headers (Ethernet + IPv4 + TCP options + a small
+// payload) and keeps each event well under the SSE per-message budget.
+const sseMaxRawPacketBytes = 256
+
+// ipv4Len is the byte length of an IPv4 protocol address.
+const ipv4Len = 4
+
+// OnPacket is called by the stack for every rx/tx packet.
+func (o *sseHubPacketObserver) OnPacket(direction string, pkt *protocols.Packet) {
+	if o == nil || o.hub == nil || pkt == nil {
+		return
+	}
+	o.hub.BroadcastPacket(packetToWire(direction, pkt))
+}
+
+// packetToWire flattens a Packet into a map suitable for SSE JSON.
+// Fields use snake_case to match the UI's existing fallback path —
+// SSE payloads don't go through the camelCase converter.
+func packetToWire(direction string, pkt *protocols.Packet) map[string]any {
+	raw := pkt.Buffer
+	if pkt.Length > 0 && pkt.Length <= len(raw) {
+		raw = raw[:pkt.Length]
+	}
+	truncated := false
+	if len(raw) > sseMaxRawPacketBytes {
+		raw = raw[:sseMaxRawPacketBytes]
+		truncated = true
+	}
+
+	out := map[string]any{
+		"timestamp": pkt.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z"),
+		"direction": direction,
+		"size":      pkt.Length,
+		"raw_data":  hex.EncodeToString(raw),
+		"truncated": truncated,
+		"serial":    pkt.SerialNumber,
+		"protocol":  "Unknown",
+		"summary":   "",
+	}
+	if pkt.VLAN >= 0 {
+		out["vlan"] = pkt.VLAN
+	}
+	enrichWithLayers(out, pkt.Buffer)
+	return out
+}
+
+// enrichWithLayers does a best-effort gopacket decode to fill in
+// source/dest IPs, ports, and protocol. Decode errors are swallowed —
+// the event still carries the raw bytes.
+func enrichWithLayers(out map[string]any, buf []byte) {
+	if len(buf) == 0 {
+		return
+	}
+	packet := gopacket.NewPacket(buf, layers.LayerTypeEthernet, gopacket.NoCopy)
+
+	if ethLayer := packet.Layer(layers.LayerTypeEthernet); ethLayer != nil {
+		if eth, ok := ethLayer.(*layers.Ethernet); ok {
+			out["src_mac"] = eth.SrcMAC.String()
+			out["dst_mac"] = eth.DstMAC.String()
+		}
+	}
+
+	enrichNetworkLayer(out, packet)
+	enrichTransportLayer(out, packet)
+}
+
+// enrichNetworkLayer sets source/dest IP and the L3 protocol label.
+func enrichNetworkLayer(out map[string]any, packet gopacket.Packet) {
+	if l := packet.Layer(layers.LayerTypeIPv4); l != nil {
+		if ip, ok := l.(*layers.IPv4); ok {
+			out["source_ip"] = ip.SrcIP.String()
+			out["dest_ip"] = ip.DstIP.String()
+			out["protocol"] = "IPv4"
+		}
+		return
+	}
+	if l := packet.Layer(layers.LayerTypeIPv6); l != nil {
+		if ip, ok := l.(*layers.IPv6); ok {
+			out["source_ip"] = ip.SrcIP.String()
+			out["dest_ip"] = ip.DstIP.String()
+			out["protocol"] = "IPv6"
+		}
+		return
+	}
+	if l := packet.Layer(layers.LayerTypeARP); l != nil {
+		out["protocol"] = "ARP"
+		enrichARP(out, l)
+	}
+}
+
+// enrichARP adds source/dest IPv4 keys for an ARP layer if the
+// addresses are well-formed.
+func enrichARP(out map[string]any, l gopacket.Layer) {
+	arp, ok := l.(*layers.ARP)
+	if !ok {
+		return
+	}
+	if len(arp.SourceProtAddress) == ipv4Len {
+		out["source_ip"] = ipv4String(arp.SourceProtAddress)
+	}
+	if len(arp.DstProtAddress) == ipv4Len {
+		out["dest_ip"] = ipv4String(arp.DstProtAddress)
+	}
+}
+
+// enrichTransportLayer sets ports + L4 protocol label.
+func enrichTransportLayer(out map[string]any, packet gopacket.Packet) {
+	if l := packet.Layer(layers.LayerTypeTCP); l != nil {
+		if tcp, ok := l.(*layers.TCP); ok {
+			out["source_port"] = uint16(tcp.SrcPort)
+			out["dest_port"] = uint16(tcp.DstPort)
+			out["protocol"] = "TCP"
+			out["summary"] = "TCP " + strconv.Itoa(int(tcp.SrcPort)) + "→" + strconv.Itoa(int(tcp.DstPort))
+		}
+		return
+	}
+	if l := packet.Layer(layers.LayerTypeUDP); l != nil {
+		if udp, ok := l.(*layers.UDP); ok {
+			out["source_port"] = uint16(udp.SrcPort)
+			out["dest_port"] = uint16(udp.DstPort)
+			out["protocol"] = "UDP"
+			out["summary"] = "UDP " + strconv.Itoa(int(udp.SrcPort)) + "→" + strconv.Itoa(int(udp.DstPort))
+		}
+		return
+	}
+	if packet.Layer(layers.LayerTypeICMPv4) != nil {
+		out["protocol"] = "ICMP"
+		return
+	}
+	if packet.Layer(layers.LayerTypeICMPv6) != nil {
+		out["protocol"] = "ICMPv6"
+	}
+}
+
+// ipv4String formats a 4-byte IPv4 address as dotted-quad. Avoids a
+// net.IP allocation on the hot path.
+func ipv4String(b []byte) string {
+	return strconv.Itoa(int(b[0])) + "." +
+		strconv.Itoa(int(b[1])) + "." +
+		strconv.Itoa(int(b[2])) + "." +
+		strconv.Itoa(int(b[3]))
+}

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -118,6 +118,24 @@ type Stack struct {
 	debugConfig  *logging.DebugConfig
 	snmpAgents   map[*config.Device]*snmpAgentGroup
 	errorManager *apperr.StateManager
+
+	// observers receive every packet the stack sees (rx) or sends (tx).
+	// The API server registers one to feed its SSE hub. Observers are
+	// expected to be cheap; the stack drops to the floor on observer
+	// panic via the recover in notifyObservers.
+	observerMu sync.RWMutex
+	observers  []PacketObserver
+}
+
+// PacketObserver receives every packet the stack handles. Direction is
+// "rx" for inbound (just decoded) or "tx" for outbound (about to send).
+//
+// Implementations MUST NOT block — the stack holds an RLock while
+// iterating observers, and a slow observer would back-pressure the
+// receive thread. Use a buffered channel or goroutine on the consumer
+// side if any heavier processing is needed.
+type PacketObserver interface {
+	OnPacket(direction string, pkt *Packet)
 }
 
 // Statistics holds protocol statistics.
@@ -191,6 +209,34 @@ func NewStack(
 	stack.initializeDevices(cfg)
 
 	return stack
+}
+
+// AddPacketObserver registers an observer for stack packet events.
+// Safe to call before or after Start.
+func (s *Stack) AddPacketObserver(obs PacketObserver) {
+	if obs == nil {
+		return
+	}
+	s.observerMu.Lock()
+	s.observers = append(s.observers, obs)
+	s.observerMu.Unlock()
+}
+
+// notifyObservers fans a packet event out to every registered observer.
+// A panicking observer is dropped — the stack's job is to forward
+// packets, not to keep buggy observers safe.
+func (s *Stack) notifyObservers(direction string, pkt *Packet) {
+	s.observerMu.RLock()
+	obs := s.observers
+	s.observerMu.RUnlock()
+	for _, o := range obs {
+		func() {
+			defer func() {
+				_ = recover()
+			}()
+			o.OnPacket(direction, pkt)
+		}()
+	}
 }
 
 // initializeDevices repopulates device-dependent state from the provided config.
@@ -429,6 +475,7 @@ func (s *Stack) receiveAndQueuePacket(buffer []byte) {
 		return
 	}
 
+	s.notifyObservers("rx", pkt)
 	s.queuePacket(pkt)
 }
 
@@ -665,6 +712,8 @@ func (s *Stack) sendPacket(pkt *Packet) {
 	s.stats.mu.Lock()
 	s.stats.PacketsSent++
 	s.stats.mu.Unlock()
+
+	s.notifyObservers("tx", pkt)
 
 	if s.debugConfig.GetGlobal() >= DebugLevelVerbose {
 		_, _ = fmt.Fprintf(os.Stdout, "Sent packet sn=%d length=%d\n", pkt.SerialNumber, pkt.Length)


### PR DESCRIPTION
**The big one.** Packet Capture was showing nothing despite an active simulation because the SSE hub had `BroadcastPacket` defined but it was never called.

## What changed

- `protocols.Stack` gets a new `PacketObserver` interface + `AddPacketObserver` / `notifyObservers` plumbing. Fires on every successful rx (`parseReceivedPacket`) and tx (`sendPacket`).
- New `internal/api/sse_packet_observer.go` implements `PacketObserver`, flattens each `Packet` into the snake_case map the UI fallback layer already expects (timestamp, direction, size, raw_data hex, src/dst MAC, source/dest IP, source/dest port, protocol label). Best-effort gopacket decode; raw bytes truncated to 256B to keep SSE small at high packet rates.
- `Server.UpdateSimulation` registers the observer when it receives a new stack pointer. Old simulations get garbage-collected along with their stack so observers don't leak between runs.

## Verified locally

```
make build && ./niac daemon --listen :8080 &
# start sim via complete template
ping -c 4 10.0.0.1
curl -sN http://localhost:8080/api/v1/stream/packets | head
# → ICMP echo + reply events stream in real time
```

## Out of scope, deferred

Log streaming. A sister `sse_log_handler.go` is included as scaffolding but not installed — wiring `slog.SetDefault` through it caused the hub's `Run` loop to deadlock because the hub's own internal slog calls fed back into the tee. Needs a reentrancy guard or a dedicated internal channel. The Protocol Debug Console page will still show device-CRUD events but not protocol-stack runtime logs until that lands.