### PR TITLE
fix(api,ui): pass template_name through sim start so walk-file include_path resolves

### DIFF
--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -57,6 +57,10 @@ func (s *Server) handleSimulationStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.daemon.StartSimulation(req); err != nil {
+		// SECURITY: Don't leak internal error details to the client, but
+		// log them server-side so the daemon log can be used to diagnose
+		// why a start failed (config parse, capture engine, walk file…).
+		s.logger.Error("[API] Failed to start simulation", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "simulation_start_failed",
 			"Failed to start simulation", nil)
 		return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -178,6 +178,14 @@ type SimulationRequest struct {
 	Interface  string `json:"interface"`
 	ConfigPath string `json:"config_path,omitempty"`
 	ConfigData string `json:"config_data,omitempty"`
+	// TemplateName, when set, tells the daemon to load a built-in
+	// template directly from disk by name. This preserves the template's
+	// own directory as the include_path base, which matters for templates
+	// like vendors/paloalto-firewall.yaml that reference walk files via
+	// `include_path: ".."` plus a relative `walk_file:` path. Fetching the
+	// template content and POSTing it as ConfigData would lose that
+	// directory context and trip the walk-file path-traversal guard.
+	TemplateName string `json:"template_name,omitempty"`
 }
 
 // SimulationStatus represents the current simulation status.

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -422,6 +422,16 @@ func (s *Server) handleTemplateContent(w http.ResponseWriter, r *http.Request, n
 	s.writeJSON(w, response)
 }
 
+// FindTemplateOnDisk searches for a template by name in all template
+// directories and returns the absolute path, or empty string if not
+// found. Exposed for callers like the daemon's StartSimulation that
+// need to load a template directly off disk (so include_path resolves
+// against the template's source directory rather than the wherever
+// inline data happens to be persisted).
+func FindTemplateOnDisk(name string) string {
+	return findTemplateRecursive(name)
+}
+
 // findTemplateRecursive searches for a template by name in all template directories.
 func findTemplateRecursive(name string) string {
 	for _, dir := range getTemplateDirs() {

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,11 +20,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-BZFh-aIk.js"></script>
+    <script type="module" crossorigin src="/assets/index-DeN2_m22.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-BoJ-pB7h.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-DtDwoORA.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-uzW8H4LC.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BtchU08s.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-CNjH12JY.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-codemirror-BjllbsfA.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-B6jpQMrx.css">
   </head>
   <body>
     <div id="root"></div>

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -426,10 +426,10 @@ func validateSimulationStartRequest(req SimulationRequest) []ErrorDetail {
 	if req.Interface == "" {
 		errs = append(errs, ErrorDetail{Field: "interface", Issue: "interface is required"})
 	}
-	if req.ConfigPath == "" && req.ConfigData == "" {
+	if req.ConfigPath == "" && req.ConfigData == "" && req.TemplateName == "" {
 		errs = append(errs, ErrorDetail{
 			Field: "config",
-			Issue: "either config_path or config_data must be provided",
+			Issue: "either config_path, config_data, or template_name must be provided",
 		})
 	}
 	return errs

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -24,8 +24,9 @@ import (
 var (
 	ErrInterfaceNotExist        = errors.New("interface does not exist")
 	ErrConfigDataExceedsMaxSize = errors.New("config data exceeds maximum size")
-	ErrConfigPathOrDataRequired = errors.New("either config_path or config_data must be provided")
+	ErrConfigPathOrDataRequired = errors.New("either config_path, config_data, or template_name must be provided")
 	ErrNoSimulationRunning      = errors.New("no simulation running")
+	ErrTemplateNotFound         = errors.New("template not found")
 )
 
 const (
@@ -174,6 +175,22 @@ const maxSimulationConfigSize = 10 * 1024 * 1024 // 10MB limit
 // did a file Stat on the literal string "<inline>".
 func loadSimulationConfig(req api.SimulationRequest) (*config.Config, string, error) {
 	switch {
+	case req.TemplateName != "":
+		// Loading templates by name preserves the template's own
+		// directory as the include_path base — needed for vendor
+		// templates with `include_path: ".."` plus relative walk_file
+		// refs that resolve to sibling directories (e.g. examples/
+		// device_walks_sanitized/...). Fetching the YAML text and
+		// POSTing it as ConfigData would lose that context.
+		templatePath := api.FindTemplateOnDisk(req.TemplateName)
+		if templatePath == "" {
+			return nil, "", fmt.Errorf("%w: %s", ErrTemplateNotFound, req.TemplateName)
+		}
+		cfg, err := config.Load(templatePath)
+		if err != nil {
+			return nil, "", fmt.Errorf("load template %q: %w", req.TemplateName, err)
+		}
+		return cfg, templatePath, nil
 	case req.ConfigData != "":
 		if len(req.ConfigData) > maxSimulationConfigSize {
 			return nil, "", fmt.Errorf(

--- a/internal/daemon/daemon_coverage_test.go
+++ b/internal/daemon/daemon_coverage_test.go
@@ -549,7 +549,7 @@ func TestSentinelErrors(t *testing.T) {
 	}{
 		{ErrInterfaceNotExist, "interface does not exist"},
 		{ErrConfigDataExceedsMaxSize, "config data exceeds maximum size"},
-		{ErrConfigPathOrDataRequired, "either config_path or config_data must be provided"},
+		{ErrConfigPathOrDataRequired, "either config_path, config_data, or template_name must be provided"},
 		{ErrNoSimulationRunning, "no simulation running"},
 	}
 

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -203,4 +203,11 @@ export interface SimulationRequest {
   interface: string;
   configPath?: string;
   configData?: string;
+  /**
+   * Built-in template to load directly from disk. Mutually exclusive
+   * with configPath / configData. Lets the daemon resolve relative
+   * include_path / walk_file references against the template's own
+   * source directory rather than the inline-config cache.
+   */
+  templateName?: string;
 }

--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -5,7 +5,6 @@ import {
   fetchConfig,
   fetchProtocolDebugLevels,
   fetchSimulationStatus,
-  fetchTemplateContent,
   fetchUsableInterfaces,
   fetchUserConfigContent,
   startSimulation,
@@ -150,16 +149,21 @@ export const RuntimeControlPage: FC = () => {
     try {
       let configData: string | undefined;
       let configPath: string | undefined;
+      let templateName: string | undefined;
 
       // Handle quick upload file
       if (quickUploadFile) {
         configData = await fileToText(quickUploadFile);
       }
-      // Handle template - need to apply it first to get a config path
+      // Handle template — pass the template name so the daemon loads
+      // the YAML directly from disk. This preserves the template's own
+      // directory as the include_path base, which matters for vendor
+      // templates that reference walk files via relative paths.
+      // Fetching the content and sending it inline used to trip the
+      // walk-file path-traversal guard for templates like
+      // vendors/paloalto-firewall.yaml.
       else if (simulationSettings.configSource === 'template') {
-        // Fetch template content and send as configData
-        const templateContent = await fetchTemplateContent(simulationSettings.configName);
-        configData = templateContent.content;
+        templateName = simulationSettings.configName;
       }
       // Handle user config - use the stored path
       else if (simulationSettings.configSource === 'userConfig') {
@@ -176,6 +180,7 @@ export const RuntimeControlPage: FC = () => {
         interface: simulationSettings.selectedInterface,
         configPath: configPath,
         configData: configData,
+        templateName: templateName,
       });
 
       setMessage({ tone: 'success', text: 'Simulation started successfully!' });


### PR DESCRIPTION
## Summary
Sims started failing on built-in vendor templates (e.g. \`paloalto-firewall\`) after the consolidation work landed.  Symptom: a generic 500 \`simulation_start_failed\`.  Root cause: the UI fetched template YAML and POSTed it as inline \`config_data\`, so \`config.LoadYAMLBytes\` ran with \`configDir=""\`. Templates like \`vendors/paloalto-firewall.yaml\` use \`include_path: ".."\` + a relative \`walk_file:\` — when resolved against an empty configDir, the joined path retains \`..\` and trips the walk-file path-traversal guard.

## Fix
- Add \`template_name\` field to \`SimulationRequest\`.
- When set, the daemon resolves the template via \`api.FindTemplateOnDisk(name)\` (same scan order as \`/api/v1/templates\`) and loads it with \`config.Load(path)\`, so the template's source directory becomes the include_path base.
- UI: when the user picks a built-in template, send \`template_name\` instead of fetching+inlining content.
- Bonus: add server-side error logging on sim-start failures so future cases don't surface as opaque 500s.

## Verified
\`\`\`
$ curl -X POST /api/v1/simulation -d '{"interface":"lo0","template_name":"paloalto-firewall"}'
{"running":true,"interface":"lo0","config_path":"examples/vendors/paloalto-firewall.yaml", ...}
\`\`\`

## Test plan
- [x] Backend builds; biome / tsc / vitest pass.
- [x] curl reproduction with \`paloalto-firewall\` now returns 201.
- [ ] In the browser: pick \`paloalto-firewall\` → Start → simulation shows running.