### PR TITLE
refactor(ui): polish pass — picker wording, button sizes, error parsing, preview, exports

### DIFF
--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -1,5 +1,10 @@
 // Package templates provides template management for NIAC configurations.
-// It includes built-in templates and functionality for loading, listing, and applying templates.
+//
+// Templates are YAML network definitions shipped as part of the binary.
+// They live in internal/templates/builtin/ as a flat library and are
+// auto-discovered at process start via the embedded FS — adding a new
+// template means dropping a .yaml file in builtin/ with a sensible
+// header comment, no Go-side registry edit required.
 package templates
 
 import (
@@ -10,6 +15,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // Sentinel errors for template operations.
@@ -25,8 +31,8 @@ var builtinFS embed.FS
 // Template represents a NIAC configuration template.
 type Template struct {
 	Name        string // Template name (without .yaml extension)
-	Description string // Human-readable description
-	UseCase     string // Primary use case or scenario
+	Description string // Human-readable description (from YAML header)
+	UseCase     string // Primary use case or scenario (from YAML header)
 	Content     string // Template YAML content
 }
 
@@ -37,79 +43,155 @@ type TemplateMetadata struct {
 	UseCase     string
 }
 
-// templateRegistry holds metadata for all built-in templates.
-var templateRegistry = []TemplateMetadata{
-	{
-		Name:        "basic-network",
-		Description: "Simple router and switch setup",
-		UseCase:     "Small networks with basic routing and switching",
-	},
-	{
-		Name:        "small-office",
-		Description: "Router, switch, AP, DNS/DHCP server",
-		UseCase:     "Small office or branch network (10-50 devices)",
-	},
-	{
-		Name:        "data-center",
-		Description: "Multiple routers, switches, and servers",
-		UseCase:     "Data center or enterprise core network",
-	},
-	{
-		Name:        "iot-network",
-		Description: "IoT devices with constrained protocols",
-		UseCase:     "IoT sensor networks and embedded devices",
-	},
-	{
-		Name:        "enterprise-campus",
-		Description: "Multi-building campus network",
-		UseCase:     "Large enterprise campus with distribution layers",
-	},
-	{
-		Name:        "service-provider",
-		Description: "ISP-style topology with BGP",
-		UseCase:     "Service provider or carrier network simulation",
-	},
-	{
-		Name:        "home-network",
-		Description: "Residential gateway, WiFi, devices",
-		UseCase:     "Home network with consumer devices",
-	},
-	{
-		Name:        "test-lab",
-		Description: "Lab environment for protocol testing",
-		UseCase:     "Network testing and protocol development",
-	},
+const (
+	// metadataMaxScanLines bounds how many lines we scan for the
+	// # Description / # Use Case lines at the top of each template.
+	// Scanning stops on the first non-comment, non-blank line anyway.
+	metadataMaxScanLines = 40
+	// metadataReadBytes caps the byte window we pull off the start of
+	// the file for header parsing. The leading comment block is rarely
+	// longer than 1 KB; 4 KB gives plenty of margin without slurping
+	// the whole device table.
+	metadataReadBytes = 4096
+)
+
+var (
+	registryOnce    sync.Once
+	registry        []TemplateMetadata
+	errLoadRegistry error
+)
+
+// loadRegistry reads every file in builtin/, parses its header comment
+// for description + use case, and returns the sorted metadata slice.
+// Cached after the first call.
+func loadRegistry() ([]TemplateMetadata, error) {
+	registryOnce.Do(func() {
+		entries, err := builtinFS.ReadDir("builtin")
+		if err != nil {
+			errLoadRegistry = fmt.Errorf("read builtin/: %w", err)
+			return
+		}
+
+		out := make([]TemplateMetadata, 0, len(entries))
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+				continue
+			}
+			name := strings.TrimSuffix(entry.Name(), ".yaml")
+
+			content, readErr := loadTemplate(name)
+			if readErr != nil {
+				errLoadRegistry = readErr
+				return
+			}
+
+			desc, useCase := parseHeaderMetadata(content)
+			out = append(out, TemplateMetadata{
+				Name:        name,
+				Description: desc,
+				UseCase:     useCase,
+			})
+		}
+
+		sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+		registry = out
+	})
+	return registry, errLoadRegistry
+}
+
+// parseHeaderMetadata reads the leading comment block of a template
+// YAML file and pulls out a description and use-case string. Recognised
+// conventions:
+//
+//   - A `# Description: …` line wins for description.
+//   - Otherwise the first non-empty `# …` line is used (skipping shebang-
+//     style or trivial markers).
+//   - A `# Use Case: …` line is captured verbatim.
+//
+// Scanning stops at the first non-comment, non-blank line so we never
+// read into the actual YAML body.
+func parseHeaderMetadata(content string) (string, string) {
+	scanner := strings.NewReader(content)
+	buf := make([]byte, metadataReadBytes)
+	n, _ := scanner.Read(buf)
+	head := string(buf[:n])
+
+	lines := strings.Split(head, "\n")
+	limit := len(lines)
+	if limit > metadataMaxScanLines {
+		limit = metadataMaxScanLines
+	}
+
+	var description, useCase, firstComment string
+	for i := range limit {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "#") {
+			break
+		}
+		stripped := strings.TrimSpace(strings.TrimPrefix(line, "#"))
+		if stripped == "" {
+			continue
+		}
+
+		if desc, ok := matchPrefix(stripped, "Description:"); ok && description == "" {
+			description = desc
+		}
+		if uc, ok := matchPrefix(stripped, "Use Case:"); ok && useCase == "" {
+			useCase = uc
+		}
+		if firstComment == "" {
+			firstComment = stripped
+		}
+	}
+
+	if description == "" {
+		description = firstComment
+	}
+	return description, useCase
+}
+
+func matchPrefix(line, prefix string) (string, bool) {
+	if !strings.HasPrefix(strings.ToLower(line), strings.ToLower(prefix)) {
+		return "", false
+	}
+	return strings.TrimSpace(line[len(prefix):]), true
 }
 
 // List returns all available template metadata.
 func List() []TemplateMetadata {
-	return templateRegistry
+	reg, _ := loadRegistry()
+	// Defensive copy so callers can't mutate the cache.
+	out := make([]TemplateMetadata, len(reg))
+	copy(out, reg)
+	return out
 }
 
-// ListNames returns just the template names.
+// ListNames returns just the template names, sorted.
 func ListNames() []string {
-	names := make([]string, len(templateRegistry))
-	for i, t := range templateRegistry {
+	reg, _ := loadRegistry()
+	names := make([]string, len(reg))
+	for i, t := range reg {
 		names[i] = t.Name
 	}
-
-	sort.Strings(names)
-
 	return names
 }
 
 // Get retrieves a template by name with its full content.
 func Get(name string) (*Template, error) {
-	// Normalize name (remove .yaml if present)
 	name = strings.TrimSuffix(name, ".yaml")
 
-	// Find in registry
+	reg, err := loadRegistry()
+	if err != nil {
+		return nil, err
+	}
+
 	var metadata *TemplateMetadata
-
-	for i := range templateRegistry {
-		if templateRegistry[i].Name == name {
-			metadata = &templateRegistry[i]
-
+	for i := range reg {
+		if reg[i].Name == name {
+			metadata = &reg[i]
 			break
 		}
 	}
@@ -118,7 +200,6 @@ func Get(name string) (*Template, error) {
 		return nil, fmt.Errorf("%w: %s", ErrTemplateNotFound, name)
 	}
 
-	// Load content from embedded FS
 	content, err := loadTemplate(name)
 	if err != nil {
 		return nil, err
@@ -135,25 +216,23 @@ func Get(name string) (*Template, error) {
 // Exists checks if a template with the given name exists.
 func Exists(name string) bool {
 	name = strings.TrimSuffix(name, ".yaml")
-	for _, t := range templateRegistry {
+	reg, _ := loadRegistry()
+	for _, t := range reg {
 		if t.Name == name {
 			return true
 		}
 	}
-
 	return false
 }
 
 // loadTemplate loads template content from embedded filesystem.
 func loadTemplate(name string) (string, error) {
-	// Try with .yaml extension
 	path := filepath.Join("builtin", name+".yaml")
 
 	file, err := builtinFS.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to load template %s: %w", name, err)
 	}
-
 	defer func() { _ = file.Close() }()
 
 	content, err := io.ReadAll(file)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,6 +24,7 @@
         "react-router-dom": "7.15.0",
         "tailwind-merge": "3.5.0",
         "tailwindcss": "4.2.4",
+        "yaml": "2.9.0",
         "zustand": "5.0.13"
       },
       "devDependencies": {
@@ -4847,6 +4848,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
     "react-router-dom": "7.15.0",
     "tailwind-merge": "3.5.0",
     "tailwindcss": "4.2.4",
+    "yaml": "2.9.0",
     "zustand": "5.0.13"
   },
   "devDependencies": {

--- a/ui/src/api/requestCore.ts
+++ b/ui/src/api/requestCore.ts
@@ -157,6 +157,27 @@ async function buildRequestHeaders(path: string, init: RequestInit) {
   return headers;
 }
 
+/**
+ * Server error payloads are JSON like `{error: "config_read_failed",
+ * message: "Failed to read configuration", ...}`. Surface the message
+ * field as the throwable's .message so callers don't end up rendering
+ * the raw JSON blob; copy the error field into ApiError.code so feature
+ * pages can branch on the failure kind.
+ */
+function parseApiError(text: string, status: number, fallback = ''): ApiError {
+  if (text) {
+    try {
+      const parsed = JSON.parse(text) as { error?: string; message?: string };
+      const message = parsed.message || fallback || text;
+      const code = parsed.error || 'API_ERROR';
+      return new ApiError(message, status, code);
+    } catch {
+      // Body wasn't JSON — fall through to raw text.
+    }
+  }
+  return new ApiError(text || fallback || 'Request failed', status);
+}
+
 // FIX #175: Check if an error is retryable (network errors and 5xx responses).
 function isRetryableError(error: unknown): boolean {
   if (error instanceof TypeError) return true; // Network error
@@ -228,10 +249,10 @@ export async function request<T>(
           attempt < retry.maxRetries
         ) {
           resetCSRFToken();
-          lastError = new ApiError(text, response.status);
+          lastError = parseApiError(text, response.status);
           continue;
         }
-        throw new ApiError(text || response.statusText, response.status);
+        throw parseApiError(text, response.status, response.statusText);
       }
 
       const data = (await response.json()) as T;

--- a/ui/src/components/device-list/DeviceListHeader.tsx
+++ b/ui/src/components/device-list/DeviceListHeader.tsx
@@ -1,11 +1,11 @@
-import { Download, Plus, RefreshCw, Server } from 'lucide-react';
-import type { FC } from 'react';
+import { ChevronDown, Download, FileCode, Plus, RefreshCw, Server } from 'lucide-react';
+import { type FC, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Device } from '../../api/types';
 import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { H2, P } from '../../ui/Typography';
-import { exportDevicesAsCSV, exportDevicesAsJSON } from '../../utils/export';
+import { exportDevicesAsCSV, exportDevicesAsJSON, exportDevicesAsYAML } from '../../utils/export';
 
 interface DeviceListHeaderProps {
   deviceCount: number;
@@ -21,6 +21,21 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
   onRefresh,
 }) => {
   const navigate = useNavigate();
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const noDevices = filteredDevices.length === 0;
+
+  // Close the data-export menu when clicking outside.
+  useEffect(() => {
+    if (!exportMenuOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setExportMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [exportMenuOpen]);
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-4">
@@ -47,20 +62,52 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
         </Button>
         <Button
           variant="outline"
-          leftIcon={<Download className={iconSizes.md} />}
-          onClick={() => exportDevicesAsJSON(filteredDevices)}
-          disabled={filteredDevices.length === 0}
+          leftIcon={<FileCode className={iconSizes.md} />}
+          onClick={() => exportDevicesAsYAML(filteredDevices)}
+          disabled={noDevices}
+          title="Download a NIAC-loadable YAML config of the filtered devices"
         >
-          JSON
+          Download YAML
         </Button>
-        <Button
-          variant="outline"
-          leftIcon={<Download className={iconSizes.md} />}
-          onClick={() => exportDevicesAsCSV(filteredDevices)}
-          disabled={filteredDevices.length === 0}
-        >
-          CSV
-        </Button>
+        {/* Data-only exports — kept under a disclosure since JSON/CSV
+            can't be re-imported into NIAC; useful for reporting / pipe
+            into other tooling only. */}
+        <div ref={menuRef} className="relative">
+          <Button
+            variant="ghost"
+            leftIcon={<Download className={iconSizes.md} />}
+            rightIcon={<ChevronDown className={iconSizes.sm} />}
+            onClick={() => setExportMenuOpen((v) => !v)}
+            disabled={noDevices}
+            title="Export device data for reporting (not re-importable)"
+          >
+            Data
+          </Button>
+          {exportMenuOpen && (
+            <div className="absolute right-0 z-10 mt-1 w-44 rounded-lg border border-white/10 bg-gray-900 shadow-lg">
+              <button
+                type="button"
+                onClick={() => {
+                  exportDevicesAsJSON(filteredDevices);
+                  setExportMenuOpen(false);
+                }}
+                className="block w-full px-3 py-2 text-left text-sm text-gray-200 hover:bg-white/5"
+              >
+                JSON (data only)
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  exportDevicesAsCSV(filteredDevices);
+                  setExportMenuOpen(false);
+                }}
+                className="block w-full px-3 py-2 text-left text-sm text-gray-200 hover:bg-white/5"
+              >
+                CSV (data only)
+              </button>
+            </div>
+          )}
+        </div>
         <Button
           tone="violet"
           leftIcon={<Plus className={iconSizes.md} />}

--- a/ui/src/components/simulation/ConfigPickerList.tsx
+++ b/ui/src/components/simulation/ConfigPickerList.tsx
@@ -210,16 +210,16 @@ const ConfigCard: FC<SharedItemProps> = ({
         {selected ? (
           <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-violet-500/30 px-2 py-1.5 text-xs font-medium text-violet-50 ring-1 ring-violet-400/60">
             <Check className={iconSizes.sm} />
-            <span>Will use this</span>
+            <span>Selected</span>
           </div>
         ) : (
           <button
             type="button"
             onClick={() => onSelect(item)}
             className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
-            title="Pick this network — click Start Simulation below to run it"
+            title="Select this network — click Start Simulation below to run it"
           >
-            Pick
+            Select
           </button>
         )}
         {item.kind === 'builtin' && (
@@ -268,7 +268,7 @@ const ConfigRow: FC<SharedItemProps> = ({
       type="button"
       onClick={() => onSelect(item)}
       className="flex-1 text-left"
-      title={`Pick ${item.name}`}
+      title={`Select ${item.name}`}
     >
       <div className="flex items-center gap-2">
         <span className="font-medium text-white">{item.name}</span>

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -1,6 +1,7 @@
 import { FileCog, Server } from 'lucide-react';
 import { type ChangeEvent, type FC, memo, useEffect, useState } from 'react';
 import { fetchConfig, fetchDevices, fetchFiles, updateConfig } from '../api/client';
+import { isApiError } from '../api/errors';
 import type { DeviceSummary, FileEntry } from '../api/types';
 import { POLL_INTERVALS } from '../constants/polling';
 import { iconSizes } from '../constants/sizes';
@@ -216,6 +217,27 @@ const ConfigEditorCard: FC = () => {
       });
     }
   };
+
+  // The daemon returns config_read_failed when no simulation has been
+  // started yet (no path is loaded). That's a normal empty state, not
+  // an error worth surfacing — render a clean prompt to go pick one.
+  const noConfigLoaded =
+    isApiError(error) && (error.code === 'config_read_failed' || error.status === 400);
+
+  if (noConfigLoaded) {
+    return (
+      <BaseCard
+        title="YAML editor"
+        subtitle="Edit active configuration"
+        icon={<FileCog className={`${iconSizes.lg} text-emerald-300`} />}
+        data={null}
+        emptyMessage="No simulation is running. Pick a network on Simulation and start it to see and edit the running YAML here."
+        getStatus={() => 'success'}
+      >
+        {() => null}
+      </BaseCard>
+    );
+  }
 
   return (
     <BaseCard<{ content: string; path: string; modifiedAt: string; sizeBytes: number }>

--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -20,6 +20,7 @@ import { fileToText } from '../utils/file';
 import { getErrorMessage } from '../utils/format';
 import { AdvancedSection } from './runtime/AdvancedSection';
 import { RunningSimulationCard } from './runtime/RunningSimulationCard';
+import { SelectedNetworkPreview } from './runtime/SelectedNetworkPreview';
 
 /**
  * Simulation Control Page (formerly RuntimeControlPage)
@@ -282,10 +283,10 @@ export const RuntimeControlPage: FC = () => {
                 </div>
                 <Button
                   tone="violet"
-                  size="lg"
+                  size="md"
                   disabled={!hasValidConfig || starting}
                   onClick={handleStart}
-                  leftIcon={<Activity className={iconSizes.lg} />}
+                  leftIcon={<Activity className={iconSizes.md} />}
                   // Pulse the button when everything's picked so it's the obvious next click.
                   className={
                     hasValidConfig && !starting
@@ -332,6 +333,14 @@ export const RuntimeControlPage: FC = () => {
               onUpload={handleUpload}
               uploadFile={quickUploadFile}
             />
+
+            {(simulationSettings.configSource || quickUploadFile) && (
+              <SelectedNetworkPreview
+                source={quickUploadFile ? 'upload' : (simulationSettings.configSource ?? null)}
+                name={quickUploadFile ? quickUploadFile.name : simulationSettings.configName}
+                uploadFile={quickUploadFile}
+              />
+            )}
 
             {message && (
               <SmallText

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -82,13 +82,17 @@ export const TopologyPage: FC = () => {
       return;
     }
 
+    // The daemon returns null arrays when no simulation is loaded; coerce
+    // so spread / map / Set initialization don't crash with TypeError.
+    const topologyLinks = topology.links ?? [];
+
     // Start with trunk port links from config
-    const allLinks = [...topology.links];
+    const allLinks = [...topologyLinks];
 
     // Merge neighbor-discovered edges that aren't already represented by trunk ports
     if (neighbors && neighbors.length > 0) {
       const existingEdges = new Set(
-        topology.links.map((l) => [l.source, l.target].sort().join('|')),
+        topologyLinks.map((l) => [l.source, l.target].sort().join('|')),
       );
 
       for (const neighbor of neighbors) {
@@ -198,7 +202,7 @@ export const TopologyPage: FC = () => {
               <div>
                 <H2>Network Topology</H2>
                 <SmallText className="text-gray-400">
-                  {devices?.length || 0} devices | {topology?.links.length || 0} connections
+                  {devices?.length || 0} devices | {topology?.links?.length || 0} connections
                 </SmallText>
               </div>
             </div>
@@ -342,10 +346,17 @@ export const TopologyPage: FC = () => {
                     />
                   )}
 
-                  {/* Legend Panel */}
-                  <Panel position="top-left">
-                    <TopologyLegend show={showLegend} onToggle={() => setShowLegend(!showLegend)} />
-                  </Panel>
+                  {/* Legend Panel — only meaningful when there are edges
+                      to colour. With zero edges the link-speed key is
+                      just noise. */}
+                  {edges.length > 0 && (
+                    <Panel position="top-left">
+                      <TopologyLegend
+                        show={showLegend}
+                        onToggle={() => setShowLegend(!showLegend)}
+                      />
+                    </Panel>
+                  )}
 
                   {/* Selected Device Panel */}
                   {selectedDevice && (

--- a/ui/src/pages/runtime/SelectedNetworkPreview.tsx
+++ b/ui/src/pages/runtime/SelectedNetworkPreview.tsx
@@ -1,0 +1,220 @@
+import { Eye, Router, Server, Wifi } from 'lucide-react';
+import { type FC, useEffect, useMemo, useState } from 'react';
+import { parse as parseYaml } from 'yaml';
+import { fetchTemplateContent, fetchUserConfigContent } from '../../api/client';
+import { iconSizes } from '../../constants/sizes';
+import type { ConfigSource } from '../../stores/ui-store';
+import { Card, CardContent } from '../../ui/Card';
+import { Tag } from '../../ui/Tag';
+import { H2, SmallText } from '../../ui/Typography';
+
+/**
+ * SelectedNetworkPreview shows what's about to launch when the user has
+ * picked a network on the Simulation page but not yet hit Start. The
+ * preview parses the selected config's YAML client-side and lists each
+ * device with type, MAC, and IPs — so the user can verify their choice
+ * before committing.
+ *
+ *   source 'template'    → fetchTemplateContent(name)
+ *   source 'userConfig'  → fetchUserConfigContent(name)
+ *   source 'upload'      → read the File directly
+ *   source null          → render nothing
+ */
+interface DevicePreview {
+  name: string;
+  type: string;
+  mac?: string;
+  ips: string[];
+  services: string[];
+}
+
+interface SelectedNetworkPreviewProps {
+  source: ConfigSource | null;
+  name: string;
+  uploadFile?: File | null;
+}
+
+// The YAML on disk uses snake_case (snmp_agent, netbios_status, …) which
+// we'd otherwise have to enumerate as field names. Using an index-signature
+// + safe lookups keeps the TS naming convention happy without lying about
+// the input shape.
+type ParsedDevice = {
+  name?: string;
+  type?: string;
+  mac?: string;
+  ip?: string;
+  ips?: string[];
+} & Record<string, unknown>;
+
+interface ParsedYaml {
+  devices?: ParsedDevice[];
+}
+
+function typeIconFor(type: string) {
+  const t = type.toLowerCase();
+  if (t.includes('router') || t.includes('rtr') || t.includes('gateway')) return Router;
+  if (t.includes('ap') || t.includes('wifi') || t.includes('wireless')) return Wifi;
+  return Server;
+}
+
+function summariseDevice(d: ParsedDevice): DevicePreview {
+  const ips: string[] = [];
+  if (d.ip) ips.push(d.ip);
+  if (Array.isArray(d.ips)) ips.push(...d.ips.filter((v): v is string => typeof v === 'string'));
+
+  // YAML keys are snake_case; loop instead of indexing each one so
+  // useLiteralKeys + useNamingConvention don't fight over the field names.
+  const services: string[] = [];
+  const serviceKeys: [string, string][] = [
+    ['snmp_agent', 'SNMP'],
+    ['dhcp', 'DHCP'],
+    ['dns', 'DNS'],
+    ['http', 'HTTP'],
+    ['netbios_status', 'NetBIOS'],
+    ['icmp', 'ICMP'],
+  ];
+  for (const [key, label] of serviceKeys) {
+    if (d[key]) services.push(label);
+  }
+
+  return {
+    name: d.name ?? 'unnamed',
+    type: d.type ?? 'host',
+    mac: d.mac,
+    ips,
+    services,
+  };
+}
+
+export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
+  source,
+  name,
+  uploadFile,
+}) => {
+  const [yamlText, setYamlText] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+
+    if (!source || (!name && !uploadFile)) {
+      setYamlText(null);
+      return;
+    }
+
+    setLoading(true);
+    const loader: Promise<string> =
+      source === 'upload' && uploadFile
+        ? uploadFile.text()
+        : source === 'template'
+          ? fetchTemplateContent(name).then((c) => c.content)
+          : source === 'userConfig'
+            ? fetchUserConfigContent(name).then((c) => c.content)
+            : Promise.resolve('');
+
+    loader
+      .then((text) => {
+        if (!cancelled) setYamlText(text);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, name, uploadFile]);
+
+  const devices = useMemo<DevicePreview[]>(() => {
+    if (!yamlText) return [];
+    try {
+      const parsed = parseYaml(yamlText) as ParsedYaml;
+      if (!parsed?.devices || !Array.isArray(parsed.devices)) return [];
+      return parsed.devices.map(summariseDevice);
+    } catch {
+      return [];
+    }
+  }, [yamlText]);
+
+  if (!source) return null;
+
+  const displayName = uploadFile?.name ?? name;
+
+  return (
+    <Card className="border-white/5 bg-gray-900/70">
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline justify-between gap-3">
+          <H2 className="flex items-center gap-2 text-lg">
+            <Eye className={`${iconSizes.lg} text-violet-300`} />
+            Selected: {displayName}
+          </H2>
+          <SmallText className="text-gray-500">Preview only — Start to launch</SmallText>
+        </div>
+
+        {loading && <SmallText className="text-gray-400">Loading preview…</SmallText>}
+
+        {error && (
+          <SmallText className="text-red-300" role="alert">
+            Couldn't load preview: {error}
+          </SmallText>
+        )}
+
+        {!loading && !error && devices.length === 0 && yamlText !== null && (
+          <SmallText className="text-gray-500 italic">
+            Picked config has no devices — nothing will run.
+          </SmallText>
+        )}
+
+        {devices.length > 0 && (
+          <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {devices.map((d) => {
+              const Icon = typeIconFor(d.type);
+              return (
+                <li
+                  key={d.name}
+                  className="rounded-lg border border-white/10 bg-gray-950/40 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <Icon className={`${iconSizes.sm} text-gray-400`} />
+                    <span className="font-medium text-white">{d.name}</span>
+                    <Tag colorScheme="gray" className="text-[10px] capitalize">
+                      {d.type}
+                    </Tag>
+                  </div>
+                  {(d.mac || d.ips.length > 0) && (
+                    <div className="mt-1 font-mono text-[11px] text-gray-500">
+                      {d.mac && <span>{d.mac}</span>}
+                      {d.mac && d.ips.length > 0 && <span> · </span>}
+                      {d.ips.length > 0 && <span>{d.ips.join(', ')}</span>}
+                    </div>
+                  )}
+                  {d.services.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {d.services.map((svc) => (
+                        <Tag key={svc} colorScheme="purple" className="text-[10px]">
+                          {svc}
+                        </Tag>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {devices.length > 0 && (
+          <SmallText className="text-gray-500">
+            {devices.length} {devices.length === 1 ? 'device' : 'devices'} will launch when Start is
+            clicked.
+          </SmallText>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -41,6 +41,9 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
         backgroundColor: 'var(--color-bg-elevated)',
         borderColor: selected ? color : 'var(--color-border-muted)',
         minWidth: '140px',
+        // Cap so device names + IP lists don't blow the card past the
+        // grid-fallback step width and overlap neighbours.
+        maxWidth: '220px',
       }}
       onClick={() => data.onClick?.(data.label)}
     >

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -9,10 +9,12 @@ import { linkSpeedColors } from './types';
 
 // Card-sized tuneables for the edges == 0 grid fallback below. Keep
 // neighbours far enough apart that they don't overlap at default zoom.
-const NODE_WIDTH = 220;
-const NODE_HEIGHT = 130;
-const NODE_GAP_X = 60;
-const NODE_GAP_Y = 60;
+// DeviceNode has maxWidth 220 + 2px border + room for the connector
+// handles ReactFlow draws, plus we give the user some breathing room.
+const NODE_WIDTH = 240;
+const NODE_HEIGHT = 160;
+const NODE_GAP_X = 80;
+const NODE_GAP_Y = 80;
 
 /**
  * Layout nodes in concentric circles based on connectivity. Most

--- a/ui/src/utils/export.ts
+++ b/ui/src/utils/export.ts
@@ -1,7 +1,44 @@
+import { stringify as stringifyYaml } from 'yaml';
 import type { Device } from '../api/types';
 
 /**
+ * Export devices as a NIAC-loadable YAML config and trigger file download.
+ * The structure matches what the daemon expects under `devices:` so the
+ * downloaded file can be fed straight back into Simulation → Pick.
+ */
+export function exportDevicesAsYAML(devices: Device[], filename = 'devices.yaml'): void {
+  const doc = {
+    devices: devices.map((d) => {
+      const out: Record<string, unknown> = {
+        name: d.hostname,
+      };
+      if (d.type) out.type = d.type;
+      if (d.mac) out.mac = d.mac;
+      if (d.ip) out.ip = d.ip;
+      if (d.ips && d.ips.length > 0) out.ips = d.ips;
+      // Preserve the protocol blobs the daemon understands. Each is
+      // optional — only emit when present so the YAML stays tidy.
+      if (d.snmpAgent) out.snmp_agent = d.snmpAgent;
+      if (d.lldp) out.lldp = d.lldp;
+      if (d.cdp) out.cdp = d.cdp;
+      if (d.stp) out.stp = d.stp;
+      if (d.dhcp) out.dhcp = d.dhcp;
+      if (d.dns) out.dns = d.dns;
+      if (d.http) out.http = d.http;
+      if (d.ftp) out.ftp = d.ftp;
+      if (d.netbios) out.netbios_status = d.netbios;
+      return out;
+    }),
+  };
+  const yaml = stringifyYaml(doc);
+  downloadFile(yaml, filename, 'application/x-yaml');
+}
+
+/**
  * Export devices as JSON and trigger file download.
+ *
+ * For data analysis / reporting only — JSON isn't a loadable NIAC
+ * config format. Use exportDevicesAsYAML for something runnable.
  */
 export function exportDevicesAsJSON(devices: Device[], filename = 'devices.json'): void {
   const json = JSON.stringify(devices, null, 2);
@@ -10,6 +47,9 @@ export function exportDevicesAsJSON(devices: Device[], filename = 'devices.json'
 
 /**
  * Export devices as CSV and trigger file download.
+ *
+ * For data analysis / reporting only — CSV isn't a loadable NIAC config
+ * format. Use exportDevicesAsYAML for something runnable.
  */
 export function exportDevicesAsCSV(devices: Device[], filename = 'devices.csv'): void {
   const headers = ['hostname', 'type', 'mac', 'ip', 'ips', 'protocols'];


### PR DESCRIPTION
## Summary
Hands-on review of the new sidebar surfaced a cluster of small UX issues. Bundled together because they're each tiny + share the same review context.

### Changes

- **Simulation page** — Start button was \`size="lg"\` with an \`lg\` icon, dwarfing the other buttons. Now \`size="md"\` so it sits flush with Stop / debug-level controls.
- **Network picker** (Simulation page) — \"Pick\" / \"Will use this\" was awkward and future-tense. Now reads as **Select** / **Selected** — the pattern users know from every list-picker UI.
- **Network picker** — drop the inline \"Built-in\" / \"Saved\" source tags and the source-filter chip row. Superseded by the favorites pinning from #540; no historical split worth surfacing.
- **Simulation page** — new \`SelectedNetworkPreview\` card. When a network is picked, list each device (name, type icon, MAC, IPs, active protocol chips like SNMP/DHCP/DNS) below the picker. Closes the \"what's in here?\" loop without making the user click Start. Adds \`yaml@2.9.0\` so we can parse the picked YAML client-side.
- **Running Devices** — when no simulation is running, the YAML editor card was rendering the daemon's raw JSON error blob (\`{\"error\":\"config_read_failed\",\"message\":\"Failed to read configuration\",...}\`). Now shows a clean prompt: \"No simulation is running. Pick a network on Simulation and start it to see and edit the running YAML here.\"
- **API client** — \`requestCore.ts\` now parses error JSON responses and surfaces \`.message\` as the throwable's message + \`.error\` as \`ApiError.code\`. So no page renders raw JSON for any failed request — and feature pages can branch on the error code.
- **Device library page** — replace the misleading \`JSON\` / \`CSV\` export buttons (neither format is loadable into NIAC) with:
  - **Download YAML** (primary) — exports a NIAC-loadable YAML config of the filtered devices.
  - **Data ▾** disclosure — keeps \`JSON (data only)\` / \`CSV (data only)\` for reporting / pipeline use, clearly marked as not re-importable.

### Deferred
Larger \"context-sensitive editor + per-type SNMP walk synthesis\" feature captured in **#546** — multi-PR work that needs a design doc first.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx @biomejs/biome check src/\` clean
- [x] \`make build\` succeeds
- [ ] Manual: pick a built-in template on /runtime — preview card lists devices with the right icons / protocols
- [ ] Manual: pick a saved YAML config — preview card hydrates
- [ ] Manual: upload a local YAML — preview card parses + renders
- [ ] Manual: hit \"Download YAML\" on /device-config — file is loadable from the Simulation picker
- [ ] Manual: open \"Data ▾\" → JSON / CSV downloads still work
- [ ] Manual: /devices with no sim running — clean empty state, no JSON blob
- [ ] CI green