### PR TITLE
refactor(ui): sweep pages and components onto iconSizes tokens

### DIFF
--- a/ui/src/components/BpfFilterBar.tsx
+++ b/ui/src/components/BpfFilterBar.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, CheckCircle2, Filter, X } from 'lucide-react';
 import { type FC, memo, useCallback, useEffect, useState } from 'react';
 import { clearCaptureFilter, getCaptureFilter, setCaptureFilter } from '../api/capture';
+import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
 import { SmallText } from '../ui/Typography';
 import { getErrorMessage } from '../utils/format';
@@ -112,7 +113,7 @@ export const BpfFilterBar: FC = memo(() => {
       <div className="flex items-center gap-2">
         {/* Filter icon and active indicator */}
         <div className="flex items-center gap-1.5 flex-shrink-0">
-          <Filter className="h-4 w-4 text-gray-400" />
+          <Filter className={`${iconSizes.md} text-gray-400`} />
           {isActive && <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />}
         </div>
 
@@ -163,7 +164,7 @@ export const BpfFilterBar: FC = memo(() => {
       {/* Error message */}
       {error && (
         <div className="flex items-center gap-1.5 px-1">
-          <AlertCircle className="h-3.5 w-3.5 text-red-400 flex-shrink-0" />
+          <AlertCircle className={`${iconSizes.sm} text-red-400 flex-shrink-0`} />
           <SmallText className="text-red-400">{error}</SmallText>
         </div>
       )}

--- a/ui/src/components/ColoringRulesPanel.tsx
+++ b/ui/src/components/ColoringRulesPanel.tsx
@@ -1,5 +1,6 @@
 import { ArrowDown, ArrowUp, Plus, RotateCcw, Trash2, X } from 'lucide-react';
 import { type FC, memo, useCallback, useState } from 'react';
+import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
 import { SmallText } from '../ui/Typography';
 import type { ColoringRule } from '../utils/coloring-rules';
@@ -93,7 +94,7 @@ const RuleRow: FC<{
         className="p-1 text-gray-500 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
         title="Move up"
       >
-        <ArrowUp className="h-3.5 w-3.5" />
+        <ArrowUp className={iconSizes.sm} />
       </button>
       <button
         type="button"
@@ -102,7 +103,7 @@ const RuleRow: FC<{
         className="p-1 text-gray-500 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
         title="Move down"
       >
-        <ArrowDown className="h-3.5 w-3.5" />
+        <ArrowDown className={iconSizes.sm} />
       </button>
 
       {/* Delete */}
@@ -228,7 +229,7 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
                 variant="ghost"
                 size="sm"
                 onClick={handleAdd}
-                leftIcon={<Plus className="h-4 w-4" />}
+                leftIcon={<Plus className={iconSizes.md} />}
               >
                 Add Rule
               </Button>
@@ -236,7 +237,7 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
                 variant="ghost"
                 size="sm"
                 onClick={handleReset}
-                leftIcon={<RotateCcw className="h-4 w-4" />}
+                leftIcon={<RotateCcw className={iconSizes.md} />}
               >
                 Reset Defaults
               </Button>

--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -5,6 +5,7 @@
 
 import { AlertCircle, RefreshCw } from 'lucide-react';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { iconSizes } from '../constants/sizes';
 import { reportError } from '../utils/error-reporter';
 
 interface Props {
@@ -74,7 +75,7 @@ export class ErrorBoundary extends Component<Props, State> {
           <div className="mx-auto max-w-md text-center">
             <div className="mb-4 flex justify-center">
               <div className="rounded-full bg-red-100 p-4 dark:bg-red-900/20">
-                <AlertCircle className="h-12 w-12 text-red-600 dark:text-red-400" />
+                <AlertCircle className={`${iconSizes['3xl']} text-red-600 dark:text-red-400`} />
               </div>
             </div>
 
@@ -114,7 +115,7 @@ export class ErrorBoundary extends Component<Props, State> {
                 onClick={this.handleRetry}
                 className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
               >
-                <RefreshCw className="h-4 w-4" />
+                <RefreshCw className={iconSizes.md} />
                 Try Again
               </button>
               <button
@@ -144,7 +145,9 @@ export class PageErrorBoundary extends ErrorBoundary {
       return (
         <div className="rounded-lg border border-red-200 bg-red-50 p-6 dark:border-red-800 dark:bg-red-900/10">
           <div className="flex items-start gap-4">
-            <AlertCircle className="h-6 w-6 flex-shrink-0 text-red-600 dark:text-red-400" />
+            <AlertCircle
+              className={`${iconSizes.xl} flex-shrink-0 text-red-600 dark:text-red-400`}
+            />
             <div className="flex-1">
               <h3 className="text-sm font-medium text-red-800 dark:text-red-200">Page Error</h3>
               <p className="mt-1 text-sm text-red-700 dark:text-red-300">

--- a/ui/src/components/LogFilters.tsx
+++ b/ui/src/components/LogFilters.tsx
@@ -1,6 +1,7 @@
 import { Download, Pause, Play, Search, Trash2 } from 'lucide-react';
 import { type ChangeEvent, type FC, memo } from 'react';
 import type { LogLevel, Protocol } from '../api/types';
+import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
 import { SmallText } from '../ui/Typography';
 
@@ -162,7 +163,9 @@ export const LogFilters: FC<LogFiltersProps> = memo(
                 variant={paused ? 'solid' : 'outline'}
                 size="sm"
                 onClick={onPauseToggle}
-                leftIcon={paused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+                leftIcon={
+                  paused ? <Play className={iconSizes.md} /> : <Pause className={iconSizes.md} />
+                }
                 aria-label={paused ? 'Resume log stream' : 'Pause log stream'}
                 className={paused ? 'bg-green-600 hover:bg-green-700 border-green-500' : ''}
               >
@@ -173,7 +176,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
               variant="outline"
               size="sm"
               onClick={onExport}
-              leftIcon={<Download className="h-4 w-4" />}
+              leftIcon={<Download className={iconSizes.md} />}
               aria-label="Export logs to file"
             >
               Export

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -247,9 +247,9 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
           aria-label="Copy log entry"
         >
           {copied ? (
-            <Check className="h-3.5 w-3.5 text-green-400" />
+            <Check className={`${iconSizes.sm} text-green-400`} />
           ) : (
-            <Copy className="h-3.5 w-3.5" />
+            <Copy className={iconSizes.sm} />
           )}
         </button>
       </div>

--- a/ui/src/components/ProtocolTreeLayer.tsx
+++ b/ui/src/components/ProtocolTreeLayer.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { type FC, memo, useCallback, useState } from 'react';
+import { iconSizes } from '../constants/sizes';
 import type { ProtocolField, ProtocolLayer } from '../utils/protocol-layers';
 
 interface ProtocolTreeLayerProps {
@@ -35,9 +36,9 @@ export const ProtocolTreeLayer: FC<ProtocolTreeLayerProps> = memo(({ layer, onFi
         className="flex items-center gap-1 w-full text-left py-0.5 hover:bg-white/5 rounded px-1 -ml-1"
       >
         {isExpanded ? (
-          <ChevronDown className="h-3.5 w-3.5 text-gray-500 flex-shrink-0" />
+          <ChevronDown className={`${iconSizes.sm} text-gray-500 flex-shrink-0`} />
         ) : (
-          <ChevronRight className="h-3.5 w-3.5 text-gray-500 flex-shrink-0" />
+          <ChevronRight className={`${iconSizes.sm} text-gray-500 flex-shrink-0`} />
         )}
         <span className="text-violet-300 font-medium">{layer.name}</span>
       </button>

--- a/ui/src/components/SettingsDrawer.tsx
+++ b/ui/src/components/SettingsDrawer.tsx
@@ -29,6 +29,7 @@ import type { ReactElement, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { fetchInterfaces } from '../api/client';
 import type { NetworkInterface } from '../api/types';
+import { iconSizes } from '../constants/sizes';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { badge, cn, drawer, layout, spacing } from '../styles/theme';
 import { SimulationSection } from './settings/SimulationSection';
@@ -415,7 +416,7 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
         <div className="bg-white/5 rounded-lg p-4 space-y-3">
           <div className="flex items-center gap-3">
             <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-violet-500 to-violet-700 flex items-center justify-center shadow-lg shadow-violet-500/30">
-              <Network className="h-6 w-6 text-white" />
+              <Network className={`${iconSizes.xl} text-white`} />
             </div>
             <div>
               <h4 className="text-lg font-bold text-white">NIAC</h4>

--- a/ui/src/components/TemplateCard.tsx
+++ b/ui/src/components/TemplateCard.tsx
@@ -1,6 +1,7 @@
 import { Building2, FileCode, Globe, Layers, Router, Server, Wifi } from 'lucide-react';
 import { type FC, memo } from 'react';
 import type { Template } from '../api/types';
+import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { Tag } from '../ui/Tag';
@@ -42,7 +43,7 @@ export const TemplateCard: FC<TemplateCardProps> = memo(({ template, onView, onU
         {/* Header with icon and type */}
         <div className="flex items-start justify-between">
           <div className={`rounded-lg p-3 border ${colorClass}`}>
-            <IconComponent className="h-6 w-6" />
+            <IconComponent className={iconSizes.xl} />
           </div>
           <Tag colorScheme="gray" className="text-xs capitalize">
             {template.type}

--- a/ui/src/components/TemplatePreviewModal.tsx
+++ b/ui/src/components/TemplatePreviewModal.tsx
@@ -3,6 +3,7 @@ import { type FC, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { applyTemplate } from '../api/client';
 import type { Template, TemplateContent } from '../api/types';
+import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
 import { Tag } from '../ui/Tag';
 import { SmallText } from '../ui/Typography';
@@ -116,7 +117,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
           <div className="flex items-center gap-3">
             <div className="rounded-lg bg-violet-500/20 p-2">
-              <FileCode className="h-5 w-5 text-violet-300" />
+              <FileCode className={`${iconSizes.lg} text-violet-300`} />
             </div>
             <div>
               <h2 id="modal-title" className="text-lg font-semibold text-white">
@@ -133,7 +134,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
             className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
             aria-label="Close modal"
           >
-            <X className="h-5 w-5" />
+            <X className={iconSizes.lg} />
           </button>
         </div>
 
@@ -193,7 +194,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
             <Button
               variant="ghost"
               size="sm"
-              leftIcon={<Copy className="h-4 w-4" />}
+              leftIcon={<Copy className={iconSizes.md} />}
               onClick={onCopy}
               disabled={!content}
             >
@@ -202,7 +203,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
             <Button
               variant="ghost"
               size="sm"
-              leftIcon={<Download className="h-4 w-4" />}
+              leftIcon={<Download className={iconSizes.md} />}
               onClick={handleDownload}
               disabled={!content}
             >
@@ -216,7 +217,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
               </Button>
               <Button
                 variant="outline"
-                leftIcon={<Pencil className="h-4 w-4" />}
+                leftIcon={<Pencil className={iconSizes.md} />}
                 onClick={handleEditCopy}
                 disabled={editing || !content}
                 title="Clone this template to your saved configs and open the device editor"

--- a/ui/src/components/config/MergeControls.tsx
+++ b/ui/src/components/config/MergeControls.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { type FC, useCallback, useMemo, useState } from 'react';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { ConfirmModal } from '../../ui/ConfirmModal';
@@ -113,19 +114,19 @@ export const MergeControls: FC<MergeControlsProps> = ({
         {/* Header */}
         <div className="flex items-center justify-between">
           <H2 className="mb-0 flex items-center gap-2">
-            <FileCheck className="h-5 w-5 text-violet-300" />
+            <FileCheck className={`${iconSizes.lg} text-violet-300`} />
             Merge Controls
           </H2>
           {stats.totalChanges > 0 && (
             <div className="flex items-center gap-2">
               {stats.isComplete ? (
                 <Tag colorScheme="green" className="flex items-center gap-1">
-                  <CheckCircle2 className="h-3 w-3" />
+                  <CheckCircle2 className={iconSizes.xs} />
                   All resolved
                 </Tag>
               ) : (
                 <Tag colorScheme="yellow" className="flex items-center gap-1">
-                  <AlertCircle className="h-3 w-3" />
+                  <AlertCircle className={iconSizes.xs} />
                   {stats.totalChanges - stats.decisionsCount} pending
                 </Tag>
               )}
@@ -158,13 +159,13 @@ export const MergeControls: FC<MergeControlsProps> = ({
             <SmallText className="text-gray-400">Decisions:</SmallText>
             {stats.leftCount > 0 && (
               <Tag colorScheme="blue" className="text-xs">
-                <ChevronLeft className="h-3 w-3 mr-1" />
+                <ChevronLeft className={`${iconSizes.xs} mr-1`} />
                 {stats.leftCount} left
               </Tag>
             )}
             {stats.rightCount > 0 && (
               <Tag colorScheme="green" className="text-xs">
-                <ChevronRight className="h-3 w-3 mr-1" />
+                <ChevronRight className={`${iconSizes.xs} mr-1`} />
                 {stats.rightCount} right
               </Tag>
             )}
@@ -187,7 +188,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
               variant="outline"
               disabled={disabled || stats.totalChanges === 0}
               onClick={() => setShowAcceptLeftConfirm(true)}
-              leftIcon={<ChevronLeft className="h-4 w-4" />}
+              leftIcon={<ChevronLeft className={iconSizes.md} />}
               className="justify-start"
             >
               Accept all from {leftLabel}
@@ -197,7 +198,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
               variant="outline"
               disabled={disabled || stats.totalChanges === 0}
               onClick={() => setShowAcceptRightConfirm(true)}
-              leftIcon={<ChevronRight className="h-4 w-4" />}
+              leftIcon={<ChevronRight className={iconSizes.md} />}
               className="justify-start"
             >
               Accept all from {rightLabel}
@@ -211,7 +212,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
             tone="violet"
             disabled={disabled || stats.totalChanges === 0}
             onClick={onPreview}
-            leftIcon={<FileCheck className="h-4 w-4" />}
+            leftIcon={<FileCheck className={iconSizes.md} />}
           >
             Preview Merged
           </Button>
@@ -220,7 +221,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
             tone="violet"
             disabled={disabled || !stats.isComplete}
             onClick={onExport}
-            leftIcon={<Download className="h-4 w-4" />}
+            leftIcon={<Download className={iconSizes.md} />}
           >
             Export Result
           </Button>
@@ -229,7 +230,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
             variant="outline"
             disabled={disabled || stats.decisionsCount === 0}
             onClick={() => setShowResetConfirm(true)}
-            leftIcon={<RotateCcw className="h-4 w-4" />}
+            leftIcon={<RotateCcw className={iconSizes.md} />}
           >
             Reset Decisions
           </Button>
@@ -238,7 +239,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
             variant="ghost"
             disabled={disabled}
             onClick={() => setShowClearAllConfirm(true)}
-            leftIcon={<Trash2 className="h-4 w-4" />}
+            leftIcon={<Trash2 className={iconSizes.md} />}
           >
             Clear All
           </Button>
@@ -335,7 +336,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
         <div className="flex items-center justify-between border-b border-white/10 px-6 py-4 flex-shrink-0">
           <div className="flex items-center gap-3">
             <div className="rounded-lg bg-violet-500/20 p-2">
-              <FileCheck className="h-5 w-5 text-violet-300" />
+              <FileCheck className={`${iconSizes.lg} text-violet-300`} />
             </div>
             <div>
               <h2 id="preview-modal-title" className="text-lg font-semibold text-white">
@@ -382,7 +383,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
           <Button variant="outline" onClick={handleCopy}>
             Copy to Clipboard
           </Button>
-          <Button tone="violet" onClick={onExport} leftIcon={<Download className="h-4 w-4" />}>
+          <Button tone="violet" onClick={onExport} leftIcon={<Download className={iconSizes.md} />}>
             Download YAML
           </Button>
         </div>

--- a/ui/src/components/config/diff-viewer/DiffBlock.tsx
+++ b/ui/src/components/config/diff-viewer/DiffBlock.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight, ChevronsLeftRight } from 'lucide-react';
 import { type FC, memo } from 'react';
+import { iconSizes } from '../../../constants/sizes';
 import { Button } from '../../../ui/Button';
 import { Tag } from '../../../ui/Tag';
 import { SmallText } from '../../../ui/Typography';
@@ -42,7 +43,7 @@ const MergeControls: FC<{
       variant={decision?.choice === 'left' ? undefined : 'outline'}
       tone={decision?.choice === 'left' ? 'violet' : undefined}
       onClick={() => onDecision('left')}
-      leftIcon={<ChevronLeft className="h-3 w-3" />}
+      leftIcon={<ChevronLeft className={iconSizes.xs} />}
     >
       Left
     </Button>
@@ -51,7 +52,7 @@ const MergeControls: FC<{
       variant={decision?.choice === 'both' ? undefined : 'outline'}
       tone={decision?.choice === 'both' ? 'violet' : undefined}
       onClick={() => onDecision('both')}
-      leftIcon={<ChevronsLeftRight className="h-3 w-3" />}
+      leftIcon={<ChevronsLeftRight className={iconSizes.xs} />}
     >
       Both
     </Button>
@@ -60,7 +61,7 @@ const MergeControls: FC<{
       variant={decision?.choice === 'right' ? undefined : 'outline'}
       tone={decision?.choice === 'right' ? 'violet' : undefined}
       onClick={() => onDecision('right')}
-      leftIcon={<ChevronRight className="h-3 w-3" />}
+      leftIcon={<ChevronRight className={iconSizes.xs} />}
     >
       Right
     </Button>

--- a/ui/src/components/debug/ProtocolDebugLevels.tsx
+++ b/ui/src/components/debug/ProtocolDebugLevels.tsx
@@ -6,6 +6,7 @@ import type {
   ProtocolCategory,
   ProtocolDebugConfig,
 } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import {
   CATEGORY_ORDER,
   DEBUG_LEVELS,
@@ -232,7 +233,7 @@ export const ProtocolDebugLevels: FC = () => {
     return (
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="py-12 text-center">
-          <RefreshCw className="mx-auto h-8 w-8 animate-spin text-gray-400" />
+          <RefreshCw className={`mx-auto ${iconSizes['2xl']} animate-spin text-gray-400`} />
           <SmallText className="mt-3 text-gray-400">Loading protocol debug settings...</SmallText>
         </CardContent>
       </Card>
@@ -245,7 +246,7 @@ export const ProtocolDebugLevels: FC = () => {
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Settings2 className="h-6 w-6 text-violet-400" />
+            <Settings2 className={`${iconSizes.xl} text-violet-400`} />
             <H2 className="mb-0">Protocol Debug Levels</H2>
           </div>
 
@@ -267,7 +268,7 @@ export const ProtocolDebugLevels: FC = () => {
                   size="sm"
                   onClick={saveChanges}
                   disabled={saving}
-                  leftIcon={<Save className="h-4 w-4" />}
+                  leftIcon={<Save className={iconSizes.md} />}
                   aria-label="Save changes"
                 >
                   {saving ? 'Saving...' : 'Save Changes'}
@@ -279,7 +280,7 @@ export const ProtocolDebugLevels: FC = () => {
               size="sm"
               onClick={handleReset}
               disabled={saving}
-              leftIcon={<RotateCcw className="h-4 w-4" />}
+              leftIcon={<RotateCcw className={iconSizes.md} />}
               aria-label="Reset all protocols to defaults"
             >
               Reset All

--- a/ui/src/components/device-editor/AdditionalIPsSection.tsx
+++ b/ui/src/components/device-editor/AdditionalIPsSection.tsx
@@ -1,6 +1,7 @@
 import { Plus, X } from 'lucide-react';
 import type { FC } from 'react';
 import type { Device } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { SmallText } from '../../ui/Typography';
 import { CollapsibleSection } from '../form/CollapsibleSection';
@@ -57,7 +58,7 @@ export const AdditionalIPsSection: FC<AdditionalIPsSectionProps> = ({
         <Button
           variant="outline"
           size="sm"
-          leftIcon={<Plus className="h-4 w-4" />}
+          leftIcon={<Plus className={iconSizes.md} />}
           onClick={handleAddIp}
         >
           Add IP Address

--- a/ui/src/components/device-editor/DHCPSection.tsx
+++ b/ui/src/components/device-editor/DHCPSection.tsx
@@ -1,6 +1,7 @@
 import { Database, Plus, X } from 'lucide-react';
 import type { FC } from 'react';
 import type { DHCPConfig, DHCPLease } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { CollapsibleSection, FormField } from '../form';
 import type { ProtocolSectionProps } from './types';
@@ -108,7 +109,7 @@ export const DhcpSection: FC<ProtocolSectionProps> = ({
           {/* Static Leases */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Database className="h-4 w-4 text-violet-400" />
+              <Database className={`${iconSizes.md} text-violet-400`} />
               Static Leases
             </h4>
             {(device.dhcp.clientLeases || []).map((lease: DHCPLease, index: number) => (
@@ -162,7 +163,7 @@ export const DhcpSection: FC<ProtocolSectionProps> = ({
             <Button
               variant="outline"
               size="sm"
-              leftIcon={<Plus className="h-4 w-4" />}
+              leftIcon={<Plus className={iconSizes.md} />}
               onClick={() => {
                 const leases = [
                   ...(device.dhcp?.clientLeases || []),

--- a/ui/src/components/device-editor/DNSSection.tsx
+++ b/ui/src/components/device-editor/DNSSection.tsx
@@ -1,6 +1,7 @@
 import { Globe, Plus, X } from 'lucide-react';
 import type { FC } from 'react';
 import type { DNSConfig, DNSRecord } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { CollapsibleSection } from '../form';
 import type { ProtocolSectionProps } from './types';
@@ -41,7 +42,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
           {/* Forward Records (A records) */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Globe className="h-4 w-4 text-violet-400" />
+              <Globe className={`${iconSizes.md} text-violet-400`} />
               Forward Records (A Records)
             </h4>
             {(device.dns.forwardRecords || []).map((record: DNSRecord, index: number) => (
@@ -106,7 +107,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
             <Button
               variant="outline"
               size="sm"
-              leftIcon={<Plus className="h-4 w-4" />}
+              leftIcon={<Plus className={iconSizes.md} />}
               onClick={() => {
                 const records = [
                   ...(device.dns?.forwardRecords || []),
@@ -122,7 +123,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
           {/* Reverse Records (PTR records) */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Globe className="h-4 w-4 text-violet-400" />
+              <Globe className={`${iconSizes.md} text-violet-400`} />
               Reverse Records (PTR Records)
             </h4>
             {(device.dns.reverseRecords || []).map((record: DNSRecord, index: number) => (
@@ -173,7 +174,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
             <Button
               variant="outline"
               size="sm"
-              leftIcon={<Plus className="h-4 w-4" />}
+              leftIcon={<Plus className={iconSizes.md} />}
               onClick={() => {
                 const records = [
                   ...(device.dns?.reverseRecords || []),

--- a/ui/src/components/device-editor/DeleteConfirmModal.tsx
+++ b/ui/src/components/device-editor/DeleteConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from 'lucide-react';
 import type { FC } from 'react';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 
 export interface DeleteConfirmModalProps {
@@ -30,7 +31,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
       >
         <div className="p-6 space-y-4">
           <div className="flex items-center gap-3 text-red-400">
-            <Trash2 className="h-6 w-6" />
+            <Trash2 className={iconSizes.xl} />
             <h2 className="text-lg font-semibold">Delete Device</h2>
           </div>
           <p className="text-gray-300">

--- a/ui/src/components/device-editor/DeviceEditorHeader.tsx
+++ b/ui/src/components/device-editor/DeviceEditorHeader.tsx
@@ -2,6 +2,7 @@ import { AlertCircle, ArrowLeft, Check, RefreshCw, Save, Trash2 } from 'lucide-r
 import type { FC } from 'react';
 import type { Device, DeviceType } from '../../api/types';
 import { deviceTypeIcons } from '../../constants/device-types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { Tag } from '../../ui/Tag';
@@ -55,9 +56,9 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
               className="p-2 text-gray-400 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
               title="Back to device list"
             >
-              <ArrowLeft className="h-5 w-5" />
+              <ArrowLeft className={iconSizes.lg} />
             </button>
-            <DeviceIcon className="h-6 w-6 text-violet-300" />
+            <DeviceIcon className={`${iconSizes.xl} text-violet-300`} />
             <div>
               <H2 className="mb-0">
                 {isNewDevice ? 'New Device' : device.hostname || 'Edit Device'}
@@ -79,7 +80,7 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
             {!isNewDevice && (
               <Button
                 variant="outline"
-                leftIcon={<Trash2 className="h-4 w-4" />}
+                leftIcon={<Trash2 className={iconSizes.md} />}
                 onClick={onDelete}
                 className="text-red-400 hover:text-red-300 border-red-400/30 hover:border-red-400/50"
                 disabled={deleting}
@@ -94,9 +95,9 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
               tone="violet"
               leftIcon={
                 saving ? (
-                  <RefreshCw className="h-4 w-4 animate-spin" />
+                  <RefreshCw className={`${iconSizes.md} animate-spin`} />
                 ) : (
-                  <Save className="h-4 w-4" />
+                  <Save className={iconSizes.md} />
                 )
               }
               onClick={onSave}
@@ -118,9 +119,9 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
             role="alert"
           >
             {message.type === 'success' ? (
-              <Check className="h-4 w-4" />
+              <Check className={iconSizes.md} />
             ) : (
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className={iconSizes.md} />
             )}
             <span>{message.text}</span>
           </div>

--- a/ui/src/components/device-editor/FTPSection.tsx
+++ b/ui/src/components/device-editor/FTPSection.tsx
@@ -1,6 +1,7 @@
 import { Folder, Plus, X } from 'lucide-react';
 import type { FC } from 'react';
 import type { FTPConfig, FTPUser } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { CollapsibleSection, FormField } from '../form';
 import type { ProtocolSectionProps } from './types';
@@ -89,7 +90,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
           {/* FTP Users */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Folder className="h-4 w-4 text-violet-400" />
+              <Folder className={`${iconSizes.md} text-violet-400`} />
               FTP Users
             </h4>
             {(device.ftp.users || []).map((user: FTPUser, index: number) => (
@@ -154,7 +155,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
             <Button
               variant="outline"
               size="sm"
-              leftIcon={<Plus className="h-4 w-4" />}
+              leftIcon={<Plus className={iconSizes.md} />}
               onClick={() => {
                 const users = [
                   ...(device.ftp?.users || []),

--- a/ui/src/components/device-editor/HTTPSection.tsx
+++ b/ui/src/components/device-editor/HTTPSection.tsx
@@ -1,6 +1,7 @@
 import { FileText, Plus, X } from 'lucide-react';
 import type { FC } from 'react';
 import type { HTTPConfig, HTTPEndpoint } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { CollapsibleSection, FormField } from '../form';
 import type { ProtocolSectionProps } from './types';
@@ -50,7 +51,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
           {/* Endpoints */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <FileText className="h-4 w-4 text-violet-400" />
+              <FileText className={`${iconSizes.md} text-violet-400`} />
               Endpoints
             </h4>
             {(device.http.endpoints || []).map((endpoint: HTTPEndpoint, index: number) => (
@@ -153,7 +154,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
             <Button
               variant="outline"
               size="sm"
-              leftIcon={<Plus className="h-4 w-4" />}
+              leftIcon={<Plus className={iconSizes.md} />}
               onClick={() => {
                 const endpoints = [
                   ...(device.http?.endpoints || []),

--- a/ui/src/components/device-editor/NetBIOSSection.tsx
+++ b/ui/src/components/device-editor/NetBIOSSection.tsx
@@ -1,6 +1,7 @@
 import { Network } from 'lucide-react';
 import type { FC } from 'react';
 import type { NetBIOSConfig, NetBIOSService } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { CollapsibleSection, FormField } from '../form';
 import type { ProtocolSectionProps } from './types';
 import { inputClassName } from './types';
@@ -104,7 +105,7 @@ export const NetBiosSection: FC<ProtocolSectionProps> = ({
           {/* Services */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Network className="h-4 w-4 text-violet-400" />
+              <Network className={`${iconSizes.md} text-violet-400`} />
               NetBIOS Services
             </h4>
             <div className="flex flex-wrap gap-4">

--- a/ui/src/components/device-editor/TrafficSection.tsx
+++ b/ui/src/components/device-editor/TrafficSection.tsx
@@ -1,6 +1,7 @@
 import { Radio } from 'lucide-react';
 import type { FC } from 'react';
 import type { TrafficConfig } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { CollapsibleSection, FormField } from '../form';
 import type { ProtocolSectionProps } from './types';
 
@@ -50,7 +51,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
           <div className="rounded-lg border border-white/5 bg-gray-950/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="text-sm font-medium text-white flex items-center gap-2">
-                <Radio className="h-4 w-4 text-violet-400" />
+                <Radio className={`${iconSizes.md} text-violet-400`} />
                 ARP Announcements
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -102,7 +103,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
           <div className="rounded-lg border border-white/5 bg-gray-950/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="text-sm font-medium text-white flex items-center gap-2">
-                <Radio className="h-4 w-4 text-violet-400" />
+                <Radio className={`${iconSizes.md} text-violet-400`} />
                 Periodic Pings
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -177,7 +178,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
           <div className="rounded-lg border border-white/5 bg-gray-950/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="text-sm font-medium text-white flex items-center gap-2">
-                <Radio className="h-4 w-4 text-violet-400" />
+                <Radio className={`${iconSizes.md} text-violet-400`} />
                 Random Traffic
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">

--- a/ui/src/components/device-list/CloneDeviceModal.tsx
+++ b/ui/src/components/device-list/CloneDeviceModal.tsx
@@ -1,5 +1,6 @@
 import { Copy } from 'lucide-react';
 import { type FC, useState } from 'react';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 
 interface CloneDeviceModalProps {
@@ -33,7 +34,7 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
       >
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
           <div className="flex items-center gap-3 text-blue-400">
-            <Copy className="h-6 w-6" />
+            <Copy className={iconSizes.xl} />
             <h2 className="text-lg font-semibold">Clone Device</h2>
           </div>
           <p className="text-gray-300">

--- a/ui/src/components/device-list/DeviceListHeader.tsx
+++ b/ui/src/components/device-list/DeviceListHeader.tsx
@@ -2,6 +2,7 @@ import { Download, Plus, RefreshCw, Server } from 'lucide-react';
 import type { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Device } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { H2, P } from '../../ui/Typography';
 import { exportDevicesAsCSV, exportDevicesAsJSON } from '../../utils/export';
@@ -25,7 +26,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
     <div className="flex flex-wrap items-center justify-between gap-4">
       <div>
         <H2 className="mb-0 flex items-center gap-2">
-          <Server className="h-5 w-5 text-violet-300" />
+          <Server className={`${iconSizes.lg} text-violet-300`} />
           Device Configuration
         </H2>
         <P className="text-gray-400 mt-1">
@@ -38,7 +39,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
       <div className="flex gap-2">
         <Button
           variant="outline"
-          leftIcon={<RefreshCw className="h-4 w-4" />}
+          leftIcon={<RefreshCw className={iconSizes.md} />}
           onClick={onRefresh}
           disabled={loading}
         >
@@ -46,7 +47,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
         </Button>
         <Button
           variant="outline"
-          leftIcon={<Download className="h-4 w-4" />}
+          leftIcon={<Download className={iconSizes.md} />}
           onClick={() => exportDevicesAsJSON(filteredDevices)}
           disabled={filteredDevices.length === 0}
         >
@@ -54,7 +55,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
         </Button>
         <Button
           variant="outline"
-          leftIcon={<Download className="h-4 w-4" />}
+          leftIcon={<Download className={iconSizes.md} />}
           onClick={() => exportDevicesAsCSV(filteredDevices)}
           disabled={filteredDevices.length === 0}
         >
@@ -62,7 +63,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
         </Button>
         <Button
           tone="violet"
-          leftIcon={<Plus className="h-4 w-4" />}
+          leftIcon={<Plus className={iconSizes.md} />}
           onClick={() => navigate('/device-config/new')}
         >
           Add Device

--- a/ui/src/components/device-list/DeviceListStates.tsx
+++ b/ui/src/components/device-list/DeviceListStates.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, Plus, Search, Server } from 'lucide-react';
 import type { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { DeviceCardGridSkeleton, DeviceTableSkeleton } from '../../ui/Skeleton';
@@ -73,7 +74,7 @@ export const DeviceListEmptyState: FC = () => {
         <Button
           tone="violet"
           className="mt-4"
-          leftIcon={<Plus className="h-4 w-4" />}
+          leftIcon={<Plus className={iconSizes.md} />}
           onClick={() => navigate('/device-config/new')}
         >
           Add Device

--- a/ui/src/components/device-list/DeviceSearchFilters.tsx
+++ b/ui/src/components/device-list/DeviceSearchFilters.tsx
@@ -1,6 +1,7 @@
 import { Filter, LayoutGrid, LayoutList, Search, X } from 'lucide-react';
 import type { FC } from 'react';
 import type { DeviceType } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 
 interface DeviceSearchFiltersProps {
   searchQuery: string;
@@ -53,7 +54,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
 
       {/* Type filter */}
       <div className="flex items-center gap-2">
-        <Filter className="h-4 w-4 text-gray-400" />
+        <Filter className={`${iconSizes.md} text-gray-400`} />
         <select
           value={typeFilter}
           onChange={(e) => onTypeFilterChange(e.target.value as DeviceType | 'all')}
@@ -95,7 +96,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
           title="Table view"
           aria-label="Table view"
         >
-          <LayoutList className="h-4 w-4" />
+          <LayoutList className={iconSizes.md} />
         </button>
         <button
           type="button"
@@ -108,7 +109,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
           title="Card view"
           aria-label="Card view"
         >
-          <LayoutGrid className="h-4 w-4" />
+          <LayoutGrid className={iconSizes.md} />
         </button>
       </div>
     </div>

--- a/ui/src/components/device-list/DeviceStatusMessage.tsx
+++ b/ui/src/components/device-list/DeviceStatusMessage.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, X } from 'lucide-react';
 import type { FC } from 'react';
+import { iconSizes } from '../../constants/sizes';
 
 export interface StatusMessage {
   type: 'success' | 'error';
@@ -25,7 +26,7 @@ export const DeviceStatusMessage: FC<DeviceStatusMessageProps> = ({ message, onD
       }`}
       role="alert"
     >
-      {message.type === 'error' && <AlertCircle className="h-4 w-4" />}
+      {message.type === 'error' && <AlertCircle className={iconSizes.md} />}
       <span>{message.text}</span>
       <button
         type="button"

--- a/ui/src/components/form/CollapsibleSection.tsx
+++ b/ui/src/components/form/CollapsibleSection.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { FC, ReactNode } from 'react';
+import { iconSizes } from '../../constants/sizes';
 import { Card, CardContent } from '../../ui/Card';
 import { Tag } from '../../ui/Tag';
 
@@ -33,9 +34,9 @@ export const CollapsibleSection: FC<CollapsibleSectionProps> = ({
           className="flex items-center gap-3 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-violet-500 rounded-lg px-1 -ml-1"
         >
           {isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-gray-400" />
+            <ChevronDown className={`${iconSizes.md} text-gray-400`} />
           ) : (
-            <ChevronRight className="h-4 w-4 text-gray-400" />
+            <ChevronRight className={`${iconSizes.md} text-gray-400`} />
           )}
           <h3 className="font-semibold text-white">{title}</h3>
           {required && (

--- a/ui/src/components/form/FormField.tsx
+++ b/ui/src/components/form/FormField.tsx
@@ -1,5 +1,6 @@
 import { HelpCircle } from 'lucide-react';
 import type { FC, ReactNode } from 'react';
+import { iconSizes } from '../../constants/sizes';
 
 export interface FormFieldProps {
   label: string;
@@ -28,7 +29,7 @@ export const FormField: FC<FormFieldProps> = ({
         {required && <span className="text-red-400">*</span>}
         {helpText && (
           <span className="relative group">
-            <HelpCircle className="h-3.5 w-3.5 text-gray-500 cursor-help" />
+            <HelpCircle className={`${iconSizes.sm} text-gray-500 cursor-help`} />
             <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-gray-800 text-gray-200 text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
               {helpText}
             </span>
@@ -41,7 +42,7 @@ export const FormField: FC<FormFieldProps> = ({
         {required && <span className="text-red-400">*</span>}
         {helpText && (
           <span className="relative group">
-            <HelpCircle className="h-3.5 w-3.5 text-gray-500 cursor-help" />
+            <HelpCircle className={`${iconSizes.sm} text-gray-500 cursor-help`} />
             <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-gray-800 text-gray-200 text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
               {helpText}
             </span>

--- a/ui/src/components/pcap/PcapStats.tsx
+++ b/ui/src/components/pcap/PcapStats.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightLeft, BarChart3, Clock, FileText, Network, Server } from 'lucide-react';
 import { type FC, memo } from 'react';
 import type { PcapStats as PcapStatsType } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Card, CardContent } from '../../ui/Card';
 import { Tag } from '../../ui/Tag';
 import { H2, SmallText } from '../../ui/Typography';
@@ -119,7 +120,7 @@ const TopEndpoints: FC<{
       {/* Top Sources */}
       <div className="space-y-2">
         <div className="flex items-center gap-2 mb-3">
-          <Server className="h-4 w-4 text-blue-400" />
+          <Server className={`${iconSizes.md} text-blue-400`} />
           <SmallText className="text-gray-400 uppercase tracking-wide font-semibold">
             Top Sources
           </SmallText>
@@ -146,7 +147,7 @@ const TopEndpoints: FC<{
       {/* Top Destinations */}
       <div className="space-y-2">
         <div className="flex items-center gap-2 mb-3">
-          <Network className="h-4 w-4 text-green-400" />
+          <Network className={`${iconSizes.md} text-green-400`} />
           <SmallText className="text-gray-400 uppercase tracking-wide font-semibold">
             Top Destinations
           </SmallText>
@@ -189,7 +190,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
     return (
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="py-12 text-center">
-          <BarChart3 className="h-12 w-12 text-gray-600 mx-auto mb-4" />
+          <BarChart3 className={`${iconSizes['3xl']} text-gray-600 mx-auto mb-4`} />
           <p className="text-gray-400">No statistics available</p>
           <SmallText className="text-gray-500">
             Upload and analyze a PCAP file to see statistics
@@ -206,7 +207,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
         <Card className="border-white/5 bg-gray-900/70">
           <CardContent>
             <div className="flex items-center gap-3">
-              <FileText className="h-5 w-5 text-violet-400" />
+              <FileText className={`${iconSizes.lg} text-violet-400`} />
               <div>
                 <p className="font-medium text-white">{filename}</p>
                 {fileSize && (
@@ -222,29 +223,29 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="space-y-4">
           <H2 className="flex items-center gap-2 mb-0">
-            <BarChart3 className="h-5 w-5 text-cyan-300" />
+            <BarChart3 className={`${iconSizes.lg} text-cyan-300`} />
             Summary Statistics
           </H2>
 
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <StatBlock
-              icon={<ArrowRightLeft className="h-4 w-4 text-violet-400" />}
+              icon={<ArrowRightLeft className={`${iconSizes.md} text-violet-400`} />}
               label="Total Packets"
               value={stats.totalPackets.toLocaleString()}
             />
             <StatBlock
-              icon={<FileText className="h-4 w-4 text-blue-400" />}
+              icon={<FileText className={`${iconSizes.md} text-blue-400`} />}
               label="Total Bytes"
               value={formatBytes(stats.totalBytes)}
               helper={`${stats.totalBytes.toLocaleString()} bytes`}
             />
             <StatBlock
-              icon={<Clock className="h-4 w-4 text-green-400" />}
+              icon={<Clock className={`${iconSizes.md} text-green-400`} />}
               label="Duration"
               value={formatDurationMs(stats.timeRange.durationMs)}
             />
             <StatBlock
-              icon={<Network className="h-4 w-4 text-yellow-400" />}
+              icon={<Network className={`${iconSizes.md} text-yellow-400`} />}
               label="Protocols"
               value={Object.keys(stats.protocols).length}
               helper="Unique protocols"
@@ -257,7 +258,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
-            <Clock className="h-5 w-5 text-emerald-300" />
+            <Clock className={`${iconSizes.lg} text-emerald-300`} />
             <H2 className="mb-0">Time Range</H2>
           </div>
 
@@ -282,7 +283,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
-            <BarChart3 className="h-5 w-5 text-violet-300" />
+            <BarChart3 className={`${iconSizes.lg} text-violet-300`} />
             <H2 className="mb-0">Protocol Breakdown</H2>
           </div>
 
@@ -294,7 +295,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
-            <Network className="h-5 w-5 text-blue-300" />
+            <Network className={`${iconSizes.lg} text-blue-300`} />
             <H2 className="mb-0">Top Endpoints</H2>
           </div>
 

--- a/ui/src/components/pcap/PcapUploader.tsx
+++ b/ui/src/components/pcap/PcapUploader.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, CheckCircle, FileUp, Upload, X } from 'lucide-react';
 import { type FC, useCallback, useRef, useState } from 'react';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { Tag } from '../../ui/Tag';
@@ -172,7 +173,9 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
             <div
               className={`rounded-full p-4 ${isDragOver ? 'bg-violet-500/20' : 'bg-gray-800/50'}`}
             >
-              <Upload className={`h-8 w-8 ${isDragOver ? 'text-violet-400' : 'text-gray-400'}`} />
+              <Upload
+                className={`${iconSizes['2xl']} ${isDragOver ? 'text-violet-400' : 'text-gray-400'}`}
+              />
             </div>
 
             <div>
@@ -194,7 +197,7 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
         {selectedFile && (
           <div className="flex items-center justify-between rounded-lg border border-white/10 bg-gray-950/50 p-4">
             <div className="flex items-center gap-3">
-              <FileUp className="h-5 w-5 text-violet-400" />
+              <FileUp className={`${iconSizes.lg} text-violet-400`} />
               <div>
                 <p className="font-medium text-white">{selectedFile.name}</p>
                 <SmallText className="text-gray-400">{formatBytes(selectedFile.size)}</SmallText>
@@ -210,7 +213,7 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
                 size="sm"
                 onClick={handleClear}
                 disabled={isAnalyzing}
-                leftIcon={<X className="h-4 w-4" />}
+                leftIcon={<X className={iconSizes.md} />}
               >
                 Clear
               </Button>
@@ -221,14 +224,14 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
         {/* Status Messages */}
         {error && (
           <div className="flex items-center gap-2 rounded-lg border border-red-500/30 bg-red-900/20 p-3">
-            <AlertCircle className="h-5 w-5 flex-shrink-0 text-red-400" />
+            <AlertCircle className={`${iconSizes.lg} flex-shrink-0 text-red-400`} />
             <SmallText className="text-red-300">{error}</SmallText>
           </div>
         )}
 
         {success && (
           <div className="flex items-center gap-2 rounded-lg border border-green-500/30 bg-green-900/20 p-3">
-            <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-400" />
+            <CheckCircle className={`${iconSizes.lg} flex-shrink-0 text-green-400`} />
             <SmallText className="text-green-300">{success}</SmallText>
           </div>
         )}
@@ -244,7 +247,7 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
             isAnalyzing ? (
               <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
             ) : (
-              <FileUp className="h-5 w-5" />
+              <FileUp className={iconSizes.lg} />
             )
           }
         >

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -24,6 +24,7 @@ import {
   importConfig,
 } from '../../api/client';
 import type { Template, TemplateContent, UserConfig } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Tag } from '../../ui/Tag';
 import { SmallText } from '../../ui/Typography';
 import { TemplatePreviewModal } from '../TemplatePreviewModal';
@@ -335,7 +336,7 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
           }`}
           title="Pick a config from disk. YAML is used as-is; legacy Java-DSL (.cfg) is auto-converted."
         >
-          <FileUp className="h-3.5 w-3.5" />
+          <FileUp className={iconSizes.sm} />
           {convertingDsl ? 'Converting…' : uploadFile ? 'Replace local file' : 'Upload local file…'}
         </label>
         <input
@@ -381,13 +382,13 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
           <ViewToggle
             active={viewMode === 'grid'}
             onClick={() => updateViewMode('grid')}
-            icon={<LayoutGrid className="h-4 w-4" />}
+            icon={<LayoutGrid className={iconSizes.md} />}
             label="Card view"
           />
           <ViewToggle
             active={viewMode === 'list'}
             onClick={() => updateViewMode('list')}
-            icon={<List className="h-4 w-4" />}
+            icon={<List className={iconSizes.md} />}
             label="Compact list"
           />
         </fieldset>
@@ -411,8 +412,12 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
         onToggle={(e) => setShowJavaDsl(e.currentTarget.open)}
       >
         <summary className="flex cursor-pointer items-center gap-2 text-sm text-gray-300 hover:text-white">
-          {showJavaDsl ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-          <FileCode className="h-4 w-4" />
+          {showJavaDsl ? (
+            <ChevronDown className={iconSizes.md} />
+          ) : (
+            <ChevronRight className={iconSizes.md} />
+          )}
+          <FileCode className={iconSizes.md} />
           <span>
             Convert a legacy Java-DSL <code className="text-xs">.cfg</code> to YAML
           </span>
@@ -606,7 +611,7 @@ const ConfigCard: FC<{
     >
       <div className="flex items-start justify-between gap-2">
         <div className={`rounded-md border p-2 ${tint}`}>
-          <Icon className="h-5 w-5" />
+          <Icon className={iconSizes.lg} />
         </div>
         {sourceTagFor(item)}
       </div>
@@ -632,7 +637,7 @@ const ConfigCard: FC<{
       <div className="flex gap-2">
         {selected ? (
           <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-violet-500/30 px-2 py-1.5 text-xs font-medium text-violet-50 ring-1 ring-violet-400/60">
-            <Check className="h-3.5 w-3.5" />
+            <Check className={iconSizes.sm} />
             <span>Will use this</span>
           </div>
         ) : (
@@ -652,7 +657,7 @@ const ConfigCard: FC<{
             className="rounded border border-white/10 bg-gray-900/60 px-2 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
             title="Preview YAML"
           >
-            <Eye className="h-3.5 w-3.5" />
+            <Eye className={iconSizes.sm} />
           </button>
         )}
         {item.kind === 'local' && (
@@ -719,7 +724,7 @@ const ConfigRow: FC<{
         className="rounded p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
         title="Preview the template YAML"
       >
-        <Eye className="h-4 w-4" />
+        <Eye className={iconSizes.md} />
       </button>
     )}
     {item.kind === 'local' && (

--- a/ui/src/components/templates/JavaDslImportCard.tsx
+++ b/ui/src/components/templates/JavaDslImportCard.tsx
@@ -1,6 +1,7 @@
 import { FileInput } from 'lucide-react';
 import { type FC, useState } from 'react';
 import { importConfig } from '../../api/client';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { H2, P, SmallText } from '../../ui/Typography';
@@ -58,7 +59,7 @@ export const JavaDslImportCard: FC = () => {
     <Card className="border-white/5 bg-gray-900/70">
       <CardContent className="space-y-4">
         <H2 className="mb-0 flex items-center gap-2">
-          <FileInput className="h-5 w-5 text-emerald-300" />
+          <FileInput className={`${iconSizes.lg} text-emerald-300`} />
           Import legacy config (Java DSL → YAML)
         </H2>
         <P className="text-sm text-gray-400">

--- a/ui/src/pages/AnalysisPage.tsx
+++ b/ui/src/pages/AnalysisPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '../api/client';
 import type { ReplayRequest } from '../api/types';
 import { POLL_INTERVALS } from '../constants/polling';
+import { iconSizes } from '../constants/sizes';
 import { useApiResource } from '../hooks/useApiResource';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
@@ -43,7 +44,7 @@ export const AnalysisPage: FC = () => {
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="space-y-3">
           <H2 className="mb-0 flex items-center gap-2 text-lg">
-            <LineChart className="h-5 w-5 text-gray-400" />
+            <LineChart className={`${iconSizes.lg} text-gray-400`} />
             Recent runs
           </H2>
           <SmallText className="text-gray-400">Past simulation runs the daemon recorded.</SmallText>
@@ -154,7 +155,7 @@ const ReplayPanel: FC = () => {
     <Card className="border-white/5 bg-gray-900/70">
       <CardContent className="space-y-4">
         <H2 className="mb-0 flex items-center gap-2">
-          <PlugZap className="h-5 w-5 text-pink-300" />
+          <PlugZap className={`${iconSizes.lg} text-pink-300`} />
           Packet replay
         </H2>
         <P className="text-gray-300">

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -2,6 +2,7 @@ import { BellRing } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
 import { fetchAlerts, fetchStats, updateAlerts } from '../api/client';
 import type { AlertConfig } from '../api/types';
+import { iconSizes } from '../constants/sizes';
 import { useApiResource } from '../hooks/useApiResource';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
@@ -82,7 +83,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
     <Card className="border-white/5 bg-gray-900/70">
       <CardContent className="space-y-4">
         <H2 className="mb-0 flex items-center gap-2">
-          <BellRing className="h-5 w-5 text-orange-300" />
+          <BellRing className={`${iconSizes.lg} text-orange-300`} />
           Alert policy
         </H2>
         <P className="text-gray-300">

--- a/ui/src/pages/ConfigDiffPage.tsx
+++ b/ui/src/pages/ConfigDiffPage.tsx
@@ -9,6 +9,7 @@ import {
   type MergeDecision,
 } from '../components/config/DiffViewer';
 import { MergeControls, MergePreviewModal } from '../components/config/MergeControls';
+import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { Tag } from '../ui/Tag';
@@ -104,7 +105,7 @@ const FileUploadZone: FC<{
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
             <div className="rounded-lg bg-green-500/20 p-2">
-              <FileCode className="h-5 w-5 text-green-300" />
+              <FileCode className={`${iconSizes.lg} text-green-300`} />
             </div>
             <div>
               <p className="font-semibold text-white">{file.name}</p>
@@ -120,7 +121,7 @@ const FileUploadZone: FC<{
             className="rounded-lg p-1.5 text-gray-400 hover:bg-white/10 hover:text-white transition-colors disabled:opacity-50"
             aria-label={`Remove ${file.name}`}
           >
-            <X className="h-4 w-4" />
+            <X className={iconSizes.md} />
           </button>
         </div>
       </div>
@@ -146,13 +147,13 @@ const FileUploadZone: FC<{
           disabled={disabled}
           className="hidden"
         />
-        <Upload className="mx-auto h-8 w-8 text-gray-400 mb-2" />
+        <Upload className={`mx-auto ${iconSizes['2xl']} text-gray-400 mb-2`} />
         <p className="text-gray-300 font-medium">{label}</p>
         <SmallText className="text-gray-500">Drag & drop or click to select a YAML file</SmallText>
       </label>
       {error && (
         <div className="flex items-center gap-2 text-red-400 text-sm">
-          <AlertCircle className="h-4 w-4" />
+          <AlertCircle className={iconSizes.md} />
           {error}
         </div>
       )}
@@ -298,7 +299,7 @@ export const ConfigDiffPage: FC = () => {
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <H2 className="mb-0 flex items-center gap-2">
-                <GitCompare className="h-5 w-5 text-violet-300" />
+                <GitCompare className={`${iconSizes.lg} text-violet-300`} />
                 Config Diff & Merge
               </H2>
               <P className="text-gray-400 mt-1">
@@ -325,9 +326,9 @@ export const ConfigDiffPage: FC = () => {
               role="alert"
             >
               {message.type === 'success' ? (
-                <FileCheck className="h-4 w-4" />
+                <FileCheck className={iconSizes.md} />
               ) : (
-                <AlertCircle className="h-4 w-4" />
+                <AlertCircle className={iconSizes.md} />
               )}
               <span>{message.text}</span>
               <button
@@ -336,7 +337,7 @@ export const ConfigDiffPage: FC = () => {
                 className="ml-auto text-current hover:opacity-70"
                 aria-label="Dismiss message"
               >
-                <X className="h-4 w-4" />
+                <X className={iconSizes.md} />
               </button>
             </div>
           )}
@@ -396,7 +397,7 @@ export const ConfigDiffPage: FC = () => {
           <Card className="border-white/5 bg-gray-900/70">
             <CardContent className="space-y-4">
               <H2 className="mb-0 flex items-center gap-2">
-                <GitCompare className="h-5 w-5 text-cyan-300" />
+                <GitCompare className={`${iconSizes.lg} text-cyan-300`} />
                 Side-by-Side Comparison
               </H2>
               <DiffViewer
@@ -430,7 +431,7 @@ export const ConfigDiffPage: FC = () => {
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <H2 className="mb-1 flex items-center gap-2 text-lg">
-                    <Layers className="h-5 w-5 text-violet-300" />
+                    <Layers className={`${iconSizes.lg} text-violet-300`} />
                     Server-side overlay merge
                   </H2>
                   <P className="text-sm text-gray-400">
@@ -482,7 +483,7 @@ export const ConfigDiffPage: FC = () => {
       {!hasFiles && (
         <Card className="border-white/5 bg-gray-900/70">
           <CardContent className="py-12 text-center">
-            <GitCompare className="mx-auto h-12 w-12 text-gray-600" />
+            <GitCompare className={`mx-auto ${iconSizes['3xl']} text-gray-600`} />
             <H2 className="mt-4 mb-2">Ready to Compare</H2>
             <P className="text-gray-400 max-w-md mx-auto">
               Upload two YAML configuration files above to see a side-by-side comparison with

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -12,6 +12,7 @@ import { type FC, memo, useState } from 'react';
 import { fetchSimulationStatus } from '../api/client';
 import type { ErrorType, HistoryRecord } from '../api/types';
 import { POLL_INTERVALS } from '../constants/polling';
+import { iconSizes } from '../constants/sizes';
 import { useAppState } from '../contexts/AppContext';
 import { useApiResource } from '../hooks/useApiResource';
 import { Button } from '../ui/Button';
@@ -76,7 +77,9 @@ export const DashboardPage: FC = () => {
           <CardContent className="space-y-1">
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium text-gray-400">Devices Online</span>
-              <Server className="h-5 w-5 text-violet-400 group-hover:scale-110 transition-transform" />
+              <Server
+                className={`${iconSizes.lg} text-violet-400 group-hover:scale-110 transition-transform`}
+              />
             </div>
             <p className="text-3xl font-bold text-white">{stats?.deviceCount ?? '—'}</p>
             <p className="text-xs text-gray-500">Active network devices</p>
@@ -87,7 +90,9 @@ export const DashboardPage: FC = () => {
           <CardContent className="space-y-1">
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium text-gray-400">Packets RX</span>
-              <Activity className="h-5 w-5 text-emerald-400 group-hover:scale-110 transition-transform" />
+              <Activity
+                className={`${iconSizes.lg} text-emerald-400 group-hover:scale-110 transition-transform`}
+              />
             </div>
             <p className="text-3xl font-bold text-white">
               {stats ? formatNumber(stats.stack.packetsReceived) : '—'}
@@ -102,7 +107,9 @@ export const DashboardPage: FC = () => {
           <CardContent className="space-y-1">
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium text-gray-400">DNS Queries</span>
-              <SatelliteDish className="h-5 w-5 text-amber-400 group-hover:scale-110 transition-transform" />
+              <SatelliteDish
+                className={`${iconSizes.lg} text-amber-400 group-hover:scale-110 transition-transform`}
+              />
             </div>
             <p className="text-3xl font-bold text-white">
               {stats ? formatNumber(stats.stack.dnsQueries) : '—'}
@@ -120,7 +127,7 @@ export const DashboardPage: FC = () => {
         <Card className="lg:col-span-2">
           <CardContent className="space-y-4">
             <H2 className="mb-0 flex items-center gap-2">
-              <Zap className="h-5 w-5 text-violet-400" />
+              <Zap className={`${iconSizes.lg} text-violet-400`} />
               Quick Actions
             </H2>
             <div className="grid gap-3 sm:grid-cols-2">
@@ -130,7 +137,7 @@ export const DashboardPage: FC = () => {
                 className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group"
               >
                 <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-yellow-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                  <PlugZap className="h-5 w-5 text-yellow-400" />
+                  <PlugZap className={`${iconSizes.lg} text-yellow-400`} />
                 </div>
                 <div>
                   <p className="font-medium text-white">Error Injection</p>
@@ -141,7 +148,7 @@ export const DashboardPage: FC = () => {
               <AccentLink to="/debug" className="no-underline">
                 <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group">
                   <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-violet-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <Terminal className="h-5 w-5 text-violet-400" />
+                    <Terminal className={`${iconSizes.lg} text-violet-400`} />
                   </div>
                   <div>
                     <p className="font-medium text-white">Debug Console</p>
@@ -153,7 +160,7 @@ export const DashboardPage: FC = () => {
               <AccentLink to="/traffic" className="no-underline">
                 <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group">
                   <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-blue-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <Activity className="h-5 w-5 text-blue-400" />
+                    <Activity className={`${iconSizes.lg} text-blue-400`} />
                   </div>
                   <div>
                     <p className="font-medium text-white">Traffic Injection</p>
@@ -165,7 +172,7 @@ export const DashboardPage: FC = () => {
               <AccentLink to="/topology" className="no-underline">
                 <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group">
                   <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-emerald-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <Network className="h-5 w-5 text-emerald-400" />
+                    <Network className={`${iconSizes.lg} text-emerald-400`} />
                   </div>
                   <div>
                     <p className="font-medium text-white">View Topology</p>
@@ -211,7 +218,7 @@ export const DashboardPage: FC = () => {
               ))}
               {history?.length === 0 && (
                 <div className="text-center py-6 text-gray-500">
-                  <Activity className="h-8 w-8 mx-auto mb-2 opacity-50" />
+                  <Activity className={`${iconSizes['2xl']} mx-auto mb-2 opacity-50`} />
                   <p className="text-sm">No run history yet</p>
                 </div>
               )}
@@ -237,7 +244,7 @@ const ErrorInjectionPanel = memo(
   ({ errorTypes, info }: { errorTypes: ErrorType[]; info: string }) => (
     <div className="mt-4 rounded-xl border border-yellow-500/20 bg-yellow-900/10 p-4">
       <div className="mb-3 flex items-start gap-2">
-        <PlugZap className="mt-0.5 h-5 w-5 text-yellow-400" />
+        <PlugZap className={`mt-0.5 ${iconSizes.lg} text-yellow-400`} />
         <div>
           <p className="font-semibold text-yellow-200">Error Injection Types</p>
           <SmallText className="text-yellow-300/80">{info}</SmallText>
@@ -295,7 +302,7 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
       <CardContent className="space-y-4">
         <div className="flex items-center justify-between">
           <H2 className="mb-0 flex items-center gap-2">
-            <SatelliteDish className="h-5 w-5 text-violet-300" />
+            <SatelliteDish className={`${iconSizes.lg} text-violet-300`} />
             Automation timeline
           </H2>
           <Tag colorScheme="gray">Latest events</Tag>
@@ -315,7 +322,7 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
                 variant="ghost"
                 size="sm"
                 className="mt-2 sm:mt-0"
-                leftIcon={<Bot className="h-4 w-4" />}
+                leftIcon={<Bot className={iconSizes.md} />}
               >
                 View details
               </Button>

--- a/ui/src/pages/DebugConsolePage.tsx
+++ b/ui/src/pages/DebugConsolePage.tsx
@@ -4,6 +4,7 @@ import type { LogEntry, LogLevel, Protocol } from '../api/types';
 import { ProtocolDebugLevels } from '../components/debug/ProtocolDebugLevels';
 import { LogFilters } from '../components/LogFilters';
 import { LogViewer } from '../components/LogViewer';
+import { iconSizes } from '../constants/sizes';
 import { useLogStream } from '../hooks/useEventSource';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
@@ -177,12 +178,12 @@ export const DebugConsolePage: FC = () => {
                 variant="outline"
                 size="sm"
                 onClick={() => setShowDebugSettings(!showDebugSettings)}
-                leftIcon={<Settings2 className="h-4 w-4" />}
+                leftIcon={<Settings2 className={iconSizes.md} />}
                 rightIcon={
                   showDebugSettings ? (
-                    <ChevronUp className="h-4 w-4" />
+                    <ChevronUp className={iconSizes.md} />
                   ) : (
-                    <ChevronDown className="h-4 w-4" />
+                    <ChevronDown className={iconSizes.md} />
                   )
                 }
                 aria-expanded={showDebugSettings}

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -3,6 +3,7 @@ import { type ChangeEvent, type FC, memo, useEffect, useState } from 'react';
 import { fetchConfig, fetchDevices, fetchFiles, updateConfig } from '../api/client';
 import type { DeviceSummary, FileEntry } from '../api/types';
 import { POLL_INTERVALS } from '../constants/polling';
+import { iconSizes } from '../constants/sizes';
 import { useApiResource } from '../hooks/useApiResource';
 import { useVirtualScroll } from '../hooks/useVirtualScroll';
 import { BaseCard } from '../ui/BaseCard';
@@ -39,7 +40,7 @@ const DeviceListCard: FC = () => {
     <BaseCard<DeviceSummary[]>
       title="Config workspace"
       subtitle="Devices rendered from active YAML config"
-      icon={<Server className="h-5 w-5 text-cyan-300" />}
+      icon={<Server className={`${iconSizes.lg} text-cyan-300`} />}
       data={devices}
       loading={loading && !devices}
       error={error?.message}
@@ -220,7 +221,7 @@ const ConfigEditorCard: FC = () => {
     <BaseCard<{ content: string; path: string; modifiedAt: string; sizeBytes: number }>
       title="YAML editor"
       subtitle="Edit active configuration"
-      icon={<FileCog className="h-5 w-5 text-emerald-300" />}
+      icon={<FileCog className={`${iconSizes.lg} text-emerald-300`} />}
       data={data}
       loading={loading && !data}
       error={error?.message}

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -20,6 +20,7 @@ import { PacketDetails } from '../components/PacketDetails';
 import { type Packet, PacketList } from '../components/PacketList';
 import { StreamView } from '../components/StreamView';
 import { POLL_INTERVALS } from '../constants/polling';
+import { iconSizes } from '../constants/sizes';
 import { useApiResource } from '../hooks/useApiResource';
 import { useColoringRules } from '../hooks/useColoringRules';
 import { useDisplayFilter } from '../hooks/useDisplayFilter';
@@ -50,7 +51,7 @@ const ConnectionStatus: FC<{
   if (connected) {
     return (
       <div className="flex items-center gap-2">
-        <Wifi className="h-4 w-4 text-green-400" />
+        <Wifi className={`${iconSizes.md} text-green-400`} />
         <Tag colorScheme="green">Connected</Tag>
       </div>
     );
@@ -59,7 +60,7 @@ const ConnectionStatus: FC<{
   // SSE auto-reconnects, so disconnected state is brief
   return (
     <div className="flex items-center gap-2">
-      <WifiOff className="h-4 w-4 text-yellow-400 animate-pulse" />
+      <WifiOff className={`${iconSizes.md} text-yellow-400 animate-pulse`} />
       <Tag colorScheme="yellow">Connecting...</Tag>
     </div>
   );
@@ -241,7 +242,7 @@ export const PacketInspectorPage: FC = () => {
       <Card className="border-yellow-500/30 bg-yellow-900/20">
         <CardContent className="space-y-3">
           <div className="flex items-start gap-3">
-            <Activity className="mt-1 h-5 w-5 text-yellow-400" />
+            <Activity className={`mt-1 ${iconSizes.lg} text-yellow-400`} />
             <div className="flex-1">
               <p className="font-semibold text-yellow-200">No simulation running</p>
               <SmallText className="text-yellow-300/90">
@@ -281,7 +282,9 @@ export const PacketInspectorPage: FC = () => {
                 variant={isPaused ? 'outline' : 'ghost'}
                 size="sm"
                 onClick={handlePauseToggle}
-                leftIcon={isPaused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+                leftIcon={
+                  isPaused ? <Play className={iconSizes.md} /> : <Pause className={iconSizes.md} />
+                }
               >
                 {isPaused ? 'Resume' : 'Pause'}
               </Button>
@@ -290,7 +293,7 @@ export const PacketInspectorPage: FC = () => {
                 variant="ghost"
                 size="sm"
                 onClick={handleClear}
-                leftIcon={<Trash2 className="h-4 w-4" />}
+                leftIcon={<Trash2 className={iconSizes.md} />}
                 disabled={packets.length === 0}
               >
                 Clear
@@ -300,7 +303,7 @@ export const PacketInspectorPage: FC = () => {
                 variant="ghost"
                 size="sm"
                 onClick={handleExport}
-                leftIcon={<Download className="h-4 w-4" />}
+                leftIcon={<Download className={iconSizes.md} />}
                 disabled={packets.length === 0}
               >
                 Export
@@ -310,7 +313,7 @@ export const PacketInspectorPage: FC = () => {
                 variant="ghost"
                 size="sm"
                 onClick={() => setShowColoringRules(true)}
-                leftIcon={<Palette className="h-4 w-4" />}
+                leftIcon={<Palette className={iconSizes.md} />}
               >
                 Colors
               </Button>
@@ -319,7 +322,7 @@ export const PacketInspectorPage: FC = () => {
                 variant="ghost"
                 size="sm"
                 onClick={handleFollowStream}
-                leftIcon={<Share2 className="h-4 w-4" />}
+                leftIcon={<Share2 className={iconSizes.md} />}
                 disabled={!canFollowStream}
               >
                 Follow Stream

--- a/ui/src/pages/PcapAnalyzerPage.tsx
+++ b/ui/src/pages/PcapAnalyzerPage.tsx
@@ -12,6 +12,7 @@ import { PcapPacketList } from '../components/pcap/PcapPacketList';
 import { PcapStats } from '../components/pcap/PcapStats';
 import { PcapUploader } from '../components/pcap/PcapUploader';
 import { StreamView } from '../components/StreamView';
+import { iconSizes } from '../constants/sizes';
 import { useColoringRules } from '../hooks/useColoringRules';
 import { useDisplayFilter } from '../hooks/useDisplayFilter';
 import { Button } from '../ui/Button';
@@ -231,7 +232,7 @@ export const PcapAnalyzerPage: FC = () => {
                 {/* Title and file info */}
                 <div className="flex items-center gap-4">
                   <H2 className="mb-0 flex items-center gap-2">
-                    <FileSearch className="h-5 w-5 text-violet-400" />
+                    <FileSearch className={`${iconSizes.lg} text-violet-400`} />
                     PCAP Analysis
                   </H2>
                   <Tag colorScheme="green">{analysisResult.packets.length} packets</Tag>
@@ -280,7 +281,7 @@ export const PcapAnalyzerPage: FC = () => {
                     variant="ghost"
                     size="sm"
                     onClick={handleExport}
-                    leftIcon={<Download className="h-4 w-4" />}
+                    leftIcon={<Download className={iconSizes.md} />}
                   >
                     Export
                   </Button>
@@ -289,7 +290,7 @@ export const PcapAnalyzerPage: FC = () => {
                     variant="ghost"
                     size="sm"
                     onClick={() => setShowColoringRules(true)}
-                    leftIcon={<Palette className="h-4 w-4" />}
+                    leftIcon={<Palette className={iconSizes.md} />}
                   >
                     Colors
                   </Button>
@@ -298,7 +299,7 @@ export const PcapAnalyzerPage: FC = () => {
                     variant="ghost"
                     size="sm"
                     onClick={handleFollowStream}
-                    leftIcon={<Share2 className="h-4 w-4" />}
+                    leftIcon={<Share2 className={iconSizes.md} />}
                     disabled={!canFollowStream}
                   >
                     Follow Stream
@@ -308,7 +309,7 @@ export const PcapAnalyzerPage: FC = () => {
                     variant="ghost"
                     size="sm"
                     onClick={handleClear}
-                    leftIcon={<Trash2 className="h-4 w-4" />}
+                    leftIcon={<Trash2 className={iconSizes.md} />}
                   >
                     Clear
                   </Button>
@@ -400,7 +401,7 @@ export const PcapAnalyzerPage: FC = () => {
         <Card className="border-white/5 bg-gray-900/70">
           <CardContent>
             <div className="flex items-start gap-3">
-              <Info className="h-5 w-5 text-blue-400 flex-shrink-0 mt-0.5" />
+              <Info className={`${iconSizes.lg} text-blue-400 flex-shrink-0 mt-0.5`} />
               <div>
                 <p className="font-medium text-white">About PCAP Analyzer</p>
                 <SmallText className="text-gray-400">

--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -16,6 +16,7 @@ import type { DebugLevel, NetworkInterface, Template, UserConfig } from '../api/
 import { StatBlock } from '../components/StatBlock';
 import { ConfigPicker } from '../components/simulation/ConfigPicker';
 import { POLL_INTERVALS } from '../constants/polling';
+import { iconSizes } from '../constants/sizes';
 import { useApiResource } from '../hooks/useApiResource';
 import { useUIStore } from '../stores/ui-store';
 import { Button } from '../ui/Button';
@@ -218,7 +219,7 @@ export const RuntimeControlPage: FC = () => {
         <Card className="border-yellow-500/30 bg-yellow-900/20">
           <CardContent className="space-y-3">
             <div className="flex items-start gap-3">
-              <BellRing className="mt-1 h-5 w-5 text-yellow-400" />
+              <BellRing className={`mt-1 ${iconSizes.lg} text-yellow-400`} />
               <div>
                 <p className="font-semibold text-yellow-200">Daemon Mode Not Detected</p>
                 <SmallText className="text-yellow-300/90">
@@ -242,7 +243,7 @@ export const RuntimeControlPage: FC = () => {
                 immediately next to it so the action is obvious. */}
             <div className="flex flex-wrap items-end gap-3">
               <div className="flex items-center gap-3">
-                <PlugZap className="h-6 w-6 text-violet-400" />
+                <PlugZap className={`${iconSizes.xl} text-violet-400`} />
                 <H2 className="mb-0">Start Simulation</H2>
               </div>
               <div className="ml-auto flex flex-wrap items-end gap-3">
@@ -251,7 +252,9 @@ export const RuntimeControlPage: FC = () => {
                     Network interface
                   </label>
                   <div className="relative">
-                    <Network className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                    <Network
+                      className={`absolute left-3 top-1/2 -translate-y-1/2 ${iconSizes.md} text-gray-500`}
+                    />
                     <select
                       id="rc-interface"
                       value={simulationSettings.selectedInterface}
@@ -281,7 +284,7 @@ export const RuntimeControlPage: FC = () => {
                   size="lg"
                   disabled={!hasValidConfig || starting}
                   onClick={handleStart}
-                  leftIcon={<Activity className="h-5 w-5" />}
+                  leftIcon={<Activity className={iconSizes.lg} />}
                   // Pulse the button when everything's picked so it's the obvious next click.
                   className={
                     hasValidConfig && !starting
@@ -448,20 +451,20 @@ const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
             variant="outline"
             disabled={stopping}
             onClick={onStop}
-            leftIcon={<Activity className="h-4 w-4" />}
+            leftIcon={<Activity className={iconSizes.md} />}
           >
             {stopping ? 'Stopping…' : 'Stop Simulation'}
           </Button>
           <Button
             variant="ghost"
-            leftIcon={<FileCog className="h-4 w-4" />}
+            leftIcon={<FileCog className={iconSizes.md} />}
             onClick={() => navigate('/devices')}
           >
             View Devices
           </Button>
           <Button
             variant="ghost"
-            leftIcon={<Download className="h-4 w-4" />}
+            leftIcon={<Download className={iconSizes.md} />}
             onClick={handleDownload}
             title="Download the running config as YAML (the equivalent of niac config dump)."
           >
@@ -538,7 +541,7 @@ const GlobalDebugLevelCard: FC = () => {
     <Card className="border-white/5 bg-gray-900/70">
       <CardContent className="space-y-3">
         <H2 className="mb-0 flex items-center gap-2 text-lg">
-          <Activity className="h-5 w-5 text-violet-300" />
+          <Activity className={`${iconSizes.lg} text-violet-300`} />
           Debug level
         </H2>
         <SmallText className="text-gray-400">

--- a/ui/src/pages/templates/TemplateStates.tsx
+++ b/ui/src/pages/templates/TemplateStates.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, FileCode, Search, Upload } from 'lucide-react';
 import type { FC } from 'react';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { H2, P, SmallText } from '../../ui/Typography';
@@ -17,7 +18,9 @@ export const TemplatesLoadingState: FC<LoadingStateProps> = ({ show }) => {
     <Card className="border-white/5 bg-gray-900/70">
       <CardContent className="flex items-center justify-center py-12">
         <div className="flex items-center gap-3 text-gray-400">
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-violet-500 border-t-transparent" />
+          <div
+            className={`${iconSizes.lg} animate-spin rounded-full border-2 border-violet-500 border-t-transparent`}
+          />
           <span>Loading templates...</span>
         </div>
       </CardContent>
@@ -39,7 +42,7 @@ export const TemplatesErrorState: FC<ErrorStateProps> = ({ error, onRetry }) => 
     <Card className="border-red-500/30 bg-red-900/20">
       <CardContent className="space-y-3">
         <div className="flex items-start gap-3">
-          <AlertCircle className="mt-1 h-5 w-5 text-red-400" />
+          <AlertCircle className={`mt-1 ${iconSizes.lg} text-red-400`} />
           <div>
             <p className="font-semibold text-red-200">Failed to Load Templates</p>
             <SmallText className="text-red-300/90">{error.message}</SmallText>
@@ -66,13 +69,13 @@ export const TemplatesEmptyState: FC<EmptyStateProps> = ({ show, onUploadClick }
   return (
     <Card className="border-white/5 bg-gray-900/70">
       <CardContent className="py-12 text-center">
-        <FileCode className="mx-auto h-12 w-12 text-gray-600" />
+        <FileCode className={`mx-auto ${iconSizes['3xl']} text-gray-600`} />
         <H2 className="mt-4 mb-2">No Templates Available</H2>
         <P className="text-gray-400">Upload your first configuration template to get started.</P>
         <Button
           tone="violet"
           className="mt-4"
-          leftIcon={<Upload className="h-4 w-4" />}
+          leftIcon={<Upload className={iconSizes.md} />}
           onClick={onUploadClick}
         >
           Upload Template
@@ -100,7 +103,7 @@ export const TemplatesNoResultsState: FC<NoResultsStateProps> = ({
   return (
     <Card className="border-white/5 bg-gray-900/70">
       <CardContent className="py-12 text-center">
-        <Search className="mx-auto h-12 w-12 text-gray-600" />
+        <Search className={`mx-auto ${iconSizes['3xl']} text-gray-600`} />
         <H2 className="mt-4 mb-2">No Matching Templates</H2>
         <P className="text-gray-400">
           No templates match your search &quot;{searchQuery}&quot;. Try a different search term.

--- a/ui/src/pages/templates/TemplatesHeader.tsx
+++ b/ui/src/pages/templates/TemplatesHeader.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, FileCode, Search, Upload, X } from 'lucide-react';
 import type { FC } from 'react';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { H2, P } from '../../ui/Typography';
@@ -26,21 +27,27 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
             <H2 className="mb-0 flex items-center gap-2">
-              <FileCode className="h-5 w-5 text-violet-300" />
+              <FileCode className={`${iconSizes.lg} text-violet-300`} />
               Configuration Templates
             </H2>
             <P className="text-gray-400 mt-1">
               Browse and use pre-configured network templates to quickly start simulations.
             </P>
           </div>
-          <Button tone="violet" leftIcon={<Upload className="h-4 w-4" />} onClick={onUploadClick}>
+          <Button
+            tone="violet"
+            leftIcon={<Upload className={iconSizes.md} />}
+            onClick={onUploadClick}
+          >
             Upload Template
           </Button>
         </div>
 
         {/* Search bar */}
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <Search
+            className={`absolute left-3 top-1/2 ${iconSizes.lg} -translate-y-1/2 text-gray-400`}
+          />
           <input
             type="text"
             placeholder="Search templates by name, description, or type..."
@@ -55,7 +62,7 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
               aria-label="Clear search"
             >
-              <X className="h-4 w-4" />
+              <X className={iconSizes.md} />
             </button>
           )}
         </div>
@@ -70,7 +77,7 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
             }`}
             role="alert"
           >
-            {message.type === 'error' && <AlertCircle className="h-4 w-4" />}
+            {message.type === 'error' && <AlertCircle className={iconSizes.md} />}
             <span>{message.text}</span>
             <button
               type="button"
@@ -78,7 +85,7 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
               className="ml-auto text-current hover:opacity-70"
               aria-label="Dismiss message"
             >
-              <X className="h-4 w-4" />
+              <X className={iconSizes.md} />
             </button>
           </div>
         )}

--- a/ui/src/pages/templates/UploadTemplateModal.tsx
+++ b/ui/src/pages/templates/UploadTemplateModal.tsx
@@ -2,6 +2,7 @@ import { Upload, X } from 'lucide-react';
 import { type FC, useState } from 'react';
 import { uploadTemplate } from '../../api/client';
 import type { Template } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { SmallText } from '../../ui/Typography';
 
@@ -100,7 +101,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
         <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
           <div className="flex items-center gap-3">
             <div className="rounded-lg bg-violet-500/20 p-2">
-              <Upload className="h-5 w-5 text-violet-300" />
+              <Upload className={`${iconSizes.lg} text-violet-300`} />
             </div>
             <div>
               <h2 id="upload-modal-title" className="text-lg font-semibold text-white">
@@ -115,7 +116,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
             className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
             aria-label="Close modal"
           >
-            <X className="h-5 w-5" />
+            <X className={iconSizes.lg} />
           </button>
         </div>
 

--- a/ui/src/ui/Layout.tsx
+++ b/ui/src/ui/Layout.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { iconSizes } from '../constants/sizes';
 
 export interface NavItem {
   path: string;
@@ -160,7 +161,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
           className="flex-shrink-0 p-1.5 rounded-lg bg-gray-800/80 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
           aria-label="Scroll left"
         >
-          <ChevronLeft className="h-4 w-4" />
+          <ChevronLeft className={iconSizes.md} />
         </button>
       )}
 
@@ -210,7 +211,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
           className="flex-shrink-0 p-1.5 rounded-lg bg-gray-800/80 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
           aria-label="Scroll right"
         >
-          <ChevronRight className="h-4 w-4" />
+          <ChevronRight className={iconSizes.md} />
         </button>
       )}
 
@@ -276,7 +277,7 @@ export const PageHeader: FC<PageHeaderProps> = ({
               title={`What is ${title}?`}
               className="rounded-full p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
             >
-              <HelpCircle className="h-5 w-5" />
+              <HelpCircle className={iconSizes.lg} />
             </button>
           )}
         </div>
@@ -413,7 +414,7 @@ export const Breadcrumb: FC<BreadcrumbProps> = ({ items, className = '' }) => (
   <nav className={`flex items-center gap-1 text-sm ${className}`} aria-label="Breadcrumb">
     {items.map((item, index) => (
       <div key={item.label} className="flex items-center gap-1">
-        {index > 0 && <ChevronRight className="h-4 w-4 text-gray-600" />}
+        {index > 0 && <ChevronRight className={`${iconSizes.md} text-gray-600`} />}
         {item.href ? (
           <Link to={item.href} className="text-gray-400 hover:text-white transition-colors">
             {item.label}


### PR DESCRIPTION
## Summary
Follow-up to #520 that finishes migrating the UI off raw \`h-N w-N\` Tailwind classes onto the \`iconSizes\` token map. Two commits:

1. **pages/* sweep** — 12 page files
2. **components/* sweep** — 33 component files including device editor, modal chrome variants, debug, pcap, form, config, and the new ConfigPicker

After this PR, **no raw \`h-N w-N\` remains on lucide icons anywhere in \`ui/src\`**. Status dots, spinner divs, and other non-icon size uses stay as raw classes since they aren't sized like icons.

## Why
The convention planted by #520 only covered base chrome (sidebar, breadcrumbs, modal primitives, device list). Per-page and per-component icons were still hardcoded, so adding a new page meant guessing the size scale. With everything on \`iconSizes.{xs|sm|md|lg|xl|2xl|3xl}\`, new code naturally picks the right scale.

## Scope
Files touched: 45 across \`ui/src/pages/\` and \`ui/src/components/\`. No visual changes — every replacement preserves the original Tailwind class (e.g. \`h-4 w-4\` → \`iconSizes.md\` → \`h-4 w-4\` at runtime).

## Test plan
- [x] \`npm run lint\` (biome) clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — all 65 tests pass
- [ ] Local UI smoke test