### PR TITLE
refactor(ui): restructure left nav around the user's session flow

### DIFF
--- a/ui/src/components/help-drawer/data.ts
+++ b/ui/src/components/help-drawer/data.ts
@@ -8,52 +8,54 @@ import type { Feature, GlossaryEntry, Shortcut } from './types';
 
 export const FEATURES: Feature[] = [
   {
-    title: 'Command Center',
-    description: 'Live counters, run snapshots, and automation status for the active NIAC stack.',
+    title: 'Dashboard',
+    description: 'Live counters, run snapshots, and alert state for the active NIAC stack.',
     path: '/',
   },
   {
-    title: 'Runtime Control',
-    description: 'Monitor runtime status, view network interfaces, and manage NIAC configuration.',
+    title: 'Simulation',
+    description: 'Pick a network, choose an interface, start or stop the daemon.',
     path: '/runtime',
   },
   {
-    title: 'Devices & Config',
-    description:
-      'Review YAML-derived devices, SNMP walks, DHCP/DNS personas, and packet playback targets.',
+    title: 'Running Devices',
+    description: 'Read-only view of the devices the daemon is currently simulating.',
     path: '/devices',
   },
   {
-    title: 'Config Builder',
-    description: 'Create, edit, and manage device configurations with a visual interface.',
+    title: 'Devices',
+    description: 'Reusable device definitions. Edit, clone, delete the library on disk.',
     path: '/device-config',
-    badge: 'New',
   },
   {
-    title: 'Topology View',
-    description: 'LLDP/CDP/EDP/FDP visibility for verifying intent before exporting to Graphviz.',
+    title: 'Topology',
+    description: 'Visual graph of the configured network plus the live neighbor table.',
     path: '/topology',
   },
   {
-    title: 'Analysis & Playback',
-    description: 'Replay PCAPs, inspect SNMP walks, and publish bundles directly from the UI.',
-    path: '/analysis',
+    title: 'Traffic',
+    description: 'Inject controlled errors into the simulation and replay captured PCAPs.',
+    path: '/traffic',
   },
   {
-    title: 'Traffic Injection',
-    description: 'Configure and execute traffic injection scenarios with real-time feedback.',
-    path: '/injection',
+    title: 'Logs',
+    description: 'Live log stream from the daemon, with per-protocol debug-level controls.',
+    path: '/debug',
   },
   {
-    title: 'Packet Inspector',
-    description: 'Deep packet inspection with protocol decoding and hex dump viewing.',
+    title: 'Packets',
+    description: 'Live packets crossing the simulation — hex view, BPF filter, save to PCAP.',
     path: '/packets',
   },
   {
-    title: 'PCAP Analyzer',
-    description: 'Upload and analyze PCAP files with detailed statistics and filtering.',
-    path: '/pcap',
-    badge: 'Beta',
+    title: 'SNMP Walks',
+    description: 'Validate and auto-fix SNMP walk files used by the simulated SNMP agents.',
+    path: '/walk-validator',
+  },
+  {
+    title: 'Compare & Merge',
+    description: 'Compare two YAML network configs side-by-side and merge changes between them.',
+    path: '/config-diff',
   },
 ];
 

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -16,32 +16,32 @@ import {
 } from '../../api/client';
 import type { Template, TemplateContent, UserConfig } from '../../api/types';
 import { iconSizes } from '../../constants/sizes';
+import { useFavorites } from '../../hooks/useFavorites';
 import { SmallText } from '../../ui/Typography';
 import { TemplatePreviewModal } from '../TemplatePreviewModal';
 import { JavaDslImportCard } from '../templates/JavaDslImportCard';
 import {
   type ConfigItem,
   type ConfigPickerProps,
+  FAVORITES_STORAGE_KEY,
   readPref,
-  SOURCE_FILTER_PREF_KEY,
-  type SourceFilter,
   VIEW_PREF_KEY,
   type ViewMode,
   writePref,
 } from './ConfigPicker.types';
-import { SourceChip, ViewToggle } from './ConfigPickerControls';
+import { ViewToggle } from './ConfigPickerControls';
 import { ConfigsList } from './ConfigPickerList';
 
 export type { ConfigPickerProps } from './ConfigPicker.types';
 
 /**
- * ConfigPicker is the single config-source picker for the Simulation
- * page. Built-in templates, user-saved configs, and a one-shot local
- * upload all live in the same list with a "source" filter chip; there
- * are no tabs. Subcomponents live alongside this file:
+ * ConfigPicker is the single network-picker for the Simulation page.
+ * Built-in and user-saved configs are presented as one flat list; the
+ * user only sees "favorites" vs "everything else", with a one-shot
+ * local upload pinned above both when present. Subcomponents:
  *
  *   ConfigPicker.types.ts     — ConfigItem, props, persisted-pref helpers
- *   ConfigPickerControls.tsx  — source-filter chip + grid/list toggle
+ *   ConfigPickerControls.tsx  — grid/list view toggle
  *   ConfigPickerList.tsx      — card grid + compact list presenters
  */
 export const ConfigPicker: FC<ConfigPickerProps> = ({
@@ -56,10 +56,8 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [viewMode, setViewMode] = useState<ViewMode>(() => readPref(VIEW_PREF_KEY, 'grid'));
-  const [sourceFilter, setSourceFilter] = useState<SourceFilter>(() =>
-    readPref(SOURCE_FILTER_PREF_KEY, 'all'),
-  );
   const [showJavaDsl, setShowJavaDsl] = useState(false);
+  const { isFavorite, toggleFavorite } = useFavorites(FAVORITES_STORAGE_KEY);
 
   // Preview modal state (built-in templates only)
   const [previewTemplate, setPreviewTemplate] = useState<Template | null>(null);
@@ -123,34 +121,36 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
     return list;
   }, [templates, userConfigs, uploadFile]);
 
-  const filtered = useMemo(() => {
+  /**
+   * Searching narrows the list and keeps results alphabetical regardless
+   * of star status — otherwise filtering would hide what the user typed
+   * behind the favorites zone. Browsing (empty search) sorts favorites
+   * first, then non-favorites, both alphabetical. The transient "local"
+   * upload always pins to the very top, since it's the user's last
+   * action.
+   */
+  const sections = useMemo(() => {
     const q = search.trim().toLowerCase();
-    return items.filter((item) => {
-      if (sourceFilter === 'builtin' && item.kind !== 'builtin') return false;
-      if (sourceFilter === 'saved' && item.kind !== 'saved') return false;
-      if (sourceFilter === 'local' && item.kind !== 'local') return false;
-      if (!q) return true;
-      return item.name.toLowerCase().includes(q) || item.description.toLowerCase().includes(q);
-    });
-  }, [items, sourceFilter, search]);
+    const matchesQuery = (item: ConfigItem) =>
+      !q || item.name.toLowerCase().includes(q) || item.description.toLowerCase().includes(q);
 
-  const counts = useMemo(
-    () => ({
-      all: items.length,
-      builtin: items.filter((i) => i.kind === 'builtin').length,
-      saved: items.filter((i) => i.kind === 'saved').length,
-      local: items.filter((i) => i.kind === 'local').length,
-    }),
-    [items],
-  );
+    const byName = (a: ConfigItem, b: ConfigItem) => a.name.localeCompare(b.name);
+
+    const local = items.filter((i) => i.kind === 'local' && matchesQuery(i));
+    const matched = items.filter((i) => i.kind !== 'local' && matchesQuery(i));
+
+    if (q) {
+      return { local, favorites: [], all: matched.sort(byName) };
+    }
+
+    const favorites = matched.filter((i) => isFavorite(i.key)).sort(byName);
+    const all = matched.filter((i) => !isFavorite(i.key)).sort(byName);
+    return { local, favorites, all };
+  }, [items, isFavorite, search]);
 
   const updateViewMode = (mode: ViewMode) => {
     setViewMode(mode);
     writePref(VIEW_PREF_KEY, mode);
-  };
-  const updateSourceFilter = (f: SourceFilter) => {
-    setSourceFilter(f);
-    writePref(SOURCE_FILTER_PREF_KEY, f);
   };
 
   const handleSelectItem = (item: ConfigItem) => {
@@ -213,7 +213,6 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
     const isJavaDsl = /^\s*device\s+[\w.-]+\s*\{/m.test(head);
     if (!isJavaDsl) {
       onUpload(file);
-      updateSourceFilter('local');
       return;
     }
     setConvertingDsl(true);
@@ -223,7 +222,6 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
       const yamlName = `${file.name.replace(/\.(cfg|conf|txt)$/i, '')}.yaml`;
       const yamlFile = new File([result.yaml], yamlName, { type: 'application/x-yaml' });
       onUpload(yamlFile);
-      updateSourceFilter('local');
     } catch (err) {
       setConvertError(
         err instanceof Error
@@ -237,34 +235,8 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
 
   return (
     <div className="space-y-3">
-      {/* Source filter chips + Upload button */}
+      {/* Upload + clear */}
       <div className="flex flex-wrap items-center gap-2">
-        <SourceChip
-          active={sourceFilter === 'all'}
-          onClick={() => updateSourceFilter('all')}
-          label="All"
-          count={counts.all}
-        />
-        <SourceChip
-          active={sourceFilter === 'builtin'}
-          onClick={() => updateSourceFilter('builtin')}
-          label="Built-in"
-          count={counts.builtin}
-        />
-        <SourceChip
-          active={sourceFilter === 'saved'}
-          onClick={() => updateSourceFilter('saved')}
-          label="Saved"
-          count={counts.saved}
-        />
-        {counts.local > 0 && (
-          <SourceChip
-            active={sourceFilter === 'local'}
-            onClick={() => updateSourceFilter('local')}
-            label="Local"
-            count={counts.local}
-          />
-        )}
         <div className="flex-1" />
         <label
           htmlFor="config-upload"
@@ -331,15 +303,18 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
         </fieldset>
       </div>
 
-      {/* List / grid */}
+      {/* Sectioned list — local upload pinned, then favorites, then everything else */}
       <ConfigsList
-        items={filtered}
+        sections={sections}
         loading={loading}
         viewMode={viewMode}
         isSelected={isItemSelected}
+        isFavorite={isFavorite}
         onSelect={handleSelectItem}
+        onToggleFavorite={toggleFavorite}
         onView={handleViewItem}
         onClearLocal={handleClearLocal}
+        searching={search.trim().length > 0}
       />
 
       {/* Java-DSL import — collapsed by default since most users won't need it */}

--- a/ui/src/components/simulation/ConfigPicker.types.ts
+++ b/ui/src/components/simulation/ConfigPicker.types.ts
@@ -12,10 +12,9 @@ import type { Template, UserConfig } from '../../api/types';
  */
 
 export type ViewMode = 'grid' | 'list';
-export type SourceFilter = 'all' | 'builtin' | 'saved' | 'local';
 
 export const VIEW_PREF_KEY = 'niac.configs.viewMode';
-export const SOURCE_FILTER_PREF_KEY = 'niac.configs.sourceFilter';
+export const FAVORITES_STORAGE_KEY = 'niac.configs.favorites';
 
 export const TEMPLATE_TYPE_ICON: Record<Template['type'], FC<{ className?: string }>> = {
   basic: Globe,

--- a/ui/src/components/simulation/ConfigPickerControls.tsx
+++ b/ui/src/components/simulation/ConfigPickerControls.tsx
@@ -1,38 +1,6 @@
 import type { FC, ReactNode } from 'react';
 
 /**
- * Small pill button used for the All / Built-in / Saved / Local source
- * filter row above the configs list. Renders the label with a small
- * count chip on the right.
- */
-export const SourceChip: FC<{
-  active: boolean;
-  onClick: () => void;
-  label: string;
-  count: number;
-}> = ({ active, onClick, label, count }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    aria-pressed={active}
-    className={`flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-      active
-        ? 'bg-violet-500/20 text-violet-100 ring-1 ring-violet-400/40'
-        : 'bg-gray-800/60 text-gray-400 ring-1 ring-white/10 hover:bg-white/5 hover:text-gray-200'
-    }`}
-  >
-    <span>{label}</span>
-    <span
-      className={`rounded-full px-1.5 py-0.5 text-[10px] ${
-        active ? 'bg-violet-500/30 text-violet-100' : 'bg-white/10 text-gray-300'
-      }`}
-    >
-      {count}
-    </span>
-  </button>
-);
-
-/**
  * One half of the grid/list view-density toggle. Two of these live
  * inside a <fieldset> in ConfigPicker so screen readers see them as
  * an exclusive group.

--- a/ui/src/components/simulation/ConfigPickerList.tsx
+++ b/ui/src/components/simulation/ConfigPickerList.tsx
@@ -1,4 +1,4 @@
-import { Check, Eye, FileCode, FolderOpen, HardDrive } from 'lucide-react';
+import { Check, Eye, FileCode, FolderOpen, HardDrive, Star } from 'lucide-react';
 import type { FC } from 'react';
 import { iconSizes } from '../../constants/sizes';
 import { Tag } from '../../ui/Tag';
@@ -13,96 +13,151 @@ import {
 interface SharedItemProps {
   item: ConfigItem;
   selected: boolean;
+  favorited: boolean;
   onSelect: (item: ConfigItem) => void;
+  onToggleFavorite: (key: string) => void;
   onView: (item: ConfigItem) => void;
   onClearLocal: () => void;
 }
 
-/**
- * sourceTagFor stamps a one-word colour-coded badge onto a config row
- * so the user can tell at a glance whether they're looking at a
- * built-in template, a saved YAML, or the one-shot local upload.
- */
-function sourceTagFor(item: ConfigItem) {
-  if (item.kind === 'builtin')
-    return (
-      <Tag colorScheme="purple" className="text-[10px]">
-        Built-in
-      </Tag>
-    );
-  if (item.kind === 'saved')
-    return (
-      <Tag colorScheme="green" className="text-[10px]">
-        Saved
-      </Tag>
-    );
-  return (
-    <Tag colorScheme="blue" className="text-[10px]">
-      Local
-    </Tag>
-  );
+export interface ConfigSections {
+  local: ConfigItem[];
+  favorites: ConfigItem[];
+  all: ConfigItem[];
 }
 
 /**
- * ConfigsList chooses between the card-grid view and the compact-list
- * view based on viewMode, and surfaces the loading + empty states.
- * The card / row presenters live below.
+ * ConfigsList renders the network list as up to three zones:
+ *   1. Local upload (only when the user has picked a file on this page)
+ *   2. Favorites   (only when there are starred entries — hidden during search)
+ *   3. All         (everything else, or all matches when searching)
+ *
+ * Each zone gets a small heading with a count so the list stays scannable
+ * even when there are dozens of saved networks.
  */
 export const ConfigsList: FC<{
-  items: ConfigItem[];
+  sections: ConfigSections;
   loading: boolean;
   viewMode: ViewMode;
   isSelected: (item: ConfigItem) => boolean;
+  isFavorite: (key: string) => boolean;
   onSelect: (item: ConfigItem) => void;
+  onToggleFavorite: (key: string) => void;
   onView: (item: ConfigItem) => void;
   onClearLocal: () => void;
-}> = ({ items, loading, viewMode, isSelected, onSelect, onView, onClearLocal }) => {
+  searching: boolean;
+}> = ({
+  sections,
+  loading,
+  viewMode,
+  isSelected,
+  isFavorite,
+  onSelect,
+  onToggleFavorite,
+  onView,
+  onClearLocal,
+  searching,
+}) => {
   if (loading) {
-    return <SmallText className="text-gray-500">Loading configs…</SmallText>;
+    return <SmallText className="text-gray-500">Loading networks…</SmallText>;
   }
-  if (items.length === 0) {
+
+  const total = sections.local.length + sections.favorites.length + sections.all.length;
+  if (total === 0) {
     return (
       <SmallText className="text-gray-500">
-        Nothing matches. Try a different search, switch the source filter, or upload a local YAML
-        with the button above.
+        Nothing matches. Try a different search or upload a local YAML with the button above.
       </SmallText>
     );
   }
 
-  if (viewMode === 'grid') {
+  const renderSection = (label: string, items: ConfigItem[]) => {
+    if (items.length === 0) return null;
     return (
-      <div className="grid max-h-[420px] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => (
-          <ConfigCard
-            key={item.key}
-            item={item}
-            selected={isSelected(item)}
-            onSelect={onSelect}
-            onView={onView}
-            onClearLocal={onClearLocal}
-          />
-        ))}
-      </div>
+      <section className="space-y-2" key={label}>
+        <header className="flex items-baseline gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400">{label}</h3>
+          <span className="text-xs text-gray-500">· {items.length}</span>
+        </header>
+        {viewMode === 'grid' ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {items.map((item) => (
+              <ConfigCard
+                key={item.key}
+                item={item}
+                selected={isSelected(item)}
+                favorited={isFavorite(item.key)}
+                onSelect={onSelect}
+                onToggleFavorite={onToggleFavorite}
+                onView={onView}
+                onClearLocal={onClearLocal}
+              />
+            ))}
+          </div>
+        ) : (
+          <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-white/10 bg-gray-950/40">
+            {items.map((item) => (
+              <ConfigRow
+                key={item.key}
+                item={item}
+                selected={isSelected(item)}
+                favorited={isFavorite(item.key)}
+                onSelect={onSelect}
+                onToggleFavorite={onToggleFavorite}
+                onView={onView}
+                onClearLocal={onClearLocal}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
     );
-  }
+  };
 
   return (
-    <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto rounded-lg border border-white/10 bg-gray-950/40">
-      {items.map((item) => (
-        <ConfigRow
-          key={item.key}
-          item={item}
-          selected={isSelected(item)}
-          onSelect={onSelect}
-          onView={onView}
-          onClearLocal={onClearLocal}
-        />
-      ))}
-    </ul>
+    <div className="max-h-[480px] space-y-4 overflow-y-auto pr-1">
+      {renderSection('Local upload', sections.local)}
+      {!searching && renderSection('Favorites', sections.favorites)}
+      {renderSection(searching ? 'Results' : 'All networks', sections.all)}
+    </div>
   );
 };
 
-const ConfigCard: FC<SharedItemProps> = ({ item, selected, onSelect, onView, onClearLocal }) => {
+const FavoriteStar: FC<{
+  itemKey: string;
+  favorited: boolean;
+  onToggle: (key: string) => void;
+  compact?: boolean;
+}> = ({ itemKey, favorited, onToggle, compact }) => (
+  <button
+    type="button"
+    onClick={(e) => {
+      e.stopPropagation();
+      onToggle(itemKey);
+    }}
+    aria-pressed={favorited}
+    aria-label={favorited ? 'Remove from favorites' : 'Add to favorites'}
+    title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+    className={`rounded p-1 transition-colors ${
+      favorited ? 'text-amber-300 hover:text-amber-200' : 'text-gray-500 hover:text-amber-300'
+    } ${compact ? '' : 'hover:bg-white/5'}`}
+  >
+    <Star
+      className={compact ? iconSizes.sm : iconSizes.md}
+      fill={favorited ? 'currentColor' : 'none'}
+    />
+  </button>
+);
+
+const ConfigCard: FC<SharedItemProps> = ({
+  item,
+  selected,
+  favorited,
+  onSelect,
+  onToggleFavorite,
+  onView,
+  onClearLocal,
+}) => {
   const Icon =
     item.kind === 'builtin'
       ? (TEMPLATE_TYPE_ICON[item.template.type] ?? FileCode)
@@ -128,7 +183,9 @@ const ConfigCard: FC<SharedItemProps> = ({ item, selected, onSelect, onView, onC
         <div className={`rounded-md border p-2 ${tint}`}>
           <Icon className={iconSizes.lg} />
         </div>
-        {sourceTagFor(item)}
+        {item.kind !== 'local' && (
+          <FavoriteStar itemKey={item.key} favorited={favorited} onToggle={onToggleFavorite} />
+        )}
       </div>
       <div>
         <div className="font-semibold text-white">{item.name}</div>
@@ -160,7 +217,7 @@ const ConfigCard: FC<SharedItemProps> = ({ item, selected, onSelect, onView, onC
             type="button"
             onClick={() => onSelect(item)}
             className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
-            title="Pick this config — you'll still need to click Start Simulation below to run it"
+            title="Pick this network — click Start Simulation below to run it"
           >
             Pick
           </button>
@@ -190,29 +247,39 @@ const ConfigCard: FC<SharedItemProps> = ({ item, selected, onSelect, onView, onC
   );
 };
 
-const ConfigRow: FC<SharedItemProps> = ({ item, selected, onSelect, onView, onClearLocal }) => (
+const ConfigRow: FC<SharedItemProps> = ({
+  item,
+  selected,
+  favorited,
+  onSelect,
+  onToggleFavorite,
+  onView,
+  onClearLocal,
+}) => (
   <li
     className={`flex items-center gap-3 px-3 py-2 transition-colors ${
       selected ? 'bg-violet-500/10' : 'hover:bg-white/5'
     }`}
   >
+    {item.kind !== 'local' && (
+      <FavoriteStar itemKey={item.key} favorited={favorited} onToggle={onToggleFavorite} compact />
+    )}
     <button
       type="button"
       onClick={() => onSelect(item)}
       className="flex-1 text-left"
-      title={`Use ${item.name}`}
+      title={`Pick ${item.name}`}
     >
       <div className="flex items-center gap-2">
         <span className="font-medium text-white">{item.name}</span>
-        {sourceTagFor(item)}
         {item.kind !== 'local' && (
           <Tag colorScheme="purple" className="text-[10px]">
             {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
           </Tag>
         )}
-        {item.kind === 'builtin' && (
-          <Tag colorScheme="gray" className="text-[10px] capitalize">
-            {item.template.type}
+        {item.kind === 'local' && (
+          <Tag colorScheme="blue" className="text-[10px]">
+            Local
           </Tag>
         )}
       </div>

--- a/ui/src/hooks/useFavorites.ts
+++ b/ui/src/hooks/useFavorites.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * useFavorites stores a Set of arbitrary string keys in localStorage so
+ * the user's "favorite" markings survive reloads. Keyed by storageKey
+ * so multiple feature areas (Networks, Devices, …) can keep separate
+ * favorite sets without colliding.
+ *
+ * SSR-safe — if window is undefined the initial set is empty and writes
+ * no-op. Storage is read once on mount; subsequent edits update both
+ * state and the backing store.
+ */
+export function useFavorites(storageKey: string) {
+  const [favorites, setFavorites] = useState<Set<string>>(() => {
+    if (typeof window === 'undefined') return new Set();
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) return new Set();
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed)) {
+        return new Set(parsed.filter((v): v is string => typeof v === 'string'));
+      }
+    } catch {
+      // Corrupted / non-JSON value — start clean.
+    }
+    return new Set();
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify([...favorites]));
+    } catch {
+      // Quota / privacy mode — just skip persistence.
+    }
+  }, [storageKey, favorites]);
+
+  const isFavorite = useCallback((key: string) => favorites.has(key), [favorites]);
+
+  const toggleFavorite = useCallback((key: string) => {
+    setFavorites((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  return { isFavorite, toggleFavorite };
+}

--- a/ui/src/navGroups.ts
+++ b/ui/src/navGroups.ts
@@ -1,12 +1,9 @@
 import {
   Activity,
   FileBox,
-  FileSearch,
   GitCompare,
-  LineChart,
   Network,
   PlugZap,
-  Radar,
   Server,
   ShieldCheck,
   Terminal,
@@ -23,53 +20,48 @@ import type { SidebarNavGroup } from './ui/Sidebar';
  * route handlers themselves. Keep the two in rough sync but they're
  * deliberately not the same source: sidebar wants short, page header
  * wants verbose.
+ *
+ * Groups are ordered to follow the natural session flow:
+ *
+ *   1. Overview   — am I running? start/stop the sim.
+ *   2. Library    — pick the network + manage device definitions.
+ *   3. Live View  — look at the currently running sim.
+ *   4. Inspect    — debug logs, packets, walk files.
+ *   5. Alerts     — notify me when things break.
  */
 export const navGroups: SidebarNavGroup[] = [
   {
-    label: 'Control',
+    label: 'Overview',
     items: [
       { path: '/', label: 'Dashboard', icon: Activity },
       { path: '/runtime', label: 'Simulation', icon: PlugZap },
     ],
   },
   {
-    label: 'Configuration',
+    label: 'Library',
+    items: [
+      { path: '/device-config', label: 'Devices', icon: Wrench },
+      { path: '/config-diff', label: 'Compare & Merge', icon: GitCompare },
+    ],
+  },
+  {
+    label: 'Live View',
     items: [
       { path: '/devices', label: 'Running Devices', icon: Server },
-      {
-        path: '/device-config',
-        label: 'Device Library',
-        icon: Wrench,
-      },
-      { path: '/config-diff', label: 'Config Diff', icon: GitCompare },
-    ],
-  },
-  {
-    label: 'Network',
-    items: [
       { path: '/topology', label: 'Topology', icon: Network },
-      { path: '/neighbors', label: 'Neighbors', icon: Radar },
-      { path: '/traffic', label: 'Traffic Injection', icon: Zap },
+      { path: '/traffic', label: 'Traffic', icon: Zap },
     ],
   },
   {
-    label: 'Analysis',
+    label: 'Inspect',
     items: [
-      { path: '/analysis', label: 'Replay', icon: LineChart },
-      { path: '/debug', label: 'Protocol Debug', icon: Terminal },
-      { path: '/packets', label: 'Packet Capture', icon: FileSearch },
-      { path: '/pcap-analyzer', label: 'PCAP Inspector', icon: FileBox },
-      { path: '/walk-validator', label: 'Walk Validator', icon: ShieldCheck },
+      { path: '/debug', label: 'Logs', icon: Terminal },
+      { path: '/packets', label: 'Packets', icon: FileBox },
+      { path: '/walk-validator', label: 'SNMP Walks', icon: ShieldCheck },
     ],
   },
   {
-    label: 'Automation',
-    items: [
-      {
-        path: '/automation',
-        label: 'Alerts',
-        icon: Workflow,
-      },
-    ],
+    label: 'Alerts',
+    items: [{ path: '/automation', label: 'Alerts', icon: Workflow }],
   },
 ];

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -116,7 +116,7 @@ export const pages: PageConfig[] = [
             <strong>Running Devices</strong> to see what the running config produced.
           </li>
           <li>
-            <strong>Packet Capture</strong> to watch traffic in real time.
+            <strong>Packets</strong> to watch traffic in real time.
           </li>
           <li>
             <strong>Alerts</strong> to set the threshold and webhook target.
@@ -128,7 +128,7 @@ export const pages: PageConfig[] = [
   {
     path: '/runtime',
     label: 'Simulation',
-    title: 'Simulation Control',
+    title: 'Simulation',
     description: 'Monitor runtime status, view network interfaces, and manage NIAC configuration.',
     icon: PlugZap,
     component: RuntimeControlPage,
@@ -147,7 +147,7 @@ export const pages: PageConfig[] = [
           </li>
           <li>
             <code>capture_playbacks:</code> in the YAML auto-starts a PCAP replay alongside the sim.
-            The Replay page (Analysis → Replay) lets you switch the playback file at runtime.
+            <strong>Traffic</strong> lets you switch the playback file at runtime.
           </li>
           <li>
             Use <code>lo0</code> (macOS) / <code>lo</code> (Linux) for safe local testing.
@@ -172,18 +172,19 @@ export const pages: PageConfig[] = [
         </p>
         <h4>For editing</h4>
         <p>
-          To modify your saved device library, go to <strong>Device Library</strong>. To swap the
-          running config wholesale, restart the simulation from <strong>Simulation</strong>.
+          To modify saved device definitions, go to <strong>Devices</strong> (under Library). To
+          swap the running network wholesale, restart the simulation from{' '}
+          <strong>Simulation</strong>.
         </p>
       </>
     ),
   },
   {
     path: '/device-config',
-    label: 'Device Library',
-    title: 'Device Library',
+    label: 'Devices',
+    title: 'Devices',
     description:
-      'Manage saved device configurations: search, filter, edit, clone, and delete. Click a device to open the visual editor.',
+      'Reusable device definitions: search, filter, edit, clone, and delete. Click a device to open the visual editor.',
     icon: Wrench,
     component: DeviceListPage,
     help: (
@@ -209,9 +210,10 @@ export const pages: PageConfig[] = [
   },
   {
     path: '/topology',
-    label: 'Topology & Neighbors',
-    title: 'Topology & Neighbor Insight',
-    description: 'LLDP/CDP/EDP/FDP visibility for verifying intent before exporting to Graphviz.',
+    label: 'Topology',
+    title: 'Topology',
+    description:
+      'Visual graph of the configured network plus the live CDP/LLDP/EDP/FDP neighbor table.',
     icon: Network,
     component: TopologyPage,
     help: (
@@ -223,7 +225,7 @@ export const pages: PageConfig[] = [
         </p>
         <h4>Live discovery vs design</h4>
         <p>
-          The graph shows the <em>design</em>. Use <strong>Neighbors</strong> to see which
+          The graph shows the <em>design</em> from your YAML; the neighbor table shows which
           adjacencies actually formed at runtime via CDP / LLDP / EDP / FDP — useful for catching
           mistyped <code>remote_device</code> references.
         </p>
@@ -237,8 +239,8 @@ export const pages: PageConfig[] = [
   {
     path: '/analysis',
     label: 'Replay',
-    title: 'Replay & Playback',
-    description: 'Replay PCAPs, inspect SNMP walks, and publish bundles directly from the UI.',
+    title: 'Replay',
+    description: 'Replay a captured PCAP through the running simulation.',
     icon: LineChart,
     component: AnalysisPage,
     help: (
@@ -297,9 +299,9 @@ export const pages: PageConfig[] = [
   },
   {
     path: '/traffic',
-    label: 'Traffic Injection',
-    title: 'Traffic & Error Injection',
-    description: 'Inject network errors and replay PCAP traffic for testing and simulation.',
+    label: 'Traffic',
+    title: 'Traffic',
+    description: 'Inject controlled errors into the running simulation and replay captured PCAPs.',
     icon: Zap,
     component: TrafficInjectionPage,
     help: (
@@ -329,9 +331,9 @@ export const pages: PageConfig[] = [
   },
   {
     path: '/debug',
-    label: 'Protocol Debug',
-    title: 'Protocol Debug',
-    description: 'Real-time log streaming and debugging tools for monitoring NIAC operations.',
+    label: 'Logs',
+    title: 'Logs',
+    description: 'Live log stream from the daemon, with per-protocol debug-level controls.',
     icon: Terminal,
     component: DebugConsolePage,
     help: (
@@ -352,10 +354,10 @@ export const pages: PageConfig[] = [
   },
   {
     path: '/packets',
-    label: 'Packet Capture',
-    title: 'Packet Capture',
+    label: 'Packets',
+    title: 'Packets',
     description:
-      'Real-time packet hex dump viewing with protocol filtering and search capabilities.',
+      'Live packets crossing the simulation — hex view, BPF filter, freeze frame, save to PCAP.',
     icon: FileSearch,
     component: PacketInspectorPage,
     help: (
@@ -374,9 +376,9 @@ export const pages: PageConfig[] = [
   },
   {
     path: '/config-diff',
-    label: 'Config Diff',
-    title: 'Config Diff & Merge',
-    description: 'Compare and merge YAML configuration files with visual diff and merge controls.',
+    label: 'Compare & Merge',
+    title: 'Compare & Merge',
+    description: 'Compare two YAML network configs side-by-side and merge changes between them.',
     icon: GitCompare,
     component: ConfigDiffPage,
     help: (
@@ -413,8 +415,8 @@ export const pages: PageConfig[] = [
         </p>
         <h4>Live vs offline</h4>
         <p>
-          For traffic on the running simulator, use <strong>Packet Capture</strong>. This page is
-          for static analysis of files you've captured elsewhere.
+          For traffic on the running simulator, use <strong>Packets</strong>. This page is for
+          static analysis of files you've captured elsewhere.
         </p>
       </>
     ),
@@ -452,9 +454,9 @@ export const pages: PageConfig[] = [
   },
   {
     path: '/walk-validator',
-    label: 'Walk Validator',
-    title: 'SNMP Walk Validator',
-    description: 'Validate and auto-fix SNMP walk files (the same engine niac analyze-walk uses).',
+    label: 'SNMP Walks',
+    title: 'SNMP Walks',
+    description: 'Validate and auto-fix SNMP walk files used by the simulated SNMP agents.',
     icon: ShieldCheck,
     component: WalkValidatorPage,
     help: (

--- a/ui/src/pages/ConfigDiffPage.tsx
+++ b/ui/src/pages/ConfigDiffPage.tsx
@@ -155,10 +155,10 @@ export const ConfigDiffPage: FC = () => {
             <div>
               <H2 className="mb-0 flex items-center gap-2">
                 <GitCompare className={`${iconSizes.lg} text-violet-300`} />
-                Config Diff & Merge
+                Compare & Merge
               </H2>
               <P className="text-gray-400 mt-1">
-                Compare and merge two YAML configuration files with visual diff and merge controls.
+                Compare two YAML network configs side-by-side and merge changes between them.
               </P>
             </div>
             {hasFiles && (

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -275,7 +275,7 @@ export const PacketInspectorPage: FC = () => {
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             {/* Title and connection status */}
             <div className="flex items-center gap-4">
-              <H2 className="mb-0">Packet Capture</H2>
+              <H2 className="mb-0">Packets</H2>
               <SmallText className="text-gray-400">
                 on <span className="font-mono text-gray-200">{activeInterface ?? '—'}</span>
               </SmallText>

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -91,7 +91,7 @@ export const WalkValidatorPage: FC = () => {
       <Card className="border-white/5 bg-gray-900/70">
         <CardContent className="space-y-4">
           <header>
-            <h1 className="text-2xl font-semibold text-white">SNMP Walk Validator</h1>
+            <h1 className="text-2xl font-semibold text-white">SNMP Walks</h1>
             <p className="text-sm text-gray-400">
               Same engine as <code>niac analyze-walk</code>. Validate detects malformed lines,
               missing OIDs, and unquoted strings; fix auto-rewrites the file in place.

--- a/ui/src/ui/Breadcrumbs.tsx
+++ b/ui/src/ui/Breadcrumbs.tsx
@@ -9,19 +9,21 @@ interface BreadcrumbItem {
 }
 
 const ROUTE_LABELS: Record<string, string> = {
-  '/': 'Command Center',
-  '/runtime': 'Runtime Control',
-  '/devices': 'Devices & Config',
-  '/device-config': 'Config Builder',
+  '/': 'Dashboard',
+  '/runtime': 'Simulation',
+  '/devices': 'Running Devices',
+  '/device-config': 'Devices',
   '/topology': 'Topology',
-  '/analysis': 'Analysis',
-  '/automation': 'Automation',
-  '/traffic': 'Traffic Injection',
-  '/debug': 'Debug Console',
-  '/packets': 'Packet Inspector',
+  '/analysis': 'Replay',
+  '/automation': 'Alerts',
+  '/traffic': 'Traffic',
+  '/debug': 'Logs',
+  '/packets': 'Packets',
   '/templates': 'Templates',
-  '/config-diff': 'Config Diff',
-  '/pcap-analyzer': 'PCAP Analyzer',
+  '/config-diff': 'Compare & Merge',
+  '/pcap-analyzer': 'PCAP Inspector',
+  '/neighbors': 'Neighbors',
+  '/walk-validator': 'SNMP Walks',
 };
 
 export const Breadcrumbs: FC = () => {


### PR DESCRIPTION
## Summary
Two-bundle nav cleanup: (1) restructure the left sidebar around the user's session flow, then (2) collapse the network picker to a single flat list with favorites pinning.

### Bundle 1 — Nav restructure (commit \`f4688ba\`)

5 groups (was 5), 11 sidebar items (was 14):

| Group | Items |
|-------|-------|
| **Overview**  | Dashboard, Simulation |
| **Library**   | Devices, Compare & Merge |
| **Live View** | Running Devices, Topology, Traffic |
| **Inspect**   | Logs, Packets, SNMP Walks |
| **Alerts**    | Alerts |

Plain-English renames so the sidebar reads like a session, not a feature list:

| Old | New |
|---|---|
| Simulation Control | Simulation |
| Topology & Neighbor Insight | Topology |
| Replay & Playback | Replay |
| Traffic & Error Injection | Traffic |
| Protocol Debug | Logs |
| Packet Capture | Packets |
| Config Diff & Merge | Compare & Merge |
| Device Library | Devices |
| Walk Validator | SNMP Walks |

Sidebar label = page title (no more "Simulation" vs "Simulation Control" confusion). Breadcrumbs + help-drawer copy updated to match.

\`/neighbors\`, \`/pcap-analyzer\`, \`/analysis\` are still live routes but dropped from the sidebar — fold-in to their hosts (Topology / Packets / Traffic) comes in a follow-up.

### Bundle 2 — Unified network picker (commit \`a52943c\`)

The Simulation picker used to show three source-filter chips (All / Built-in / Saved / Local) and tag every row with a coloured source pill. Since NIAC hasn't shipped yet there's no historical split worth preserving — all YAML configs are just "networks you might run."

- Drop the Built-in / Saved filter chips and row tags
- Add a star toggle on each card / row; favorites stored in localStorage under \`niac.configs.favorites\`
- Sort: local upload pinned, favorites alphabetical, then everything else alphabetical
- Section headers with counts (\`Favorites · 3\`, \`All networks · 47\`) so long lists stay scannable
- Search hides the favorites zone and shows one alphabetical \`Results\` block, so what the user typed isn't buried behind starred items
- New \`useFavorites\` hook is generic — keyed by storage key so Devices / other libraries can adopt favorites later

No backend changes; existing \`onSelectTemplate\` / \`onSelectUserConfig\` callbacks unchanged.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx @biomejs/biome check src/\` clean
- [x] \`make build\` succeeds
- [ ] Manual: hit every old URL — it still loads (no 404s)
- [ ] Manual: star a few networks, refresh page, confirm they're still starred and pinned on top
- [ ] Manual: search box still narrows the list and shows a single alphabetical \`Results\` block
- [ ] CI green