### PR TITLE
refactor(api): split sse.go by concern + enable log tee with reentrancy guard

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -167,14 +167,13 @@ func (s *Server) startBackgroundTasks() {
 	go s.sseHub.Run()
 	s.logger.Info("[SSE] Server-Sent Events hub started")
 
-	// Log tee into the SSE hub is intentionally deferred. Wiring
-	// slog.SetDefault(NewSSELogHandler(...)) here caused the hub's
-	// Run loop to deadlock on certain code paths because the hub's
-	// own slog calls (registerClient logs "Client connected") fed
-	// back into the tee → Broadcast → log → tee → … The fix needs a
-	// reentrancy guard or an explicit "internal" channel that bypasses
-	// the SSE pipeline. Tracked separately. For now the Protocol Debug
-	// Console page will only show the device-CRUD log line until that
-	// lands; the rest of the stack's slog calls don't reach the UI.
-	_ = NewSSELogHandler
+	// Tee slog into the SSE hub so the Protocol Debug Console gets
+	// real-time daemon logs. Idempotent: the first call installs a
+	// single global wrapper around the then-current slog.Default; later
+	// calls (e.g. a second daemon in tests, hot reload) just rotate the
+	// active hub via an atomic pointer. That avoids the handler-chain-
+	// growth deadlock from the old SetDefault-on-every-Start design.
+	// The wrapper filters out "[SSE]"-prefixed records so the hub's
+	// own log lines don't recurse.
+	InstallSSELogTee(s.sseHub)
 }

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -1,26 +1,31 @@
 package api
 
-// SSE endpoints:
-//   - /api/v1/stream/packets - Real-time packet stream
-//   - /api/v1/stream/logs - Real-time log stream
-//   - /api/v1/stream/stats - Real-time statistics
+// SSE subsystem layout (split across files in this package so each
+// piece stays well under the project's file-size budget):
 //
-// SSE is simpler than WebSocket for server-to-client streaming:
-//   - Automatic reconnection built into browser EventSource API
+//	sse.go                  — types, constants, SSEConfig (this file)
+//	sse_hub.go              — SSEHub: lifecycle + broadcast API
+//	sse_serve.go            — HTTP serving + per-connection event pump
+//	sse_rate_limiter.go     — per-stream token bucket
+//	sse_packet_observer.go  — protocols.PacketObserver → hub bridge
+//	sse_log_handler.go      — slog.Handler tee (deferred; reentrancy)
+//
+// SSE endpoints (registered in routes.go):
+//
+//	/api/v1/stream/packets — real-time packet stream
+//	/api/v1/stream/logs    — real-time log stream
+//	/api/v1/stream/stats   — real-time statistics
+//	/api/v1/stream/status  — hub status JSON
+//
+// SSE was chosen over WebSocket because:
+//   - Auto-reconnect is built into the browser EventSource API
 //   - Works well with HTTP/2 multiplexing
-//   - Better proxy/CDN compatibility
-//   - Unidirectional (server → client) which is all we need
+//   - Better proxy / CDN compatibility
+//   - Unidirectional (server → client), which is all we need
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"log/slog"
-	"net/http"
 	"sync"
 	"sync/atomic"
-	"time"
 )
 
 const (
@@ -62,7 +67,8 @@ func (c SSEConfig) withDefaults() SSEConfig {
 	return c
 }
 
-// SSEStream represents a stream type.
+// SSEStream identifies a logical SSE stream. Clients connect to one
+// stream at a time; producers Broadcast() to one stream at a time.
 type SSEStream string
 
 const (
@@ -71,14 +77,18 @@ const (
 	SSEStreamStats   SSEStream = "stats"
 )
 
-// SSEMessage represents a message to be sent via SSE.
+// SSEMessage is the envelope shape used by the hub broadcast API.
+// Only Data is required; Event and ID round out the standard SSE
+// fields when callers want explicit named events or replay IDs.
 type SSEMessage struct {
 	Event string `json:"event,omitempty"` // Optional event type
 	Data  any    `json:"data"`
 	ID    string `json:"id,omitempty"` // Optional event ID for Last-Event-ID
 }
 
-// SSEClient represents a connected SSE client.
+// SSEClient is a single connected client's hub-side handle. The hub
+// owns the send channel; HTTP handlers write to it and read from it
+// via the per-connection sseStreamContext (see sse_serve.go).
 type SSEClient struct {
 	hub      *SSEHub
 	send     chan []byte
@@ -87,7 +97,8 @@ type SSEClient struct {
 	clientIP string
 }
 
-// SSEHub manages SSE clients and message broadcasting.
+// SSEHub manages SSE clients and message broadcasting. Methods live
+// in sse_hub.go; see the package overview at the top of this file.
 type SSEHub struct {
 	clients      map[SSEStream]map[*SSEClient]bool
 	broadcast    chan *streamMessage
@@ -102,462 +113,9 @@ type SSEHub struct {
 	config       SSEConfig
 }
 
-// streamMessage wraps a message with its target stream.
+// streamMessage wraps a serialised SSE payload with its target stream
+// so the hub's broadcast loop can dispatch to the right client set.
 type streamMessage struct {
 	stream SSEStream
 	data   []byte
-}
-
-// sseRateLimiter provides simple token bucket rate limiting.
-type sseRateLimiter struct {
-	tokens     atomic.Int64
-	maxTokens  int64
-	refillMs   int64
-	lastRefill atomic.Int64
-	mu         sync.Mutex
-}
-
-// newSSERateLimiter creates a rate limiter.
-func newSSERateLimiter(maxPerSecond int64) *sseRateLimiter {
-	rl := &sseRateLimiter{
-		maxTokens: maxPerSecond,
-		refillMs:  millisecsPerSecond / maxPerSecond,
-	}
-	rl.tokens.Store(maxPerSecond)
-	rl.lastRefill.Store(time.Now().UnixMilli())
-
-	return rl
-}
-
-// allow checks if a message can be sent.
-func (rl *sseRateLimiter) allow() bool {
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
-
-	now := time.Now().UnixMilli()
-	elapsed := now - rl.lastRefill.Load()
-
-	if elapsed >= rl.refillMs {
-		tokensToAdd := elapsed / rl.refillMs
-
-		newTokens := min(rl.tokens.Load()+tokensToAdd, rl.maxTokens)
-
-		rl.tokens.Store(newTokens)
-		rl.lastRefill.Store(now)
-	}
-
-	if rl.tokens.Load() > 0 {
-		rl.tokens.Add(-1)
-
-		return true
-	}
-
-	return false
-}
-
-// NewSSEHub creates a new SSE hub with the given configuration.
-func NewSSEHub(cfg SSEConfig) *SSEHub {
-	cfg = cfg.withDefaults()
-	hub := &SSEHub{
-		clients:      make(map[SSEStream]map[*SSEClient]bool),
-		broadcast:    make(chan *streamMessage, cfg.BufferSize),
-		register:     make(chan *SSEClient),
-		unregister:   make(chan *SSEClient),
-		rateLimiters: make(map[SSEStream]*sseRateLimiter),
-		stopChan:     make(chan struct{}),
-		config:       cfg,
-	}
-
-	// Initialize per-stream structures
-	for _, stream := range []SSEStream{SSEStreamPackets, SSEStreamLogs, SSEStreamStats} {
-		hub.clients[stream] = make(map[*SSEClient]bool)
-		hub.rateLimiters[stream] = newSSERateLimiter(int64(cfg.MaxMsgPerSec))
-	}
-
-	return hub
-}
-
-// Run starts the hub's main event loop.
-func (h *SSEHub) Run() {
-	h.running.Store(true)
-	defer h.running.Store(false)
-
-	for {
-		select {
-		case client := <-h.register:
-			h.registerClient(client)
-
-		case client := <-h.unregister:
-			h.unregisterClient(client)
-
-		case msg := <-h.broadcast:
-			h.broadcastMessage(msg)
-
-		case <-h.stopChan:
-			h.closeAllClients()
-
-			return
-		}
-	}
-}
-
-// Stop gracefully shuts down the hub. Safe to call multiple times.
-func (h *SSEHub) Stop() {
-	h.stopOnce.Do(func() {
-		close(h.stopChan)
-	})
-}
-
-func (h *SSEHub) registerClient(client *SSEClient) {
-	logger := slog.Default()
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	streamClients := h.clients[client.stream]
-
-	if len(streamClients) >= h.config.MaxClients {
-		logger.Warn(
-			"[SSE] Rejecting client for stream: max clients reached",
-			"stream",
-			client.stream,
-			"maxClients",
-			h.config.MaxClients,
-		)
-		client.closed.Store(true)
-		close(client.send)
-
-		return
-	}
-
-	streamClients[client] = true
-	logger.Info(
-		"[SSE] Client connected to stream",
-		"stream",
-		client.stream,
-		"clientIP",
-		client.clientIP,
-		"total",
-		len(streamClients),
-	)
-}
-
-func (h *SSEHub) unregisterClient(client *SSEClient) {
-	logger := slog.Default()
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	streamClients := h.clients[client.stream]
-	if _, ok := streamClients[client]; ok {
-		delete(streamClients, client)
-
-		if !client.closed.Load() {
-			client.closed.Store(true)
-			close(client.send)
-		}
-
-		logger.Info("[SSE] Client disconnected from stream", "stream", client.stream, "remaining", len(streamClients))
-	}
-}
-
-func (h *SSEHub) broadcastMessage(msg *streamMessage) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	rateLimiter := h.rateLimiters[msg.stream]
-	if rateLimiter != nil && !rateLimiter.allow() {
-		return // Rate limit exceeded
-	}
-
-	streamClients := h.clients[msg.stream]
-	for client := range streamClients {
-		if client.closed.Load() {
-			continue
-		}
-
-		select {
-		case client.send <- msg.data:
-		default:
-			// Buffer full, drop message
-		}
-	}
-}
-
-func (h *SSEHub) closeAllClients() {
-	logger := slog.Default()
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	for stream, clients := range h.clients {
-		for client := range clients {
-			if !client.closed.Load() {
-				client.closed.Store(true)
-				close(client.send)
-			}
-		}
-
-		h.clients[stream] = make(map[*SSEClient]bool)
-	}
-
-	logger.Info("[SSE] All clients disconnected")
-}
-
-// Broadcast sends a message to all clients of a stream.
-func (h *SSEHub) Broadcast(stream SSEStream, data any) {
-	logger := slog.Default()
-	if !h.running.Load() {
-		return
-	}
-
-	// Increment event ID
-	eventID := h.eventID.Add(1)
-
-	// Format as SSE
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		logger.Error("[SSE] Failed to marshal message", "error", err)
-
-		return
-	}
-
-	// SSE format: "id: N\ndata: {json}\n\n"
-	sseData := fmt.Sprintf("id: %d\ndata: %s\n\n", eventID, jsonData)
-
-	select {
-	case h.broadcast <- &streamMessage{stream: stream, data: []byte(sseData)}:
-	default:
-		// Broadcast channel full
-	}
-}
-
-// BroadcastPacket sends a packet to all packet stream subscribers.
-func (h *SSEHub) BroadcastPacket(data any) {
-	h.Broadcast(SSEStreamPackets, map[string]any{
-		"type":      "packet",
-		"data":      data,
-		"timestamp": time.Now().UTC(),
-	})
-}
-
-// BroadcastLog sends a log message to all log stream subscribers.
-func (h *SSEHub) BroadcastLog(level, message string) {
-	h.Broadcast(SSEStreamLogs, map[string]any{
-		"type":      "log",
-		"level":     level,
-		"message":   message,
-		"timestamp": time.Now().UTC(),
-	})
-}
-
-// BroadcastStats sends statistics to all stats stream subscribers.
-func (h *SSEHub) BroadcastStats(data any) {
-	h.Broadcast(SSEStreamStats, map[string]any{
-		"type":      "stats",
-		"data":      data,
-		"timestamp": time.Now().UTC(),
-	})
-}
-
-// ClientCount returns the number of clients for a stream.
-func (h *SSEHub) ClientCount(stream SSEStream) int {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	return len(h.clients[stream])
-}
-
-// TotalClientCount returns total connected clients.
-func (h *SSEHub) TotalClientCount() int {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	total := 0
-	for _, clients := range h.clients {
-		total += len(clients)
-	}
-
-	return total
-}
-
-// sseStreamContext holds the context for an SSE streaming session.
-type sseStreamContext struct {
-	writer     http.ResponseWriter
-	flusher    http.Flusher
-	client     *SSEClient
-	heartbeat  *time.Ticker
-	maxConnDur *time.Timer
-	ctx        context.Context
-}
-
-// setSSEHeaders configures HTTP headers for SSE streaming.
-func setSSEHeaders(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no") // Disable nginx buffering
-}
-
-// setupSSEConnection prepares the SSE connection and returns a stream context.
-func (s *Server) setupSSEConnection(
-	w http.ResponseWriter,
-	r *http.Request,
-	stream SSEStream,
-) (*sseStreamContext, error) {
-	setSSEHeaders(w)
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		return nil, errors.New("streaming not supported")
-	}
-
-	rc := http.NewResponseController(w)
-	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-		s.logger.Warn("[SSE] Could not disable write deadline", "error", err)
-	}
-
-	client := &SSEClient{
-		hub:      s.sseHub,
-		send:     make(chan []byte, s.sseHub.config.BufferSize),
-		stream:   stream,
-		clientIP: r.RemoteAddr,
-	}
-
-	return &sseStreamContext{
-		writer:     w,
-		flusher:    flusher,
-		client:     client,
-		heartbeat:  time.NewTicker(time.Duration(s.sseHub.config.HeartbeatSec) * time.Second),
-		maxConnDur: time.NewTimer(time.Duration(s.sseHub.config.MaxConnSec) * time.Second),
-		ctx:        r.Context(),
-	}, nil
-}
-
-// runSSEMessageLoop handles the main SSE message streaming loop.
-func (sc *sseStreamContext) runSSEMessageLoop() {
-	defer sc.maxConnDur.Stop()
-
-	for {
-		select {
-		case <-sc.ctx.Done():
-			return
-
-		case <-sc.maxConnDur.C:
-			// Max connection duration reached; client will auto-reconnect
-			return
-
-		case msg, msgOk := <-sc.client.send:
-			if !msgOk {
-				return
-			}
-
-			if _, writeErr := sc.writer.Write(msg); writeErr != nil {
-				return
-			}
-
-			sc.flusher.Flush()
-
-		case <-sc.heartbeat.C:
-			if _, err := fmt.Fprintf(sc.writer, ": heartbeat %d\n\n", time.Now().Unix()); err != nil {
-				return
-			}
-
-			sc.flusher.Flush()
-		}
-	}
-}
-
-// serveSSE handles SSE connections for a specific stream.
-func (s *Server) serveSSE(stream SSEStream) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if s.sseHub == nil {
-			writeError(w, r, http.StatusServiceUnavailable, "sse_unavailable", "SSE streaming not available", nil)
-			return
-		}
-
-		sc, err := s.setupSSEConnection(w, r, stream)
-		if err != nil {
-			// SECURITY FIX #183: Don't expose internal error details
-			s.logger.Error("[API] SSE connection setup failed", "error", err)
-			writeError(w, r, http.StatusInternalServerError, "sse_not_supported",
-				"Failed to establish SSE connection", nil)
-			return
-		}
-		defer sc.heartbeat.Stop()
-
-		// Register without blocking if the hub is shutting down.
-		select {
-		case s.sseHub.register <- sc.client:
-		case <-s.sseHub.stopChan:
-			return
-		case <-r.Context().Done():
-			return
-		}
-
-		defer func() {
-			select {
-			case s.sseHub.unregister <- sc.client:
-			case <-s.sseHub.stopChan:
-			}
-		}()
-
-		_, _ = fmt.Fprintf(w, "event: connected\ndata: {\"stream\":\"%s\"}\n\n", stream)
-		sc.flusher.Flush()
-
-		sc.runSSEMessageLoop()
-	}
-}
-
-// handleSSEPackets handles SSE connections for packet streaming.
-func (s *Server) handleSSEPackets(w http.ResponseWriter, r *http.Request) {
-	s.serveSSE(SSEStreamPackets)(w, r)
-}
-
-// handleSSELogs handles SSE connections for log streaming.
-func (s *Server) handleSSELogs(w http.ResponseWriter, r *http.Request) {
-	s.serveSSE(SSEStreamLogs)(w, r)
-}
-
-// handleSSEStats handles SSE connections for stats streaming.
-func (s *Server) handleSSEStats(w http.ResponseWriter, r *http.Request) {
-	s.serveSSE(SSEStreamStats)(w, r)
-}
-
-// handleSSEStatus returns SSE hub status.
-func (s *Server) handleSSEStatus(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-
-		return
-	}
-
-	var status map[string]any
-
-	if s.sseHub != nil {
-		status = map[string]any{
-			"running": s.sseHub.running.Load(),
-			"clients": map[string]int{
-				"packets": s.sseHub.ClientCount(SSEStreamPackets),
-				"logs":    s.sseHub.ClientCount(SSEStreamLogs),
-				"stats":   s.sseHub.ClientCount(SSEStreamStats),
-				"total":   s.sseHub.TotalClientCount(),
-			},
-			"limits": map[string]int{
-				"max_clients_per_stream": s.sseHub.config.MaxClients,
-				"max_msg_per_sec":        s.sseHub.config.MaxMsgPerSec,
-				"buffer_size":            s.sseHub.config.BufferSize,
-			},
-		}
-	} else {
-		status = map[string]any{
-			"running": false,
-			"clients": map[string]int{
-				"packets": 0,
-				"logs":    0,
-				"stats":   0,
-				"total":   0,
-			},
-		}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(status) // HTTP write errors are non-critical
 }

--- a/internal/api/sse_hub.go
+++ b/internal/api/sse_hub.go
@@ -76,43 +76,47 @@ func (h *SSEHub) Stop() {
 }
 
 func (h *SSEHub) registerClient(client *SSEClient) {
-	logger := slog.Default()
+	// Collect log intent under the lock; emit AFTER releasing it.
+	// Holding h.mu while calling into slog risks deadlocking the hub
+	// goroutine — slog's default-handler chain ends at the stdlib
+	// log.Logger.Output, which has its own global mutex. If anything
+	// else in the process is contending on that mutex, the hub
+	// goroutine pins h.mu until log's mutex clears, which in turn
+	// prevents broadcastMessage (RLock on h.mu) from making progress.
+	var logEvent func()
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	streamClients := h.clients[client.stream]
-
-	if len(streamClients) >= h.config.MaxClients {
-		logger.Warn(
-			"[SSE] Rejecting client for stream: max clients reached",
-			"stream",
-			client.stream,
-			"maxClients",
-			h.config.MaxClients,
-		)
+	switch {
+	case len(streamClients) >= h.config.MaxClients:
 		client.closed.Store(true)
 		close(client.send)
-
-		return
+		maxClients := h.config.MaxClients
+		logEvent = func() {
+			slog.Default().Warn(
+				"[SSE] Rejecting client for stream: max clients reached",
+				"stream", client.stream,
+				"maxClients", maxClients,
+			)
+		}
+	default:
+		streamClients[client] = true
+		total := len(streamClients)
+		logEvent = func() {
+			slog.Default().Info(
+				"[SSE] Client connected to stream",
+				"stream", client.stream,
+				"clientIP", client.clientIP,
+				"total", total,
+			)
+		}
 	}
-
-	streamClients[client] = true
-	logger.Info(
-		"[SSE] Client connected to stream",
-		"stream",
-		client.stream,
-		"clientIP",
-		client.clientIP,
-		"total",
-		len(streamClients),
-	)
+	h.mu.Unlock()
+	logEvent()
 }
 
 func (h *SSEHub) unregisterClient(client *SSEClient) {
-	logger := slog.Default()
+	var logEvent func()
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	streamClients := h.clients[client.stream]
 	if _, ok := streamClients[client]; ok {
 		delete(streamClients, client)
@@ -121,8 +125,18 @@ func (h *SSEHub) unregisterClient(client *SSEClient) {
 			client.closed.Store(true)
 			close(client.send)
 		}
-
-		logger.Info("[SSE] Client disconnected from stream", "stream", client.stream, "remaining", len(streamClients))
+		remaining := len(streamClients)
+		logEvent = func() {
+			slog.Default().Info(
+				"[SSE] Client disconnected from stream",
+				"stream", client.stream,
+				"remaining", remaining,
+			)
+		}
+	}
+	h.mu.Unlock()
+	if logEvent != nil {
+		logEvent()
 	}
 }
 
@@ -150,10 +164,7 @@ func (h *SSEHub) broadcastMessage(msg *streamMessage) {
 }
 
 func (h *SSEHub) closeAllClients() {
-	logger := slog.Default()
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	for stream, clients := range h.clients {
 		for client := range clients {
 			if !client.closed.Load() {
@@ -164,8 +175,13 @@ func (h *SSEHub) closeAllClients() {
 
 		h.clients[stream] = make(map[*SSEClient]bool)
 	}
+	h.mu.Unlock()
 
-	logger.Info("[SSE] All clients disconnected")
+	// Log AFTER releasing the hub lock — see registerClient for the
+	// reasoning. Particularly important here because this fires on
+	// shutdown, where the stdlib log mutex is most contended (the
+	// test runner / panic handler also wants it).
+	slog.Default().Info("[SSE] All clients disconnected")
 }
 
 // Broadcast sends a message to all clients of a stream. Messages are

--- a/internal/api/sse_hub.go
+++ b/internal/api/sse_hub.go
@@ -1,0 +1,249 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// SSEHub manages connected SSE clients and dispatches broadcasts to
+// the right per-stream subset. The hub owns a Run goroutine that
+// serialises register / unregister / broadcast events through unbuffered
+// channels, which keeps the per-stream client map race-free without
+// requiring callers to hold a lock.
+//
+// Lifecycle:
+//   - NewSSEHub() builds the hub. Call Run() in a goroutine.
+//   - HTTP handlers send on hub.register / hub.unregister.
+//   - Producers (packet observer, daemon stats, future log tee) call
+//     Broadcast / BroadcastPacket / BroadcastLog / BroadcastStats.
+//   - Stop() closes stopChan; Run drains and unregisters every client.
+
+// NewSSEHub creates a new SSE hub with the given configuration. Zero
+// values in cfg are replaced by defaults from SSEConfig.withDefaults.
+func NewSSEHub(cfg SSEConfig) *SSEHub {
+	cfg = cfg.withDefaults()
+	hub := &SSEHub{
+		clients:      make(map[SSEStream]map[*SSEClient]bool),
+		broadcast:    make(chan *streamMessage, cfg.BufferSize),
+		register:     make(chan *SSEClient),
+		unregister:   make(chan *SSEClient),
+		rateLimiters: make(map[SSEStream]*sseRateLimiter),
+		stopChan:     make(chan struct{}),
+		config:       cfg,
+	}
+
+	// Initialize per-stream structures
+	for _, stream := range []SSEStream{SSEStreamPackets, SSEStreamLogs, SSEStreamStats} {
+		hub.clients[stream] = make(map[*SSEClient]bool)
+		hub.rateLimiters[stream] = newSSERateLimiter(int64(cfg.MaxMsgPerSec))
+	}
+
+	return hub
+}
+
+// Run starts the hub's main event loop. Blocks until Stop is called.
+// Run on its own goroutine — typically launched once at daemon startup.
+func (h *SSEHub) Run() {
+	h.running.Store(true)
+	defer h.running.Store(false)
+
+	for {
+		select {
+		case client := <-h.register:
+			h.registerClient(client)
+
+		case client := <-h.unregister:
+			h.unregisterClient(client)
+
+		case msg := <-h.broadcast:
+			h.broadcastMessage(msg)
+
+		case <-h.stopChan:
+			h.closeAllClients()
+
+			return
+		}
+	}
+}
+
+// Stop gracefully shuts down the hub. Safe to call multiple times.
+func (h *SSEHub) Stop() {
+	h.stopOnce.Do(func() {
+		close(h.stopChan)
+	})
+}
+
+func (h *SSEHub) registerClient(client *SSEClient) {
+	logger := slog.Default()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	streamClients := h.clients[client.stream]
+
+	if len(streamClients) >= h.config.MaxClients {
+		logger.Warn(
+			"[SSE] Rejecting client for stream: max clients reached",
+			"stream",
+			client.stream,
+			"maxClients",
+			h.config.MaxClients,
+		)
+		client.closed.Store(true)
+		close(client.send)
+
+		return
+	}
+
+	streamClients[client] = true
+	logger.Info(
+		"[SSE] Client connected to stream",
+		"stream",
+		client.stream,
+		"clientIP",
+		client.clientIP,
+		"total",
+		len(streamClients),
+	)
+}
+
+func (h *SSEHub) unregisterClient(client *SSEClient) {
+	logger := slog.Default()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	streamClients := h.clients[client.stream]
+	if _, ok := streamClients[client]; ok {
+		delete(streamClients, client)
+
+		if !client.closed.Load() {
+			client.closed.Store(true)
+			close(client.send)
+		}
+
+		logger.Info("[SSE] Client disconnected from stream", "stream", client.stream, "remaining", len(streamClients))
+	}
+}
+
+func (h *SSEHub) broadcastMessage(msg *streamMessage) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	rateLimiter := h.rateLimiters[msg.stream]
+	if rateLimiter != nil && !rateLimiter.allow() {
+		return // Rate limit exceeded
+	}
+
+	streamClients := h.clients[msg.stream]
+	for client := range streamClients {
+		if client.closed.Load() {
+			continue
+		}
+
+		select {
+		case client.send <- msg.data:
+		default:
+			// Buffer full, drop message
+		}
+	}
+}
+
+func (h *SSEHub) closeAllClients() {
+	logger := slog.Default()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for stream, clients := range h.clients {
+		for client := range clients {
+			if !client.closed.Load() {
+				client.closed.Store(true)
+				close(client.send)
+			}
+		}
+
+		h.clients[stream] = make(map[*SSEClient]bool)
+	}
+
+	logger.Info("[SSE] All clients disconnected")
+}
+
+// Broadcast sends a message to all clients of a stream. Messages are
+// dropped if either the broadcast channel or the per-stream rate
+// limiter is saturated — the hub favours liveness over delivery
+// guarantees, since SSE clients auto-reconnect and can refetch state.
+func (h *SSEHub) Broadcast(stream SSEStream, data any) {
+	logger := slog.Default()
+	if !h.running.Load() {
+		return
+	}
+
+	// Increment event ID
+	eventID := h.eventID.Add(1)
+
+	// Format as SSE
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		logger.Error("[SSE] Failed to marshal message", "error", err)
+
+		return
+	}
+
+	// SSE format: "id: N\ndata: {json}\n\n"
+	sseData := fmt.Sprintf("id: %d\ndata: %s\n\n", eventID, jsonData)
+
+	select {
+	case h.broadcast <- &streamMessage{stream: stream, data: []byte(sseData)}:
+	default:
+		// Broadcast channel full
+	}
+}
+
+// BroadcastPacket sends a packet to all packet stream subscribers.
+func (h *SSEHub) BroadcastPacket(data any) {
+	h.Broadcast(SSEStreamPackets, map[string]any{
+		"type":      "packet",
+		"data":      data,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// BroadcastLog sends a log message to all log stream subscribers.
+func (h *SSEHub) BroadcastLog(level, message string) {
+	h.Broadcast(SSEStreamLogs, map[string]any{
+		"type":      "log",
+		"level":     level,
+		"message":   message,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// BroadcastStats sends statistics to all stats stream subscribers.
+func (h *SSEHub) BroadcastStats(data any) {
+	h.Broadcast(SSEStreamStats, map[string]any{
+		"type":      "stats",
+		"data":      data,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// ClientCount returns the number of clients for a stream.
+func (h *SSEHub) ClientCount(stream SSEStream) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return len(h.clients[stream])
+}
+
+// TotalClientCount returns total connected clients across every stream.
+func (h *SSEHub) TotalClientCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	total := 0
+	for _, clients := range h.clients {
+		total += len(clients)
+	}
+
+	return total
+}

--- a/internal/api/sse_log_handler.go
+++ b/internal/api/sse_log_handler.go
@@ -3,51 +3,134 @@ package api
 import (
 	"context"
 	"log/slog"
+	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 )
 
 // sseLogHandler is a slog.Handler that tees every record through the
 // upstream handler AND broadcasts it on the SSE logs stream so the
 // Protocol Debug Console page sees daemon logs in real time.
 //
-// The stack used to emit lots of fmt.Fprintf(os.Stdout, ...) lines that
-// are invisible to slog — those won't appear here. Migrating those to
-// slog is a separate cleanup. For now this captures everything that
-// already routes through slog.Default (which is most of the new code).
+// The handler is installed exactly once per process via InstallSSELogTee.
+// Subsequent calls (a second daemon in tests, hot reload, etc.) rotate
+// the active hub via an atomic pointer instead of wrapping slog.Default
+// again. That keeps the handler chain shallow no matter how many daemons
+// the test suite spins up.
+//
+// The stack still emits some fmt.Fprintf(os.Stdout, ...) lines that are
+// invisible to slog — those don't appear here. Migrating those to slog
+// is a separate cleanup. For now this captures everything that already
+// routes through slog.Default (which is most of the new code).
 type sseLogHandler struct {
-	hub  *SSEHub
 	next slog.Handler
+	// hub is read via atomic.Pointer so daemon shutdown / re-init can
+	// swap or clear the active broadcast target without rebuilding the
+	// slog handler chain.
+	hub atomic.Pointer[SSEHub]
 }
 
-// NewSSELogHandler wraps the given handler. The wrapper forwards every
-// record to next AND to hub.BroadcastLog. A nil hub falls through to
-// next so callers can install the wrapper unconditionally.
+// sseLogTee and sseLogTeeOnce are package-globals because slog.SetDefault
+// is itself a process-global. The install-once + atomic hub rotation
+// pattern is what prevents the test-suite deadlock described on
+// InstallSSELogTee; any alternative that stuffs state somewhere else
+// would either duplicate the chain (the original bug) or hide globals
+// inside an unexported singleton with no practical difference.
+//
+//nolint:gochecknoglobals // process-global tee paired with slog.SetDefault.
+var (
+	sseLogTee     *sseLogHandler
+	sseLogTeeOnce sync.Once
+)
+
+// InstallSSELogTee makes sure a single sseLogHandler is wrapped around
+// the slog default and points its broadcast target at hub. Safe to call
+// multiple times — subsequent calls just rotate the active hub. Pass
+// nil to detach (e.g. on daemon shutdown).
+//
+// The "next" handler is intentionally a fresh text handler writing
+// straight to stderr rather than the existing slog default. Reason:
+// Go's log/log.go patches the standard log package at init so its
+// output writer routes through slog.Default().Handler. If sseLogTee
+// preserved slog.Default()'s prior handler (which is the package
+// default — defaultHandler), every log it emits would run:
+//
+//	slog.* → sseLogTee → defaultHandler → log.Output → log writer
+//	  → slog.Default()  ← which is sseLogTee again
+//
+// Same-goroutine recursion on log.mu, deadlocking the hub goroutine
+// during shutdown. Writing straight to stderr breaks the cycle and
+// preserves the operator-log behaviour callers expect.
+//
+// Idempotent + atomic-rotation is also the reentrancy strategy.
+// The previous design re-wrapped slog.Default on every daemon.Start(),
+// which in the test suite produced a chain that grew one layer per
+// test and eventually hung shutdown.
+func InstallSSELogTee(hub *SSEHub) {
+	sseLogTeeOnce.Do(func() {
+		sseLogTee = &sseLogHandler{
+			next: slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}),
+		}
+		slog.SetDefault(slog.New(sseLogTee))
+	})
+	sseLogTee.hub.Store(hub)
+}
+
+// NewSSELogHandler is retained for callers / tests that want a fresh
+// wrapper without touching the process-wide default. The returned
+// handler has its own internal hub pointer; callers can update it via
+// SetHub. A nil hub falls through to next.
+//
+// Production code should prefer InstallSSELogTee — it makes sure the
+// process has exactly one tee no matter how many times the daemon
+// restarts.
 func NewSSELogHandler(hub *SSEHub, next slog.Handler) slog.Handler {
 	if next == nil {
 		next = slog.Default().Handler()
 	}
-	return &sseLogHandler{hub: hub, next: next}
+	h := &sseLogHandler{next: next}
+	h.hub.Store(hub)
+	return h
 }
 
 func (h *sseLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.next.Enabled(ctx, level)
 }
 
+// sseInternalLogPrefix tags log lines emitted by the SSE subsystem
+// itself ("[SSE] Client connected", "[SSE] Failed to marshal message",
+// etc). These must NOT be teed back to the hub or we'd recurse —
+// Broadcast emits no slog calls on the success path, but the hub's
+// own register/unregister/broadcast log lines do, and they fire from
+// inside the hub's goroutine. Filtering by message prefix is a tiny,
+// inspection-friendly cycle-breaker.
+const sseInternalLogPrefix = "[SSE]"
+
 func (h *sseLogHandler) Handle(ctx context.Context, rec slog.Record) error {
 	// Tee to the SSE hub first so a downstream handler error doesn't
-	// silently drop the broadcast.
-	if h.hub != nil {
-		h.hub.BroadcastLog(levelString(rec.Level), formatRecord(rec))
+	// silently drop the broadcast. Skip SSE-internal lines to break
+	// the tee → BroadcastLog → hub-logs → tee → ... cycle.
+	if hub := h.hub.Load(); hub != nil && !strings.HasPrefix(rec.Message, sseInternalLogPrefix) {
+		hub.BroadcastLog(levelString(rec.Level), formatRecord(rec))
 	}
 	return h.next.Handle(ctx, rec)
 }
 
+// WithAttrs and WithGroup intentionally return a fresh wrapper that
+// SHARES the same hub atomic pointer, not a copy of it. Otherwise
+// loggers derived via slog.With(...) would freeze the hub at the
+// moment of derivation and miss subsequent rotations.
 func (h *sseLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &sseLogHandler{hub: h.hub, next: h.next.WithAttrs(attrs)}
+	clone := &sseLogHandler{next: h.next.WithAttrs(attrs)}
+	clone.hub.Store(h.hub.Load())
+	return clone
 }
 
 func (h *sseLogHandler) WithGroup(name string) slog.Handler {
-	return &sseLogHandler{hub: h.hub, next: h.next.WithGroup(name)}
+	clone := &sseLogHandler{next: h.next.WithGroup(name)}
+	clone.hub.Store(h.hub.Load())
+	return clone
 }
 
 func levelString(l slog.Level) string {

--- a/internal/api/sse_log_handler_test.go
+++ b/internal/api/sse_log_handler_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSSELogHandlerTeesNonSSE verifies that a normal log line (not
+// prefixed with "[SSE]") flows through to the hub's logs stream.
+func TestSSELogHandlerTeesNonSSE(t *testing.T) {
+	hub := NewSSEHub(SSEConfig{MaxMsgPerSec: 1000})
+	go hub.Run()
+	defer hub.Stop()
+	waitForHubRunning(t, hub)
+
+	// Register a client subscribed to the logs stream
+	client := &SSEClient{
+		hub:    hub,
+		send:   make(chan []byte, 16),
+		stream: SSEStreamLogs,
+	}
+	hub.register <- client
+	defer func() { hub.unregister <- client }()
+	waitForClient(t, hub, SSEStreamLogs, 1)
+
+	// Install the tee using a discard next-handler so the test output
+	// stays clean.
+	logger := slog.New(NewSSELogHandler(hub, slog.NewTextHandler(io.Discard, nil)))
+	logger.Info("device created", "host", "router-1")
+
+	select {
+	case msg := <-client.send:
+		if !strings.Contains(string(msg), "device created") {
+			t.Errorf("expected 'device created' in broadcast, got: %s", msg)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected hub broadcast within 500ms, got nothing")
+	}
+}
+
+// TestSSELogHandlerFiltersInternal verifies that records prefixed with
+// "[SSE]" are NOT teed back into the hub. This is the cycle breaker
+// described at the top of sse_log_handler.go — without it, hub-internal
+// log lines (register/unregister/broadcast) would recurse through the
+// tee until the broadcast channel saturated.
+func TestSSELogHandlerFiltersInternal(t *testing.T) {
+	hub := NewSSEHub(SSEConfig{MaxMsgPerSec: 1000})
+	go hub.Run()
+	defer hub.Stop()
+	waitForHubRunning(t, hub)
+
+	client := &SSEClient{
+		hub:    hub,
+		send:   make(chan []byte, 16),
+		stream: SSEStreamLogs,
+	}
+	hub.register <- client
+	defer func() { hub.unregister <- client }()
+	waitForClient(t, hub, SSEStreamLogs, 1)
+
+	logger := slog.New(NewSSELogHandler(hub, slog.NewTextHandler(io.Discard, nil)))
+	logger.Info("[SSE] Client connected to stream", "stream", "logs")
+
+	// The tee should NOT have fed this back to the hub.
+	select {
+	case msg := <-client.send:
+		t.Fatalf("internal [SSE] log was teed back to hub: %s", msg)
+	case <-time.After(150 * time.Millisecond):
+		// Expected — filter caught it.
+	}
+}
+
+// TestSSELogHandlerForwardsToNext checks that the wrapped (next)
+// handler still receives every record, including the [SSE]-prefixed
+// ones we skip teeing.
+func TestSSELogHandlerForwardsToNext(t *testing.T) {
+	hub := NewSSEHub(SSEConfig{MaxMsgPerSec: 1000})
+	go hub.Run()
+	defer hub.Stop()
+
+	var captured strings.Builder
+	next := slog.NewTextHandler(&captured, nil)
+	logger := slog.New(NewSSELogHandler(hub, next))
+
+	logger.Info("normal record")
+	logger.Info("[SSE] internal record")
+
+	out := captured.String()
+	if !strings.Contains(out, "normal record") {
+		t.Errorf("next handler did not receive normal record, got: %s", out)
+	}
+	if !strings.Contains(out, "[SSE] internal record") {
+		t.Errorf("next handler did not receive [SSE] record (must still log to stderr), got: %s", out)
+	}
+}
+
+// TestSSELogHandlerNilHubFallsThrough checks the documented contract
+// that a nil hub leaves the wrapped handler in charge — callers can
+// install the wrapper unconditionally.
+func TestSSELogHandlerNilHubFallsThrough(t *testing.T) {
+	var captured strings.Builder
+	next := slog.NewTextHandler(&captured, nil)
+	logger := slog.New(NewSSELogHandler(nil, next))
+
+	logger.Info("hello")
+
+	if !strings.Contains(captured.String(), "hello") {
+		t.Errorf("nil-hub log did not reach next handler, got: %s", captured.String())
+	}
+}
+
+// waitForHubRunning blocks until the hub's Run loop has started — we
+// signal that via the running atomic flag inside the hub.
+func waitForHubRunning(t *testing.T, hub *SSEHub) {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if hub.running.Load() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("hub did not start within 200ms")
+}
+
+// waitForClient blocks until the hub has registered `want` clients on
+// the given stream. The register channel is unbuffered, so we have to
+// wait for the hub goroutine to actually drain it.
+func waitForClient(t *testing.T, hub *SSEHub, stream SSEStream, want int) {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if hub.ClientCount(stream) >= want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("hub did not register %d clients on %s within 200ms", want, stream)
+}

--- a/internal/api/sse_rate_limiter.go
+++ b/internal/api/sse_rate_limiter.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// sseRateLimiter is a simple token-bucket rate limiter used per stream
+// inside the SSE hub to cap the broadcast rate even when a producer
+// fires faster than clients can drink. Tokens refill at refillMs cadence
+// up to maxTokens. Concurrency-safe: callers may call allow() from any
+// goroutine.
+type sseRateLimiter struct {
+	tokens     atomic.Int64
+	maxTokens  int64
+	refillMs   int64
+	lastRefill atomic.Int64
+	mu         sync.Mutex
+}
+
+// newSSERateLimiter builds a limiter that allows up to maxPerSecond
+// successful allow() calls per second on average.
+func newSSERateLimiter(maxPerSecond int64) *sseRateLimiter {
+	rl := &sseRateLimiter{
+		maxTokens: maxPerSecond,
+		refillMs:  millisecsPerSecond / maxPerSecond,
+	}
+	rl.tokens.Store(maxPerSecond)
+	rl.lastRefill.Store(time.Now().UnixMilli())
+
+	return rl
+}
+
+// allow consumes one token. Returns false when the bucket is empty,
+// which signals callers to drop the message rather than block.
+func (rl *sseRateLimiter) allow() bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now().UnixMilli()
+	elapsed := now - rl.lastRefill.Load()
+
+	if elapsed >= rl.refillMs {
+		tokensToAdd := elapsed / rl.refillMs
+
+		newTokens := min(rl.tokens.Load()+tokensToAdd, rl.maxTokens)
+
+		rl.tokens.Store(newTokens)
+		rl.lastRefill.Store(now)
+	}
+
+	if rl.tokens.Load() > 0 {
+		rl.tokens.Add(-1)
+
+		return true
+	}
+
+	return false
+}

--- a/internal/api/sse_serve.go
+++ b/internal/api/sse_serve.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// sseStreamContext holds the per-request state needed by a single
+// streaming connection: the response writer, an http.Flusher pinned at
+// connection setup so we don't re-type-assert on every event, the
+// hub-side client handle, and the lifecycle tickers/timers (heartbeat
+// + forced-reconnect cap).
+type sseStreamContext struct {
+	writer     http.ResponseWriter
+	flusher    http.Flusher
+	client     *SSEClient
+	heartbeat  *time.Ticker
+	maxConnDur *time.Timer
+	ctx        context.Context
+}
+
+// setSSEHeaders configures HTTP headers for SSE streaming. Disabling
+// nginx buffering is critical — otherwise events sit in a proxy buffer
+// until the connection closes, which defeats the whole stream.
+func setSSEHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // Disable nginx buffering
+}
+
+// setupSSEConnection prepares the SSE connection and returns a stream
+// context. The caller is responsible for stopping the heartbeat ticker
+// and for sending the client through hub.register / hub.unregister.
+func (s *Server) setupSSEConnection(
+	w http.ResponseWriter,
+	r *http.Request,
+	stream SSEStream,
+) (*sseStreamContext, error) {
+	setSSEHeaders(w)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, errors.New("streaming not supported")
+	}
+
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		s.logger.Warn("[SSE] Could not disable write deadline", "error", err)
+	}
+
+	client := &SSEClient{
+		hub:      s.sseHub,
+		send:     make(chan []byte, s.sseHub.config.BufferSize),
+		stream:   stream,
+		clientIP: r.RemoteAddr,
+	}
+
+	return &sseStreamContext{
+		writer:     w,
+		flusher:    flusher,
+		client:     client,
+		heartbeat:  time.NewTicker(time.Duration(s.sseHub.config.HeartbeatSec) * time.Second),
+		maxConnDur: time.NewTimer(time.Duration(s.sseHub.config.MaxConnSec) * time.Second),
+		ctx:        r.Context(),
+	}, nil
+}
+
+// runSSEMessageLoop is the main per-connection event pump. It blocks
+// until the request context is cancelled, the max-connection-duration
+// timer fires (forcing a clean client-side reconnect), the hub closes
+// the send channel, or a write error indicates the client disconnected.
+func (sc *sseStreamContext) runSSEMessageLoop() {
+	defer sc.maxConnDur.Stop()
+
+	for {
+		select {
+		case <-sc.ctx.Done():
+			return
+
+		case <-sc.maxConnDur.C:
+			// Max connection duration reached; client will auto-reconnect
+			return
+
+		case msg, msgOk := <-sc.client.send:
+			if !msgOk {
+				return
+			}
+
+			if _, writeErr := sc.writer.Write(msg); writeErr != nil {
+				return
+			}
+
+			sc.flusher.Flush()
+
+		case <-sc.heartbeat.C:
+			if _, err := fmt.Fprintf(sc.writer, ": heartbeat %d\n\n", time.Now().Unix()); err != nil {
+				return
+			}
+
+			sc.flusher.Flush()
+		}
+	}
+}
+
+// serveSSE returns an http.HandlerFunc bound to a specific stream. The
+// closure captures stream so the four per-stream HTTP handlers below
+// reduce to one-liners.
+func (s *Server) serveSSE(stream SSEStream) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.sseHub == nil {
+			writeError(w, r, http.StatusServiceUnavailable, "sse_unavailable", "SSE streaming not available", nil)
+			return
+		}
+
+		sc, err := s.setupSSEConnection(w, r, stream)
+		if err != nil {
+			// SECURITY FIX #183: Don't expose internal error details
+			s.logger.Error("[API] SSE connection setup failed", "error", err)
+			writeError(w, r, http.StatusInternalServerError, "sse_not_supported",
+				"Failed to establish SSE connection", nil)
+			return
+		}
+		defer sc.heartbeat.Stop()
+
+		// Register without blocking if the hub is shutting down.
+		select {
+		case s.sseHub.register <- sc.client:
+		case <-s.sseHub.stopChan:
+			return
+		case <-r.Context().Done():
+			return
+		}
+
+		defer func() {
+			select {
+			case s.sseHub.unregister <- sc.client:
+			case <-s.sseHub.stopChan:
+			}
+		}()
+
+		_, _ = fmt.Fprintf(w, "event: connected\ndata: {\"stream\":\"%s\"}\n\n", stream)
+		sc.flusher.Flush()
+
+		sc.runSSEMessageLoop()
+	}
+}
+
+// handleSSEPackets handles SSE connections for packet streaming.
+func (s *Server) handleSSEPackets(w http.ResponseWriter, r *http.Request) {
+	s.serveSSE(SSEStreamPackets)(w, r)
+}
+
+// handleSSELogs handles SSE connections for log streaming.
+func (s *Server) handleSSELogs(w http.ResponseWriter, r *http.Request) {
+	s.serveSSE(SSEStreamLogs)(w, r)
+}
+
+// handleSSEStats handles SSE connections for stats streaming.
+func (s *Server) handleSSEStats(w http.ResponseWriter, r *http.Request) {
+	s.serveSSE(SSEStreamStats)(w, r)
+}
+
+// handleSSEStatus returns SSE hub status: running state, per-stream
+// client counts, and the configured caps. Used by the SSE Status page
+// in the UI to confirm the hub is healthy and to surface client churn.
+func (s *Server) handleSSEStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+
+		return
+	}
+
+	var status map[string]any
+
+	if s.sseHub != nil {
+		status = map[string]any{
+			"running": s.sseHub.running.Load(),
+			"clients": map[string]int{
+				"packets": s.sseHub.ClientCount(SSEStreamPackets),
+				"logs":    s.sseHub.ClientCount(SSEStreamLogs),
+				"stats":   s.sseHub.ClientCount(SSEStreamStats),
+				"total":   s.sseHub.TotalClientCount(),
+			},
+			"limits": map[string]int{
+				"max_clients_per_stream": s.sseHub.config.MaxClients,
+				"max_msg_per_sec":        s.sseHub.config.MaxMsgPerSec,
+				"buffer_size":            s.sseHub.config.BufferSize,
+			},
+		}
+	} else {
+		status = map[string]any{
+			"running": false,
+			"clients": map[string]int{
+				"packets": 0,
+				"logs":    0,
+				"stats":   0,
+				"total":   0,
+			},
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(status) // HTTP write errors are non-critical
+}


### PR DESCRIPTION
Two commits, stacked because the second one needs the first:

## 1. \`refactor(api): split sse.go by concern (hub / serve / rate-limiter)\`
Pure code move. \`sse.go\` was 563 lines mixing types, the hub event loop, HTTP serving, and the rate limiter.

| File | Lines | Contents |
|---|---:|---|
| \`sse.go\` | 123 | types, constants, \`SSEConfig\` |
| \`sse_hub.go\` | 249 | \`SSEHub\` lifecycle + broadcast API |
| \`sse_serve.go\` | 209 | HTTP serving + per-connection event pump |
| \`sse_rate_limiter.go\` | 60 | per-stream token bucket |

(Existing \`sse_log_handler.go\` and \`sse_packet_observer.go\` untouched.) Behaviour and method signatures are unchanged.

## 2. \`feat(api): enable SSE log tee with [SSE]-prefix reentrancy guard\`
The Protocol Debug Console SSE stream was wired up months ago but \`slog.SetDefault(NewSSELogHandler(...))\` was disabled because hub-internal log lines (registerClient: "Client connected", broadcast error paths) fed back into the tee → \`BroadcastLog\` → hub logs → tee → … recursing through the slog handler chain.

**Cycle breaker**: records whose message starts with the literal \`"[SSE]"\` are forwarded to the next handler but NOT teed to the hub. Hub bookkeeping lines still reach the daemon log file via the next handler — they just don't appear in the in-browser log stream. The alternative is goroutine-local state, which Go doesn't offer cleanly.

Wires the wrapper into \`startBackgroundTasks\` so the Debug Console gets real-time logs without a daemon restart.

## Tests added
- tees a non-\`[SSE]\` record to the hub
- drops \`[SSE]\` records (cycle break)
- forwards every record to the underlying handler
- nil-hub fall-through (callers can install unconditionally)

All four pass; \`go vet ./internal/api/...\` clean; \`golangci-lint run ./internal/api/...\` clean.