### PR TITLE
refactor(ui): expand Typography primitives + document theme convention

### DIFF
--- a/ui/src/ui/Typography.tsx
+++ b/ui/src/ui/Typography.tsx
@@ -1,15 +1,63 @@
 import type { FC, HTMLAttributes, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
+/**
+ * Typography primitives — one canonical class set per visual level so the
+ * app doesn't drift into a dozen "almost h2" inline classNames.
+ *
+ * Visual scale (top to bottom, sized for our dark-theme baseline):
+ *
+ *   H1  — page header (set by Layout's <PageHeader>, rarely used in body)
+ *         text-2xl / font-bold / text-white
+ *   H2  — section header inside a card
+ *         text-xl  / font-semibold / text-white
+ *   H3  — sub-section header
+ *         text-lg  / font-semibold / text-white
+ *   H4  — small label / pill header (often with an icon)
+ *         text-sm  / font-semibold / text-white
+ *
+ *   P         — body copy:                 text-gray-300 leading-relaxed
+ *   SmallText — secondary inline text:     text-sm  text-gray-400
+ *   Caption   — labels / captions / units: text-xs  text-gray-400
+ *
+ * Contrast — all foreground colors above hit WCAG AA against our
+ * --color-bg-base / --color-bg-elevated surfaces. Avoid text-gray-500
+ * for sustained body copy; reserve it for placeholders, disabled
+ * states, and timestamps where lower contrast is intentional.
+ *
+ * Accent colors: brand violet (text-violet-300/400) is the only
+ * "highlight" colour; status colours (red/amber/emerald) come from the
+ * Tailwind palette directly. If you find yourself reaching for
+ * text-purple/pink/sky for chrome, route it through this file first.
+ */
+
 interface TypographyProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode;
   className?: string;
 }
 
+export const H1: FC<TypographyProps> = ({ children, className = '', ...props }) => (
+  <h1 className={`text-2xl font-bold text-white ${className}`} {...props}>
+    {children}
+  </h1>
+);
+
 export const H2: FC<TypographyProps> = ({ children, className = '', ...props }) => (
   <h2 className={`text-xl font-semibold text-white mb-2 ${className}`} {...props}>
     {children}
   </h2>
+);
+
+export const H3: FC<TypographyProps> = ({ children, className = '', ...props }) => (
+  <h3 className={`text-lg font-semibold text-white ${className}`} {...props}>
+    {children}
+  </h3>
+);
+
+export const H4: FC<TypographyProps> = ({ children, className = '', ...props }) => (
+  <h4 className={`text-sm font-semibold text-white ${className}`} {...props}>
+    {children}
+  </h4>
 );
 
 export const P: FC<TypographyProps> = ({ children, className = '', ...props }) => (
@@ -20,6 +68,12 @@ export const P: FC<TypographyProps> = ({ children, className = '', ...props }) =
 
 export const SmallText: FC<TypographyProps> = ({ children, className = '', ...props }) => (
   <span className={`text-sm text-gray-400 ${className}`} {...props}>
+    {children}
+  </span>
+);
+
+export const Caption: FC<TypographyProps> = ({ children, className = '', ...props }) => (
+  <span className={`text-xs text-gray-400 ${className}`} {...props}>
     {children}
   </span>
 );
@@ -38,7 +92,7 @@ export const AccentLink: FC<AccentLinkProps> = ({
   onClick,
   ...props
 }) => {
-  const linkClass = `text-violet-400 hover:text-violet-300 underline underline-offset-2 transition-colors ${className}`;
+  const linkClass = `text-violet-300 hover:text-violet-200 underline underline-offset-2 transition-colors ${className}`;
 
   if (to) {
     return (


### PR DESCRIPTION
## Summary
Foundation pass for the theme harmonization. Adds the missing Typography primitives + documents the canonical visual / contrast convention in one place so subsequent migration PRs have a clear target.

### New exports

| Component | Visual                     |
|-----------|----------------------------|
| \`H1\`      | text-2xl / font-bold       |
| \`H3\`      | text-lg  / font-semibold   |
| \`H4\`      | text-sm  / font-semibold   |
| \`Caption\` | text-xs  / text-gray-400   |

\`H2\`, \`P\`, \`SmallText\`, \`AccentLink\` were already there.

### Documented convention (now in Typography.tsx JSDoc)

- Visual scale top→bottom (H1 / H2 / H3 / H4) — one canonical class set each
- Body: \`text-gray-300\` ; Muted: \`text-gray-400\` ; Avoid \`text-gray-500\` for sustained body copy (borderline AA contrast on \`--color-bg-base\` — reserve it for placeholders / disabled / timestamps)
- Accent: brand violet only; status colours direct from Tailwind palette

### Drive-by

\`AccentLink\` colour bumped \`text-violet-400 → text-violet-300\` (and hover \`300 → 200\`) for a small contrast win against dark surfaces.

### What's NOT in this PR

A real sweep across the ~270 inline \`text-gray-400\` / 33 raw \`<h1-h4>\` instances would touch many files. Saving those as follow-ups (3b: page heading migration; 3c: gray-scale audit) so each PR stays reviewable.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx @biomejs/biome check src/ui/Typography.tsx\` clean
- [x] No existing import broken (AccentLink only used in DashboardPage; rendered colour is the only behaviour change)
- [ ] CI green