### PR TITLE
feat(api,ui): standalone packet capture without a simulation

### DIFF
--- a/internal/api/handlers_capture.go
+++ b/internal/api/handlers_capture.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// CaptureRequest starts a standalone packet capture session that runs
+// independently of any simulation. The Packet Capture page in the UI
+// uses this when the user wants to sniff an interface without booting
+// the protocol stack on it.
+type CaptureRequest struct {
+	Interface string `json:"interface"`
+	// Filter is an optional libpcap BPF expression. Applied after the
+	// capture handle opens. Empty means "no filter — capture everything".
+	Filter string `json:"filter,omitempty"`
+}
+
+// CaptureStatus is the response body for the GET /api/v1/capture
+// endpoint and is also returned from POST on success.
+type CaptureStatus struct {
+	Running   bool   `json:"running"`
+	Interface string `json:"interface,omitempty"`
+	Filter    string `json:"filter,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
+	// Packets is the running count of packets the capture has observed
+	// since it started. Updated by the capture loop.
+	Packets uint64 `json:"packets"`
+}
+
+// CaptureController is the daemon-side surface the API server uses to
+// drive standalone capture. Kept separate from DaemonController so the
+// existing simulation-only flows keep their tight interface.
+type CaptureController interface {
+	StartCapture(req CaptureRequest) error
+	StopCapture() error
+	GetCaptureStatus() CaptureStatus
+}
+
+// SetCaptureController wires a CaptureController into the server. Like
+// SetDaemonController this is called by the daemon at startup; in tests
+// the controller is nil and the endpoints return 501.
+func (s *Server) SetCaptureController(c CaptureController) {
+	s.captureController = c
+}
+
+// handleStandaloneCapture routes the /api/v1/capture lifecycle.
+//
+//	GET    → current status
+//	POST   → start (idempotent: returns 409 if already running)
+//	DELETE → stop  (idempotent: returns 200 even when not running)
+func (s *Server) handleStandaloneCapture(w http.ResponseWriter, r *http.Request) {
+	if s.captureController == nil {
+		writeError(w, r, http.StatusNotImplemented, "capture_unavailable",
+			"Standalone packet capture is only available in daemon mode.", nil)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.writeJSON(w, s.captureController.GetCaptureStatus())
+	case http.MethodPost:
+		s.handleStandaloneCaptureStart(w, r)
+	case http.MethodDelete:
+		s.handleStandaloneCaptureStop(w, r)
+	default:
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed",
+			"Method not allowed", nil)
+	}
+}
+
+func (s *Server) handleStandaloneCaptureStart(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
+
+	var req CaptureRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_request",
+			"Failed to parse capture request body", nil)
+		return
+	}
+
+	if req.Interface == "" {
+		writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"Validation failed",
+			[]ErrorDetail{{Field: "interface", Issue: "interface is required"}})
+		return
+	}
+
+	if err := s.captureController.StartCapture(req); err != nil {
+		// Surface conflict-with-sim and not-found errors with their
+		// natural status codes; everything else is a 500. The detail
+		// string is the daemon's error message, which is operator-
+		// readable (it's already used in the sim flow's daemon log).
+		s.logger.Error("[API] Failed to start standalone capture", "error", err)
+		switch {
+		case errors.Is(err, ErrCaptureAlreadyRunning):
+			writeError(w, r, http.StatusConflict, "capture_already_running",
+				err.Error(), nil)
+		case errors.Is(err, ErrCaptureConflictsWithSim):
+			writeError(w, r, http.StatusConflict, "capture_conflicts_with_sim",
+				err.Error(), nil)
+		case errors.Is(err, ErrCaptureInterfaceNotFound):
+			writeError(w, r, http.StatusNotFound, "interface_not_found",
+				err.Error(), nil)
+		default:
+			writeError(w, r, http.StatusInternalServerError, "capture_start_failed",
+				"Failed to start capture", nil)
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	s.writeJSON(w, s.captureController.GetCaptureStatus())
+}
+
+func (s *Server) handleStandaloneCaptureStop(w http.ResponseWriter, r *http.Request) {
+	if err := s.captureController.StopCapture(); err != nil {
+		s.logger.Error("[API] Failed to stop standalone capture", "error", err)
+		writeError(w, r, http.StatusInternalServerError, "capture_stop_failed",
+			"Failed to stop capture", nil)
+		return
+	}
+	s.writeJSON(w, map[string]string{"status": "stopped"})
+}
+
+// Capture-control sentinel errors. Exported so the daemon can wrap them
+// (errors.Is checks downstream) and so test code can match without
+// scraping message strings.
+var (
+	ErrCaptureAlreadyRunning    = errors.New("standalone capture already running")
+	ErrCaptureConflictsWithSim  = errors.New("cannot start standalone capture while a simulation is running")
+	ErrCaptureInterfaceNotFound = errors.New("capture interface not found")
+)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -65,6 +65,13 @@ func (s *Server) registerWriteProtectedRoutes(mux *http.ServeMux) {
 		"/api/v1/capture/filter",
 		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleCaptureFilter)))),
 	)
+	// Standalone packet capture (no simulation required). POST=start,
+	// DELETE=stop, GET=status. Distinct from /capture/filter, which
+	// drives the BPF filter on the sim-managed capture engine.
+	mux.HandleFunc(
+		"/api/v1/capture",
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleStandaloneCapture)))),
+	)
 }
 
 // registerReadOnlyRoutes registers routes that only require authentication.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -208,25 +208,26 @@ type DaemonController interface {
 
 // Server exposes the REST API, metrics endpoint, and Web UI.
 type Server struct {
-	cfg           ServerConfig
-	logger        *slog.Logger
-	httpServer    *http.Server
-	metricsServer *http.Server
-	alertStop     chan struct{}
-	lastAlert     uint64
-	alertMu       sync.RWMutex
-	configMu      sync.RWMutex
-	daemon        DaemonController
-	startTime     time.Time
-	rateLimiter   *RateLimiter
-	csrfToken     string
-	sseHub        *SSEHub
-	uploadLimiter *RateLimiter
-	writeLimiter  *RateLimiter
-	walkLimiter   *RateLimiter
-	fileLimiter   *RateLimiter
-	bgStop        chan struct{}
-	bgStopOnce    sync.Once
+	cfg               ServerConfig
+	logger            *slog.Logger
+	httpServer        *http.Server
+	metricsServer     *http.Server
+	alertStop         chan struct{}
+	lastAlert         uint64
+	alertMu           sync.RWMutex
+	configMu          sync.RWMutex
+	daemon            DaemonController
+	captureController CaptureController
+	startTime         time.Time
+	rateLimiter       *RateLimiter
+	csrfToken         string
+	sseHub            *SSEHub
+	uploadLimiter     *RateLimiter
+	writeLimiter      *RateLimiter
+	walkLimiter       *RateLimiter
+	fileLimiter       *RateLimiter
+	bgStop            chan struct{}
+	bgStopOnce        sync.Once
 }
 
 // NewServer returns a configured API server.

--- a/internal/api/sse_packet_observer.go
+++ b/internal/api/sse_packet_observer.go
@@ -9,6 +9,7 @@ package api
 import (
 	"encoding/hex"
 	"strconv"
+	"time"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
@@ -43,6 +44,53 @@ func (o *sseHubPacketObserver) OnPacket(direction string, pkt *protocols.Packet)
 		return
 	}
 	o.hub.BroadcastPacket(packetToWire(direction, pkt))
+}
+
+// BroadcastCapturePacket ships a standalone-captured gopacket onto the
+// SSE packets stream. Used by the daemon's standalone capture loop,
+// which has no protocols.Stack and therefore no PacketObserver. The
+// shape produced here matches packetToWire() so the UI's stream
+// reader doesn't need a branch for the two sources.
+//
+// Direction is always "rx" — the standalone capture is read-only and
+// never injects frames.
+func (s *Server) BroadcastCapturePacket(pkt gopacket.Packet) {
+	if s == nil || s.sseHub == nil || pkt == nil {
+		return
+	}
+	s.sseHub.BroadcastPacket(gopacketToWire(pkt))
+}
+
+// gopacketToWire is the standalone-capture cousin of packetToWire. It
+// takes a gopacket.Packet directly rather than the protocols.Packet
+// wrapper. Same JSON shape; the only loss is the serial / VLAN
+// metadata that the protocols stack injects, which a sniff-only
+// session doesn't have anyway.
+func gopacketToWire(pkt gopacket.Packet) map[string]any {
+	md := pkt.Metadata()
+	raw := pkt.Data()
+	size := len(raw)
+	truncated := false
+	if size > sseMaxRawPacketBytes {
+		raw = raw[:sseMaxRawPacketBytes]
+		truncated = true
+	}
+
+	ts := md.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	out := map[string]any{
+		"timestamp": ts.UTC().Format("2006-01-02T15:04:05.000Z"),
+		"direction": "rx",
+		"size":      size,
+		"raw_data":  hex.EncodeToString(raw),
+		"truncated": truncated,
+		"protocol":  "Unknown",
+		"summary":   "",
+	}
+	enrichWithLayers(out, pkt.Data())
+	return out
 }
 
 // packetToWire flattens a Packet into a map suitable for SSE JSON.

--- a/internal/daemon/capture.go
+++ b/internal/daemon/capture.go
@@ -1,0 +1,137 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/gopacket/gopacket"
+
+	"github.com/krisarmstrong/niac-go/internal/api"
+	"github.com/krisarmstrong/niac-go/internal/capture"
+	"github.com/krisarmstrong/niac-go/internal/logging"
+)
+
+// standaloneCapture is the runtime state for a /api/v1/capture session.
+// Distinct from the Simulation type because no protocols.Stack is
+// involved — the engine runs in promiscuous-read mode and ships each
+// packet straight to the SSE hub. The atomic packet counter lets the
+// status endpoint report progress without contending on a mutex on the
+// hot path.
+type standaloneCapture struct {
+	iface     string
+	filter    string
+	startedAt time.Time
+	engine    *capture.Engine
+	cancel    context.CancelFunc
+	packets   atomic.Uint64
+}
+
+// StartCapture spins up a capture session on req.Interface, optionally
+// applies a BPF filter, and broadcasts every observed packet on the
+// SSE packets stream. Returns one of the api.ErrCapture* sentinels for
+// the typed-rejection paths (already running, sim active, no such
+// interface) so the API handler can map to a precise HTTP status.
+func (d *Daemon) StartCapture(req api.CaptureRequest) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.simulation != nil {
+		return api.ErrCaptureConflictsWithSim
+	}
+	if d.capture != nil {
+		return api.ErrCaptureAlreadyRunning
+	}
+
+	if !capture.InterfaceExists(req.Interface) {
+		return fmt.Errorf("%w: %s", api.ErrCaptureInterfaceNotFound, req.Interface)
+	}
+
+	engine, err := capture.New(req.Interface, DefaultDebugLevel)
+	if err != nil {
+		return fmt.Errorf("create capture engine: %w", err)
+	}
+
+	if req.Filter != "" {
+		if filterErr := engine.SetFilter(req.Filter); filterErr != nil {
+			engine.Close()
+			return fmt.Errorf("apply BPF filter %q: %w", req.Filter, filterErr)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	session := &standaloneCapture{
+		iface:     req.Interface,
+		filter:    req.Filter,
+		startedAt: time.Now(),
+		engine:    engine,
+		cancel:    cancel,
+	}
+
+	// Drive the capture in its own goroutine so the API call returns
+	// promptly. StartCaptureContext blocks until ctx is cancelled or
+	// the engine errors out, and invokes our handler synchronously
+	// for every packet — which is fine because the handler is just a
+	// counter bump + non-blocking SSE broadcast.
+	go d.runStandaloneCapture(ctx, session)
+
+	d.capture = session
+	logging.Successf("✓ Standalone capture started on %s", req.Interface)
+	return nil
+}
+
+// runStandaloneCapture is the engine.StartCaptureContext driver loop.
+// Lives on its own goroutine; exits when ctx is cancelled (StopCapture
+// or daemon shutdown) or when the engine surfaces an unrecoverable
+// error.
+func (d *Daemon) runStandaloneCapture(ctx context.Context, c *standaloneCapture) {
+	handler := func(pkt gopacket.Packet) {
+		c.packets.Add(1)
+		// Broadcast non-blocking: the SSE hub drops on overflow.
+		if d.apiServer != nil {
+			d.apiServer.BroadcastCapturePacket(pkt)
+		}
+	}
+
+	if err := c.engine.StartCaptureContext(ctx, handler); err != nil && ctx.Err() == nil {
+		logging.Errorf("standalone capture loop exited with error: %v", err)
+	}
+}
+
+// StopCapture cancels the active standalone capture (if any) and closes
+// its engine. Idempotent — calling with no active capture returns nil.
+func (d *Daemon) StopCapture() error {
+	d.mu.Lock()
+	session := d.capture
+	d.capture = nil
+	d.mu.Unlock()
+
+	if session == nil {
+		return nil
+	}
+
+	session.cancel()
+	session.engine.Close()
+	logging.Successf("✓ Standalone capture stopped on %s", session.iface)
+	return nil
+}
+
+// GetCaptureStatus returns a snapshot of the capture session. Safe to
+// call concurrently with the capture loop — the packet counter is
+// atomic and the snapshot fields are read under the daemon mutex.
+func (d *Daemon) GetCaptureStatus() api.CaptureStatus {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.capture == nil {
+		return api.CaptureStatus{Running: false}
+	}
+	return api.CaptureStatus{
+		Running:   true,
+		Interface: d.capture.iface,
+		Filter:    d.capture.filter,
+		StartedAt: d.capture.startedAt.Format(time.RFC3339),
+		Packets:   d.capture.packets.Load(),
+	}
+}

--- a/internal/daemon/capture_test.go
+++ b/internal/daemon/capture_test.go
@@ -1,0 +1,129 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/krisarmstrong/niac-go/internal/api"
+)
+
+// TestStartCapture_RejectsWhenSimulationRunning makes sure the daemon
+// won't try to open the same interface twice. The simulation side of
+// the lifecycle already owns the libpcap handle for the configured
+// interface; spinning up a standalone capture on top would either
+// fight for the handle or, worse, succeed and silently duplicate the
+// sniff loop.
+func TestStartCapture_RejectsWhenSimulationRunning(t *testing.T) {
+	d := newTestDaemon(t)
+	d.simulation = &Simulation{Interface: "lo0"}
+
+	err := d.StartCapture(api.CaptureRequest{Interface: "lo0"})
+	if err == nil {
+		t.Fatal("expected error when starting capture with a sim running, got nil")
+	}
+	if !errors.Is(err, api.ErrCaptureConflictsWithSim) {
+		t.Errorf("expected ErrCaptureConflictsWithSim, got: %v", err)
+	}
+}
+
+// TestStartCapture_RejectsWhenAlreadyRunning covers the idempotency
+// guard. A second POST should fail clean instead of leaking the old
+// engine.
+func TestStartCapture_RejectsWhenAlreadyRunning(t *testing.T) {
+	d := newTestDaemon(t)
+	d.capture = &standaloneCapture{
+		iface:     "lo0",
+		startedAt: time.Now(),
+		cancel:    func() {},
+	}
+
+	err := d.StartCapture(api.CaptureRequest{Interface: "lo0"})
+	if !errors.Is(err, api.ErrCaptureAlreadyRunning) {
+		t.Errorf("expected ErrCaptureAlreadyRunning, got: %v", err)
+	}
+}
+
+// TestStartCapture_RejectsUnknownInterface verifies the typed sentinel
+// makes it through to the API handler so HTTP status mapping (404) can
+// happen.
+func TestStartCapture_RejectsUnknownInterface(t *testing.T) {
+	d := newTestDaemon(t)
+
+	err := d.StartCapture(api.CaptureRequest{Interface: "this-iface-does-not-exist-xyz"})
+	if !errors.Is(err, api.ErrCaptureInterfaceNotFound) {
+		t.Errorf("expected ErrCaptureInterfaceNotFound, got: %v", err)
+	}
+}
+
+// TestStopCapture_NoActiveCaptureIsNoOp documents that the API
+// handler can safely call Stop on a daemon with no live capture.
+// Useful for the idempotent shutdown path.
+func TestStopCapture_NoActiveCaptureIsNoOp(t *testing.T) {
+	d := newTestDaemon(t)
+
+	if err := d.StopCapture(); err != nil {
+		t.Errorf("StopCapture with no active capture should return nil, got: %v", err)
+	}
+}
+
+// TestGetCaptureStatus_ReportsRunningSession exercises the snapshot
+// shape that the GET handler ships to the UI.
+func TestGetCaptureStatus_ReportsRunningSession(t *testing.T) {
+	d := newTestDaemon(t)
+	started := time.Now().Add(-30 * time.Second)
+	d.capture = &standaloneCapture{
+		iface:     "eth0",
+		filter:    "tcp port 80",
+		startedAt: started,
+		cancel:    func() {},
+	}
+	d.capture.packets.Store(42)
+
+	status := d.GetCaptureStatus()
+	if !status.Running {
+		t.Error("Running = false, want true")
+	}
+	if status.Interface != "eth0" {
+		t.Errorf("Interface = %q, want eth0", status.Interface)
+	}
+	if status.Filter != "tcp port 80" {
+		t.Errorf("Filter = %q, want tcp port 80", status.Filter)
+	}
+	if status.Packets != 42 {
+		t.Errorf("Packets = %d, want 42", status.Packets)
+	}
+	if status.StartedAt == "" {
+		t.Error("StartedAt is empty; expected RFC3339 timestamp")
+	}
+}
+
+// TestGetCaptureStatus_NoSession returns an empty Running=false status.
+func TestGetCaptureStatus_NoSession(t *testing.T) {
+	d := newTestDaemon(t)
+	status := d.GetCaptureStatus()
+	if status.Running {
+		t.Error("Running = true with no active capture")
+	}
+	if status.Packets != 0 {
+		t.Errorf("Packets = %d, want 0", status.Packets)
+	}
+}
+
+// newTestDaemon builds a Daemon with the minimum scaffolding needed to
+// exercise StartCapture / StopCapture / GetCaptureStatus. Storage is
+// disabled and there's no API server attached — these tests only care
+// about the daemon-internal state transitions and the typed sentinel
+// errors that the API handler maps to HTTP statuses.
+func newTestDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	d, err := NewDaemon(Config{StoragePath: "disabled"})
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	return d
+}
+
+// silence the unused-import warning if a future cleanup drops context.
+var _ = context.Background

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -57,6 +57,11 @@ type Daemon struct {
 
 	mu         sync.RWMutex
 	simulation *Simulation
+	// capture is the optional standalone packet-capture session that
+	// runs without a simulation. Mutually exclusive with simulation
+	// because both want exclusive ownership of the same libpcap
+	// interface handle; see internal/daemon/capture.go.
+	capture *standaloneCapture
 }
 
 // Simulation represents a running NIAC simulation.
@@ -120,6 +125,7 @@ func (d *Daemon) Start() error {
 	// Set daemon controller on the API server
 	// This allows the API to call our Start/Stop/Status methods
 	d.apiServer.SetDaemonController(d)
+	d.apiServer.SetCaptureController(d)
 
 	err := d.apiServer.Start()
 	if err != nil {
@@ -142,6 +148,12 @@ func (d *Daemon) Shutdown(ctx context.Context) error {
 	stopErr := d.StopSimulation()
 	if stopErr != nil {
 		logging.Errorf("Error stopping simulation: %v", stopErr)
+	}
+
+	// Stop standalone capture if running. StopCapture is idempotent so
+	// the no-capture case is a fast nil return.
+	if captureErr := d.StopCapture(); captureErr != nil {
+		logging.Errorf("Error stopping standalone capture: %v", captureErr)
 	}
 
 	// Shutdown API server

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -199,6 +199,25 @@ export interface SimulationStatus {
   uptimeSeconds: number;
 }
 
+/**
+ * StandaloneCaptureStatus mirrors the daemon's api.CaptureStatus. It
+ * powers the "sniff this interface" mode of the PCAP Inspector — i.e.
+ * packet capture without a simulation.
+ */
+export interface StandaloneCaptureStatus {
+  running: boolean;
+  interface?: string;
+  filter?: string;
+  startedAt?: string;
+  packets: number;
+}
+
+export interface StandaloneCaptureRequest {
+  interface: string;
+  /** Optional libpcap BPF expression. Empty captures everything. */
+  filter?: string;
+}
+
 export interface SimulationRequest {
   interface: string;
   configPath?: string;

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -27,6 +27,8 @@ import type {
   SimulationRequest,
   SimulationStatus,
   StackStatsResponse,
+  StandaloneCaptureRequest,
+  StandaloneCaptureStatus,
   Template,
   TemplateContent,
   TopologyGraph,
@@ -415,6 +417,18 @@ export const startSimulation = (payload: SimulationRequest) =>
   });
 export const stopSimulation = () =>
   request<{ status: string }>('/api/v1/simulation', {
+    method: 'DELETE',
+  });
+
+// Standalone packet capture (PCAP Inspector "sniff without a sim" mode).
+// Backed by /api/v1/capture in the daemon.
+export const fetchCaptureStatus = () => deduplicatedGet<StandaloneCaptureStatus>('/api/v1/capture');
+export const startStandaloneCapture = (payload: StandaloneCaptureRequest) =>
+  requestJson<StandaloneCaptureStatus>('/api/v1/capture', payload, {
+    method: 'POST',
+  });
+export const stopStandaloneCapture = () =>
+  request<{ status: string }>('/api/v1/capture', {
     method: 'DELETE',
   });
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -31,6 +31,8 @@ export type {
   SimulationRequest,
   SimulationStatus,
   StackStatsResponse,
+  StandaloneCaptureRequest,
+  StandaloneCaptureStatus,
   TopologyGraph,
   TopologyLink,
   TopologyNode,

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -11,7 +11,14 @@ import {
 } from 'lucide-react';
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { fetchSimulationStatus } from '../api/client';
+import {
+  fetchCaptureStatus,
+  fetchSimulationStatus,
+  fetchUsableInterfaces,
+  startStandaloneCapture,
+  stopStandaloneCapture,
+} from '../api/client';
+import type { StandaloneCaptureStatus } from '../api/types';
 import { BpfFilterBar } from '../components/BpfFilterBar';
 import { ColoringRulesPanel } from '../components/ColoringRulesPanel';
 import { FilterBar } from '../components/FilterBar';
@@ -79,14 +86,24 @@ const ConnectionStatus: FC<{
  */
 export const PacketInspectorPage: FC = () => {
   const navigate = useNavigate();
-  // Today the packet stream is driven by the running simulation's capture
-  // engine, so when no sim is running the page would just sit empty and
-  // confused. Show an explicit empty state with a CTA to start a sim
-  // until we land a standalone-capture lifecycle (tracked separately).
+  // The page streams from /api/v1/stream/packets, which the daemon
+  // populates from either a running simulation OR a standalone capture
+  // session. Polling both lets us pick whichever is producing traffic
+  // and show its interface in the header.
   const { data: simStatus } = useApiResource(fetchSimulationStatus, [], {
     intervalMs: POLL_INTERVALS.fast,
   });
+  const { data: captureStatus, refetch: refetchCapture } = useApiResource(fetchCaptureStatus, [], {
+    intervalMs: POLL_INTERVALS.fast,
+  });
   const simRunning = simStatus?.running === true;
+  const captureRunning = captureStatus?.running === true;
+  const streamActive = simRunning || captureRunning;
+  const activeInterface = simRunning
+    ? simStatus?.interface
+    : captureRunning
+      ? captureStatus?.interface
+      : undefined;
 
   // Packet buffer state
   const [packets, setPackets] = useState<Packet[]>([]);
@@ -237,27 +254,16 @@ export const PacketInspectorPage: FC = () => {
     return `${selectedPacket.sourceIp}:${selectedPacket.sourcePort ?? 0}`;
   }, [selectedPacket]);
 
-  if (!simRunning) {
+  if (!streamActive) {
     return (
-      <Card className="border-yellow-500/30 bg-yellow-900/20">
-        <CardContent className="space-y-3">
-          <div className="flex items-start gap-3">
-            <Activity className={`mt-1 ${iconSizes.lg} text-yellow-400`} />
-            <div className="flex-1">
-              <p className="font-semibold text-yellow-200">No simulation running</p>
-              <SmallText className="text-yellow-300/90">
-                Packet capture follows the running simulation's interface. Start a simulation to
-                begin streaming. Standalone capture without a simulation is on the roadmap.
-              </SmallText>
-              <div className="mt-3">
-                <Button tone="violet" onClick={() => navigate('/runtime')}>
-                  Go to Simulation
-                </Button>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <StandaloneCaptureStarter
+        onStarted={() => {
+          // Force an immediate status refresh so the page transitions
+          // out of the empty state without waiting for the poll tick.
+          refetchCapture();
+        }}
+        navigateToSim={() => navigate('/runtime')}
+      />
     );
   }
 
@@ -271,8 +277,9 @@ export const PacketInspectorPage: FC = () => {
             <div className="flex items-center gap-4">
               <H2 className="mb-0">Packet Capture</H2>
               <SmallText className="text-gray-400">
-                on <span className="font-mono text-gray-200">{simStatus?.interface ?? '—'}</span>
+                on <span className="font-mono text-gray-200">{activeInterface ?? '—'}</span>
               </SmallText>
+              {captureRunning && !simRunning && <Tag colorScheme="violet">Standalone</Tag>}
               <ConnectionStatus connected={connected} />
             </div>
 
@@ -298,6 +305,24 @@ export const PacketInspectorPage: FC = () => {
               >
                 Clear
               </Button>
+
+              {captureRunning && !simRunning && (
+                <Button
+                  variant="outline"
+                  tone="red"
+                  size="sm"
+                  onClick={async () => {
+                    try {
+                      await stopStandaloneCapture();
+                      refetchCapture();
+                    } catch {
+                      // Surface via the empty-state error path on next render.
+                    }
+                  }}
+                >
+                  Stop capture
+                </Button>
+              )}
 
               <Button
                 variant="ghost"
@@ -454,3 +479,123 @@ export const PacketInspectorPage: FC = () => {
     </div>
   );
 };
+
+/**
+ * StandaloneCaptureStarter is the empty-state UI for PCAP Inspector
+ * when neither a simulation nor a standalone capture session is
+ * running. It lets the user start a sniff-only capture on an
+ * interface of their choice, with an optional BPF filter.
+ *
+ * Once StartStandaloneCapture succeeds, the parent's polling picks up
+ * captureStatus.running and re-renders into the regular packet stream
+ * UI on the next tick. Calling onStarted forces an immediate refetch
+ * so the transition doesn't wait on the poll interval.
+ */
+const StandaloneCaptureStarter: FC<{
+  onStarted: () => void;
+  navigateToSim: () => void;
+}> = ({ onStarted, navigateToSim }) => {
+  const { data: interfacesResp } = useApiResource(fetchUsableInterfaces, []);
+  const interfaces = interfacesResp?.interfaces ?? [];
+  const [selectedIface, setSelectedIface] = useState('');
+  const [bpfFilter, setBpfFilter] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Default to the first usable interface once the list arrives.
+  useEffect(() => {
+    if (!selectedIface && interfaces.length > 0) {
+      setSelectedIface(interfaces[0]?.name ?? '');
+    }
+  }, [interfaces, selectedIface]);
+
+  const handleStart = useCallback(async () => {
+    if (!selectedIface || busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await startStandaloneCapture({
+        interface: selectedIface,
+        filter: bpfFilter.trim() || undefined,
+      });
+      onStarted();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start capture');
+      setBusy(false);
+    }
+  }, [bpfFilter, busy, onStarted, selectedIface]);
+
+  return (
+    <Card className="border-white/5 bg-gray-900/70">
+      <CardContent className="space-y-4">
+        <div className="flex items-start gap-3">
+          <Activity className={`mt-1 ${iconSizes.lg} text-violet-300`} />
+          <div className="flex-1">
+            <p className="font-semibold text-white">Standalone packet capture</p>
+            <SmallText className="text-gray-400">
+              Sniff an interface without starting a simulation. Frames stream into the viewer below
+              as soon as they hit the wire. Or{' '}
+              <button
+                type="button"
+                onClick={navigateToSim}
+                className="text-violet-300 underline hover:text-violet-200"
+              >
+                start a simulation
+              </button>{' '}
+              if you want NIAC to also respond on the wire.
+            </SmallText>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-[1fr_2fr_auto] sm:items-end">
+          <label className="flex flex-col gap-1 text-sm text-gray-400">
+            Interface
+            <select
+              value={selectedIface}
+              onChange={(e) => setSelectedIface(e.target.value)}
+              disabled={busy || interfaces.length === 0}
+              className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+            >
+              {interfaces.length === 0 ? (
+                <option value="">No interfaces detected</option>
+              ) : (
+                interfaces.map((iface) => (
+                  <option key={iface.name} value={iface.name}>
+                    {iface.name}
+                    {iface.addresses && iface.addresses.length > 0
+                      ? ` (${iface.addresses[0]})`
+                      : ''}
+                  </option>
+                ))
+              )}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-gray-400">
+            BPF filter (optional)
+            <input
+              type="text"
+              value={bpfFilter}
+              onChange={(e) => setBpfFilter(e.target.value)}
+              disabled={busy}
+              placeholder="e.g. tcp port 80"
+              className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-2 font-mono text-sm text-white focus:border-violet-400 focus:outline-none"
+            />
+          </label>
+          <Button tone="violet" onClick={handleStart} disabled={!selectedIface || busy}>
+            {busy ? 'Starting…' : 'Start capture'}
+          </Button>
+        </div>
+        {error && (
+          <SmallText className="text-red-400" role="alert">
+            {error}
+          </SmallText>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+// Keep the import live even if the type is only used implicitly via
+// the API client return types.
+export type { StandaloneCaptureStatus };


### PR DESCRIPTION
## Summary
PCAP Inspector previously sat empty without a running simulation — the SSE packet stream only had a source while the protocol stack was up. This PR adds a sniff-only capture lifecycle so the page is useful outside a sim run.

## Backend
- \`internal/api/handlers_capture.go\`: \`GET/POST/DELETE /api/v1/capture\` with typed sentinel errors (already-running, sim conflict, interface-not-found) → precise HTTP status codes.
- \`internal/api/sse_packet_observer.go\`: \`Server.BroadcastCapturePacket\` + \`gopacketToWire\` that match the existing \`packetToWire\` shape so the UI SSE consumer doesn't need a branch.
- \`internal/daemon/capture.go\`: standalone capture lifecycle. Mutually exclusive with \`Simulation\` (both want exclusive ownership of the libpcap interface handle). Atomic packet counter, RW-mutex status snapshot.
- Daemon Start wires \`SetCaptureController(d)\`; Shutdown stops a running capture before tearing down the API server.

## Tests
- \`internal/daemon/capture_test.go\`: sim conflict, already-running guard, unknown interface, idempotent stop, status snapshot — 6 tests, all green.

## UI
- API client: \`fetchCaptureStatus\` / \`startStandaloneCapture\` / \`stopStandaloneCapture\` + matching types.
- \`PacketInspectorPage.tsx\`: when neither a sim nor a capture is running, render \`StandaloneCaptureStarter\` — an interface picker + optional BPF filter + Start. While a standalone capture is active, the header gets a \`Standalone\` tag and the controls include a \`Stop capture\` button.

## Verified locally
\`\`\`
$ curl -X POST /api/v1/capture -d '{"interface":"lo0"}'
{"running":true,"interface":"lo0","started_at":"...","packets":0}

$ curl /api/v1/capture
{"running":true,"interface":"lo0","started_at":"...","packets":4}

$ curl -X DELETE /api/v1/capture
{"status":"stopped"}
\`\`\`

## Test plan
- [x] \`go test ./internal/api/... ./internal/daemon/...\` clean
- [x] \`golangci-lint run ./internal/api/... ./internal/daemon/...\` clean
- [x] \`biome check src/\` + \`tsc --noEmit\` clean
- [x] curl reproduction
- [ ] Browser: load Packet Capture page with no sim, pick lo0, click Start → frames stream