### PR TITLE
refactor(ui): split ConfigPicker into types + controls + list

### DIFF
--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -1,20 +1,11 @@
 import {
-  Building2,
-  Check,
   ChevronDown,
   ChevronRight,
-  Eye,
   FileCode,
   FileUp,
-  FolderOpen,
-  Globe,
-  HardDrive,
   LayoutGrid,
   List,
-  Router,
   Search,
-  Server,
-  Wifi,
 } from 'lucide-react';
 import { type FC, useEffect, useMemo, useState } from 'react';
 import {
@@ -25,87 +16,33 @@ import {
 } from '../../api/client';
 import type { Template, TemplateContent, UserConfig } from '../../api/types';
 import { iconSizes } from '../../constants/sizes';
-import { Tag } from '../../ui/Tag';
 import { SmallText } from '../../ui/Typography';
 import { TemplatePreviewModal } from '../TemplatePreviewModal';
 import { JavaDslImportCard } from '../templates/JavaDslImportCard';
+import {
+  type ConfigItem,
+  type ConfigPickerProps,
+  readPref,
+  SOURCE_FILTER_PREF_KEY,
+  type SourceFilter,
+  VIEW_PREF_KEY,
+  type ViewMode,
+  writePref,
+} from './ConfigPicker.types';
+import { SourceChip, ViewToggle } from './ConfigPickerControls';
+import { ConfigsList } from './ConfigPickerList';
 
-type ViewMode = 'grid' | 'list';
-type SourceFilter = 'all' | 'builtin' | 'saved' | 'local';
-
-const VIEW_PREF_KEY = 'niac.configs.viewMode';
-const SOURCE_FILTER_PREF_KEY = 'niac.configs.sourceFilter';
-
-const TEMPLATE_TYPE_ICON: Record<Template['type'], FC<{ className?: string }>> = {
-  basic: Globe,
-  router: Router,
-  switch: FileCode,
-  'access-point': Wifi,
-  server: Server,
-  complete: Building2,
-  custom: FileCode,
-};
-
-const TEMPLATE_TYPE_TINT: Record<Template['type'], string> = {
-  basic: 'bg-blue-500/15 text-blue-200 border-blue-400/30',
-  router: 'bg-orange-500/15 text-orange-200 border-orange-400/30',
-  switch: 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30',
-  'access-point': 'bg-purple-500/15 text-purple-200 border-purple-400/30',
-  server: 'bg-cyan-500/15 text-cyan-200 border-cyan-400/30',
-  complete: 'bg-amber-500/15 text-amber-200 border-amber-400/30',
-  custom: 'bg-pink-500/15 text-pink-200 border-pink-400/30',
-};
-
-// One row in the unified Configs list.
-type ConfigItem =
-  | {
-      kind: 'builtin';
-      key: string;
-      name: string;
-      description: string;
-      deviceCount: number;
-      template: Template;
-    }
-  | {
-      kind: 'saved';
-      key: string;
-      name: string;
-      description: string;
-      deviceCount: number;
-      config: UserConfig;
-    }
-  | {
-      kind: 'local';
-      key: string;
-      name: string;
-      description: string;
-      deviceCount: number;
-      file: File;
-    };
-
-interface Selection {
-  source: 'template' | 'userConfig' | 'upload' | null;
-  name: string;
-  path?: string;
-}
-
-export interface ConfigPickerProps {
-  /** The currently selected config. */
-  selection: Selection;
-  /** Called when the user picks a built-in template. */
-  onSelectTemplate: (template: Template) => void;
-  /** Called when the user picks a saved (user) config. */
-  onSelectUserConfig: (config: UserConfig) => void;
-  /** Called when the user uploads a file (or clears it). */
-  onUpload: (file: File | null) => void;
-  /** The current upload file, if any. */
-  uploadFile: File | null;
-}
+export type { ConfigPickerProps } from './ConfigPicker.types';
 
 /**
- * ConfigPicker is the single config-source picker for the Simulation page.
- * Built-in templates, user-saved configs, and a one-shot local upload all
- * live in the same list with a "source" filter chip; there are no tabs.
+ * ConfigPicker is the single config-source picker for the Simulation
+ * page. Built-in templates, user-saved configs, and a one-shot local
+ * upload all live in the same list with a "source" filter chip; there
+ * are no tabs. Subcomponents live alongside this file:
+ *
+ *   ConfigPicker.types.ts     — ConfigItem, props, persisted-pref helpers
+ *   ConfigPickerControls.tsx  — source-filter chip + grid/list toggle
+ *   ConfigPickerList.tsx      — card grid + compact list presenters
  */
 export const ConfigPicker: FC<ConfigPickerProps> = ({
   selection,
@@ -446,296 +383,3 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
     </div>
   );
 };
-
-function readPref<T extends string>(key: string, fallback: T): T {
-  if (typeof window === 'undefined') return fallback;
-  const saved = window.localStorage.getItem(key);
-  return (saved as T) || fallback;
-}
-
-function writePref(key: string, value: string) {
-  if (typeof window !== 'undefined') {
-    window.localStorage.setItem(key, value);
-  }
-}
-
-const SourceChip: FC<{
-  active: boolean;
-  onClick: () => void;
-  label: string;
-  count: number;
-}> = ({ active, onClick, label, count }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    aria-pressed={active}
-    className={`flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-      active
-        ? 'bg-violet-500/20 text-violet-100 ring-1 ring-violet-400/40'
-        : 'bg-gray-800/60 text-gray-400 ring-1 ring-white/10 hover:bg-white/5 hover:text-gray-200'
-    }`}
-  >
-    <span>{label}</span>
-    <span
-      className={`rounded-full px-1.5 py-0.5 text-[10px] ${
-        active ? 'bg-violet-500/30 text-violet-100' : 'bg-white/10 text-gray-300'
-      }`}
-    >
-      {count}
-    </span>
-  </button>
-);
-
-const ViewToggle: FC<{
-  active: boolean;
-  onClick: () => void;
-  icon: React.ReactNode;
-  label: string;
-}> = ({ active, onClick, icon, label }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    aria-pressed={active}
-    title={label}
-    className={`rounded px-2 py-1 transition-colors ${
-      active
-        ? 'bg-violet-500/20 text-violet-100'
-        : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
-    }`}
-  >
-    {icon}
-  </button>
-);
-
-const ConfigsList: FC<{
-  items: ConfigItem[];
-  loading: boolean;
-  viewMode: ViewMode;
-  isSelected: (item: ConfigItem) => boolean;
-  onSelect: (item: ConfigItem) => void;
-  onView: (item: ConfigItem) => void;
-  onClearLocal: () => void;
-}> = ({ items, loading, viewMode, isSelected, onSelect, onView, onClearLocal }) => {
-  if (loading) {
-    return <SmallText className="text-gray-500">Loading configs…</SmallText>;
-  }
-  if (items.length === 0) {
-    return (
-      <SmallText className="text-gray-500">
-        Nothing matches. Try a different search, switch the source filter, or upload a local YAML
-        with the button above.
-      </SmallText>
-    );
-  }
-
-  if (viewMode === 'grid') {
-    return (
-      <div className="grid max-h-[420px] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => (
-          <ConfigCard
-            key={item.key}
-            item={item}
-            selected={isSelected(item)}
-            onSelect={onSelect}
-            onView={onView}
-            onClearLocal={onClearLocal}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto rounded-lg border border-white/10 bg-gray-950/40">
-      {items.map((item) => (
-        <ConfigRow
-          key={item.key}
-          item={item}
-          selected={isSelected(item)}
-          onSelect={onSelect}
-          onView={onView}
-          onClearLocal={onClearLocal}
-        />
-      ))}
-    </ul>
-  );
-};
-
-function sourceTagFor(item: ConfigItem) {
-  if (item.kind === 'builtin')
-    return (
-      <Tag colorScheme="purple" className="text-[10px]">
-        Built-in
-      </Tag>
-    );
-  if (item.kind === 'saved')
-    return (
-      <Tag colorScheme="green" className="text-[10px]">
-        Saved
-      </Tag>
-    );
-  return (
-    <Tag colorScheme="blue" className="text-[10px]">
-      Local
-    </Tag>
-  );
-}
-
-const ConfigCard: FC<{
-  item: ConfigItem;
-  selected: boolean;
-  onSelect: (item: ConfigItem) => void;
-  onView: (item: ConfigItem) => void;
-  onClearLocal: () => void;
-}> = ({ item, selected, onSelect, onView, onClearLocal }) => {
-  const Icon =
-    item.kind === 'builtin'
-      ? (TEMPLATE_TYPE_ICON[item.template.type] ?? FileCode)
-      : item.kind === 'saved'
-        ? FolderOpen
-        : HardDrive;
-  const tint =
-    item.kind === 'builtin'
-      ? (TEMPLATE_TYPE_TINT[item.template.type] ?? TEMPLATE_TYPE_TINT.custom)
-      : item.kind === 'saved'
-        ? 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30'
-        : 'bg-blue-500/15 text-blue-200 border-blue-400/30';
-
-  return (
-    <div
-      className={`flex flex-col gap-3 rounded-lg border p-3 transition-colors ${
-        selected
-          ? 'border-violet-400/50 bg-violet-500/10'
-          : 'border-white/10 bg-gray-950/40 hover:border-violet-500/30'
-      }`}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className={`rounded-md border p-2 ${tint}`}>
-          <Icon className={iconSizes.lg} />
-        </div>
-        {sourceTagFor(item)}
-      </div>
-      <div>
-        <div className="font-semibold text-white">{item.name}</div>
-        <SmallText className="mt-0.5 line-clamp-2 text-gray-400">
-          {item.description || 'No description'}
-        </SmallText>
-      </div>
-      <div className="flex flex-wrap items-center gap-1.5">
-        {item.kind !== 'local' && (
-          <Tag colorScheme="purple" className="text-[10px]">
-            {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
-          </Tag>
-        )}
-        {item.kind === 'builtin' &&
-          item.template.tags?.slice(0, 2).map((tag) => (
-            <Tag key={tag} colorScheme="gray" className="text-[10px]">
-              {tag}
-            </Tag>
-          ))}
-      </div>
-      <div className="flex gap-2">
-        {selected ? (
-          <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-violet-500/30 px-2 py-1.5 text-xs font-medium text-violet-50 ring-1 ring-violet-400/60">
-            <Check className={iconSizes.sm} />
-            <span>Will use this</span>
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => onSelect(item)}
-            className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
-            title="Pick this config — you'll still need to click Start Simulation below to run it"
-          >
-            Pick
-          </button>
-        )}
-        {item.kind === 'builtin' && (
-          <button
-            type="button"
-            onClick={() => onView(item)}
-            className="rounded border border-white/10 bg-gray-900/60 px-2 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
-            title="Preview YAML"
-          >
-            <Eye className={iconSizes.sm} />
-          </button>
-        )}
-        {item.kind === 'local' && (
-          <button
-            type="button"
-            onClick={onClearLocal}
-            className="rounded border border-red-400/30 bg-red-500/10 px-2 py-1.5 text-xs font-medium text-red-200 hover:bg-red-500/20"
-            title="Drop the local file"
-          >
-            Clear
-          </button>
-        )}
-      </div>
-    </div>
-  );
-};
-
-const ConfigRow: FC<{
-  item: ConfigItem;
-  selected: boolean;
-  onSelect: (item: ConfigItem) => void;
-  onView: (item: ConfigItem) => void;
-  onClearLocal: () => void;
-}> = ({ item, selected, onSelect, onView, onClearLocal }) => (
-  <li
-    className={`flex items-center gap-3 px-3 py-2 transition-colors ${
-      selected ? 'bg-violet-500/10' : 'hover:bg-white/5'
-    }`}
-  >
-    <button
-      type="button"
-      onClick={() => onSelect(item)}
-      className="flex-1 text-left"
-      title={`Use ${item.name}`}
-    >
-      <div className="flex items-center gap-2">
-        <span className="font-medium text-white">{item.name}</span>
-        {sourceTagFor(item)}
-        {item.kind !== 'local' && (
-          <Tag colorScheme="purple" className="text-[10px]">
-            {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
-          </Tag>
-        )}
-        {item.kind === 'builtin' && (
-          <Tag colorScheme="gray" className="text-[10px] capitalize">
-            {item.template.type}
-          </Tag>
-        )}
-      </div>
-      {item.description && (
-        <SmallText
-          className={`mt-0.5 line-clamp-1 text-gray-400 ${
-            item.kind === 'saved' ? 'font-mono text-[11px] text-gray-500' : ''
-          }`}
-        >
-          {item.description}
-        </SmallText>
-      )}
-    </button>
-    {item.kind === 'builtin' && (
-      <button
-        type="button"
-        onClick={() => onView(item)}
-        className="rounded p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
-        title="Preview the template YAML"
-      >
-        <Eye className={iconSizes.md} />
-      </button>
-    )}
-    {item.kind === 'local' && (
-      <button
-        type="button"
-        onClick={onClearLocal}
-        className="text-xs font-medium text-red-300 hover:text-red-200"
-        title="Drop the local file"
-      >
-        Clear
-      </button>
-    )}
-  </li>
-);

--- a/ui/src/components/simulation/ConfigPicker.types.ts
+++ b/ui/src/components/simulation/ConfigPicker.types.ts
@@ -1,0 +1,109 @@
+import { Building2, FileCode, Globe, Router, Server, Wifi } from 'lucide-react';
+import type { FC } from 'react';
+import type { Template, UserConfig } from '../../api/types';
+
+/**
+ * Shared types + helpers for the ConfigPicker family of components.
+ *
+ * Keeping the union shape (ConfigItem), the persisted-pref helpers, and
+ * the type→icon / type→tint tables in one .ts module means the list,
+ * card, row, and chip subcomponents can all import from a single
+ * declarative source.
+ */
+
+export type ViewMode = 'grid' | 'list';
+export type SourceFilter = 'all' | 'builtin' | 'saved' | 'local';
+
+export const VIEW_PREF_KEY = 'niac.configs.viewMode';
+export const SOURCE_FILTER_PREF_KEY = 'niac.configs.sourceFilter';
+
+export const TEMPLATE_TYPE_ICON: Record<Template['type'], FC<{ className?: string }>> = {
+  basic: Globe,
+  router: Router,
+  switch: FileCode,
+  'access-point': Wifi,
+  server: Server,
+  complete: Building2,
+  custom: FileCode,
+};
+
+export const TEMPLATE_TYPE_TINT: Record<Template['type'], string> = {
+  basic: 'bg-blue-500/15 text-blue-200 border-blue-400/30',
+  router: 'bg-orange-500/15 text-orange-200 border-orange-400/30',
+  switch: 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30',
+  'access-point': 'bg-purple-500/15 text-purple-200 border-purple-400/30',
+  server: 'bg-cyan-500/15 text-cyan-200 border-cyan-400/30',
+  complete: 'bg-amber-500/15 text-amber-200 border-amber-400/30',
+  custom: 'bg-pink-500/15 text-pink-200 border-pink-400/30',
+};
+
+/**
+ * ConfigItem is one row in the unified Configs list, regardless of
+ * whether the underlying source is a built-in template, a saved user
+ * config, or a one-shot local upload.
+ */
+export type ConfigItem =
+  | {
+      kind: 'builtin';
+      key: string;
+      name: string;
+      description: string;
+      deviceCount: number;
+      template: Template;
+    }
+  | {
+      kind: 'saved';
+      key: string;
+      name: string;
+      description: string;
+      deviceCount: number;
+      config: UserConfig;
+    }
+  | {
+      kind: 'local';
+      key: string;
+      name: string;
+      description: string;
+      deviceCount: number;
+      file: File;
+    };
+
+/**
+ * Selection is what the parent Simulation page tracks. Only one of
+ * source values is active at a time; the source string picks which
+ * of name/path is meaningful.
+ */
+export interface Selection {
+  source: 'template' | 'userConfig' | 'upload' | null;
+  name: string;
+  path?: string;
+}
+
+export interface ConfigPickerProps {
+  /** The currently selected config. */
+  selection: Selection;
+  /** Called when the user picks a built-in template. */
+  onSelectTemplate: (template: Template) => void;
+  /** Called when the user picks a saved (user) config. */
+  onSelectUserConfig: (config: UserConfig) => void;
+  /** Called when the user uploads a file (or clears it). */
+  onUpload: (file: File | null) => void;
+  /** The current upload file, if any. */
+  uploadFile: File | null;
+}
+
+/**
+ * readPref / writePref persist UI state (view mode, source filter)
+ * in localStorage. SSR-safe — they no-op when window is undefined.
+ */
+export function readPref<T extends string>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') return fallback;
+  const saved = window.localStorage.getItem(key);
+  return (saved as T) || fallback;
+}
+
+export function writePref(key: string, value: string) {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(key, value);
+  }
+}

--- a/ui/src/components/simulation/ConfigPickerControls.tsx
+++ b/ui/src/components/simulation/ConfigPickerControls.tsx
@@ -1,0 +1,59 @@
+import type { FC, ReactNode } from 'react';
+
+/**
+ * Small pill button used for the All / Built-in / Saved / Local source
+ * filter row above the configs list. Renders the label with a small
+ * count chip on the right.
+ */
+export const SourceChip: FC<{
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  count: number;
+}> = ({ active, onClick, label, count }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={active}
+    className={`flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+      active
+        ? 'bg-violet-500/20 text-violet-100 ring-1 ring-violet-400/40'
+        : 'bg-gray-800/60 text-gray-400 ring-1 ring-white/10 hover:bg-white/5 hover:text-gray-200'
+    }`}
+  >
+    <span>{label}</span>
+    <span
+      className={`rounded-full px-1.5 py-0.5 text-[10px] ${
+        active ? 'bg-violet-500/30 text-violet-100' : 'bg-white/10 text-gray-300'
+      }`}
+    >
+      {count}
+    </span>
+  </button>
+);
+
+/**
+ * One half of the grid/list view-density toggle. Two of these live
+ * inside a <fieldset> in ConfigPicker so screen readers see them as
+ * an exclusive group.
+ */
+export const ViewToggle: FC<{
+  active: boolean;
+  onClick: () => void;
+  icon: ReactNode;
+  label: string;
+}> = ({ active, onClick, icon, label }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={active}
+    title={label}
+    className={`rounded px-2 py-1 transition-colors ${
+      active
+        ? 'bg-violet-500/20 text-violet-100'
+        : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+    }`}
+  >
+    {icon}
+  </button>
+);

--- a/ui/src/components/simulation/ConfigPickerList.tsx
+++ b/ui/src/components/simulation/ConfigPickerList.tsx
@@ -1,0 +1,250 @@
+import { Check, Eye, FileCode, FolderOpen, HardDrive } from 'lucide-react';
+import type { FC } from 'react';
+import { iconSizes } from '../../constants/sizes';
+import { Tag } from '../../ui/Tag';
+import { SmallText } from '../../ui/Typography';
+import {
+  type ConfigItem,
+  TEMPLATE_TYPE_ICON,
+  TEMPLATE_TYPE_TINT,
+  type ViewMode,
+} from './ConfigPicker.types';
+
+interface SharedItemProps {
+  item: ConfigItem;
+  selected: boolean;
+  onSelect: (item: ConfigItem) => void;
+  onView: (item: ConfigItem) => void;
+  onClearLocal: () => void;
+}
+
+/**
+ * sourceTagFor stamps a one-word colour-coded badge onto a config row
+ * so the user can tell at a glance whether they're looking at a
+ * built-in template, a saved YAML, or the one-shot local upload.
+ */
+function sourceTagFor(item: ConfigItem) {
+  if (item.kind === 'builtin')
+    return (
+      <Tag colorScheme="purple" className="text-[10px]">
+        Built-in
+      </Tag>
+    );
+  if (item.kind === 'saved')
+    return (
+      <Tag colorScheme="green" className="text-[10px]">
+        Saved
+      </Tag>
+    );
+  return (
+    <Tag colorScheme="blue" className="text-[10px]">
+      Local
+    </Tag>
+  );
+}
+
+/**
+ * ConfigsList chooses between the card-grid view and the compact-list
+ * view based on viewMode, and surfaces the loading + empty states.
+ * The card / row presenters live below.
+ */
+export const ConfigsList: FC<{
+  items: ConfigItem[];
+  loading: boolean;
+  viewMode: ViewMode;
+  isSelected: (item: ConfigItem) => boolean;
+  onSelect: (item: ConfigItem) => void;
+  onView: (item: ConfigItem) => void;
+  onClearLocal: () => void;
+}> = ({ items, loading, viewMode, isSelected, onSelect, onView, onClearLocal }) => {
+  if (loading) {
+    return <SmallText className="text-gray-500">Loading configs…</SmallText>;
+  }
+  if (items.length === 0) {
+    return (
+      <SmallText className="text-gray-500">
+        Nothing matches. Try a different search, switch the source filter, or upload a local YAML
+        with the button above.
+      </SmallText>
+    );
+  }
+
+  if (viewMode === 'grid') {
+    return (
+      <div className="grid max-h-[420px] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2 xl:grid-cols-3">
+        {items.map((item) => (
+          <ConfigCard
+            key={item.key}
+            item={item}
+            selected={isSelected(item)}
+            onSelect={onSelect}
+            onView={onView}
+            onClearLocal={onClearLocal}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto rounded-lg border border-white/10 bg-gray-950/40">
+      {items.map((item) => (
+        <ConfigRow
+          key={item.key}
+          item={item}
+          selected={isSelected(item)}
+          onSelect={onSelect}
+          onView={onView}
+          onClearLocal={onClearLocal}
+        />
+      ))}
+    </ul>
+  );
+};
+
+const ConfigCard: FC<SharedItemProps> = ({ item, selected, onSelect, onView, onClearLocal }) => {
+  const Icon =
+    item.kind === 'builtin'
+      ? (TEMPLATE_TYPE_ICON[item.template.type] ?? FileCode)
+      : item.kind === 'saved'
+        ? FolderOpen
+        : HardDrive;
+  const tint =
+    item.kind === 'builtin'
+      ? (TEMPLATE_TYPE_TINT[item.template.type] ?? TEMPLATE_TYPE_TINT.custom)
+      : item.kind === 'saved'
+        ? 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30'
+        : 'bg-blue-500/15 text-blue-200 border-blue-400/30';
+
+  return (
+    <div
+      className={`flex flex-col gap-3 rounded-lg border p-3 transition-colors ${
+        selected
+          ? 'border-violet-400/50 bg-violet-500/10'
+          : 'border-white/10 bg-gray-950/40 hover:border-violet-500/30'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className={`rounded-md border p-2 ${tint}`}>
+          <Icon className={iconSizes.lg} />
+        </div>
+        {sourceTagFor(item)}
+      </div>
+      <div>
+        <div className="font-semibold text-white">{item.name}</div>
+        <SmallText className="mt-0.5 line-clamp-2 text-gray-400">
+          {item.description || 'No description'}
+        </SmallText>
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {item.kind !== 'local' && (
+          <Tag colorScheme="purple" className="text-[10px]">
+            {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
+          </Tag>
+        )}
+        {item.kind === 'builtin' &&
+          item.template.tags?.slice(0, 2).map((tag) => (
+            <Tag key={tag} colorScheme="gray" className="text-[10px]">
+              {tag}
+            </Tag>
+          ))}
+      </div>
+      <div className="flex gap-2">
+        {selected ? (
+          <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-violet-500/30 px-2 py-1.5 text-xs font-medium text-violet-50 ring-1 ring-violet-400/60">
+            <Check className={iconSizes.sm} />
+            <span>Will use this</span>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onSelect(item)}
+            className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
+            title="Pick this config — you'll still need to click Start Simulation below to run it"
+          >
+            Pick
+          </button>
+        )}
+        {item.kind === 'builtin' && (
+          <button
+            type="button"
+            onClick={() => onView(item)}
+            className="rounded border border-white/10 bg-gray-900/60 px-2 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
+            title="Preview YAML"
+          >
+            <Eye className={iconSizes.sm} />
+          </button>
+        )}
+        {item.kind === 'local' && (
+          <button
+            type="button"
+            onClick={onClearLocal}
+            className="rounded border border-red-400/30 bg-red-500/10 px-2 py-1.5 text-xs font-medium text-red-200 hover:bg-red-500/20"
+            title="Drop the local file"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const ConfigRow: FC<SharedItemProps> = ({ item, selected, onSelect, onView, onClearLocal }) => (
+  <li
+    className={`flex items-center gap-3 px-3 py-2 transition-colors ${
+      selected ? 'bg-violet-500/10' : 'hover:bg-white/5'
+    }`}
+  >
+    <button
+      type="button"
+      onClick={() => onSelect(item)}
+      className="flex-1 text-left"
+      title={`Use ${item.name}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-white">{item.name}</span>
+        {sourceTagFor(item)}
+        {item.kind !== 'local' && (
+          <Tag colorScheme="purple" className="text-[10px]">
+            {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
+          </Tag>
+        )}
+        {item.kind === 'builtin' && (
+          <Tag colorScheme="gray" className="text-[10px] capitalize">
+            {item.template.type}
+          </Tag>
+        )}
+      </div>
+      {item.description && (
+        <SmallText
+          className={`mt-0.5 line-clamp-1 text-gray-400 ${
+            item.kind === 'saved' ? 'font-mono text-[11px] text-gray-500' : ''
+          }`}
+        >
+          {item.description}
+        </SmallText>
+      )}
+    </button>
+    {item.kind === 'builtin' && (
+      <button
+        type="button"
+        onClick={() => onView(item)}
+        className="rounded p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
+        title="Preview the template YAML"
+      >
+        <Eye className={iconSizes.md} />
+      </button>
+    )}
+    {item.kind === 'local' && (
+      <button
+        type="button"
+        onClick={onClearLocal}
+        className="text-xs font-medium text-red-300 hover:text-red-200"
+        title="Drop the local file"
+      >
+        Clear
+      </button>
+    )}
+  </li>
+);


### PR DESCRIPTION
## Why
\`ConfigPicker.tsx\` had grown to 741 lines — over the project's red-flag size budget — and mixed four concerns in one file: the hook-driven main component, the persisted-pref + \`ConfigItem\` union type, the source-filter chip + view-density toggle, and the card/row presenters for the unified list.

## Layout

| File | Lines | Role |
|---|---:|---|
| \`ConfigPicker.tsx\` | 377 | main component |
| \`ConfigPicker.types.ts\` | 116 | \`ConfigItem\` union, \`ConfigPickerProps\`, view-mode / source-filter types, type→icon + type→tint tables, readPref/writePref helpers |
| \`ConfigPickerControls.tsx\` | 59 | \`SourceChip\` + \`ViewToggle\` |
| \`ConfigPickerList.tsx\` | 250 | \`ConfigsList\` + \`ConfigCard\` + \`ConfigRow\` + \`sourceTagFor\` |

## Test plan
- [x] biome / tsc / vitest (65 tests) all pass
- [x] \`make build\` produces a working bundle
- [ ] Browser smoke: pick a built-in template, pick a saved config, upload a YAML, upload a Java-DSL .cfg (auto-converts), grid+list toggle persists across reloads