### PR TITLE
feat(topology): nav polish — search, type filter, focus, edge tooltip

### DIFF
--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -146,6 +146,10 @@ export interface TopologyLink {
   source: string;
   target: string;
   label: string;
+  /** True when the link came from runtime LLDP/CDP/EDP/FDP discovery
+   *  rather than a config-declared trunk_port. Drives the
+   *  declared-vs-discovered visual distinction (solid vs dashed). */
+  discovered?: boolean;
   /** "trunk" | "lag" | "" — set by BuildTopology from the trunk_ports
    *  declaration. Drives the edge colour: trunks get the cyan link-type
    *  hue, LAGs the same with thicker stroke. Empty falls through to

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -12,7 +12,7 @@ import {
   useEdgesState,
   useNodesState,
 } from '@xyflow/react';
-import { type FC, useCallback, useEffect, useState } from 'react';
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '@xyflow/react/dist/style.css';
 import { Download, Layers, Network, Radar, RefreshCw } from 'lucide-react';
@@ -113,6 +113,23 @@ export const TopologyPage: FC = () => {
   // for clarity; toggle off via the header to see clean lines only.
   const [showLabels, setShowLabels] = useState(true);
   const [view, setView] = useState<'graph' | 'neighbors'>('graph');
+  // Search query in the header — filters which devices show up + their
+  // edges. Matched on name (case-insensitive substring).
+  const [search, setSearch] = useState('');
+  // Type-filter chips — empty Set means "show everything". When the
+  // user toggles a type on, only that type renders.
+  const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set());
+  // Node click selects its neighbourhood: the clicked node + every
+  // node connected to it by an edge get full opacity; everything else
+  // fades to 15%. Click empty canvas to clear.
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
+  // Tracks which edge the cursor is currently over (ReactFlow's
+  // onEdgeMouseEnter / Leave). Propagated down to the TrunkEdge via
+  // data.hovered so the custom edge can render the rich tooltip.
+  // Lifted up here (rather than useState inside TrunkEdge) so we don't
+  // attach mouse handlers to raw SVG paths — that flags
+  // lint/a11y/noStaticElementInteractions.
+  const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
 
   // Build graph from API data, merging trunk port links with neighbor-discovered links
   useEffect(() => {
@@ -141,15 +158,58 @@ export const TopologyPage: FC = () => {
             source: neighbor.localDevice,
             target: neighbor.remoteDevice,
             label: `${neighbor.protocol} discovery`,
+            discovered: true,
           });
         }
       }
     }
 
-    const layoutedNodes = layoutNodes(devices, allLinks);
-    const layoutedEdges = createEdges(allLinks).map((edge) => ({
+    // Build a set of node IDs adjacent to the focused node so we can
+    // dim everything else when neighbourhood highlight is active.
+    const focused = focusedNodeId;
+    const adjacent = new Set<string>();
+    if (focused) {
+      adjacent.add(focused);
+      for (const link of allLinks) {
+        if (link.source === focused) adjacent.add(link.target);
+        else if (link.target === focused) adjacent.add(link.source);
+      }
+    }
+    const nodeOpacity = (id: string): number => {
+      if (!focused) return 1;
+      return adjacent.has(id) ? 1 : 0.15;
+    };
+    const edgeOpacity = (source: string, target: string): number => {
+      if (!focused) return 1;
+      return adjacent.has(source) && adjacent.has(target) ? 1 : 0.1;
+    };
+
+    // Type-filter + search: hide devices that don't match.
+    const q = search.trim().toLowerCase();
+    const isVisible = (device: DeviceSummary): boolean => {
+      if (activeTypes.size > 0 && !activeTypes.has((device.type || 'unknown').toLowerCase())) {
+        return false;
+      }
+      if (q && !device.name.toLowerCase().includes(q)) {
+        return false;
+      }
+      return true;
+    };
+    const visibleDevices = devices.filter(isVisible);
+    const visibleNames = new Set(visibleDevices.map((d) => d.name));
+    const visibleLinks = allLinks.filter(
+      (l) => visibleNames.has(l.source) && visibleNames.has(l.target),
+    );
+
+    const layoutedNodes = layoutNodes(visibleDevices, visibleLinks);
+    const layoutedEdges = createEdges(visibleLinks).map((edge) => ({
       ...edge,
-      data: { ...edge.data, showLabels },
+      data: {
+        ...edge.data,
+        showLabels,
+        focusOpacity: edgeOpacity(edge.source, edge.target),
+        hovered: hoveredEdgeId === edge.id,
+      },
     }));
 
     // Preserve user-dragged positions across the 15s data poll. For each
@@ -168,11 +228,26 @@ export const TopologyPage: FC = () => {
         const existing = positionByName.get(node.id);
         const saved = stored[node.id];
         const position = existing ?? saved ?? node.position;
-        return { ...node, position };
+        return {
+          ...node,
+          position,
+          style: { ...node.style, opacity: nodeOpacity(node.id) },
+        };
       });
     });
     setEdges(layoutedEdges);
-  }, [devices, topology, neighbors, showLabels, setNodes, setEdges]);
+  }, [
+    devices,
+    topology,
+    neighbors,
+    showLabels,
+    search,
+    activeTypes,
+    focusedNodeId,
+    hoveredEdgeId,
+    setNodes,
+    setEdges,
+  ]);
 
   // Persist node positions when the user stops dragging so layouts
   // survive page reloads. Keyed by device name; stored as a flat
@@ -190,9 +265,46 @@ export const TopologyPage: FC = () => {
     (deviceName: string) => {
       const device = devices?.find((d) => d.name === deviceName);
       setSelectedDevice(device || null);
+      // Toggle neighbourhood highlight — clicking the same node twice
+      // clears the focus so all nodes/edges return to full opacity.
+      setFocusedNodeId((curr) => (curr === deviceName ? null : deviceName));
     },
     [devices],
   );
+
+  // Reset Layout — wipes the saved drag positions + clears focus and
+  // search/filter state. The next data-poll effect re-runs layoutNodes
+  // from scratch, putting every device on the fresh grid slot.
+  const handleResetLayout = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(TOPOLOGY_POSITIONS_KEY);
+    }
+    setFocusedNodeId(null);
+    setSearch('');
+    setActiveTypes(new Set());
+    // Forcing a re-layout: bump nodes through layoutNodes by clearing
+    // current positions. The useEffect will pick up the empty current
+    // and assign fresh positions on next data tick.
+    setNodes((current) => current.map((node) => ({ ...node, position: { x: 0, y: 0 } })));
+  }, [setNodes]);
+
+  // The set of unique device types currently in the graph — drives the
+  // filter chip row. Sorted for stable button order.
+  const availableTypes = useMemo(() => {
+    if (!devices) return [];
+    const set = new Set<string>();
+    for (const d of devices) set.add((d.type || 'unknown').toLowerCase());
+    return [...set].sort();
+  }, [devices]);
+
+  const toggleType = useCallback((type: string) => {
+    setActiveTypes((curr) => {
+      const next = new Set(curr);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  }, []);
 
   // Update node data with click handler
   useEffect(() => {
@@ -335,6 +447,14 @@ export const TopologyPage: FC = () => {
                     Export
                   </Button>
                   <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleResetLayout}
+                    title="Reset hand-dragged positions + filters back to defaults"
+                  >
+                    Reset
+                  </Button>
+                  <Button
                     variant={showLabels ? 'outline' : 'ghost'}
                     size="sm"
                     onClick={() => setShowLabels(!showLabels)}
@@ -354,6 +474,55 @@ export const TopologyPage: FC = () => {
               )}
             </div>
           </div>
+
+          {/* Second header row: search + type-filter chips. Only shown
+              for the graph view — the Neighbors table has its own
+              filtering UI. Stays inside the header card so the toolbar
+              groups visually with the title/buttons row above. */}
+          {view === 'graph' && (
+            <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+              <input
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search devices by name…"
+                aria-label="Filter devices by name"
+                className="w-full sm:w-64 rounded-md border border-white/10 bg-gray-950/40 px-3 py-1.5 text-xs text-gray-200 placeholder:text-gray-500 focus:border-cyan-500/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+              />
+              {availableTypes.length > 0 && (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <SmallText className="text-gray-500">Types:</SmallText>
+                  {availableTypes.map((type) => {
+                    const active = activeTypes.has(type);
+                    return (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() => toggleType(type)}
+                        aria-pressed={active}
+                        className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium capitalize transition-colors ${
+                          active
+                            ? 'border-cyan-500/40 bg-cyan-500/20 text-cyan-100'
+                            : 'border-white/10 bg-gray-950/40 text-gray-400 hover:bg-white/5 hover:text-gray-200'
+                        }`}
+                      >
+                        {type}
+                      </button>
+                    );
+                  })}
+                  {activeTypes.size > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setActiveTypes(new Set())}
+                      className="rounded-full px-2 py-0.5 text-[11px] font-medium text-gray-400 hover:text-gray-200 underline-offset-2 hover:underline"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -404,6 +573,8 @@ export const TopologyPage: FC = () => {
                   onEdgesChange={onEdgesChange}
                   onConnect={onConnect}
                   onNodeDragStop={handleNodeDragStop}
+                  onEdgeMouseEnter={(_, edge) => setHoveredEdgeId(edge.id)}
+                  onEdgeMouseLeave={() => setHoveredEdgeId(null)}
                   nodeTypes={nodeTypes}
                   edgeTypes={edgeTypes}
                   fitView={true}

--- a/ui/src/pages/topology/TrunkEdge.tsx
+++ b/ui/src/pages/topology/TrunkEdge.tsx
@@ -12,11 +12,26 @@ import type { LinkEdgeData } from './types';
  *   - right near the target: the target-side interface name
  *
  * Splitting like this keeps the centre of the line — and the arrows —
- * unobscured even for short edges. Per-side labels sit ~25 % in from
+ * unobscured even for short edges. Per-side labels sit ~22 % in from
  * each end so they hug their device without overlapping the arrow.
  *
  * data.showLabels=false hides every label (just shows the line); the
  * topology header has a toggle for the user to flip.
+ *
+ * data.discovered=true renders the stroke dashed so runtime
+ * LLDP/CDP/EDP/FDP-inferred edges are visually distinct from
+ * config-declared trunk_ports.
+ *
+ * data.focusOpacity (set when a node is "selected" for neighbourhood
+ * highlighting) fades the edge to that opacity so non-adjacent links
+ * recede to the background.
+ *
+ * data.hovered (driven by ReactFlow's onEdgeMouseEnter / Leave at the
+ * page level) surfaces the richer tooltip with full interface names,
+ * speed/duplex/status, and the complete VLAN list. Lifting hover
+ * state to the page avoids putting mouse handlers on SVG paths
+ * directly (a11y rule), and ReactFlow's built-in interactionWidth
+ * provides an invisible wider hit area for easy targeting.
  */
 
 const SIDE_OFFSET_PCT = 0.22; // fraction along the path for side labels
@@ -45,6 +60,16 @@ export const TrunkEdge: FC<EdgeProps> = ({
   });
 
   const showLabels = linkData.showLabels !== false; // default on
+  const focusOpacity = linkData.focusOpacity ?? 1;
+  const hovered = linkData.hovered === true;
+
+  // Dashed stroke for discovered edges; otherwise inherit whatever
+  // the caller's style.strokeDasharray says (typically undefined → solid).
+  const finalStyle: React.CSSProperties = {
+    ...style,
+    opacity: focusOpacity,
+    ...(linkData.discovered ? { strokeDasharray: '6 4' } : {}),
+  };
 
   // Where the per-side labels sit. Linear interpolation along the
   // straight source→target vector — close enough for smoothstep paths
@@ -68,19 +93,31 @@ export const TrunkEdge: FC<EdgeProps> = ({
       <BaseEdge
         id={id}
         path={edgePath}
-        style={style}
+        style={finalStyle}
         markerEnd={markerEnd}
         markerStart={markerStart}
       />
       {showLabels && (
         <EdgeLabelRenderer>
           {linkData.sourceInterface && (
-            <EndLabel x={leftX} y={leftY} text={linkData.sourceInterface} />
+            <EndLabel x={leftX} y={leftY} text={linkData.sourceInterface} opacity={focusOpacity} />
           )}
-          {middleLabel && <MiddleLabel x={labelX} y={labelY} text={middleLabel} />}
+          {middleLabel && (
+            <MiddleLabel x={labelX} y={labelY} text={middleLabel} opacity={focusOpacity} />
+          )}
           {linkData.targetInterface && (
-            <EndLabel x={rightX} y={rightY} text={linkData.targetInterface} />
+            <EndLabel
+              x={rightX}
+              y={rightY}
+              text={linkData.targetInterface}
+              opacity={focusOpacity}
+            />
           )}
+        </EdgeLabelRenderer>
+      )}
+      {hovered && (
+        <EdgeLabelRenderer>
+          <EdgeTooltip x={labelX} y={labelY} data={linkData} />
         </EdgeLabelRenderer>
       )}
     </>
@@ -91,28 +128,79 @@ const labelBoxStyle =
   'absolute pointer-events-none px-1.5 py-0.5 rounded text-[10px] font-medium ' +
   'border border-white/10 bg-gray-950/90 text-gray-200 shadow-sm whitespace-nowrap';
 
-const EndLabel: FC<{ x: number; y: number; text: string }> = ({ x, y, text }) => (
+const EndLabel: FC<{ x: number; y: number; text: string; opacity: number }> = ({
+  x,
+  y,
+  text,
+  opacity,
+}) => (
   <div
     className={labelBoxStyle}
-    style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)` }}
+    style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)`, opacity }}
   >
     {text}
   </div>
 );
 
-const MiddleLabel: FC<{ x: number; y: number; text: string }> = ({ x, y, text }) => (
+const MiddleLabel: FC<{ x: number; y: number; text: string; opacity: number }> = ({
+  x,
+  y,
+  text,
+  opacity,
+}) => (
   <div
     className={`${labelBoxStyle} text-violet-200`}
-    style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)` }}
+    style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)`, opacity }}
   >
     {text}
   </div>
 );
+
+const EdgeTooltip: FC<{ x: number; y: number; data: LinkEdgeData }> = ({ x, y, data }) => {
+  const rows: [string, string][] = [];
+  if (data.sourceInterface || data.targetInterface) {
+    rows.push(['Interfaces', `${data.sourceInterface ?? '?'} ↔ ${data.targetInterface ?? '?'}`]);
+  }
+  if (data.vlans && data.vlans.length > 0) {
+    rows.push(['VLANs', data.vlans.join(', ')]);
+  }
+  if (data.speed) {
+    rows.push(['Speed', formatSpeed(data.speed)]);
+  }
+  if (data.duplex) {
+    rows.push(['Duplex', data.duplex]);
+  }
+  if (data.status) {
+    rows.push(['Status', data.status]);
+  }
+  if (data.linkType) {
+    rows.push(['Type', data.linkType]);
+  }
+  rows.push([
+    'Source',
+    data.discovered ? 'Discovered (LLDP/CDP/EDP/FDP)' : 'Declared (trunk_ports)',
+  ]);
+
+  return (
+    <div
+      className="absolute pointer-events-none rounded-lg border border-white/10 bg-gray-950/95 px-3 py-2 text-xs text-gray-200 shadow-lg z-50"
+      style={{ transform: `translate(-50%, calc(-100% - 12px)) translate(${x}px, ${y}px)` }}
+    >
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
+        {rows.map(([k, v]) => (
+          <div key={k} className="contents">
+            <span className="text-gray-500">{k}</span>
+            <span className="font-medium text-white">{v}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 function formatVlans(vlans: number[]): string {
   if (vlans.length === 0) return '';
   if (vlans.length === 1) return `VLAN ${vlans[0]}`;
-  // Compact contiguous runs: [1,2,3,5,6] → "1-3,5-6"
   const sorted = [...vlans].sort((a, b) => a - b);
   const runs: string[] = [];
   let start = sorted[0];

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -224,6 +224,7 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
     data.sourceInterface = link.sourceInterface;
     data.targetInterface = link.targetInterface;
     data.vlans = link.vlans;
+    data.discovered = link.discovered;
 
     const edgeColor = getEdgeColor(data);
     // Trunk + LAG links are bidirectional by nature (both sides send
@@ -253,6 +254,11 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
       },
       markerEnd: marker,
       ...(bidirectional ? { markerStart: marker } : {}),
+      // ReactFlow renders an invisible wider stroke for hit-testing;
+      // 20 px gives the user a comfortable target for hover-tooltips
+      // even on thin 2 px access links. Pan/zoom still works because
+      // ReactFlow only consumes events on actual edge hover/click.
+      interactionWidth: 20,
       data,
     };
   });

--- a/ui/src/pages/topology/types.ts
+++ b/ui/src/pages/topology/types.ts
@@ -35,6 +35,18 @@ export interface LinkEdgeData extends Record<string, unknown> {
   /** When false, the custom edge component hides all its labels —
    *  driven by the "Show labels" toggle in the topology header. */
   showLabels?: boolean;
+  /** True when the link was inferred from runtime LLDP/CDP/EDP/FDP
+   *  discovery (not declared in trunk_ports:). TrunkEdge renders
+   *  these dashed so the user can tell design from runtime. */
+  discovered?: boolean;
+  /** Opacity multiplier for the neighbourhood-highlight feature.
+   *  1 = fully opaque (default), 0.15 = faded background. Driven by
+   *  the selected-node state in TopologyPage. */
+  focusOpacity?: number;
+  /** True when this edge is currently being hovered. Driven by
+   *  ReactFlow's onEdgeMouseEnter / Leave at the page level; the
+   *  TrunkEdge component renders the rich tooltip while true. */
+  hovered?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
Layers six small navigation/UX wins onto the topology graph so it scales past a handful of devices without manual rearranging:

- **Search**: header `<input type=search>` filters devices by case-insensitive name substring; edges whose endpoints are filtered out collapse too.
- **Type-filter chips**: one chip per `device.type` present in the current graph; toggle to isolate routers / switches / etc., with a `Clear` shortcut when any filter is active.
- **Click-to-focus**: clicking a node selects its neighbourhood — that node + every adjacent node stay full opacity, everything else fades to 15 % (nodes) / 10 % (edges). Click again or use Reset to clear.
- **Reset button**: wipes saved drag positions, search, type filters, and focus back to defaults in one shot.
- **Edge hover tooltip**: hovering a link surfaces a rich tooltip with full interface names, speed/duplex/status, complete VLAN list, and a `Declared (trunk_ports)` vs `Discovered (LLDP/CDP/EDP/FDP)` source row. Hover state is lifted to the page via ReactFlow's `onEdgeMouseEnter`/`onEdgeMouseLeave` so we don't put mouse handlers on raw SVG paths (a11y rule), and ReactFlow's built-in `interactionWidth=20` gives a comfortable hit area even on thin access links.
- **Declared vs. discovered styling**: runtime-discovered edges render dashed (`strokeDasharray: '6 4'`) so the user can tell config-declared trunks from runtime-inferred adjacencies at a glance.

## Test plan
- [ ] Start any simulation with ≥3 devices and trunk_ports declared
- [ ] Type a device name fragment in the header search box — only matching devices and their edges remain
- [ ] Toggle a type chip — only that type renders; Clear resets
- [ ] Click a node — that node + its neighbours stay bright, others fade; click again to clear
- [ ] Drag a node, reload page — drag persists; click Reset — drag wipes
- [ ] Hover an edge — tooltip pops with full interface names + VLAN list + "Declared"/"Discovered" row
- [ ] Stop simulation and start one with LLDP/CDP active — those edges render dashed