### PR TITLE
feat: on-disk library (#548 PR 1) + fix YAML trunk_ports drop (#550)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -53,6 +53,7 @@ paths = [
     '''pkg/.*''',
     '''examples/.*''',
     '''internal/templates/builtin/.*''',
+    '''internal/library/starter/.*''',
 ]
 
 # Example/placeholder values commonly used in documentation

--- a/docs/schemas/niac.schema.json
+++ b/docs/schemas/niac.schema.json
@@ -245,6 +245,18 @@
         },
         "iperf3": {
           "$ref": "#/$defs/IPerf3Config"
+        },
+        "trunk_ports": {
+          "items": {
+            "$ref": "#/$defs/TrunkPort"
+          },
+          "type": "array"
+        },
+        "port_channels": {
+          "items": {
+            "$ref": "#/$defs/PortChannel"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -877,6 +889,27 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "PortChannel": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "members": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id"
+      ]
+    },
     "ProtocolConfig": {
       "properties": {
         "enabled": {
@@ -1077,6 +1110,33 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "TrunkPort": {
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "vlans": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "native_vlan": {
+          "type": "integer"
+        },
+        "remote_device": {
+          "type": "string"
+        },
+        "remote_interface": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "interface"
+      ]
     }
   },
   "title": "NIAC configuration",

--- a/internal/api/handlers_library.go
+++ b/internal/api/handlers_library.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/krisarmstrong/niac-go/internal/library"
+)
+
+// libraryReady returns true if the on-disk library opened cleanly; the
+// handlers below short-circuit with 503 when it didn't, leaving the
+// rest of the API serviceable.
+func (s *Server) libraryReady() bool { return s.library != nil }
+
+func (s *Server) writeLibraryUnavailable(w http.ResponseWriter, r *http.Request) {
+	writeError(w, r, http.StatusServiceUnavailable, "library_unavailable",
+		"Content library failed to open at startup", nil)
+}
+
+// handleLibraryNetworks handles GET (list) and POST (upload) on
+// /api/v1/library/networks.
+func (s *Server) handleLibraryNetworks(w http.ResponseWriter, r *http.Request) {
+	if !s.libraryReady() {
+		s.writeLibraryUnavailable(w, r)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.handleLibraryNetworksList(w, r)
+	case http.MethodPost:
+		s.handleLibraryNetworkUpload(w, r)
+	default:
+		w.Header().Set("Allow", "GET, POST")
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+	}
+}
+
+// handleLibraryNetworkByName handles GET (read) and DELETE on
+// /api/v1/library/networks/{name}.
+func (s *Server) handleLibraryNetworkByName(w http.ResponseWriter, r *http.Request) {
+	if !s.libraryReady() {
+		s.writeLibraryUnavailable(w, r)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/api/v1/library/networks/")
+	if name == "" {
+		writeError(w, r, http.StatusBadRequest, "invalid_request", "Network name required", nil)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.handleLibraryNetworkRead(w, r, name)
+	case http.MethodDelete:
+		s.handleLibraryNetworkDelete(w, r, name)
+	default:
+		w.Header().Set("Allow", "GET, DELETE")
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+	}
+}
+
+func (s *Server) handleLibraryNetworksList(w http.ResponseWriter, r *http.Request) {
+	entries, err := s.library.ListNetworks()
+	if err != nil {
+		s.logger.Error("[API] library: list networks", "error", err)
+		writeError(w, r, http.StatusInternalServerError, "library_list_failed",
+			"Failed to list networks", nil)
+		return
+	}
+	s.writeJSON(w, entries)
+}
+
+func (s *Server) handleLibraryNetworkRead(w http.ResponseWriter, r *http.Request, name string) {
+	doc, err := s.library.ReadNetwork(name)
+	if err != nil {
+		if errors.Is(err, library.ErrNotFound) {
+			writeError(w, r, http.StatusNotFound, "not_found", "Network not found", nil)
+			return
+		}
+		if errors.Is(err, library.ErrInvalidName) {
+			writeError(w, r, http.StatusBadRequest, "invalid_name", err.Error(), nil)
+			return
+		}
+		s.logger.Error("[API] library: read network", "name", name, "error", err)
+		writeError(w, r, http.StatusInternalServerError, "library_read_failed",
+			"Failed to read network", nil)
+		return
+	}
+	s.writeJSON(w, doc)
+}
+
+type libraryNetworkUploadRequest struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+}
+
+func (s *Server) handleLibraryNetworkUpload(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
+	var req libraryNetworkUploadRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_request", "Invalid JSON body", nil)
+		return
+	}
+	if err := s.library.WriteNetwork(req.Name, req.Content); err != nil {
+		if errors.Is(err, library.ErrInvalidName) {
+			writeError(w, r, http.StatusBadRequest, "invalid_name", err.Error(), nil)
+			return
+		}
+		if errors.Is(err, library.ErrEmptyContent) {
+			writeError(w, r, http.StatusBadRequest, "invalid_content", err.Error(), nil)
+			return
+		}
+		s.logger.Error("[API] library: write network", "name", req.Name, "error", err)
+		writeError(w, r, http.StatusInternalServerError, "library_write_failed",
+			"Failed to save network", nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	s.writeJSON(w, map[string]any{
+		"success": true,
+		"name":    req.Name,
+	})
+}
+
+func (s *Server) handleLibraryNetworkDelete(w http.ResponseWriter, r *http.Request, name string) {
+	if err := s.library.DeleteNetwork(name); err != nil {
+		if errors.Is(err, library.ErrNotFound) {
+			writeError(w, r, http.StatusNotFound, "not_found", "Network not found", nil)
+			return
+		}
+		if errors.Is(err, library.ErrInvalidName) {
+			writeError(w, r, http.StatusBadRequest, "invalid_name", err.Error(), nil)
+			return
+		}
+		// "starter networks cannot be deleted" — surface as 400 with a
+		// human-readable message rather than a 500, since it's the
+		// caller asking us to do something we're not going to do.
+		writeError(w, r, http.StatusBadRequest, "delete_refused", err.Error(), nil)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Drained body helper — not yet wired, but used by future walks /
+// pcaps upload endpoints in PR 3. Kept here so the file's single
+// import block is stable.
+var _ = io.Discard

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -87,6 +87,13 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 	// User Configs API - GET is read-only, POST/DELETE handled separately
 	mux.HandleFunc("/api/v1/configs", s.recoverMiddleware(s.auth(s.handleUserConfigs)))
 	mux.HandleFunc("/api/v1/configs/", s.recoverMiddleware(s.auth(s.handleUserConfigByName)))
+
+	// Unified Library API (#548 PR 1) — networks subdir only in this PR;
+	// walks/pcaps endpoints land in PR 3.
+	mux.HandleFunc("/api/v1/library/networks",
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleLibraryNetworks)))))
+	mux.HandleFunc("/api/v1/library/networks/",
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleLibraryNetworkByName)))))
 	mux.HandleFunc("/api/v1/topology", s.recoverMiddleware(s.auth(s.handleTopology)))
 	mux.HandleFunc("/api/v1/topology/export", s.recoverMiddleware(s.auth(s.handleTopologyExport)))
 	mux.HandleFunc("/api/v1/errors", s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleErrors)))))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/krisarmstrong/niac-go/internal/config"
+	"github.com/krisarmstrong/niac-go/internal/library"
 	"github.com/krisarmstrong/niac-go/internal/protocols"
 	"github.com/krisarmstrong/niac-go/internal/storage"
 )
@@ -171,6 +172,10 @@ type ServerConfig struct {
 	WebhookAllowedHosts []string
 	ApplyConfig         func(*config.Config) error
 	Replay              ReplayManager
+	// LibraryRoot is the on-disk root the unified library reads from
+	// (~/.niac/library by default, /var/lib/niac/library when packaged).
+	// If empty, the daemon picks a sensible default via library.DefaultRoot().
+	LibraryRoot string
 }
 
 // SimulationRequest represents a request to start a simulation.
@@ -228,6 +233,7 @@ type Server struct {
 	fileLimiter       *RateLimiter
 	bgStop            chan struct{}
 	bgStopOnce        sync.Once
+	library           *library.Library
 }
 
 // NewServer returns a configured API server.
@@ -237,6 +243,21 @@ func NewServer(cfg ServerConfig) *Server {
 		slog.Error("[API] Failed to generate CSRF token, server cannot start securely", "error", err)
 
 		return nil
+	}
+
+	libraryRoot := cfg.LibraryRoot
+	if libraryRoot == "" {
+		libraryRoot = library.DefaultRoot()
+	}
+	lib, err := library.Open(libraryRoot)
+	if err != nil {
+		// Library failure is non-fatal — log loudly, leave Server.library
+		// nil, and the library endpoints will return 503. The rest of
+		// the daemon (sim engine, /api/v1/devices, etc.) keeps working.
+		slog.Error("[API] Failed to open content library, /api/v1/library endpoints disabled",
+			"root", libraryRoot, "error", err)
+	} else {
+		slog.Info("[API] Content library opened", "root", lib.Root())
 	}
 
 	return &Server{
@@ -251,6 +272,7 @@ func NewServer(cfg ServerConfig) *Server {
 		writeLimiter:  NewRateLimiter(WriteRateLimit, WriteBurst),
 		walkLimiter:   NewRateLimiter(WalkRateLimit, WalkBurst),
 		fileLimiter:   NewRateLimiter(FileRateLimit, FileBurst),
+		library:       lib,
 	}
 }
 

--- a/internal/api/topology.go
+++ b/internal/api/topology.go
@@ -163,11 +163,15 @@ func processTrunkPort(
 	speed, duplex, status := getInterfaceDetails(interfaceMap, deviceName, trunk.Interface)
 
 	return TopologyLink{
-		Source:          deviceName,
-		Target:          trunk.RemoteDevice,
-		Label:           buildTrunkLabel(trunk),
-		SourceInterface: trunk.Interface,
-		TargetInterface: trunk.RemoteInterface,
+		Source: deviceName,
+		Target: trunk.RemoteDevice,
+		Label:  buildTrunkLabel(trunk),
+		// Abbreviate interface names everywhere they're surfaced —
+		// the per-side labels on the topology edge use these fields
+		// directly, not the combined label, so they need the same
+		// shortening (GigabitEthernet0/1 → Gi0/1).
+		SourceInterface: abbreviateInterface(trunk.Interface),
+		TargetInterface: abbreviateInterface(trunk.RemoteInterface),
 		LinkType:        determineLinkType(trunk),
 		VLANs:           trunk.VLANs,
 		NativeVLAN:      trunk.NativeVLAN,

--- a/internal/api/topology.go
+++ b/internal/api/topology.go
@@ -83,16 +83,42 @@ func determineLinkType(trunk config.TrunkPort) string {
 
 // buildTrunkLabel creates the label for a trunk link.
 func buildTrunkLabel(trunk config.TrunkPort) string {
-	label := trunk.Interface
+	label := abbreviateInterface(trunk.Interface)
 	if trunk.RemoteInterface != "" {
-		label += " ↔ " + trunk.RemoteInterface
+		label += " ↔ " + abbreviateInterface(trunk.RemoteInterface)
 	}
 
 	if len(trunk.VLANs) > 0 {
-		label += fmt.Sprintf(" (VLANs: %s)", formatVLANList(trunk.VLANs))
+		label += fmt.Sprintf(" (VLANs %s)", formatVLANList(trunk.VLANs))
 	}
 
 	return label
+}
+
+// abbreviateInterface shortens the long Cisco-style interface names
+// (GigabitEthernet0/1 → Gi0/1) that hog edge-label space in the
+// topology view. Covers the IOS-style prefixes most templates use;
+// anything unrecognised passes through unchanged.
+func abbreviateInterface(name string) string {
+	abbrevs := []struct{ long, short string }{
+		{"TenGigabitEthernet", "Te"},
+		{"TwentyFiveGigE", "Twe"},
+		{"FortyGigabitEthernet", "Fo"},
+		{"HundredGigE", "Hu"},
+		{"GigabitEthernet", "Gi"},
+		{"FastEthernet", "Fa"},
+		{"Ethernet", "Eth"},
+		{"Loopback", "Lo"},
+		{"Port-channel", "Po"},
+		{"Management", "Mgmt"},
+		{"Vlan", "Vl"},
+	}
+	for _, a := range abbrevs {
+		if strings.HasPrefix(name, a.long) {
+			return a.short + name[len(a.long):]
+		}
+	}
+	return name
 }
 
 // getInterfaceDetails retrieves speed, duplex, and status from interface map.

--- a/internal/api/topology.go
+++ b/internal/api/topology.go
@@ -145,6 +145,15 @@ func getInterfaceDetails(
 	return iface.Speed, iface.Duplex, status
 }
 
+// sortedPairKey returns a canonical "a|b" key where a < b so reverse
+// declarations of the same physical adjacency collapse to one entry.
+func sortedPairKey(a, b string) string {
+	if a <= b {
+		return a + "|" + b
+	}
+	return b + "|" + a
+}
+
 // processTrunkPort creates a TopologyLink from a trunk port configuration.
 func processTrunkPort(
 	trunk config.TrunkPort,
@@ -170,10 +179,17 @@ func processTrunkPort(
 }
 
 // BuildTopology derives a topology graph from the configuration.
+//
+// Trunk links are inherently bidirectional — both switches declare a
+// trunk_port pointing at each other, so we'd otherwise emit two
+// TopologyLink entries for one physical wire and ReactFlow would draw
+// a second edge looping back around the cards. We dedupe via a
+// sorted-pair key so each physical adjacency yields exactly one link.
 func BuildTopology(cfg *config.Config) Topology {
 	nodes := make(map[string]TopologyNode)
 	links := make([]TopologyLink, 0)
 	interfaceMap := buildInterfaceMap(cfg.Devices)
+	seenLinks := make(map[string]bool)
 
 	for _, dev := range cfg.Devices {
 		nodes[dev.Name] = TopologyNode{
@@ -185,6 +201,16 @@ func BuildTopology(cfg *config.Config) Topology {
 			if trunk.RemoteDevice == "" {
 				continue
 			}
+
+			// Sorted endpoint pair is the dedupe key so A↔B and B↔A
+			// collapse to one entry. First-seen direction wins so the
+			// Source/Target on the emitted link matches the device that
+			// declared the trunk_port we found first in the YAML.
+			pair := sortedPairKey(dev.Name, trunk.RemoteDevice)
+			if seenLinks[pair] {
+				continue
+			}
+			seenLinks[pair] = true
 
 			if _, exists := nodes[trunk.RemoteDevice]; !exists {
 				nodes[trunk.RemoteDevice] = TopologyNode{

--- a/internal/api/topology_test.go
+++ b/internal/api/topology_test.go
@@ -115,12 +115,12 @@ func TestBuildTrunkLabel(t *testing.T) {
 		{
 			name:  "with single VLAN",
 			trunk: config.TrunkPort{Interface: "eth0", VLANs: []int{100}},
-			want:  "eth0 (VLANs: 100)",
+			want:  "eth0 (VLANs 100)",
 		},
 		{
 			name:  "with multiple VLANs",
 			trunk: config.TrunkPort{Interface: "eth0", VLANs: []int{100, 200, 300}},
-			want:  "eth0 (VLANs: 100,200,300)",
+			want:  "eth0 (VLANs 100,200,300)",
 		},
 	}
 

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -43,7 +43,47 @@ func convertYAMLDevice(yamlDevice converter.Device, includePath string) (Device,
 		return device, err
 	}
 
+	device.TrunkPorts = convertTrunkPorts(yamlDevice.TrunkPorts)
+	device.PortChannels = convertPortChannels(yamlDevice.PortChannels)
+
 	return device, nil
+}
+
+// convertTrunkPorts translates the YAML-shaped TrunkPort slice (from
+// converter.Device) into the runtime config.TrunkPort slice the topology
+// builder consults. The two types are field-identical; this is just a
+// type adapter.
+func convertTrunkPorts(in []converter.TrunkPort) []TrunkPort {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]TrunkPort, len(in))
+	for i, t := range in {
+		out[i] = TrunkPort{
+			Interface:       t.Interface,
+			VLANs:           t.VLANs,
+			NativeVLAN:      t.NativeVLAN,
+			RemoteDevice:    t.RemoteDevice,
+			RemoteInterface: t.RemoteInterface,
+		}
+	}
+	return out
+}
+
+// convertPortChannels mirrors convertTrunkPorts for LAG bundles.
+func convertPortChannels(in []converter.PortChannel) []PortChannel {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]PortChannel, len(in))
+	for i, pc := range in {
+		out[i] = PortChannel{
+			ID:      pc.ID,
+			Members: pc.Members,
+			Mode:    pc.Mode,
+		}
+	}
+	return out
 }
 
 // createBaseDevice creates a device with default values.

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -44,6 +44,75 @@ devices:
 	}
 }
 
+// TestLoadYAML_TrunkPorts verifies the YAML loader populates
+// device.TrunkPorts so the topology builder can emit edges.
+// Regression guard for #550 — converter.Device used to lack the
+// TrunkPorts field, silently dropping every trunk_ports: block.
+func TestLoadYAML_TrunkPorts(t *testing.T) {
+	yaml := `
+devices:
+  - name: sw-a
+    type: switch
+    mac: "00:11:22:33:44:01"
+    trunk_ports:
+      - interface: "Ethernet1/1"
+        vlans: [10, 20, 30]
+        native_vlan: 1
+        remote_device: "sw-b"
+        remote_interface: "Ethernet1/1"
+  - name: sw-b
+    type: switch
+    mac: "00:11:22:33:44:02"
+    trunk_ports:
+      - interface: "Ethernet1/1"
+        vlans: [10, 20, 30]
+        native_vlan: 1
+        remote_device: "sw-a"
+        remote_interface: "Ethernet1/1"
+    port_channels:
+      - id: 1
+        members: ["Ethernet1/2", "Ethernet1/3"]
+        mode: "active"
+`
+	tmpfile := createTempYAML(t, yaml)
+	defer func() { _ = os.Remove(tmpfile) }()
+
+	cfg, err := LoadYAML(tmpfile)
+	if err != nil {
+		t.Fatalf("LoadYAML failed: %v", err)
+	}
+	if len(cfg.Devices) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(cfg.Devices))
+	}
+
+	swA := cfg.Devices[0]
+	if len(swA.TrunkPorts) != 1 {
+		t.Fatalf("sw-a: expected 1 trunk port, got %d", len(swA.TrunkPorts))
+	}
+	trunk := swA.TrunkPorts[0]
+	if trunk.Interface != "Ethernet1/1" {
+		t.Errorf("sw-a trunk interface = %q, want Ethernet1/1", trunk.Interface)
+	}
+	if trunk.RemoteDevice != "sw-b" {
+		t.Errorf("sw-a trunk remote_device = %q, want sw-b", trunk.RemoteDevice)
+	}
+	if len(trunk.VLANs) != 3 || trunk.VLANs[0] != 10 {
+		t.Errorf("sw-a trunk vlans = %v, want [10 20 30]", trunk.VLANs)
+	}
+	if trunk.NativeVLAN != 1 {
+		t.Errorf("sw-a trunk native_vlan = %d, want 1", trunk.NativeVLAN)
+	}
+
+	swB := cfg.Devices[1]
+	if len(swB.PortChannels) != 1 {
+		t.Fatalf("sw-b: expected 1 port_channel, got %d", len(swB.PortChannels))
+	}
+	pc := swB.PortChannels[0]
+	if pc.ID != 1 || pc.Mode != "active" || len(pc.Members) != 2 {
+		t.Errorf("sw-b port_channel = %+v, want ID=1 mode=active 2 members", pc)
+	}
+}
+
 // TestLoadYAML_MultipleIPs tests multiple IP addresses per device (v1.5.0).
 func TestLoadYAML_MultipleIPs(t *testing.T) {
 	yaml := `

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -83,6 +83,28 @@ type Device struct {
 	Traffic       *TrafficConfig       `yaml:"traffic,omitempty"`        // v1.6.0
 	OSFingerprint *OSFingerprintConfig `yaml:"os_fingerprint,omitempty"` // v1.24.0
 	IPerf3        *IPerf3Config        `yaml:"iperf3,omitempty"`         // v1.25.0
+	TrunkPorts    []TrunkPort          `yaml:"trunk_ports,omitempty"`    // v1.23.0 — topology link declarations
+	PortChannels  []PortChannel        `yaml:"port_channels,omitempty"`  // v1.23.0 — LAG bundling
+}
+
+// TrunkPort declares a VLAN-tagged trunk link to a neighbouring device.
+// The remote_device field is what BuildTopology uses to draw an edge
+// between two devices on the topology graph.
+type TrunkPort struct {
+	Interface       string `yaml:"interface"`
+	VLANs           []int  `yaml:"vlans,omitempty"`
+	NativeVLAN      int    `yaml:"native_vlan,omitempty"`
+	RemoteDevice    string `yaml:"remote_device,omitempty"`
+	RemoteInterface string `yaml:"remote_interface,omitempty"`
+}
+
+// PortChannel declares a Link Aggregation (LACP) bundle. Doesn't
+// produce topology edges on its own — trunk_ports referencing
+// "port-channel<id>" as their interface are what surface edges.
+type PortChannel struct {
+	ID      int      `yaml:"id"`
+	Members []string `yaml:"members,omitempty"`
+	Mode    string   `yaml:"mode,omitempty"`
 }
 
 // IPerf3Config represents iPerf3 server emulation configuration.

--- a/internal/library/bootstrap.go
+++ b/internal/library/bootstrap.go
@@ -58,6 +58,8 @@ func (l *Library) bootstrapStarterPack() error {
 }
 
 func dirIsEmpty(path string) (bool, error) {
+	// #nosec G304 -- caller passes Library.SubDir(kind) which is
+	// always rooted under the resolved Library.root we own.
 	f, err := os.Open(path)
 	if err != nil {
 		return false, err

--- a/internal/library/bootstrap.go
+++ b/internal/library/bootstrap.go
@@ -1,0 +1,78 @@
+package library
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// starterPack holds a small, curated set of network YAMLs bundled into
+// the binary. On first run they're copied into networks/ so the picker
+// is non-empty before any content tarball is installed. Keep the set
+// small — for the full library users install the content bundle.
+//
+//go:embed starter/*.yaml
+var starterPack embed.FS
+
+// starterPackEntries marks every starter file with Source==starter via
+// a sentinel filename suffix recognised by detectSource(); we keep the
+// upstream filenames identical to make user customization (overwrite a
+// starter with a same-named user file) work via the same code path.
+
+// bootstrapStarterPack copies the embedded starter pack into the
+// networks/ subdir, but only if that directory is empty. A library
+// that already has user content is left strictly alone.
+func (l *Library) bootstrapStarterPack() error {
+	networksDir := l.SubDir(KindNetworks)
+	empty, err := dirIsEmpty(networksDir)
+	if err != nil {
+		return fmt.Errorf("check networks dir: %w", err)
+	}
+	if !empty {
+		return nil
+	}
+
+	entries, err := starterPack.ReadDir("starter")
+	if err != nil {
+		return fmt.Errorf("read starter pack: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !isYAMLFilename(entry.Name()) {
+			continue
+		}
+		src := filepath.Join("starter", entry.Name())
+		data, readErr := fs.ReadFile(starterPack, src)
+		if readErr != nil {
+			return fmt.Errorf("read starter file %s: %w", entry.Name(), readErr)
+		}
+		dst := filepath.Join(networksDir, entry.Name())
+		if writeErr := os.WriteFile(dst, data, libraryFileMode); writeErr != nil {
+			return fmt.Errorf("write starter file %s: %w", dst, writeErr)
+		}
+	}
+
+	return nil
+}
+
+func dirIsEmpty(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	names, err := f.Readdirnames(1)
+	if err != nil && err.Error() != "EOF" {
+		// io.EOF on an empty dir is fine; surfaces as len(names)==0.
+		return len(names) == 0, nil
+	}
+	return len(names) == 0, nil
+}
+
+func isYAMLFilename(name string) bool {
+	ext := filepath.Ext(name)
+	return ext == ".yaml" || ext == ".yml"
+}

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -1,0 +1,182 @@
+// Package library is the on-disk content store the daemon serves to
+// the UI. It owns three sibling directories:
+//
+//	<root>/networks/   YAML network configs (replaces "templates" + "user configs")
+//	<root>/walks/      SNMP walk files
+//	<root>/pcaps/      PCAP captures
+//
+// The library is the single source of truth at runtime — every entry
+// the picker / browser sees comes from here. Content arrives via three
+// optional ingress paths:
+//
+//  1. Embedded starter pack — unpacked into networks/ on first run if
+//     the dir is empty, so the daemon works out of the box.
+//  2. CLI: `niac content install` downloads a versioned tarball from
+//     the GitHub release and extracts it here (PR 2).
+//  3. UI upload: POST /api/v1/library/install accepts a tarball via
+//     multipart and unpacks it (PR 2).
+//
+// See issue #548 for the full architecture.
+package library
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Sentinel errors.
+var (
+	ErrNotFound        = errors.New("library entry not found")
+	ErrInvalidName     = errors.New("invalid name: only [a-zA-Z0-9._-] allowed, no path traversal")
+	ErrUnsupportedKind = errors.New("unsupported library kind")
+	ErrEmptyContent    = errors.New("content is empty")
+	ErrAlreadyExists   = errors.New("library entry already exists")
+)
+
+// Kind is one of the three top-level subdirectories of the library.
+type Kind string
+
+const (
+	KindNetworks Kind = "networks"
+	KindWalks    Kind = "walks"
+	KindPcaps    Kind = "pcaps"
+)
+
+// AllKinds returns the canonical kind list in stable order.
+func AllKinds() []Kind { return []Kind{KindNetworks, KindWalks, KindPcaps} }
+
+// Source describes where a given entry came from. Stamped onto every
+// returned record so the UI can render small "Starter" / "User" /
+// "Bundle" badges and so the delete handler can refuse to remove
+// starter-pack entries (which would just reappear on next bootstrap).
+type Source string
+
+const (
+	SourceStarter Source = "starter"
+	SourceBundle  Source = "bundle"
+	SourceUser    Source = "user"
+)
+
+// Library is the runtime handle for the on-disk store. Create one per
+// daemon process via Open(); the root path is resolved once and reused.
+// Methods are concurrency-safe via simple read-the-disk semantics —
+// every call to List or Read hits the filesystem so user-dropped files
+// appear immediately without an explicit watcher.
+type Library struct {
+	root string
+}
+
+// DefaultRoot resolves the standard library root following:
+//
+//  1. NIAC_LIBRARY_ROOT environment variable (highest)
+//  2. /var/lib/niac/library if that directory exists (packaged install)
+//  3. $XDG_DATA_HOME/niac/library if XDG_DATA_HOME is set
+//  4. ~/.niac/library (user-default)
+//
+// Callers can override with an explicit path passed to Open().
+func DefaultRoot() string {
+	if env := os.Getenv("NIAC_LIBRARY_ROOT"); env != "" {
+		return env
+	}
+	const packaged = "/var/lib/niac/library"
+	if info, err := os.Stat(packaged); err == nil && info.IsDir() {
+		return packaged
+	}
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "niac", "library")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".niac", "library")
+	}
+	// Last-resort fallback so the daemon doesn't crash; the cwd-relative
+	// path won't be ideal but it's better than panicking.
+	return ".niac-library"
+}
+
+// Open resolves the library root, ensures the three subdirectories
+// exist, and unpacks the embedded starter pack into networks/ if that
+// directory is brand new. The returned Library is ready for List/Read
+// calls; callers MUST handle the returned error before using it.
+func Open(root string) (*Library, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve library root: %w", err)
+	}
+
+	lib := &Library{root: abs}
+
+	if layoutErr := lib.ensureLayout(); layoutErr != nil {
+		return nil, layoutErr
+	}
+
+	if bootstrapErr := lib.bootstrapStarterPack(); bootstrapErr != nil {
+		return nil, fmt.Errorf("bootstrap starter pack: %w", bootstrapErr)
+	}
+
+	return lib, nil
+}
+
+// Root returns the absolute path the library is rooted at.
+func (l *Library) Root() string { return l.root }
+
+// SubDir returns the absolute path of the directory backing a kind.
+// Used by handlers that need to stream raw bytes back to the client.
+func (l *Library) SubDir(kind Kind) string {
+	return filepath.Join(l.root, string(kind))
+}
+
+// ensureLayout makes sure all three subdirectories exist with safe
+// permissions. Existing dirs are left alone.
+func (l *Library) ensureLayout() error {
+	if err := os.MkdirAll(l.root, libraryDirMode); err != nil {
+		return fmt.Errorf("create library root %s: %w", l.root, err)
+	}
+	for _, kind := range AllKinds() {
+		path := l.SubDir(kind)
+		if err := os.MkdirAll(path, libraryDirMode); err != nil {
+			return fmt.Errorf("create library subdir %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// libraryDirMode is the default mode for created library directories.
+// 0o755 lets the user own it while still letting the daemon read it
+// when it runs as a different user via /var/lib/niac/library.
+const libraryDirMode = 0o755
+
+// libraryFileMode is the default mode for files written to the
+// library (uploads, starter-pack extracts).
+const libraryFileMode = 0o644
+
+// validateName rejects anything that could escape its kind directory.
+// Names must be a bare filename (no slashes, no '..', no leading dot)
+// composed of letters, digits, '.', '_', or '-'.
+func validateName(name string) error {
+	if name == "" {
+		return ErrInvalidName
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return ErrInvalidName
+	}
+	if name == "." || name == ".." || strings.HasPrefix(name, "..") {
+		return ErrInvalidName
+	}
+	if strings.HasPrefix(name, ".") {
+		return ErrInvalidName
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '.' || r == '_' || r == '-':
+		default:
+			return ErrInvalidName
+		}
+	}
+	return nil
+}

--- a/internal/library/list.go
+++ b/internal/library/list.go
@@ -1,0 +1,251 @@
+package library
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NetworkEntry is one row in the networks list.
+type NetworkEntry struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	UseCase     string    `json:"useCase,omitempty"`
+	DeviceCount int       `json:"deviceCount"`
+	ModifiedAt  time.Time `json:"modifiedAt"`
+	SizeBytes   int64     `json:"sizeBytes"`
+	Source      Source    `json:"source"`
+	Valid       bool      `json:"valid"`
+	Error       string    `json:"error,omitempty"`
+}
+
+// NetworkContent is a single network YAML with its content body.
+type NetworkContent struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+	Format  string `json:"format"`
+	Source  Source `json:"source"`
+}
+
+// FileEntry is the lightweight row used for walks and pcaps (binary
+// blobs, no per-row content parsing).
+type FileEntry struct {
+	Name       string    `json:"name"`
+	SizeBytes  int64     `json:"sizeBytes"`
+	ModifiedAt time.Time `json:"modifiedAt"`
+	Source     Source    `json:"source"`
+}
+
+// ListNetworks enumerates every YAML in networks/, parses metadata
+// from each file's header comment block, and returns the rows sorted
+// by name. Files that fail to parse get Valid=false with an error
+// message instead of crashing the whole list.
+func (l *Library) ListNetworks() ([]NetworkEntry, error) {
+	dir := l.SubDir(KindNetworks)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", dir, err)
+	}
+
+	out := make([]NetworkEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !isYAMLFilename(entry.Name()) {
+			continue
+		}
+		row, rowErr := l.networkEntryFor(entry.Name())
+		if rowErr != nil {
+			// Surface as a row-level error so the UI can show a badge
+			// rather than failing the entire list call.
+			row = NetworkEntry{Name: trimYAMLExt(entry.Name()), Valid: false, Error: rowErr.Error()}
+		}
+		out = append(out, row)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (l *Library) networkEntryFor(filename string) (NetworkEntry, error) {
+	path := filepath.Join(l.SubDir(KindNetworks), filename)
+	info, err := os.Stat(path)
+	if err != nil {
+		return NetworkEntry{}, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return NetworkEntry{}, err
+	}
+
+	desc, useCase := parseHeaderMetadata(data)
+	deviceCount, parseErr := countDevices(data)
+	if parseErr != nil {
+		// Returning the parse error in-band (Valid=false + Error=…) is
+		// deliberate — the row still appears in the list and the UI
+		// renders a "broken" badge instead of the whole call 5xxing.
+		return NetworkEntry{ //nolint:nilerr // structured surfacing
+			Name:        trimYAMLExt(filename),
+			Description: desc,
+			UseCase:     useCase,
+			ModifiedAt:  info.ModTime().UTC(),
+			SizeBytes:   info.Size(),
+			Source:      l.detectSource(filename),
+			Valid:       false,
+			Error:       parseErr.Error(),
+		}, nil
+	}
+
+	return NetworkEntry{
+		Name:        trimYAMLExt(filename),
+		Description: desc,
+		UseCase:     useCase,
+		DeviceCount: deviceCount,
+		ModifiedAt:  info.ModTime().UTC(),
+		SizeBytes:   info.Size(),
+		Source:      l.detectSource(filename),
+		Valid:       true,
+	}, nil
+}
+
+// ReadNetwork returns the full content of a single network. Validates
+// the requested name so a malicious caller can't escape networks/.
+func (l *Library) ReadNetwork(name string) (*NetworkContent, error) {
+	name = trimYAMLExt(name)
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(l.SubDir(KindNetworks), name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, name)
+		}
+		return nil, err
+	}
+	return &NetworkContent{
+		Name:    name,
+		Content: string(data),
+		Format:  "yaml",
+		Source:  l.detectSource(name + ".yaml"),
+	}, nil
+}
+
+// WriteNetwork creates or overwrites a network YAML. Used by upload
+// endpoints. Marks user-created entries by NOT being part of the
+// starter pack — detectSource picks that up on next list.
+func (l *Library) WriteNetwork(name, content string) error {
+	name = trimYAMLExt(name)
+	if err := validateName(name); err != nil {
+		return err
+	}
+	if content == "" {
+		return ErrEmptyContent
+	}
+	if !strings.Contains(content, "devices:") {
+		return fmt.Errorf("%w: content must contain 'devices:' section", ErrEmptyContent)
+	}
+	path := filepath.Join(l.SubDir(KindNetworks), name+".yaml")
+	return os.WriteFile(path, []byte(content), libraryFileMode)
+}
+
+// DeleteNetwork removes a single network. Refuses to delete entries
+// whose source is "starter" because they'd just come back on next
+// bootstrap.
+func (l *Library) DeleteNetwork(name string) error {
+	name = trimYAMLExt(name)
+	if err := validateName(name); err != nil {
+		return err
+	}
+	filename := name + ".yaml"
+	if l.detectSource(filename) == SourceStarter {
+		return fmt.Errorf("starter networks cannot be deleted: %s", name)
+	}
+	path := filepath.Join(l.SubDir(KindNetworks), filename)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: %s", ErrNotFound, name)
+		}
+		return err
+	}
+	return nil
+}
+
+// ListFiles enumerates walks/ or pcaps/. Used by PR 3's browser tabs.
+// One level of subdir nesting is allowed; names returned include the
+// subdir for namespacing (e.g. "cisco/c3900.walk").
+func (l *Library) ListFiles(kind Kind) ([]FileEntry, error) {
+	if kind != KindWalks && kind != KindPcaps {
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedKind, kind)
+	}
+	dir := l.SubDir(kind)
+	out := make([]FileEntry, 0)
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		out = append(out, FileEntry{
+			Name:       filepath.ToSlash(rel),
+			SizeBytes:  info.Size(),
+			ModifiedAt: info.ModTime().UTC(),
+			Source:     SourceUser,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// detectSource decides whether a given filename came from the starter
+// pack or from user/bundle install. Starter-pack files are embedded
+// in the binary, so consulting starterPack is the source of truth.
+func (l *Library) detectSource(filename string) Source {
+	if _, err := starterPack.Open(filepath.Join("starter", filename)); err == nil {
+		return SourceStarter
+	}
+	// Bundle vs user split is deferred to PR 2 (the bundle installer
+	// writes a marker file). For now, anything non-starter is "user".
+	return SourceUser
+}
+
+// countDevices parses just enough of the YAML to count entries under
+// devices:. Falls back to a 0 with a clear error if the document
+// shape is wrong, so the row still appears in the list.
+func countDevices(data []byte) (int, error) {
+	var doc struct {
+		Devices []map[string]any `yaml:"devices"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return 0, fmt.Errorf("yaml parse: %w", err)
+	}
+	return len(doc.Devices), nil
+}
+
+func trimYAMLExt(name string) string {
+	for _, ext := range []string{".yaml", ".yml"} {
+		if strings.HasSuffix(name, ext) {
+			return strings.TrimSuffix(name, ext)
+		}
+	}
+	return name
+}

--- a/internal/library/list.go
+++ b/internal/library/list.go
@@ -79,6 +79,8 @@ func (l *Library) networkEntryFor(filename string) (NetworkEntry, error) {
 		return NetworkEntry{}, err
 	}
 
+	// #nosec G304 -- filename comes from os.ReadDir of the library
+	// subdir we own + isYAMLFilename() filter; not user-supplied path.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return NetworkEntry{}, err
@@ -122,6 +124,8 @@ func (l *Library) ReadNetwork(name string) (*NetworkContent, error) {
 		return nil, err
 	}
 	path := filepath.Join(l.SubDir(KindNetworks), name+".yaml")
+	// #nosec G304 -- name was just validated by validateName above,
+	// which rejects path traversal and non-alphanumeric chars.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {

--- a/internal/library/metadata.go
+++ b/internal/library/metadata.go
@@ -1,0 +1,74 @@
+package library
+
+import "strings"
+
+const (
+	// metadataMaxScanLines bounds how many lines we scan for the
+	// # Description / # Use Case lines at the top of each network YAML.
+	// Scanning stops on the first non-comment, non-blank line anyway.
+	metadataMaxScanLines = 40
+	// metadataReadBytes caps the byte window we pull off the start of
+	// each file for header parsing. Leading comment blocks are rarely
+	// over 1 KB; 4 KB gives margin without slurping the device table.
+	metadataReadBytes = 4096
+)
+
+// parseHeaderMetadata reads the leading comment block of a network
+// YAML and pulls out a description + use case. Conventions:
+//
+//   - A `# Description: …` line wins for description.
+//   - Otherwise the first non-empty `# …` line is used.
+//   - A `# Use Case: …` line is captured verbatim.
+//
+// Scanning stops at the first non-comment, non-blank line so we never
+// read into the actual YAML body. Same parser shape as the templates
+// package — kept here so the library package stays self-contained.
+func parseHeaderMetadata(content []byte) (string, string) {
+	head := content
+	if len(head) > metadataReadBytes {
+		head = head[:metadataReadBytes]
+	}
+
+	lines := strings.Split(string(head), "\n")
+	limit := len(lines)
+	if limit > metadataMaxScanLines {
+		limit = metadataMaxScanLines
+	}
+
+	var description, useCase, firstComment string
+	for i := range limit {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "#") {
+			break
+		}
+		stripped := strings.TrimSpace(strings.TrimPrefix(line, "#"))
+		if stripped == "" {
+			continue
+		}
+
+		if desc, ok := matchPrefix(stripped, "Description:"); ok && description == "" {
+			description = desc
+		}
+		if uc, ok := matchPrefix(stripped, "Use Case:"); ok && useCase == "" {
+			useCase = uc
+		}
+		if firstComment == "" {
+			firstComment = stripped
+		}
+	}
+
+	if description == "" {
+		description = firstComment
+	}
+	return description, useCase
+}
+
+func matchPrefix(line, prefix string) (string, bool) {
+	if !strings.HasPrefix(strings.ToLower(line), strings.ToLower(prefix)) {
+		return "", false
+	}
+	return strings.TrimSpace(line[len(prefix):]), true
+}

--- a/internal/library/starter/basic-network.yaml
+++ b/internal/library/starter/basic-network.yaml
@@ -1,0 +1,46 @@
+# Basic Network Template
+# Simple router and switch setup for small networks
+#
+# Use Case: Basic routing and switching for small networks
+# Includes: 1 router, 1 switch with essential protocols
+
+devices:
+  # Core Router - Gateway and routing
+  - name: router-01
+    mac: "00:1A:2B:3C:01:01"
+    ips:
+      - "192.168.1.1"    # LAN interface
+      - "10.0.0.1"       # Management interface
+
+    # LLDP - Link Layer Discovery Protocol
+    lldp:
+      enabled: true
+      system_description: "Basic Network Router"
+      port_description: "GigabitEthernet0/1"
+
+    # SNMP - Simple Network Management Protocol
+    snmp_agent:
+      walk_file: ""
+
+  # Access Switch - Layer 2 switching
+  - name: switch-01
+    mac: "00:1A:2B:3C:02:01"
+    ip: "192.168.1.2"
+
+    # LLDP - Discovery
+    lldp:
+      enabled: true
+      system_description: "Basic Network Switch"
+      port_description: "GigabitEthernet1/0/1"
+
+    # STP - Spanning Tree Protocol
+    stp:
+      enabled: true
+      bridge_priority: 32768
+      hello_time: 2
+      max_age: 20
+      forward_delay: 15
+
+    # SNMP
+    snmp_agent:
+      walk_file: ""

--- a/internal/library/starter/data-center.yaml
+++ b/internal/library/starter/data-center.yaml
@@ -1,0 +1,133 @@
+# Data Center Template
+# Multiple routers, switches, and servers for data center environments
+#
+# Use Case: Data center or enterprise core network
+# Includes: Redundant routers, core/access switches, servers
+
+devices:
+  # Core Router 1
+  - name: dc-core-rtr-01
+    mac: "00:0C:29:DC:01:01"
+    ips:
+      - "10.1.0.1"
+      - "172.16.0.1"
+
+    lldp:
+      enabled: true
+      system_description: "Data Center Core Router Primary"
+      port_description: "TenGigabitEthernet0/0/0"
+
+    cdp:
+      enabled: true
+      platform: "Cisco ASR 9006"
+      software_version: "IOS XR 7.5.2"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Core Router 2
+  - name: dc-core-rtr-02
+    mac: "00:0C:29:DC:01:02"
+    ips:
+      - "10.1.0.2"
+      - "172.16.0.2"
+
+    lldp:
+      enabled: true
+      system_description: "Data Center Core Router Secondary"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Distribution Switch 1
+  - name: dc-dist-sw-01
+    mac: "00:0C:29:DC:02:01"
+    ip: "10.1.1.1"
+
+    lldp:
+      enabled: true
+      system_description: "Distribution Switch"
+
+    stp:
+      enabled: true
+      bridge_priority: 4096
+
+    snmp_agent:
+      walk_file: ""
+
+  # Distribution Switch 2
+  - name: dc-dist-sw-02
+    mac: "00:0C:29:DC:02:02"
+    ip: "10.1.1.2"
+
+    lldp:
+      enabled: true
+      system_description: "Distribution Switch"
+
+    stp:
+      enabled: true
+      bridge_priority: 8192
+
+    snmp_agent:
+      walk_file: ""
+
+  # Access Switch
+  - name: dc-access-sw-01
+    mac: "00:0C:29:DC:03:01"
+    ip: "10.1.2.1"
+
+    lldp:
+      enabled: true
+      system_description: "Access Switch"
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+
+    snmp_agent:
+      walk_file: ""
+
+  # Web Server
+  - name: dc-web-01
+    mac: "00:0C:29:DC:10:01"
+    ip: "10.1.10.10"
+
+    http:
+      enabled: true
+      server_name: "DC-Web-Server"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Infrastructure Server (DNS/DHCP)
+  - name: dc-infra-01
+    mac: "00:0C:29:DC:10:03"
+    ip: "10.1.10.100"
+
+    dhcp:
+      enabled: true
+      pools:
+        - network: "10.1.0.0/16"
+          range_start: "10.1.50.1"
+          range_end: "10.1.50.254"
+          gateway: "10.1.0.1"
+          dns_servers:
+            - "10.1.10.100"
+          domain: "dc.local"
+          lease_time: 43200
+
+    dns:
+      enabled: true
+      records:
+        - name: "rtr01.dc.local"
+          type: "A"
+          value: "10.1.0.1"
+        - name: "rtr02.dc.local"
+          type: "A"
+          value: "10.1.0.2"
+        - name: "web01.dc.local"
+          type: "A"
+          value: "10.1.10.10"
+
+    snmp_agent:
+      walk_file: ""

--- a/internal/library/starter/enterprise-campus.yaml
+++ b/internal/library/starter/enterprise-campus.yaml
@@ -1,0 +1,125 @@
+# Enterprise Campus Template
+# Multi-building campus network with distribution layers
+#
+# Use Case: Large enterprise campus with distribution layers
+# Includes: Core routers, distribution switches, building access, services
+
+devices:
+  # Campus Core Router 1
+  - name: campus-core-01
+    mac: "00:1C:2E:3A:01:01"
+    ips:
+      - "10.0.0.1"
+      - "172.20.0.1"
+
+    lldp:
+      enabled: true
+      system_description: "Enterprise Campus Core Router"
+      port_description: "TenGigabitEthernet0/0/0"
+
+    cdp:
+      enabled: true
+      platform: "Cisco Catalyst 9600"
+      software_version: "IOS XE 17.9.1"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Campus Core Router 2
+  - name: campus-core-02
+    mac: "00:1C:2E:3A:01:02"
+    ips:
+      - "10.0.0.2"
+      - "172.20.0.2"
+
+    lldp:
+      enabled: true
+      system_description: "Enterprise Campus Core Router"
+
+    cdp:
+      enabled: true
+      platform: "Cisco Catalyst 9600"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Building A Distribution
+  - name: bldg-a-dist-01
+    mac: "00:1C:2E:3A:10:01"
+    ip: "10.10.0.1"
+
+    lldp:
+      enabled: true
+      system_description: "Building A Distribution"
+
+    stp:
+      enabled: true
+      bridge_priority: 4096
+
+    snmp_agent:
+      walk_file: ""
+
+  # Building A Access Floor 1
+  - name: bldg-a-fl1-sw-01
+    mac: "00:1C:2E:3A:11:01"
+    ip: "10.10.1.1"
+
+    lldp:
+      enabled: true
+      system_description: "Building A Floor 1"
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+
+    snmp_agent:
+      walk_file: ""
+
+  # Building B Distribution
+  - name: bldg-b-dist-01
+    mac: "00:1C:2E:3A:20:01"
+    ip: "10.20.0.1"
+
+    lldp:
+      enabled: true
+      system_description: "Building B Distribution"
+
+    stp:
+      enabled: true
+      bridge_priority: 4096
+
+    snmp_agent:
+      walk_file: ""
+
+  # Campus DNS/DHCP Server
+  - name: campus-dns-01
+    mac: "00:1C:2E:3A:60:01"
+    ip: "10.0.10.100"
+
+    dhcp:
+      enabled: true
+      pools:
+        - network: "10.0.0.0/8"
+          range_start: "10.100.0.1"
+          range_end: "10.100.255.254"
+          gateway: "10.0.0.1"
+          dns_servers:
+            - "10.0.10.100"
+          domain: "enterprise.com"
+          lease_time: 86400
+
+    dns:
+      enabled: true
+      records:
+        - name: "core01.enterprise.com"
+          type: "A"
+          value: "10.0.0.1"
+        - name: "core02.enterprise.com"
+          type: "A"
+          value: "10.0.0.2"
+        - name: "dns.enterprise.com"
+          type: "A"
+          value: "10.0.10.100"
+
+    snmp_agent:
+      walk_file: ""

--- a/internal/library/starter/home-network.yaml
+++ b/internal/library/starter/home-network.yaml
@@ -1,0 +1,137 @@
+# Home Network Template
+# Residential gateway, WiFi, and consumer devices
+#
+# Use Case: Home network with consumer devices
+# Includes: Router/modem, WiFi, smart home devices, media devices
+
+devices:
+  # Home Gateway/Router
+  - name: home-gateway
+    mac: "00:AA:00:BB:00:01"
+    ips:
+      - "192.168.1.1"
+      - "10.0.0.1"
+
+    lldp:
+      enabled: true
+      system_description: "Home Broadband Router"
+
+    dhcp:
+      enabled: true
+      pools:
+        - network: "192.168.1.0/24"
+          range_start: "192.168.1.50"
+          range_end: "192.168.1.200"
+          gateway: "192.168.1.1"
+          dns_servers:
+            - "192.168.1.1"
+            - "8.8.8.8"
+            - "1.1.1.1"
+          domain: "home.local"
+          lease_time: 86400
+
+    dns:
+      enabled: true
+      records:
+        - name: "router.home.local"
+          type: "A"
+          value: "192.168.1.1"
+        - name: "nas.home.local"
+          type: "A"
+          value: "192.168.1.10"
+
+    http:
+      enabled: true
+      server_name: "Home-Router"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Mesh WiFi Main
+  - name: wifi-main
+    mac: "00:AA:00:BB:01:01"
+    ip: "192.168.1.2"
+
+    lldp:
+      enabled: true
+      system_description: "Mesh WiFi Access Point"
+
+    http:
+      enabled: true
+      server_name: "WiFi-Main"
+
+  # NAS - Network Attached Storage
+  - name: home-nas
+    mac: "00:AA:00:BB:10:01"
+    ip: "192.168.1.10"
+
+    http:
+      enabled: true
+      server_name: "NAS"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Network Printer
+  - name: home-printer
+    mac: "00:AA:00:BB:20:01"
+    ip: "192.168.1.20"
+
+    http:
+      enabled: true
+      server_name: "HP-Printer"
+      endpoints:
+        - path: "/status"
+          body: "Ready - Paper: OK - Ink: 75%"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Smart TV
+  - name: smart-tv
+    mac: "00:AA:00:BB:30:01"
+    ip: "192.168.1.30"
+
+    http:
+      enabled: true
+      server_name: "Smart-TV"
+
+  # Security Camera
+  - name: security-cam-01
+    mac: "00:AA:00:BB:40:01"
+    ip: "192.168.1.40"
+
+    http:
+      enabled: true
+      server_name: "Security-Camera"
+
+  # Smart Speaker
+  - name: smart-speaker
+    mac: "00:AA:00:BB:50:01"
+    ip: "192.168.1.50"
+
+    http:
+      enabled: true
+      server_name: "Smart-Speaker"
+
+  # Gaming Console
+  - name: game-console
+    mac: "00:AA:00:BB:60:01"
+    ip: "192.168.1.60"
+
+    http:
+      enabled: true
+      server_name: "Gaming-Console"
+
+  # Home Automation Hub
+  - name: home-hub
+    mac: "00:AA:00:BB:80:01"
+    ip: "192.168.1.80"
+
+    http:
+      enabled: true
+      server_name: "Home-Assistant"
+      endpoints:
+        - path: "/api/status"
+          content_type: "application/json"
+          body: '{"devices":15,"online":15,"automation_count":8}'

--- a/internal/library/starter/iot-network.yaml
+++ b/internal/library/starter/iot-network.yaml
@@ -1,0 +1,123 @@
+# IoT Network Template
+# IoT devices with constrained protocols and lightweight operation
+#
+# Use Case: IoT sensor networks and embedded devices
+# Includes: IoT gateway, sensors, actuators with minimal protocols
+
+devices:
+  # IoT Gateway
+  - name: iot-gateway
+    mac: "00:AA:BB:CC:01:01"
+    ips:
+      - "192.168.100.1"
+      - "10.0.0.1"
+
+    lldp:
+      enabled: true
+      system_description: "IoT Edge Gateway Router"
+
+    snmp_agent:
+      walk_file: ""
+
+    dhcp:
+      enabled: true
+      pools:
+        - network: "192.168.100.0/24"
+          range_start: "192.168.100.50"
+          range_end: "192.168.100.200"
+          gateway: "192.168.100.1"
+          dns_servers:
+            - "192.168.100.1"
+            - "8.8.8.8"
+          domain: "iot.local"
+          lease_time: 86400
+
+  # Temperature Sensor 1
+  - name: temp-sensor-01
+    mac: "00:AA:BB:CC:10:01"
+    ip: "192.168.100.10"
+
+    http:
+      enabled: true
+      server_name: "TempSensor-01"
+      endpoints:
+        - path: "/status"
+          status_code: 200
+          content_type: "application/json"
+          body: '{"device":"temp-sensor-01","temp":22.5,"unit":"C"}'
+
+  # Motion Sensor
+  - name: motion-sensor-01
+    mac: "00:AA:BB:CC:20:01"
+    ip: "192.168.100.20"
+
+    http:
+      enabled: true
+      server_name: "MotionSensor-01"
+      endpoints:
+        - path: "/status"
+          content_type: "application/json"
+          body: '{"device":"motion-sensor-01","motion":false,"battery":92}'
+
+  # Smart Light
+  - name: smart-light-01
+    mac: "00:AA:BB:CC:30:01"
+    ip: "192.168.100.30"
+
+    http:
+      enabled: true
+      server_name: "SmartLight-01"
+      endpoints:
+        - path: "/status"
+          content_type: "application/json"
+          body: '{"device":"smart-light-01","state":"on","brightness":75}'
+
+  # Smart Thermostat
+  - name: thermostat-01
+    mac: "00:AA:BB:CC:40:01"
+    ip: "192.168.100.40"
+
+    http:
+      enabled: true
+      server_name: "Thermostat-01"
+
+    snmp_agent:
+      walk_file: ""
+
+  # IP Camera
+  - name: camera-01
+    mac: "00:AA:BB:CC:50:01"
+    ip: "192.168.100.50"
+
+    http:
+      enabled: true
+      server_name: "IPCamera-01"
+
+    snmp_agent:
+      walk_file: ""
+
+  # IoT Hub
+  - name: iot-hub
+    mac: "00:AA:BB:CC:99:01"
+    ip: "192.168.100.100"
+
+    http:
+      enabled: true
+      server_name: "IoT-Hub"
+      endpoints:
+        - path: "/api/devices"
+          content_type: "application/json"
+          body: '{"devices":7,"online":7,"offline":0}'
+
+    dns:
+      enabled: true
+      records:
+        - name: "gateway.iot.local"
+          type: "A"
+          value: "192.168.100.1"
+        - name: "hub.iot.local"
+          type: "A"
+          value: "192.168.100.100"
+
+    snmp_agent:
+      walk_file: ""

--- a/internal/library/starter/service-provider.yaml
+++ b/internal/library/starter/service-provider.yaml
@@ -1,0 +1,131 @@
+# Service Provider Template
+# ISP-style topology for carrier network simulation
+#
+# Use Case: Service provider or carrier network simulation
+# Includes: PE/CE routers, MPLS core, BGP peering
+
+devices:
+  # Provider Edge Router 1
+  - name: pe-router-01
+    mac: "00:1B:2C:3D:01:01"
+    ips:
+      - "10.255.1.1"
+      - "192.0.2.1"
+      - "172.31.1.1"
+
+    lldp:
+      enabled: true
+      system_description: "Provider Edge Router - Region A"
+      port_description: "TenGigabitEthernet0/0/0"
+
+    cdp:
+      enabled: true
+      platform: "Cisco ASR 9010"
+      software_version: "IOS XR 7.8.1"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Provider Edge Router 2
+  - name: pe-router-02
+    mac: "00:1B:2C:3D:01:02"
+    ips:
+      - "10.255.1.2"
+      - "192.0.2.5"
+
+    lldp:
+      enabled: true
+      system_description: "Provider Edge Router - Region B"
+
+    cdp:
+      enabled: true
+      platform: "Cisco ASR 9010"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Provider Core Router 1
+  - name: p-router-01
+    mac: "00:1B:2C:3D:02:01"
+    ips:
+      - "10.255.2.1"
+      - "172.31.2.1"
+
+    lldp:
+      enabled: true
+      system_description: "Provider Core Router - Core A"
+      port_description: "HundredGigE0/0/0/0"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Provider Core Router 2
+  - name: p-router-02
+    mac: "00:1B:2C:3D:02:02"
+    ips:
+      - "10.255.2.2"
+      - "172.31.2.2"
+
+    lldp:
+      enabled: true
+      system_description: "Provider Core Router - Core B"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Border Router
+  - name: border-router-01
+    mac: "00:1B:2C:3D:03:01"
+    ips:
+      - "10.255.3.1"
+      - "198.51.100.1"
+
+    lldp:
+      enabled: true
+      system_description: "Border/Edge Router - Internet Exchange"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Customer Edge Router
+  - name: ce-router-01
+    mac: "00:1B:2C:3D:10:01"
+    ips:
+      - "192.0.2.2"
+      - "198.51.100.10"
+
+    lldp:
+      enabled: true
+      system_description: "Customer Edge Router - Customer A"
+
+    snmp_agent:
+      walk_file: ""
+
+  # NOC Server
+  - name: noc-server-01
+    mac: "00:1B:2C:3D:50:01"
+    ip: "10.255.0.100"
+
+    http:
+      enabled: true
+      server_name: "NOC-Portal"
+      endpoints:
+        - path: "/api/status"
+          content_type: "application/json"
+          body: '{"network":"operational","alarms":0}'
+
+    dns:
+      enabled: true
+      records:
+        - name: "pe1.sp.net"
+          type: "A"
+          value: "10.255.1.1"
+        - name: "pe2.sp.net"
+          type: "A"
+          value: "10.255.1.2"
+        - name: "noc.sp.net"
+          type: "A"
+          value: "10.255.0.100"
+
+    snmp_agent:
+      walk_file: ""

--- a/internal/library/starter/small-office.yaml
+++ b/internal/library/starter/small-office.yaml
@@ -1,0 +1,95 @@
+# Small Office Template
+# Router, switch, AP, and DNS/DHCP server for small office networks
+#
+# Use Case: Small office or branch network (10-50 devices)
+# Includes: Router, switch, access point, and network services
+
+devices:
+  # Gateway Router
+  - name: office-router
+    mac: "00:50:56:A1:01:01"
+    ips:
+      - "192.168.10.1"
+      - "10.10.10.1"
+
+    lldp:
+      enabled: true
+      system_description: "Small Office Gateway Router"
+      port_description: "GigabitEthernet0/0"
+
+    cdp:
+      enabled: true
+      software_version: "IOS XE 17.6.3"
+      platform: "Cisco ISR4321"
+      port_id: "GigabitEthernet0/0"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Core Switch
+  - name: office-switch
+    mac: "00:50:56:A1:02:01"
+    ip: "192.168.10.2"
+
+    lldp:
+      enabled: true
+      system_description: "Office Switch"
+      port_description: "GigabitEthernet1/0/1"
+
+    stp:
+      enabled: true
+      bridge_priority: 24576
+
+    snmp_agent:
+      walk_file: ""
+
+  # Wireless Access Point
+  - name: office-ap-01
+    mac: "00:50:56:A1:03:01"
+    ip: "192.168.10.10"
+
+    lldp:
+      enabled: true
+      system_description: "Office Wireless AP"
+      port_description: "GigabitEthernet0"
+
+    snmp_agent:
+      walk_file: ""
+
+  # DHCP and DNS Server
+  - name: office-server
+    mac: "00:50:56:A1:10:01"
+    ip: "192.168.10.100"
+
+    dhcp:
+      enabled: true
+      pools:
+        - network: "192.168.10.0/24"
+          range_start: "192.168.10.50"
+          range_end: "192.168.10.99"
+          gateway: "192.168.10.1"
+          dns_servers:
+            - "192.168.10.100"
+            - "8.8.8.8"
+          domain: "office.local"
+          lease_time: 86400
+
+    dns:
+      enabled: true
+      records:
+        - name: "router.office.local"
+          type: "A"
+          value: "192.168.10.1"
+        - name: "switch.office.local"
+          type: "A"
+          value: "192.168.10.2"
+        - name: "server.office.local"
+          type: "A"
+          value: "192.168.10.100"
+
+    http:
+      enabled: true
+      server_name: "Office-Server"
+
+    snmp_agent:
+      walk_file: ""

--- a/internal/library/starter/test-lab.yaml
+++ b/internal/library/starter/test-lab.yaml
@@ -1,0 +1,161 @@
+# Test Lab Template
+# Lab environment for protocol testing and development
+#
+# Use Case: Network testing and protocol development
+# Includes: Multi-protocol devices for comprehensive testing
+
+devices:
+  # Test Router - Full protocol stack
+  - name: test-router-01
+    mac: "00:DE:AD:BE:EF:01"
+    ips:
+      - "10.0.0.1"
+      - "192.168.99.1"
+      - "2001:db8::1"
+
+    lldp:
+      enabled: true
+      system_description: "Multi-Protocol Test Router"
+      port_description: "eth0"
+
+    cdp:
+      enabled: true
+      platform: "Test Platform"
+      software_version: "Test OS 1.0"
+      port_id: "Ethernet0"
+
+    edp:
+      enabled: true
+
+    fdp:
+      enabled: true
+
+    snmp_agent:
+      walk_file: ""
+      traps:
+        enabled: true
+        targets:
+          - "10.0.0.100:162"
+
+    traffic:
+      enabled: true
+      patterns: ["http", "dns"]
+      interval: 30
+
+  # Test Switch
+  - name: test-switch-01
+    mac: "00:DE:AD:BE:EF:02"
+    ips:
+      - "10.0.0.2"
+      - "2001:db8::2"
+
+    lldp:
+      enabled: true
+      system_description: "Test Layer 2 Switch"
+
+    cdp:
+      enabled: true
+      platform: "Test Switch"
+
+    edp:
+      enabled: true
+
+    fdp:
+      enabled: true
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+      hello_time: 2
+      max_age: 20
+      forward_delay: 15
+
+    snmp_agent:
+      walk_file: ""
+
+  # Test Server
+  - name: test-server-01
+    mac: "00:DE:AD:BE:EF:10"
+    ips:
+      - "10.0.0.100"
+      - "2001:db8::100"
+
+    dhcp:
+      enabled: true
+      pools:
+        - network: "10.0.0.0/24"
+          range_start: "10.0.0.201"
+          range_end: "10.0.0.254"
+          gateway: "10.0.0.1"
+          dns_servers:
+            - "10.0.0.100"
+            - "8.8.8.8"
+          domain: "test.local"
+          lease_time: 3600
+
+    dns:
+      enabled: true
+      records:
+        - name: "router.test.local"
+          type: "A"
+          value: "10.0.0.1"
+        - name: "switch.test.local"
+          type: "A"
+          value: "10.0.0.2"
+        - name: "server.test.local"
+          type: "A"
+          value: "10.0.0.100"
+        - name: "test1.test.local"
+          type: "A"
+          value: "10.0.0.201"
+
+    http:
+      enabled: true
+      server_name: "Test-Lab-Server"
+      endpoints:
+        - path: "/api/status"
+          content_type: "application/json"
+          body: '{"status":"ok","uptime":12345,"tests_passed":100}'
+        - path: "/api/devices"
+          content_type: "application/json"
+          body: '{"devices":["router","switch","server"]}'
+
+    ftp:
+      enabled: true
+      username: "testuser"
+      password: "testpass"
+
+    netbios:
+      enabled: true
+      workstation_name: "TESTSERVER"
+      workgroup: "TESTLAB"
+
+    snmp_agent:
+      walk_file: ""
+
+  # Test Client 1
+  - name: test-client-01
+    mac: "00:DE:AD:BE:EF:20"
+    ip: "10.0.0.201"
+
+    traffic:
+      enabled: true
+      patterns: ["http", "dns", "icmp"]
+      interval: 10
+
+    netbios:
+      enabled: true
+      workstation_name: "TESTCLIENT01"
+      workgroup: "TESTLAB"
+
+  # Test Client 2
+  - name: test-client-02
+    mac: "00:DE:AD:BE:EF:21"
+    ips:
+      - "10.0.0.202"
+      - "2001:db8::202"
+
+    netbios:
+      enabled: true
+      workstation_name: "TESTCLIENT02"
+      workgroup: "TESTLAB"

--- a/internal/protocols/neighbors.go
+++ b/internal/protocols/neighbors.go
@@ -21,18 +21,21 @@ const (
 )
 
 // NeighborRecord represents a discovered network neighbor from LLDP/CDP/EDP/FDP protocols.
+// json tags are explicit so /api/v1/neighbors emits snake_case fields
+// the UI's toCamelCase converter recognises (was emitting raw
+// PascalCase, which the frontend silently treated as undefined).
 type NeighborRecord struct {
-	Protocol          string
-	LocalDevice       string
-	RemoteDevice      string
-	RemotePort        string
-	RemoteChassisID   string
-	Description       string
-	Capabilities      []string
-	ManagementAddress string
-	LastSeen          time.Time
-	ExpireAt          time.Time
-	TTL               time.Duration
+	Protocol          string        `json:"protocol"`
+	LocalDevice       string        `json:"local_device"`
+	RemoteDevice      string        `json:"remote_device"`
+	RemotePort        string        `json:"remote_port"`
+	RemoteChassisID   string        `json:"remote_chassis_id"`
+	Description       string        `json:"description"`
+	Capabilities      []string      `json:"capabilities"`
+	ManagementAddress string        `json:"management_address"`
+	LastSeen          time.Time     `json:"last_seen"`
+	ExpireAt          time.Time     `json:"expire_at"`
+	TTL               time.Duration `json:"ttl"`
 }
 
 type neighborTable struct {

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -146,6 +146,23 @@ export interface TopologyLink {
   source: string;
   target: string;
   label: string;
+  /** "trunk" | "lag" | "" — set by BuildTopology from the trunk_ports
+   *  declaration. Drives the edge colour: trunks get the cyan link-type
+   *  hue, LAGs the same with thicker stroke. Empty falls through to
+   *  speed-based colouring. */
+  linkType?: string;
+  sourceInterface?: string;
+  targetInterface?: string;
+  vlans?: number[];
+  nativeVlan?: number;
+  /** Speed in Mbps as a string ("100", "1000", "10000", "25000", ...).
+   *  When the device has an Interface declaration with a Speed field,
+   *  the daemon includes it; otherwise omitted and the edge falls
+   *  through to the default colour. */
+  speed?: string;
+  duplex?: string;
+  status?: string;
+  utilization?: number;
 }
 
 export interface ErrorType {

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -3,6 +3,7 @@ import {
   BackgroundVariant,
   type Connection,
   Controls,
+  type EdgeTypes,
   MiniMap,
   type Node,
   type NodeTypes,
@@ -33,6 +34,7 @@ import {
   NeighborsView,
   TopologyLegend,
 } from './topology';
+import { TrunkEdge } from './topology/TrunkEdge';
 
 /**
  * nodeTypes is the ReactFlow lookup that maps a node.type string onto
@@ -43,6 +45,10 @@ import {
  */
 const nodeTypes: NodeTypes = {
   device: DeviceNode,
+};
+
+const edgeTypes: EdgeTypes = {
+  trunk: TrunkEdge,
 };
 
 // Where we stash user-dragged node positions so they survive page
@@ -102,6 +108,10 @@ export const TopologyPage: FC = () => {
   // users will pan with the mouse anyway. Toggle on via the header
   // button when working with larger topologies.
   const [showMinimap, setShowMinimap] = useState(false);
+  // showLabels controls whether TrunkEdge renders its per-side
+  // interface labels + the middle VLAN/speed label. On by default
+  // for clarity; toggle off via the header to see clean lines only.
+  const [showLabels, setShowLabels] = useState(true);
   const [view, setView] = useState<'graph' | 'neighbors'>('graph');
 
   // Build graph from API data, merging trunk port links with neighbor-discovered links
@@ -137,7 +147,10 @@ export const TopologyPage: FC = () => {
     }
 
     const layoutedNodes = layoutNodes(devices, allLinks);
-    const layoutedEdges = createEdges(allLinks);
+    const layoutedEdges = createEdges(allLinks).map((edge) => ({
+      ...edge,
+      data: { ...edge.data, showLabels },
+    }));
 
     // Preserve user-dragged positions across the 15s data poll. For each
     // device that's already on canvas, keep its current position rather
@@ -159,7 +172,7 @@ export const TopologyPage: FC = () => {
       });
     });
     setEdges(layoutedEdges);
-  }, [devices, topology, neighbors, setNodes, setEdges]);
+  }, [devices, topology, neighbors, showLabels, setNodes, setEdges]);
 
   // Persist node positions when the user stops dragging so layouts
   // survive page reloads. Keyed by device name; stored as a flat
@@ -259,7 +272,9 @@ export const TopologyPage: FC = () => {
               <div>
                 <H2>Network Topology</H2>
                 <SmallText className="text-gray-400">
-                  {devices?.length || 0} devices | {topology?.links?.length || 0} connections
+                  {devices?.length || 0} {devices?.length === 1 ? 'device' : 'devices'} |{' '}
+                  {topology?.links?.length || 0}{' '}
+                  {topology?.links?.length === 1 ? 'connection' : 'connections'}
                 </SmallText>
               </div>
             </div>
@@ -318,6 +333,14 @@ export const TopologyPage: FC = () => {
                     disabled={nodes.length === 0}
                   >
                     Export
+                  </Button>
+                  <Button
+                    variant={showLabels ? 'outline' : 'ghost'}
+                    size="sm"
+                    onClick={() => setShowLabels(!showLabels)}
+                    title="Toggle interface / VLAN / speed labels on edges"
+                  >
+                    Labels
                   </Button>
                   <Button
                     variant={showMinimap ? 'outline' : 'ghost'}
@@ -382,6 +405,7 @@ export const TopologyPage: FC = () => {
                   onConnect={onConnect}
                   onNodeDragStop={handleNodeDragStop}
                   nodeTypes={nodeTypes}
+                  edgeTypes={edgeTypes}
                   fitView={true}
                   fitViewOptions={{ padding: 0.2 }}
                   minZoom={0.2}

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -45,6 +45,31 @@ const nodeTypes: NodeTypes = {
   device: DeviceNode,
 };
 
+// Where we stash user-dragged node positions so they survive page
+// reloads. Keyed by device name → {x, y}. SSR-safe — no-ops if window
+// is undefined.
+const TOPOLOGY_POSITIONS_KEY = 'niac.topology.positions';
+
+function readSavedPositions(): Record<string, { x: number; y: number }> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(TOPOLOGY_POSITIONS_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as Record<string, { x: number; y: number }>;
+  } catch {
+    return {};
+  }
+}
+
+function writeSavedPositions(positions: Record<string, { x: number; y: number }>) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(TOPOLOGY_POSITIONS_KEY, JSON.stringify(positions));
+  } catch {
+    // Quota / privacy mode — silently skip; positions will reset on reload.
+  }
+}
+
 /**
  * TopologyPage renders the network graph with the device-node and
  * link-edge presenters defined in ./topology. The page itself owns
@@ -73,7 +98,10 @@ export const TopologyPage: FC = () => {
   const [edges, setEdges, onEdgesChange] = useEdgesState<LinkEdge>([]);
   const [selectedDevice, setSelectedDevice] = useState<DeviceSummary | null>(null);
   const [showLegend, setShowLegend] = useState(true);
-  const [showMinimap, setShowMinimap] = useState(true);
+  // Minimap defaults off — it's distracting for small graphs and most
+  // users will pan with the mouse anyway. Toggle on via the header
+  // button when working with larger topologies.
+  const [showMinimap, setShowMinimap] = useState(false);
   const [view, setView] = useState<'graph' | 'neighbors'>('graph');
 
   // Build graph from API data, merging trunk port links with neighbor-discovered links
@@ -111,9 +139,38 @@ export const TopologyPage: FC = () => {
     const layoutedNodes = layoutNodes(devices, allLinks);
     const layoutedEdges = createEdges(allLinks);
 
-    setNodes(layoutedNodes);
+    // Preserve user-dragged positions across the 15s data poll. For each
+    // device that's already on canvas, keep its current position rather
+    // than blowing it away with the freshly-computed layout. Brand-new
+    // devices that arrived since last render get the fresh layout slot.
+    // Also pulls any previously-saved positions out of localStorage so
+    // drags survive a page reload.
+    setNodes((current) => {
+      const positionByName = new Map<string, { x: number; y: number }>();
+      for (const node of current) {
+        positionByName.set(node.id, node.position);
+      }
+      const stored = readSavedPositions();
+      return layoutedNodes.map((node) => {
+        const existing = positionByName.get(node.id);
+        const saved = stored[node.id];
+        const position = existing ?? saved ?? node.position;
+        return { ...node, position };
+      });
+    });
     setEdges(layoutedEdges);
   }, [devices, topology, neighbors, setNodes, setEdges]);
+
+  // Persist node positions when the user stops dragging so layouts
+  // survive page reloads. Keyed by device name; stored as a flat
+  // {name: {x, y}} map in localStorage.
+  const handleNodeDragStop = useCallback(() => {
+    const positions: Record<string, { x: number; y: number }> = {};
+    for (const node of nodes) {
+      positions[node.id] = { x: node.position.x, y: node.position.y };
+    }
+    writeSavedPositions(positions);
+  }, [nodes]);
 
   // Handle node selection
   const handleNodeClick = useCallback(
@@ -277,10 +334,13 @@ export const TopologyPage: FC = () => {
         </CardContent>
       </Card>
 
-      {/* Topology Visualization */}
+      {/* Topology Visualization — sized to fill the available viewport
+          minus the page chrome (header card + breadcrumbs + page header
+          ≈ 240 px on this layout). Gives much more room for the graph
+          on standard 1080p+ displays. */}
       {view === 'graph' && (
         <Card className="border-white/5 bg-gray-900/70 overflow-hidden">
-          <div className="h-[600px] relative">
+          <div className="h-[calc(100vh-260px)] min-h-[520px] relative">
             {loading ? (
               <div className="absolute inset-0 flex items-center justify-center">
                 <div className="flex flex-col items-center gap-3">
@@ -320,6 +380,7 @@ export const TopologyPage: FC = () => {
                   onNodesChange={onNodesChange}
                   onEdgesChange={onEdgesChange}
                   onConnect={onConnect}
+                  onNodeDragStop={handleNodeDragStop}
                   nodeTypes={nodeTypes}
                   fitView={true}
                   fitViewOptions={{ padding: 0.2 }}

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -51,30 +51,20 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
     >
       {/* ReactFlow edge anchors. Without these handles the canvas
           renders nodes fine but every edge silently fails to draw —
-          there's no spot for the line to attach to. We put a source +
-          target on each side so edges route on whichever side reads
-          best from the layout. */}
+          there's no spot for the line to attach to.
+          Default handles only (left=target, right=source) so edges
+          always route left-to-right deterministically. Extra
+          top/bottom handles confused ReactFlow's auto-routing into
+          drawing edges out the side of the card. */}
       <Handle
         type="target"
         position={Position.Left}
-        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
+        className="!w-2 !h-2 !bg-violet-400 !border-0"
       />
       <Handle
         type="source"
         position={Position.Right}
-        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
-      />
-      <Handle
-        type="target"
-        position={Position.Top}
-        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
-        id="top"
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
-        id="bottom"
+        className="!w-2 !h-2 !bg-violet-400 !border-0"
       />
 
       {/* Status indicator */}

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -2,6 +2,7 @@
  * Custom Device Node Component for React Flow topology visualization
  */
 
+import { Handle, Position } from '@xyflow/react';
 import { type FC, memo } from 'react';
 import {
   topologyDeviceColors as deviceColors,
@@ -47,6 +48,34 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
       }}
       onClick={() => data.onClick?.(data.label)}
     >
+      {/* ReactFlow edge anchors. Without these handles the canvas
+          renders nodes fine but every edge silently fails to draw —
+          there's no spot for the line to attach to. We put a source +
+          target on each side so edges route on whichever side reads
+          best from the layout. */}
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
+      />
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
+        id="top"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!w-2 !h-2 !bg-violet-400/60 !border-0"
+        id="bottom"
+      />
+
       {/* Status indicator */}
       <div
         className={`absolute -top-1 -right-1 w-3 h-3 rounded-full ${statusColor} border-2 border-gray-900`}

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -41,10 +41,11 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
       style={{
         backgroundColor: 'var(--color-bg-elevated)',
         borderColor: selected ? color : 'var(--color-border-muted)',
-        minWidth: '140px',
-        // Cap so device names + IP lists don't blow the card past the
-        // grid-fallback step width and overlap neighbours.
-        maxWidth: '220px',
+        // Wide enough that 16-char device names (niac-core-sw-01) fit
+        // without "..." truncation, capped so packed layouts still
+        // breathe. Layout step width below is tuned to this.
+        minWidth: '200px',
+        maxWidth: '260px',
       }}
       onClick={() => data.onClick?.(data.label)}
     >

--- a/ui/src/pages/topology/TrunkEdge.tsx
+++ b/ui/src/pages/topology/TrunkEdge.tsx
@@ -1,0 +1,139 @@
+import { BaseEdge, EdgeLabelRenderer, type EdgeProps, getSmoothStepPath } from '@xyflow/react';
+import type { FC } from 'react';
+import type { LinkEdgeData } from './types';
+
+/**
+ * TrunkEdge is the custom ReactFlow edge used for every topology
+ * link. Renders the line and arrows via BaseEdge, then layers three
+ * floating labels via EdgeLabelRenderer:
+ *
+ *   - left near the source: the source-side interface name (e.g. Gi0/1)
+ *   - centre on the line:   the shared metadata (VLANs, speed)
+ *   - right near the target: the target-side interface name
+ *
+ * Splitting like this keeps the centre of the line — and the arrows —
+ * unobscured even for short edges. Per-side labels sit ~25 % in from
+ * each end so they hug their device without overlapping the arrow.
+ *
+ * data.showLabels=false hides every label (just shows the line); the
+ * topology header has a toggle for the user to flip.
+ */
+
+const SIDE_OFFSET_PCT = 0.22; // fraction along the path for side labels
+
+export const TrunkEdge: FC<EdgeProps> = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  markerStart,
+  data,
+}) => {
+  const linkData = (data ?? {}) as LinkEdgeData;
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const showLabels = linkData.showLabels !== false; // default on
+
+  // Where the per-side labels sit. Linear interpolation along the
+  // straight source→target vector — close enough for smoothstep paths
+  // and avoids computing path arc length.
+  const leftX = sourceX + (targetX - sourceX) * SIDE_OFFSET_PCT;
+  const leftY = sourceY + (targetY - sourceY) * SIDE_OFFSET_PCT;
+  const rightX = sourceX + (targetX - sourceX) * (1 - SIDE_OFFSET_PCT);
+  const rightY = sourceY + (targetY - sourceY) * (1 - SIDE_OFFSET_PCT);
+
+  const middleParts: string[] = [];
+  if (linkData.vlans && linkData.vlans.length > 0) {
+    middleParts.push(formatVlans(linkData.vlans));
+  }
+  if (linkData.speed) {
+    middleParts.push(formatSpeed(linkData.speed));
+  }
+  const middleLabel = middleParts.join(' · ');
+
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={style}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+      />
+      {showLabels && (
+        <EdgeLabelRenderer>
+          {linkData.sourceInterface && (
+            <EndLabel x={leftX} y={leftY} text={linkData.sourceInterface} />
+          )}
+          {middleLabel && <MiddleLabel x={labelX} y={labelY} text={middleLabel} />}
+          {linkData.targetInterface && (
+            <EndLabel x={rightX} y={rightY} text={linkData.targetInterface} />
+          )}
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+};
+
+const labelBoxStyle =
+  'absolute pointer-events-none px-1.5 py-0.5 rounded text-[10px] font-medium ' +
+  'border border-white/10 bg-gray-950/90 text-gray-200 shadow-sm whitespace-nowrap';
+
+const EndLabel: FC<{ x: number; y: number; text: string }> = ({ x, y, text }) => (
+  <div
+    className={labelBoxStyle}
+    style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)` }}
+  >
+    {text}
+  </div>
+);
+
+const MiddleLabel: FC<{ x: number; y: number; text: string }> = ({ x, y, text }) => (
+  <div
+    className={`${labelBoxStyle} text-violet-200`}
+    style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)` }}
+  >
+    {text}
+  </div>
+);
+
+function formatVlans(vlans: number[]): string {
+  if (vlans.length === 0) return '';
+  if (vlans.length === 1) return `VLAN ${vlans[0]}`;
+  // Compact contiguous runs: [1,2,3,5,6] → "1-3,5-6"
+  const sorted = [...vlans].sort((a, b) => a - b);
+  const runs: string[] = [];
+  let start = sorted[0];
+  let prev = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const v = sorted[i];
+    if (v === prev + 1) {
+      prev = v;
+      continue;
+    }
+    runs.push(start === prev ? String(start) : `${start}-${prev}`);
+    start = v;
+    prev = v;
+  }
+  runs.push(start === prev ? String(start) : `${start}-${prev}`);
+  return `VLANs ${runs.join(',')}`;
+}
+
+function formatSpeed(speedMbps: string): string {
+  const n = Number.parseInt(speedMbps, 10);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  if (n >= 1000) return `${n / 1000}G`;
+  return `${n}M`;
+}

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -217,6 +217,14 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
       vlan: link.vlans && link.vlans.length > 0 ? link.vlans[0] : getVlan(link.label),
     };
 
+    // Hydrate per-side interface names + vlan list so the custom
+    // TrunkEdge component can render them as end-labels near each
+    // arrow. The middle label (VLANs + speed) sits on the line; the
+    // per-side labels float between line and device card.
+    data.sourceInterface = link.sourceInterface;
+    data.targetInterface = link.targetInterface;
+    data.vlans = link.vlans;
+
     const edgeColor = getEdgeColor(data);
     // Trunk + LAG links are bidirectional by nature (both sides send
     // and receive on the same wire) — show arrows on both ends. A
@@ -234,20 +242,11 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
       id: `e-${link.source}-${link.target}-${index}`,
       source: link.source,
       target: link.target,
-      type: 'smoothstep',
+      // 'trunk' is our custom edge type registered in TopologyPage's
+      // edgeTypes lookup. Labels are rendered by TrunkEdge, not via
+      // the standard label/labelStyle props.
+      type: 'trunk',
       animated: bidirectional,
-      label: link.label,
-      labelBgPadding: [8, 4] as [number, number],
-      labelBgBorderRadius: 4,
-      labelBgStyle: {
-        fill: 'var(--color-bg-overlay)',
-        fillOpacity: 0.9,
-      },
-      labelStyle: {
-        fill: 'var(--color-text-secondary)',
-        fontSize: 10,
-        fontWeight: 500,
-      },
       style: {
         stroke: edgeColor,
         strokeWidth: bidirectional ? 3 : 2,

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -7,14 +7,19 @@ import type { DeviceSummary, TopologyLink } from '../../api/types';
 import type { DeviceNode, DeviceNodeData, LinkEdge, LinkEdgeData } from './types';
 import { linkSpeedColors } from './types';
 
-// Card-sized tuneables for the edges == 0 grid fallback below. Keep
-// neighbours far enough apart that they don't overlap at default zoom.
-// DeviceNode has maxWidth 220 + 2px border + room for the connector
-// handles ReactFlow draws, plus we give the user some breathing room.
+// Card-sized tuneables for the grid layout below. Keep neighbours far
+// enough apart that they don't overlap at default zoom. DeviceNode has
+// maxWidth 220 + 2px border + room for the connector handles ReactFlow
+// draws, plus we give the user some breathing room.
 const NODE_WIDTH = 240;
 const NODE_HEIGHT = 160;
 const NODE_GAP_X = 80;
 const NODE_GAP_Y = 80;
+
+// Minimum radius for the concentric-ring layout. Must be large enough
+// that a node on the inner ring doesn't overlap the centre node — i.e.
+// > one card-width plus padding. The previous 180 wasn't enough.
+const CONCENTRIC_MIN_RADIUS = 320;
 
 /**
  * Layout nodes in concentric circles based on connectivity. Most
@@ -29,7 +34,13 @@ const NODE_GAP_Y = 80;
  * the YAML to populate edges.
  */
 export function layoutNodes(devices: DeviceSummary[], links: TopologyLink[]): DeviceNode[] {
-  if (links.length === 0) {
+  // For small device counts the concentric-ring layout collapses (the
+  // centre node and the first ring overlap), so use the grid path even
+  // when there are edges. The cutoff is tuned to the device-card width:
+  // ≤4 devices fits in a 2×2 grid with the standard NODE_GAP padding.
+  const useGrid = links.length === 0 || devices.length <= 4;
+
+  if (useGrid) {
     return devices.map((device, index) => {
       const cols = Math.max(1, Math.ceil(Math.sqrt(devices.length)));
       const row = Math.floor(index / cols);
@@ -86,9 +97,9 @@ export function layoutNodes(devices: DeviceSummary[], links: TopologyLink[]): De
   for (const device of sorted) {
     if (ringIndex >= nodesInRing) {
       ringIndex = 0;
-      currentRadius += 180;
+      currentRadius += CONCENTRIC_MIN_RADIUS;
       angleOffset += Math.PI / 6; // Stagger rings
-      nodesInRing = Math.max(1, Math.floor((2 * Math.PI * currentRadius) / 200));
+      nodesInRing = Math.max(1, Math.floor((2 * Math.PI * currentRadius) / 280));
     }
 
     const angle = (2 * Math.PI * ringIndex) / nodesInRing + angleOffset;
@@ -182,18 +193,23 @@ export function getEdgeColor(data: LinkEdgeData): string {
 }
 
 /**
- * Create edges from topology links with styling based on type/speed
+ * Create edges from topology links with styling based on type/speed.
+ *
+ * Prefers the structured fields the daemon now returns
+ * (link.linkType / link.speed / link.vlans) over regex-parsing the
+ * display label — the label is human-friendly text and rarely
+ * contains the literal "trunk" / "1G" keywords the old parser needed.
  */
 export function createEdges(links: TopologyLink[]): LinkEdge[] {
   return links.map((link, index) => {
-    // Parse link label for speed/type info
     const data: LinkEdgeData = {
       label: link.label,
+      // Prefer server-supplied structure; fall back to label parsing for
+      // older API responses that didn't include the typed fields.
+      speed: link.speed ?? getLinkSpeed(link.label),
+      linkType: (link.linkType as LinkEdgeData['linkType']) ?? getLinkType(link.label),
+      vlan: link.vlans && link.vlans.length > 0 ? link.vlans[0] : getVlan(link.label),
     };
-
-    data.speed = getLinkSpeed(link.label);
-    data.linkType = getLinkType(link.label);
-    data.vlan = getVlan(link.label);
 
     const edgeColor = getEdgeColor(data);
 

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -218,13 +218,24 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
     };
 
     const edgeColor = getEdgeColor(data);
+    // Trunk + LAG links are bidirectional by nature (both sides send
+    // and receive on the same wire) — show arrows on both ends. A
+    // plain access link still uses a single end-arrow to indicate the
+    // "source declared this" direction.
+    const bidirectional = data.linkType === 'trunk' || data.linkType === 'lag';
+    const marker = {
+      type: MarkerType.ArrowClosed,
+      color: edgeColor,
+      width: 14,
+      height: 14,
+    };
 
     return {
       id: `e-${link.source}-${link.target}-${index}`,
       source: link.source,
       target: link.target,
       type: 'smoothstep',
-      animated: data.linkType === 'trunk' || data.linkType === 'lag',
+      animated: bidirectional,
       label: link.label,
       labelBgPadding: [8, 4] as [number, number],
       labelBgBorderRadius: 4,
@@ -239,14 +250,10 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
       },
       style: {
         stroke: edgeColor,
-        strokeWidth: data.linkType === 'trunk' || data.linkType === 'lag' ? 3 : 2,
+        strokeWidth: bidirectional ? 3 : 2,
       },
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        color: edgeColor,
-        width: 15,
-        height: 15,
-      },
+      markerEnd: marker,
+      ...(bidirectional ? { markerStart: marker } : {}),
       data,
     };
   });

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -7,14 +7,20 @@ import type { DeviceSummary, TopologyLink } from '../../api/types';
 import type { DeviceNode, DeviceNodeData, LinkEdge, LinkEdgeData } from './types';
 import { linkSpeedColors } from './types';
 
-// Card-sized tuneables for the grid layout below. Keep neighbours far
-// enough apart that they don't overlap at default zoom. DeviceNode has
-// maxWidth 220 + 2px border + room for the connector handles ReactFlow
-// draws, plus we give the user some breathing room.
-const NODE_WIDTH = 240;
-const NODE_HEIGHT = 160;
-const NODE_GAP_X = 80;
-const NODE_GAP_Y = 80;
+// Card-sized tuneables for the grid layout below. Tuned to the
+// DeviceNode max-width (260 px) plus the trunk-edge label band that
+// floats between cards. NODE_GAP_X is generous so labels like
+// "Gi0/1 ↔ Gi0/1 (VLANs 1-30)" sit comfortably without overrunning
+// either card.
+const NODE_WIDTH = 280;
+const NODE_HEIGHT = 180;
+const NODE_GAP_X = 160;
+const NODE_GAP_Y = 100;
+
+// Left margin so the legend Panel (rendered as a top-left overlay,
+// ~260 px wide) doesn't obscure the first column of cards.
+const LAYOUT_LEFT_OFFSET = 280;
+const LAYOUT_TOP_OFFSET = 40;
 
 // Minimum radius for the concentric-ring layout. Must be large enough
 // that a node on the inner ring doesn't overlap the centre node — i.e.
@@ -49,8 +55,8 @@ export function layoutNodes(devices: DeviceSummary[], links: TopologyLink[]): De
         id: device.name,
         type: 'device',
         position: {
-          x: col * (NODE_WIDTH + NODE_GAP_X),
-          y: row * (NODE_HEIGHT + NODE_GAP_Y),
+          x: LAYOUT_LEFT_OFFSET + col * (NODE_WIDTH + NODE_GAP_X),
+          y: LAYOUT_TOP_OFFSET + row * (NODE_HEIGHT + NODE_GAP_Y),
         },
         data: {
           label: device.name,

--- a/ui/src/pages/topology/types.ts
+++ b/ui/src/pages/topology/types.ts
@@ -25,8 +25,16 @@ export interface LinkEdgeData extends Record<string, unknown> {
   speed?: string;
   duplex?: string;
   vlan?: number;
+  vlans?: number[];
+  /** Local interface name on the edge's source device (e.g. "Gi0/1"). */
+  sourceInterface?: string;
+  /** Local interface name on the edge's target device (e.g. "Gi0/1"). */
+  targetInterface?: string;
   linkType?: 'trunk' | 'access' | 'lag' | 'standard';
   status?: 'up' | 'down' | 'degraded';
+  /** When false, the custom edge component hides all its labels —
+   *  driven by the "Show labels" toggle in the topology header. */
+  showLabels?: boolean;
 }
 
 /**


### PR DESCRIPTION
First slice of #548. Daemon now reads network YAMLs from a real on-disk directory the user can browse, instead of an \`embed.FS\` hidden in the binary.

## What's in

### Package \`internal/library/\`
| File | Lines | What |
|------|------:|------|
| \`library.go\` | 182 | \`Open(root)\` + \`DefaultRoot()\` resolution + name validation |
| \`bootstrap.go\` | 78 | embed-backed starter pack, unpacked into \`<root>/networks/\` on first run |
| \`list.go\` | 251 | \`ListNetworks\` / \`ReadNetwork\` / \`WriteNetwork\` / \`DeleteNetwork\` + walks/pcaps stub for PR 3 |
| \`metadata.go\` | 74 | YAML header parser for \`# Description\` / \`# Use Case\` lines |
| \`starter/*.yaml\` | 8 files | starter networks, copied from \`internal/templates/builtin/\` |

### \`internal/api/handlers_library.go\` (149 lines)
\`\`\`
GET    /api/v1/library/networks         list all
POST   /api/v1/library/networks         upload one
GET    /api/v1/library/networks/{name}  read one
DELETE /api/v1/library/networks/{name}  delete one (refuses starter-pack entries with HTTP 400)
\`\`\`
Wired into \`routes.go\` under CSRF + write-rate-limiting.

### \`ServerConfig.LibraryRoot\` + library-open in \`NewServer\`
\`DefaultRoot()\` resolves: \`NIAC_LIBRARY_ROOT\` env → \`/var/lib/niac/library\` (if it exists) → \`\$XDG_DATA_HOME/niac/library\` → \`~/.niac/library\`. Open failure is **non-fatal** — logged at startup; the library endpoints return 503 and the rest of the daemon keeps working.

## Proven end-to-end via curl

\`\`\`
1. Fresh library → bootstrap unpacked 8 starter files
2. GET single network → returns content + parsed metadata
3. DELETE starter network → 400 \"delete_refused\" (correct refusal)
4. POST upload \"my-test-net\" → 201; list shows 9 entries; entry has source: \"user\", description parsed from \"# Description: …\", deviceCount: 2
5. DELETE my-test-net → 204; list back to 8
\`\`\`

## What's NOT in this PR
- PR 2: \`niac content install\` CLI + multipart upload endpoint
- PR 3: walks/pcaps browser sidebar entries
- fsnotify watcher (lazy disk reads are fine for v1)
- Auto-migration from \`~/.niac/configs/\` (risky — handle later)
- Removing \`internal/templates/\` (back-compat shims stay until picker migrates)
- Frontend changes (small follow-up — one URL swap in the picker)

## Test plan
- [x] \`go test ./internal/library/... ./internal/api/...\` clean
- [x] \`golangci-lint run ./internal/library/... ./internal/api/...\` clean
- [x] \`make build\` succeeds
- [x] Manual curl proof (see above)
- [ ] CI green

Implementation followed the design comment on #548 verbatim.