### PR TITLE
refactor(ui): split RuntimeControlPage subcomponents into pages/runtime/

### DIFF
--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -1,18 +1,13 @@
-import { Activity, BellRing, Download, FileCog, Network, PlugZap } from 'lucide-react';
+import { Activity, BellRing, Network, PlugZap } from 'lucide-react';
 import { type FC, useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
-  fetchConfig,
-  fetchProtocolDebugLevels,
   fetchSimulationStatus,
   fetchUsableInterfaces,
   fetchUserConfigContent,
   startSimulation,
   stopSimulation,
-  updateProtocolDebugLevels,
 } from '../api/client';
-import type { DebugLevel, NetworkInterface, Template, UserConfig } from '../api/types';
-import { StatBlock } from '../components/StatBlock';
+import type { NetworkInterface, Template, UserConfig } from '../api/types';
 import { ConfigPicker } from '../components/simulation/ConfigPicker';
 import { POLL_INTERVALS } from '../constants/polling';
 import { iconSizes } from '../constants/sizes';
@@ -20,10 +15,11 @@ import { useApiResource } from '../hooks/useApiResource';
 import { useUIStore } from '../stores/ui-store';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
-import { Tag } from '../ui/Tag';
 import { H2, SmallText } from '../ui/Typography';
 import { fileToText } from '../utils/file';
-import { formatTime, formatUptime, getErrorMessage } from '../utils/format';
+import { getErrorMessage } from '../utils/format';
+import { AdvancedSection } from './runtime/AdvancedSection';
+import { RunningSimulationCard } from './runtime/RunningSimulationCard';
 
 /**
  * Simulation Control Page (formerly RuntimeControlPage)
@@ -363,227 +359,3 @@ export const RuntimeControlPage: FC = () => {
     </div>
   );
 };
-
-interface RunningSimulationCardProps {
-  simStatus: {
-    interface?: string;
-    configName?: string;
-    configPath?: string;
-    deviceCount: number;
-    uptimeSeconds: number;
-    startedAt?: string;
-  };
-  stopping: boolean;
-  onStop: () => void;
-  message: { tone: 'success' | 'error'; text: string } | null;
-}
-
-/**
- * RunningSimulationCard — the green "simulation is live" card. Extracted
- * from the main render to keep RuntimeControlPage's cognitive complexity
- * under the project gate.
- */
-const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
-  simStatus,
-  stopping,
-  onStop,
-  message,
-}) => {
-  const navigate = useNavigate();
-
-  const handleDownload = async () => {
-    try {
-      const doc = await fetchConfig();
-      const blob = new Blob([doc.content], { type: 'application/x-yaml' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = doc.filename || 'niac-config.yaml';
-      link.click();
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      console.error('Failed to download config:', err);
-    }
-  };
-
-  return (
-    <Card className="border-green-500/30 bg-gradient-to-br from-green-900/30 to-gray-900/70">
-      <CardContent className="space-y-5">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="h-3 w-3 animate-pulse rounded-full bg-green-400" />
-            <H2 className="mb-0">Simulation Running</H2>
-          </div>
-          <Tag colorScheme="green">ACTIVE</Tag>
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          <StatBlock
-            label="Interface"
-            value={simStatus.interface || '—'}
-            helper="Network interface"
-          />
-          <StatBlock
-            label="Config"
-            value={simStatus.configName || '—'}
-            helper={simStatus.configPath || 'Configuration file'}
-          />
-          <StatBlock
-            label="Devices"
-            value={simStatus.deviceCount.toString()}
-            helper="Simulated devices"
-          />
-          <StatBlock
-            label="Uptime"
-            value={formatUptime(simStatus.uptimeSeconds)}
-            helper="Time running"
-          />
-          <StatBlock
-            label="Started"
-            value={simStatus.startedAt ? formatTime(simStatus.startedAt) : '—'}
-            helper="Start time"
-          />
-        </div>
-
-        {message && (
-          <SmallText className={message.tone === 'success' ? 'text-emerald-300' : 'text-red-400'}>
-            {message.text}
-          </SmallText>
-        )}
-
-        <div className="flex flex-wrap gap-3">
-          <Button
-            variant="outline"
-            disabled={stopping}
-            onClick={onStop}
-            leftIcon={<Activity className={iconSizes.md} />}
-          >
-            {stopping ? 'Stopping…' : 'Stop Simulation'}
-          </Button>
-          <Button
-            variant="ghost"
-            leftIcon={<FileCog className={iconSizes.md} />}
-            onClick={() => navigate('/devices')}
-          >
-            View Devices
-          </Button>
-          <Button
-            variant="ghost"
-            leftIcon={<Download className={iconSizes.md} />}
-            onClick={handleDownload}
-            title="Download the running config as YAML (the equivalent of niac config dump)."
-          >
-            Download YAML
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
-  );
-};
-
-/**
- * AdvancedSection — collapsible "Show advanced" container for power-user
- * knobs (currently just the global debug-level selector). Hidden by
- * default so the page reads as a clean Start/Stop flow for the 90% case.
- */
-const AdvancedSection: FC = () => {
-  const [open, setOpen] = useState(false);
-  return (
-    <details
-      className="rounded border border-white/10 bg-gray-950/40"
-      open={open}
-      onToggle={(e) => setOpen(e.currentTarget.open)}
-    >
-      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-gray-300 hover:text-white">
-        <span className="text-gray-500">{open ? '▾' : '▸'}</span>
-        <span>Advanced</span>
-        <SmallText className="text-gray-500">(global protocol debug level)</SmallText>
-      </summary>
-      <div className="border-t border-white/10 p-3">
-        <GlobalDebugLevelCard />
-      </div>
-    </details>
-  );
-};
-
-/**
- * GlobalDebugLevelCard — applies the same DebugLevel to every protocol in the
- * running stack via PUT /api/v1/debug/levels. CLI parity for the
- * --debug/--verbose/--quiet family of flags. The Protocol Debug page is
- * still the canonical place for per-protocol fine-tuning; this is the 90%
- * case for users who just want "loud" or "quiet" globally.
- */
-const DEBUG_LEVELS: DebugLevel[] = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'];
-
-const GlobalDebugLevelCard: FC = () => {
-  const { data, refetch } = useApiResource(fetchProtocolDebugLevels, [], {
-    intervalMs: 0,
-  });
-  const [pending, setPending] = useState<DebugLevel | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const current: DebugLevel = pending ?? data?.defaultLevel ?? 'INFO';
-
-  const apply = async (level: DebugLevel) => {
-    if (!data) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await updateProtocolDebugLevels({
-        protocols: data.protocols.map((p) => ({ protocol: p.protocol, level })),
-      });
-      setPending(null);
-      await refetch();
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <Card className="border-white/5 bg-gray-900/70">
-      <CardContent className="space-y-3">
-        <H2 className="mb-0 flex items-center gap-2 text-lg">
-          <Activity className={`${iconSizes.lg} text-violet-300`} />
-          Debug level
-        </H2>
-        <SmallText className="text-gray-400">
-          Sets every protocol to the same level. Use Protocol Debug for per-protocol tuning.
-        </SmallText>
-        <div className="flex flex-wrap items-center gap-3">
-          <select
-            value={current}
-            onChange={(e) => setPending(e.target.value as DebugLevel)}
-            disabled={busy || !data}
-            className="rounded border border-white/10 bg-gray-950/60 px-3 py-1.5 text-sm text-gray-100 focus:border-violet-400 focus:outline-none disabled:opacity-50"
-            aria-label="Global debug level"
-            title="Applies to every protocol in the running stack. OFF silences everything; TRACE is the loudest."
-          >
-            {DEBUG_LEVELS.map((lvl) => (
-              <option key={lvl} value={lvl}>
-                {lvl}
-              </option>
-            ))}
-          </select>
-          <Button
-            tone="violet"
-            disabled={busy || pending === null || !data}
-            onClick={() => void apply(current)}
-            title="PUT /api/v1/debug/levels with every protocol set to the chosen level."
-          >
-            {busy ? 'Applying…' : 'Apply'}
-          </Button>
-          {error && (
-            <SmallText className="text-red-300" role="alert">
-              {error}
-            </SmallText>
-          )}
-        </div>
-      </CardContent>
-    </Card>
-  );
-};
-
-export default RuntimeControlPage;

--- a/ui/src/pages/runtime/AdvancedSection.tsx
+++ b/ui/src/pages/runtime/AdvancedSection.tsx
@@ -1,0 +1,28 @@
+import { type FC, useState } from 'react';
+import { SmallText } from '../../ui/Typography';
+import { GlobalDebugLevelCard } from './GlobalDebugLevelCard';
+
+/**
+ * AdvancedSection wraps the page's power-user knobs (currently only
+ * the global debug-level card) behind a collapsed <details>. Hidden by
+ * default so the page reads as a clean Start/Stop flow for the 90% case.
+ */
+export const AdvancedSection: FC = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <details
+      className="rounded border border-white/10 bg-gray-950/40"
+      open={open}
+      onToggle={(e) => setOpen(e.currentTarget.open)}
+    >
+      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-gray-300 hover:text-white">
+        <span className="text-gray-500">{open ? '▾' : '▸'}</span>
+        <span>Advanced</span>
+        <SmallText className="text-gray-500">(global protocol debug level)</SmallText>
+      </summary>
+      <div className="border-t border-white/10 p-3">
+        <GlobalDebugLevelCard />
+      </div>
+    </details>
+  );
+};

--- a/ui/src/pages/runtime/GlobalDebugLevelCard.tsx
+++ b/ui/src/pages/runtime/GlobalDebugLevelCard.tsx
@@ -1,0 +1,90 @@
+import { Activity } from 'lucide-react';
+import { type FC, useState } from 'react';
+import { fetchProtocolDebugLevels, updateProtocolDebugLevels } from '../../api/client';
+import type { DebugLevel } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
+import { useApiResource } from '../../hooks/useApiResource';
+import { Button } from '../../ui/Button';
+import { Card, CardContent } from '../../ui/Card';
+import { H2, SmallText } from '../../ui/Typography';
+
+const DEBUG_LEVELS: DebugLevel[] = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'];
+
+/**
+ * GlobalDebugLevelCard — applies the same DebugLevel to every protocol
+ * in the running stack via PUT /api/v1/debug/levels. CLI parity for
+ * the --debug / --verbose / --quiet family of flags. The Protocol
+ * Debug page is the canonical place for per-protocol fine-tuning;
+ * this is the 90% case for users who just want "loud" or "quiet"
+ * globally.
+ */
+export const GlobalDebugLevelCard: FC = () => {
+  const { data, refetch } = useApiResource(fetchProtocolDebugLevels, [], {
+    intervalMs: 0,
+  });
+  const [pending, setPending] = useState<DebugLevel | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const current: DebugLevel = pending ?? data?.defaultLevel ?? 'INFO';
+
+  const apply = async (level: DebugLevel) => {
+    if (!data) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await updateProtocolDebugLevels({
+        protocols: data.protocols.map((p) => ({ protocol: p.protocol, level })),
+      });
+      setPending(null);
+      await refetch();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card className="border-white/5 bg-gray-900/70">
+      <CardContent className="space-y-3">
+        <H2 className="mb-0 flex items-center gap-2 text-lg">
+          <Activity className={`${iconSizes.lg} text-violet-300`} />
+          Debug level
+        </H2>
+        <SmallText className="text-gray-400">
+          Sets every protocol to the same level. Use Protocol Debug for per-protocol tuning.
+        </SmallText>
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={current}
+            onChange={(e) => setPending(e.target.value as DebugLevel)}
+            disabled={busy || !data}
+            className="rounded border border-white/10 bg-gray-950/60 px-3 py-1.5 text-sm text-gray-100 focus:border-violet-400 focus:outline-none disabled:opacity-50"
+            aria-label="Global debug level"
+            title="Applies to every protocol in the running stack. OFF silences everything; TRACE is the loudest."
+          >
+            {DEBUG_LEVELS.map((lvl) => (
+              <option key={lvl} value={lvl}>
+                {lvl}
+              </option>
+            ))}
+          </select>
+          <Button
+            tone="violet"
+            disabled={busy || pending === null || !data}
+            onClick={() => void apply(current)}
+            title="PUT /api/v1/debug/levels with every protocol set to the chosen level."
+          >
+            {busy ? 'Applying…' : 'Apply'}
+          </Button>
+          {error && (
+            <SmallText className="text-red-300" role="alert">
+              {error}
+            </SmallText>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/pages/runtime/RunningSimulationCard.tsx
+++ b/ui/src/pages/runtime/RunningSimulationCard.tsx
@@ -1,0 +1,129 @@
+import { Activity, Download, FileCog } from 'lucide-react';
+import type { FC } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchConfig } from '../../api/client';
+import { StatBlock } from '../../components/StatBlock';
+import { iconSizes } from '../../constants/sizes';
+import { Button } from '../../ui/Button';
+import { Card, CardContent } from '../../ui/Card';
+import { Tag } from '../../ui/Tag';
+import { H2, SmallText } from '../../ui/Typography';
+import { formatTime, formatUptime } from '../../utils/format';
+
+export interface RunningSimulationCardProps {
+  simStatus: {
+    interface?: string;
+    configName?: string;
+    configPath?: string;
+    deviceCount: number;
+    uptimeSeconds: number;
+    startedAt?: string;
+  };
+  stopping: boolean;
+  onStop: () => void;
+  message: { tone: 'success' | 'error'; text: string } | null;
+}
+
+/**
+ * RunningSimulationCard — the green "simulation is live" card. Lives
+ * alongside RuntimeControlPage in pages/runtime/ so the page-level
+ * file reads as a clean Start/Stop flow without 100+ lines of
+ * Stat-block markup.
+ */
+export const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
+  simStatus,
+  stopping,
+  onStop,
+  message,
+}) => {
+  const navigate = useNavigate();
+
+  const handleDownload = async () => {
+    try {
+      const doc = await fetchConfig();
+      const blob = new Blob([doc.content], { type: 'application/x-yaml' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = doc.filename || 'niac-config.yaml';
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to download config:', err);
+    }
+  };
+
+  return (
+    <Card className="border-green-500/30 bg-gradient-to-br from-green-900/30 to-gray-900/70">
+      <CardContent className="space-y-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="h-3 w-3 animate-pulse rounded-full bg-green-400" />
+            <H2 className="mb-0">Simulation Running</H2>
+          </div>
+          <Tag colorScheme="green">ACTIVE</Tag>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <StatBlock
+            label="Interface"
+            value={simStatus.interface || '—'}
+            helper="Network interface"
+          />
+          <StatBlock
+            label="Config"
+            value={simStatus.configName || '—'}
+            helper={simStatus.configPath || 'Configuration file'}
+          />
+          <StatBlock
+            label="Devices"
+            value={simStatus.deviceCount.toString()}
+            helper="Simulated devices"
+          />
+          <StatBlock
+            label="Uptime"
+            value={formatUptime(simStatus.uptimeSeconds)}
+            helper="Time running"
+          />
+          <StatBlock
+            label="Started"
+            value={simStatus.startedAt ? formatTime(simStatus.startedAt) : '—'}
+            helper="Start time"
+          />
+        </div>
+
+        {message && (
+          <SmallText className={message.tone === 'success' ? 'text-emerald-300' : 'text-red-400'}>
+            {message.text}
+          </SmallText>
+        )}
+
+        <div className="flex flex-wrap gap-3">
+          <Button
+            variant="outline"
+            disabled={stopping}
+            onClick={onStop}
+            leftIcon={<Activity className={iconSizes.md} />}
+          >
+            {stopping ? 'Stopping…' : 'Stop Simulation'}
+          </Button>
+          <Button
+            variant="ghost"
+            leftIcon={<FileCog className={iconSizes.md} />}
+            onClick={() => navigate('/devices')}
+          >
+            View Devices
+          </Button>
+          <Button
+            variant="ghost"
+            leftIcon={<Download className={iconSizes.md} />}
+            onClick={handleDownload}
+            title="Download the running config as YAML (the equivalent of niac config dump)."
+          >
+            Download YAML
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};


### PR DESCRIPTION
## Why
\`RuntimeControlPage.tsx\` had grown to 589 lines; over half was three subcomponents that don't share state with the page's Start/Stop flow.

## Layout

| File | Lines | Role |
|---|---:|---|
| \`RuntimeControlPage.tsx\` | 363 | page shell + start/stop flow |
| \`runtime/RunningSimulationCard.tsx\` | 129 | green "live" card with StatBlocks + download YAML |
| \`runtime/GlobalDebugLevelCard.tsx\` | 94 | apply one \`DebugLevel\` to every protocol |
| \`runtime/AdvancedSection.tsx\` | 28 | collapsed \`<details>\` wrapping the debug card |

## Test plan
- [x] biome / tsc / vitest all green
- [x] \`make build\` produces a working bundle