### PR TITLE
fix(cmd): deprecate daemon --token flag and close signal-handler leak

### DIFF
--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -49,7 +49,15 @@ The web UI will be available at http://localhost:8080`,
 	daemonCmd.Flags().
 		StringVar(&options.listen, "listen", ":8080", "Address to listen on for API and web UI")
 	daemonCmd.Flags().
-		StringVar(&options.token, "token", "", "Bearer token for API authentication (RECOMMENDED for network-exposed instances)")
+		StringVar(&options.token, "token", "", "Bearer token for API authentication (DEPRECATED: use NIAC_API_TOKEN env var)")
+	// SECURITY FIX #409: the --token value lands in /proc/<pid>/cmdline and
+	// `ps` output. resolveAPIToken() already prefers NIAC_API_TOKEN; this
+	// flips the flag itself to a deprecation warning so future invocations
+	// migrate away. Mirrors the root command's --api-token treatment.
+	if err := daemonCmd.Flags().MarkDeprecated("token",
+		"the value lands in /proc/<pid>/cmdline and `ps`. Set NIAC_API_TOKEN in the environment instead."); err != nil {
+		panic(fmt.Errorf("mark --token deprecated: %w", err))
+	}
 	daemonCmd.Flags().
 		StringVar(&options.storagePath, "storage", "~/.niac/niac.db", "Path to run history database (use 'disabled' to disable)")
 	daemonCmd.Flags().

--- a/cmd/niac/main.go
+++ b/cmd/niac/main.go
@@ -829,6 +829,7 @@ func runSimulationLoop(
 ) error {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(sigChan)
 
 	var statsTicker *time.Ticker
 	var statsC <-chan time.Time


### PR DESCRIPTION
## Summary
Closes #409 (HIGH security) and #415 (HIGH defect).

**#409 — bearer token in process list.** The daemon's `--token` flag accepted the API bearer token as a CLI argument, leaving the value visible in `/proc/<pid>/cmdline` and `ps` output. `resolveAPIToken()` already preferred `NIAC_API_TOKEN`, so the runtime path was safe — but the flag itself was still happily accepting the unsafe input. This change marks `--token` deprecated via cobra's `MarkDeprecated`, mirroring the existing treatment of the root command's `--api-token` flag (`root.go:191`). Users get a one-line deprecation warning every time the flag is used, steering them to the env var.

**#415 — leaked signal handler.** Of the five `signal.Notify` call sites the issue called out, four (cmd_daemon.go, monitor.go, neighbors.go, logs.go) already pair their `Notify` with a `defer signal.Stop(sigChan)`. The only remaining one was `main.go:831` in `runSimulationLoop`, which leaks the channel registration after the loop returns. Added the defer.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/niac/...` passes
- [x] `golangci-lint run cmd/niac/...` 0 issues
- [ ] Smoke: `niac daemon --token x` should now print a deprecation warning
- [ ] Smoke: `NIAC_API_TOKEN=x niac daemon` should still authenticate without a CLI flag