### PR TITLE
feat(content): niac content install/list/update CLI (#548 PR 2)

### DIFF
--- a/cmd/niac/content.go
+++ b/cmd/niac/content.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krisarmstrong/niac-go/internal/content"
+	"github.com/krisarmstrong/niac-go/internal/library"
+)
+
+// addContentCommand wires `niac content {install,list,update}` onto
+// root. The bundle layout, library root resolution, and security
+// rules all live in internal/content + internal/library — this file is
+// the thin cobra glue.
+func addContentCommand(root *cobra.Command, _ *serviceOptions) {
+	contentCmd := &cobra.Command{
+		Use:   "content",
+		Short: "Install and inspect the on-disk content library",
+		Long: `Manage the content library that the daemon serves to the UI.
+
+The library lives at ~/.niac/library by default (or /var/lib/niac/library
+on packaged installs) and contains three sibling directories:
+
+  networks/   YAML network configs
+  walks/      SNMP walk files
+  pcaps/      packet captures
+
+Bundled content is published per release at:
+  https://github.com/krisarmstrong/niac-go/releases
+
+Use 'niac content install' to fetch and unpack the bundle matching the
+running daemon, or 'niac content install --bundle path.tar.gz' to install
+from a local mirror.`,
+	}
+
+	contentCmd.AddCommand(newContentInstallCmd())
+	contentCmd.AddCommand(newContentListCmd())
+	contentCmd.AddCommand(newContentUpdateCmd())
+	root.AddCommand(contentCmd)
+}
+
+func newContentInstallCmd() *cobra.Command {
+	var (
+		root         string
+		bundlePath   string
+		bundleURL    string
+		version      string
+		dryRun       bool
+		skipExisting bool
+	)
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install a content bundle into the library",
+		Long: `Install a versioned content bundle (gzip-tar) into the local library.
+
+Source resolution (first match wins):
+  --bundle <path>    Local tarball — useful for offline installs
+  --url <url>        Explicit HTTP(S) URL
+  --version <vX.Y.Z> Pull from the matching GitHub release
+  (default)          Pull the bundle for the running daemon's version
+
+The bundle's top-level directories must be one of: networks, walks,
+pcaps. Anything else is rejected. Each entry is re-rooted under
+<library>/<kind>/ before any file is touched, so a malicious bundle
+cannot escape the library.`,
+		Example: `  # Install the bundle matching this binary's version
+  niac content install
+
+  # Install from a local file (no network needed)
+  niac content install --bundle ./niac-content-v0.66.41.tar.gz
+
+  # Install a specific version into a custom root
+  niac content install --version v0.66.40 --root /var/lib/niac/library
+
+  # Preview what would be installed
+  niac content install --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runContentInstall(cmd.Context(), contentInstallArgs{
+				root:         root,
+				bundlePath:   bundlePath,
+				bundleURL:    bundleURL,
+				version:      version,
+				dryRun:       dryRun,
+				skipExisting: skipExisting,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&root, "root", "", "Library root (default: NIAC_LIBRARY_ROOT or ~/.niac/library)")
+	cmd.Flags().StringVar(&bundlePath, "bundle", "", "Local bundle file to install")
+	cmd.Flags().StringVar(&bundleURL, "url", "", "Explicit HTTP(S) URL to fetch the bundle from")
+	cmd.Flags().StringVar(&version, "version", "", "Release tag to pull (default: this binary's version)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would be installed without writing files")
+	cmd.Flags().BoolVar(&skipExisting, "skip-existing", false, "Skip files that already exist (default: overwrite)")
+	return cmd
+}
+
+type contentInstallArgs struct {
+	root, bundlePath, bundleURL, version string
+	dryRun, skipExisting                 bool
+}
+
+func runContentInstall(ctx context.Context, args contentInstallArgs) error {
+	libRoot := args.root
+	if libRoot == "" {
+		libRoot = library.DefaultRoot()
+	}
+	if _, err := library.Open(libRoot); err != nil {
+		return fmt.Errorf("prepare library at %s: %w", libRoot, err)
+	}
+
+	source, sourceLabel, cleanup, err := resolveBundleSource(ctx, args)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	defer source.Close()
+
+	fmt.Fprintf(os.Stdout, "Installing %s into %s\n", sourceLabel, libRoot)
+
+	manifest, err := content.Extract(source, libRoot, content.ExtractOptions{
+		DryRun:       args.dryRun,
+		SkipExisting: args.skipExisting,
+	})
+	if err != nil {
+		return fmt.Errorf("extract bundle: %w", err)
+	}
+
+	verb := "Installed"
+	if args.dryRun {
+		verb = "Would install"
+	}
+	fmt.Fprintf(os.Stdout, "%s %d files (%s) across %d directories\n",
+		verb, manifest.Files, content.HumanBytes(manifest.Bytes), manifest.Directories)
+	for _, kind := range library.AllKinds() {
+		if n := manifest.PerKind[kind]; n > 0 {
+			fmt.Fprintf(os.Stdout, "  %s: %d\n", kind, n)
+		}
+	}
+	return nil
+}
+
+// resolveBundleSource picks a source based on the install args and
+// returns its bytes alongside a human-friendly label and a cleanup
+// func that removes any temp file the remote-fetch path created.
+func resolveBundleSource(ctx context.Context, args contentInstallArgs) (io.ReadCloser, string, func(), error) {
+	if args.bundlePath != "" {
+		return openLocalBundle(args.bundlePath)
+	}
+	version := strings.TrimSpace(args.version)
+	if version == "" {
+		version = readVersionInfo().version
+	}
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return downloadBundle(ctx, version, args.bundleURL)
+}
+
+func openLocalBundle(path string) (io.ReadCloser, string, func(), error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", noopCleanup, fmt.Errorf("open --bundle %s: %w", path, err)
+	}
+	return f, path, noopCleanup, nil
+}
+
+func downloadBundle(ctx context.Context, version, explicitURL string) (io.ReadCloser, string, func(), error) {
+	res, err := content.Download(ctx, version, content.DownloadOptions{URL: explicitURL})
+	if err != nil {
+		return nil, "", noopCleanup, fmt.Errorf("download bundle: %w", err)
+	}
+	f, openErr := os.Open(res.Path)
+	if openErr != nil {
+		_ = os.Remove(res.Path)
+		return nil, "", noopCleanup, fmt.Errorf("reopen downloaded bundle: %w", openErr)
+	}
+	if !res.ChecksumOK {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", res.ChecksumReason)
+	}
+	label := fmt.Sprintf("bundle %s (%s)", version, content.HumanBytes(res.Bytes))
+	cleanup := func() { _ = os.Remove(res.Path) }
+	return f, label, cleanup, nil
+}
+
+func noopCleanup() {}
+
+func newContentListCmd() *cobra.Command {
+	var root string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List what's installed in the library",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			libRoot := root
+			if libRoot == "" {
+				libRoot = library.DefaultRoot()
+			}
+			inv, err := content.Scan(libRoot)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "Library root: %s\n", inv.Root)
+			fmt.Fprintf(os.Stdout, "%-12s %8s %12s\n", "Kind", "Files", "Size")
+			for _, k := range inv.Kinds {
+				fmt.Fprintf(os.Stdout, "%-12s %8d %12s\n", k.Kind, k.Files, content.HumanBytes(k.Bytes))
+			}
+			fmt.Fprintf(os.Stdout, "%-12s %8d %12s\n",
+				"TOTAL", inv.Total.Files, content.HumanBytes(inv.Total.Bytes))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&root, "root", "", "Library root (default: NIAC_LIBRARY_ROOT or ~/.niac/library)")
+	return cmd
+}
+
+func newContentUpdateCmd() *cobra.Command {
+	var (
+		root         string
+		dryRun       bool
+		skipExisting bool
+	)
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Re-install the bundle matching this binary's version",
+		Long: `Convenience wrapper for 'niac content install' that always pulls the
+bundle for the version the running niac binary was built from.
+
+This is the safest way to keep library content paired with the binary
+after upgrading via the system package manager:
+
+  sudo dnf upgrade niac
+  niac content update`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runContentInstall(cmd.Context(), contentInstallArgs{
+				root:         root,
+				dryRun:       dryRun,
+				skipExisting: skipExisting,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&root, "root", "", "Library root (default: NIAC_LIBRARY_ROOT or ~/.niac/library)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would change without writing files")
+	cmd.Flags().BoolVar(&skipExisting, "skip-existing", false, "Skip files that already exist (default: overwrite)")
+	return cmd
+}

--- a/cmd/niac/content.go
+++ b/cmd/niac/content.go
@@ -162,7 +162,13 @@ func resolveBundleSource(ctx context.Context, args contentInstallArgs) (io.ReadC
 }
 
 func openLocalBundle(path string) (io.ReadCloser, string, func(), error) {
-	f, err := os.Open(path)
+	// G304 waiver: path is the value of the operator-supplied --bundle
+	// flag. The whole point of the flag is to let the user point at a
+	// local tarball; the only file we're authorised to open is the one
+	// they pass. The user can already read whatever the process uid
+	// can read, so opening their chosen file gains them nothing they
+	// couldn't already do with `cat`.
+	f, err := os.Open(path) // #nosec G304
 	if err != nil {
 		return nil, "", noopCleanup, fmt.Errorf("open --bundle %s: %w", path, err)
 	}
@@ -174,7 +180,12 @@ func downloadBundle(ctx context.Context, version, explicitURL string) (io.ReadCl
 	if err != nil {
 		return nil, "", noopCleanup, fmt.Errorf("download bundle: %w", err)
 	}
-	f, openErr := os.Open(res.Path)
+	// G304 waiver: res.Path was created by content.Download() in the
+	// previous statement. It's either DownloadOptions.Dest (set by
+	// the install command above to our own tmp file) or an
+	// os.CreateTemp slot the download package just produced. In both
+	// cases the path is locally constructed, not user-controlled.
+	f, openErr := os.Open(res.Path) // #nosec G304
 	if openErr != nil {
 		_ = os.Remove(res.Path)
 		return nil, "", noopCleanup, fmt.Errorf("reopen downloaded bundle: %w", openErr)

--- a/cmd/niac/main.go
+++ b/cmd/niac/main.go
@@ -95,6 +95,7 @@ func main() {
 		addAnalyzeCommand,
 		addAnalyzePcapCommand,
 		addConfigCommand,
+		addContentCommand,
 		func(root *cobra.Command, _ *serviceOptions) { addDaemonCommand(root, info) },
 		addDumpCommand,
 		addInitCommand,

--- a/internal/content/download.go
+++ b/internal/content/download.go
@@ -142,7 +142,14 @@ func fetchTo(ctx context.Context, client *http.Client, url, dest string) (int64,
 	if mkErr := os.MkdirAll(filepath.Dir(dest), libraryDirMode); mkErr != nil {
 		return 0, "", fmt.Errorf("mkdir for %s: %w", dest, mkErr)
 	}
-	out, err := os.Create(dest)
+	// G304 waiver: dest is the destination path the caller chose for
+	// the download — either DownloadOptions.Dest (set programmatically
+	// in cmd/niac/content.go) or a freshly-created os.CreateTemp file
+	// from Download() above. In neither case is it ever taken from
+	// untrusted input. The fetched body, on the other hand, is
+	// untrusted — but it is bounded by the HTTP response and the
+	// caller is responsible for choosing a safe dest.
+	out, err := os.Create(dest) // #nosec G304
 	if err != nil {
 		return 0, "", fmt.Errorf("create %s: %w", dest, err)
 	}

--- a/internal/content/download.go
+++ b/internal/content/download.go
@@ -1,0 +1,188 @@
+package content
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Sentinel errors for the download path.
+var (
+	ErrChecksumMismatch = errors.New("downloaded bundle checksum does not match expected value")
+	ErrEmptyVersion     = errors.New("version is required to build the bundle URL")
+)
+
+// DefaultBundleURLTemplate is the GitHub releases pattern the install
+// command uses when --url is not given. Both %s slots take the version
+// tag (with leading 'v', e.g. "v0.66.41"). Callers wanting to redirect
+// to a private mirror should pass DownloadOptions.URL explicitly.
+const DefaultBundleURLTemplate = "https://github.com/krisarmstrong/niac-go/releases/download/%s/niac-content-%s.tar.gz"
+
+// DefaultChecksumURLTemplate sits next to the bundle and contains the
+// hex sha256 on its first whitespace-separated token (the format
+// `sha256sum` produces). Optional — if the file 404s, the install
+// proceeds without verification but warns the caller.
+const DefaultChecksumURLTemplate = "https://github.com/krisarmstrong/niac-go/releases/download/%s/niac-content-%s.tar.gz.sha256"
+
+// httpTimeout caps any single HTTP request the install path makes.
+// Walks bundles can hit a couple of hundred MB so we leave plenty of
+// room without going so high that a stuck server hangs the CLI forever.
+const httpTimeout = 10 * time.Minute
+
+// maxChecksumBytes bounds the sha256 sidecar read so a hostile server
+// can't stream gigabytes at us before we notice. Real sidecars are
+// ~70 bytes ("<64-hex>  <filename>\n"); 1 KiB is generous headroom.
+const maxChecksumBytes = 1 << 10
+
+// DownloadOptions tunes Download. Zero value uses the GitHub release
+// pattern + a fresh http.Client with httpTimeout.
+type DownloadOptions struct {
+	// URL overrides DefaultBundleURLTemplate. Useful for offline mirrors
+	// or local fixtures.
+	URL string
+	// ChecksumURL overrides DefaultChecksumURLTemplate.
+	ChecksumURL string
+	// Client lets tests inject a custom http.Client (e.g. one pointing
+	// at httptest.Server). nil → a fresh Client with httpTimeout.
+	Client *http.Client
+	// Dest is the file path the bundle is written to. nil → a temp file
+	// inside os.TempDir() that the caller is responsible for removing.
+	Dest string
+}
+
+// DownloadResult tells the caller where the bundle landed and whether
+// the checksum was verified.
+type DownloadResult struct {
+	Path           string
+	Bytes          int64
+	ChecksumOK     bool
+	ChecksumReason string // empty when verified, populated on skip/failure
+}
+
+// Download fetches the bundle for the given version into a local file.
+// When the matching .sha256 sidecar is reachable, its hash is checked
+// against the downloaded bytes; mismatch returns ErrChecksumMismatch
+// and removes the partial file.
+func Download(ctx context.Context, version string, opts DownloadOptions) (DownloadResult, error) {
+	if version == "" {
+		return DownloadResult{}, ErrEmptyVersion
+	}
+
+	bundleURL := opts.URL
+	if bundleURL == "" {
+		bundleURL = fmt.Sprintf(DefaultBundleURLTemplate, version, version)
+	}
+	checksumURL := opts.ChecksumURL
+	if checksumURL == "" {
+		checksumURL = fmt.Sprintf(DefaultChecksumURLTemplate, version, version)
+	}
+
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: httpTimeout}
+	}
+
+	dest := opts.Dest
+	if dest == "" {
+		f, err := os.CreateTemp("", "niac-content-*.tar.gz")
+		if err != nil {
+			return DownloadResult{}, fmt.Errorf("create temp bundle file: %w", err)
+		}
+		dest = f.Name()
+		_ = f.Close()
+	}
+
+	bytes, sum, err := fetchTo(ctx, client, bundleURL, dest)
+	if err != nil {
+		_ = os.Remove(dest)
+		return DownloadResult{}, err
+	}
+
+	res := DownloadResult{Path: dest, Bytes: bytes}
+
+	expected, err := fetchChecksum(ctx, client, checksumURL)
+	switch {
+	case errors.Is(err, errChecksumNotFound):
+		res.ChecksumReason = "no checksum sidecar published; bundle was not verified"
+	case err != nil:
+		res.ChecksumReason = fmt.Sprintf("could not fetch checksum: %v", err)
+	case !strings.EqualFold(expected, sum):
+		_ = os.Remove(dest)
+		return DownloadResult{}, fmt.Errorf("%w: got %s, want %s", ErrChecksumMismatch, sum, expected)
+	default:
+		res.ChecksumOK = true
+	}
+	return res, nil
+}
+
+// fetchTo streams a GET to dest while computing sha256 in the same
+// pass — single read of the body, single write to disk.
+func fetchTo(ctx context.Context, client *http.Client, url, dest string) (int64, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, "", fmt.Errorf("build request for %s: %w", url, err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, "", fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+
+	if mkErr := os.MkdirAll(filepath.Dir(dest), libraryDirMode); mkErr != nil {
+		return 0, "", fmt.Errorf("mkdir for %s: %w", dest, mkErr)
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		return 0, "", fmt.Errorf("create %s: %w", dest, err)
+	}
+	defer out.Close()
+
+	hasher := sha256.New()
+	n, err := io.Copy(io.MultiWriter(out, hasher), resp.Body)
+	if err != nil {
+		return 0, "", fmt.Errorf("download body: %w", err)
+	}
+	return n, hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+var errChecksumNotFound = errors.New("checksum sidecar not found")
+
+func fetchChecksum(ctx context.Context, client *http.Client, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", errChecksumNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxChecksumBytes))
+	if err != nil {
+		return "", fmt.Errorf("read checksum: %w", err)
+	}
+	// `sha256sum` format: "<hex>  filename\n". Take the first whitespace
+	// token; tolerates a bare-hex file too.
+	first := strings.Fields(strings.TrimSpace(string(body)))
+	if len(first) == 0 {
+		return "", errors.New("checksum file is empty")
+	}
+	return first[0], nil
+}

--- a/internal/content/download_test.go
+++ b/internal/content/download_test.go
@@ -1,0 +1,117 @@
+package content_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/content"
+)
+
+func TestDownloadHonoursChecksum(t *testing.T) {
+	body := []byte("synthetic-bundle-bytes")
+	sum := sha256.Sum256(body)
+	hexSum := hex.EncodeToString(sum[:])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bundle.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	})
+	mux.HandleFunc("/bundle.tar.gz.sha256", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(hexSum + "  bundle.tar.gz\n"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dest := tmpDestPath(t)
+	res, err := content.Download(context.Background(), "v0.0.1-test", content.DownloadOptions{
+		URL:         srv.URL + "/bundle.tar.gz",
+		ChecksumURL: srv.URL + "/bundle.tar.gz.sha256",
+		Dest:        dest,
+		Client:      srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if !res.ChecksumOK {
+		t.Errorf("checksum should have verified, reason: %q", res.ChecksumReason)
+	}
+	if res.Bytes != int64(len(body)) {
+		t.Errorf("byte count: got %d want %d", res.Bytes, len(body))
+	}
+}
+
+func TestDownloadDetectsChecksumMismatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bundle.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("payload-A"))
+	})
+	mux.HandleFunc("/bundle.tar.gz.sha256", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("0", 64) + "  bundle.tar.gz\n"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dest := tmpDestPath(t)
+	_, err := content.Download(context.Background(), "v0.0.1-test", content.DownloadOptions{
+		URL:         srv.URL + "/bundle.tar.gz",
+		ChecksumURL: srv.URL + "/bundle.tar.gz.sha256",
+		Dest:        dest,
+		Client:      srv.Client(),
+	})
+	if !errors.Is(err, content.ErrChecksumMismatch) {
+		t.Fatalf("want ErrChecksumMismatch, got %v", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Errorf("partial file was not cleaned up: %v", statErr)
+	}
+}
+
+func TestDownloadProceedsWhenChecksumMissing(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bundle.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("payload"))
+	})
+	// no sha256 route → 404
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dest := tmpDestPath(t)
+	res, err := content.Download(context.Background(), "v0.0.1-test", content.DownloadOptions{
+		URL:         srv.URL + "/bundle.tar.gz",
+		ChecksumURL: srv.URL + "/bundle.tar.gz.sha256",
+		Dest:        dest,
+		Client:      srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if res.ChecksumOK {
+		t.Error("ChecksumOK should be false when sidecar is missing")
+	}
+	if res.ChecksumReason == "" {
+		t.Error("ChecksumReason should explain why verification was skipped")
+	}
+}
+
+func TestDownloadRequiresVersion(t *testing.T) {
+	_, err := content.Download(context.Background(), "", content.DownloadOptions{})
+	if !errors.Is(err, content.ErrEmptyVersion) {
+		t.Fatalf("want ErrEmptyVersion, got %v", err)
+	}
+}
+
+// tmpDestPath returns an absolute path inside t.TempDir() that does
+// NOT yet exist on disk, suitable as Download.Dest. We avoid
+// os.CreateTemp here so the download path can create the file fresh.
+func tmpDestPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "bundle.tar.gz")
+}

--- a/internal/content/extract.go
+++ b/internal/content/extract.go
@@ -1,0 +1,278 @@
+// Package content owns the on-disk content bundle: download, verify,
+// extract, and inventory. The bundle is a gzip-compressed tar that
+// mirrors the library layout (networks/, walks/, pcaps/) and is
+// extracted into a library root resolved by internal/library.
+//
+// Two CLI surfaces consume this package:
+//
+//   - `niac content install` (cmd/niac/content.go) — local or remote
+//     install of the versioned bundle.
+//   - The daemon's POST /api/v1/library/install handler (PR 3) —
+//     UI uploads of the same tarball format.
+//
+// Security: every path coming out of the tarball is normalised and
+// re-rooted under <library>/<kind>/ before any file is touched, so a
+// crafted bundle can't drop files outside the library or follow a
+// symlink to /etc/passwd.
+package content
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/krisarmstrong/niac-go/internal/library"
+)
+
+// Sentinel errors callers can match on.
+var (
+	ErrUnknownKind     = errors.New("entry references an unknown library kind")
+	ErrPathEscape      = errors.New("entry path escapes the library root")
+	ErrUnsafeFileMode  = errors.New("entry would have been created with an unsafe mode")
+	ErrUnsupportedType = errors.New("entry is neither a regular file nor a directory")
+	ErrEntryTooLarge   = errors.New("entry exceeds the maximum allowed size")
+	ErrBundleTooLarge  = errors.New("bundle exceeds the maximum total uncompressed size")
+)
+
+// Extraction caps. Picked to fit the largest realistic bundle (≈1.2 GB
+// of sanitised walks per the issue) with headroom, while still
+// preventing a malicious tar from filling the disk.
+const (
+	maxEntrySize  int64 = 256 << 20 // 256 MiB per file
+	maxBundleSize int64 = 4 << 30   // 4 GiB total uncompressed
+)
+
+// topLevelKindParts is the SplitN count used to peel the "kind/"
+// prefix off a tar entry path: 2 → ["networks", "rest/of/path"].
+const topLevelKindParts = 2
+
+// ExtractOptions tunes Extract behaviour. The zero value is the
+// sensible default: extract everything, overwrite existing files,
+// don't dry-run.
+type ExtractOptions struct {
+	// DryRun reports what would be installed without touching the disk.
+	DryRun bool
+	// SkipExisting flips the default overwrite-on-conflict behaviour to
+	// "skip existing files" (additive merge). The zero value (false)
+	// overwrites, so reinstalling a newer bundle replaces older
+	// content — which is what `niac content update` wants.
+	SkipExisting bool
+}
+
+// Manifest summarises an extraction. Returned by Extract; printed by
+// `niac content install` so the user sees what landed.
+type Manifest struct {
+	Files       int
+	Directories int
+	Bytes       int64
+	// PerKind reports the count of entries dropped under each library
+	// kind directory. Useful for the install summary line.
+	PerKind map[library.Kind]int
+}
+
+// Extract reads a gzip-tar bundle from r and writes its contents into
+// libRoot/<kind>/<entry-path>. Top-level directories in the tar must
+// be one of the known library kinds (networks/, walks/, pcaps/);
+// anything else is rejected with ErrUnknownKind.
+func Extract(r io.Reader, libRoot string, opts ExtractOptions) (Manifest, error) {
+	abs, absErr := filepath.Abs(libRoot)
+	if absErr != nil {
+		return Manifest{}, fmt.Errorf("resolve library root: %w", absErr)
+	}
+
+	gz, gzErr := gzip.NewReader(r)
+	if gzErr != nil {
+		return Manifest{}, fmt.Errorf("open gzip stream: %w", gzErr)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	manifest := Manifest{PerKind: map[library.Kind]int{}}
+	overwrite := !opts.SkipExisting
+
+	var totalBytes int64
+	for {
+		hdr, hdrErr := tr.Next()
+		if errors.Is(hdrErr, io.EOF) {
+			break
+		}
+		if hdrErr != nil {
+			return manifest, fmt.Errorf("read tar entry: %w", hdrErr)
+		}
+
+		if procErr := processEntry(tr, hdr, abs, opts, overwrite, &manifest, &totalBytes); procErr != nil {
+			return manifest, procErr
+		}
+	}
+
+	return manifest, nil
+}
+
+// processEntry handles a single tar entry: resolves its destination,
+// validates type/size, and writes it (unless DryRun). Pulled out of
+// Extract to keep the loop body under the cognitive-complexity cap.
+func processEntry(
+	tr *tar.Reader,
+	hdr *tar.Header,
+	libRoot string,
+	opts ExtractOptions,
+	overwrite bool,
+	manifest *Manifest,
+	totalBytes *int64,
+) error {
+	dest, kind, skipReason, err := resolveEntryPath(libRoot, hdr.Name)
+	if err != nil {
+		return err
+	}
+	if skipReason != "" {
+		// Entries like the bare "networks/" directory header carry no
+		// payload and don't need to land on disk — ensureLayout already
+		// created them. Silently skip.
+		return nil
+	}
+
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		if !opts.DryRun {
+			if mkErr := os.MkdirAll(dest, libraryDirMode); mkErr != nil {
+				return fmt.Errorf("mkdir %s: %w", dest, mkErr)
+			}
+		}
+		manifest.Directories++
+		return nil
+
+	case tar.TypeReg:
+		if hdr.Size < 0 || hdr.Size > maxEntrySize {
+			return fmt.Errorf("%w: %s is %d bytes", ErrEntryTooLarge, hdr.Name, hdr.Size)
+		}
+		*totalBytes += hdr.Size
+		if *totalBytes > maxBundleSize {
+			return fmt.Errorf("%w (running total %d bytes)", ErrBundleTooLarge, *totalBytes)
+		}
+		if !opts.DryRun {
+			if writeErr := writeFile(dest, tr, hdr.Size, overwrite); writeErr != nil {
+				return writeErr
+			}
+		}
+		manifest.Files++
+		manifest.Bytes += hdr.Size
+		manifest.PerKind[kind]++
+		return nil
+
+	default:
+		return fmt.Errorf("%w: %s (typeflag %d)", ErrUnsupportedType, hdr.Name, hdr.Typeflag)
+	}
+}
+
+// resolveEntryPath validates a tar entry path against the library
+// layout and returns its on-disk destination plus the kind it belongs
+// to. A non-empty skipReason means the entry is structurally valid but
+// carries no payload worth writing (e.g. the bare "networks/" header).
+func resolveEntryPath(libRoot, name string) (string, library.Kind, string, error) {
+	clean := strings.TrimPrefix(filepath.ToSlash(name), "./")
+	clean = strings.TrimPrefix(clean, "/")
+	if clean == "" || clean == "." {
+		return "", "", "empty entry name", nil
+	}
+
+	if pathEscapes(clean) {
+		return "", "", "", fmt.Errorf("%w: %s", ErrPathEscape, name)
+	}
+
+	parts := strings.SplitN(clean, "/", topLevelKindParts)
+	top := parts[0]
+	kind, knownKind := matchKind(top)
+	if !knownKind {
+		return "", "", "", fmt.Errorf("%w: top-level %q from entry %q", ErrUnknownKind, top, name)
+	}
+
+	if len(parts) == 1 {
+		// Bare kind directory header, no payload.
+		return "", kind, "bare kind directory", nil
+	}
+
+	dest := filepath.Join(libRoot, top, filepath.FromSlash(parts[1]))
+	prefix := filepath.Join(libRoot, top) + string(filepath.Separator)
+	if !strings.HasPrefix(dest+string(filepath.Separator), prefix) && dest != filepath.Join(libRoot, top) {
+		return "", "", "", fmt.Errorf("%w: %s resolved to %s", ErrPathEscape, name, dest)
+	}
+	return dest, kind, "", nil
+}
+
+// pathEscapes returns true when the normalised tar entry path contains
+// a `..` component that would let it leave its kind directory.
+func pathEscapes(clean string) bool {
+	if clean == ".." {
+		return true
+	}
+	if strings.HasPrefix(clean, "../") {
+		return true
+	}
+	if strings.Contains(clean, "/../") {
+		return true
+	}
+	return strings.HasSuffix(clean, "/..")
+}
+
+func matchKind(top string) (library.Kind, bool) {
+	for _, k := range library.AllKinds() {
+		if string(k) == top {
+			return k, true
+		}
+	}
+	return "", false
+}
+
+// writeFile creates or overwrites dest with size bytes from r. Always
+// writes via a temp file in the same dir then atomically renames so a
+// crash mid-extract leaves the previous version intact.
+func writeFile(dest string, r io.Reader, size int64, overwrite bool) error {
+	if !overwrite {
+		if _, statErr := os.Stat(dest); statErr == nil {
+			return nil
+		}
+	}
+
+	if mkErr := os.MkdirAll(filepath.Dir(dest), libraryDirMode); mkErr != nil {
+		return fmt.Errorf("mkdir parent of %s: %w", dest, mkErr)
+	}
+
+	tmp, createErr := os.CreateTemp(filepath.Dir(dest), ".content-*.tmp")
+	if createErr != nil {
+		return fmt.Errorf("create temp for %s: %w", dest, createErr)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, copyErr := io.CopyN(tmp, r, size); copyErr != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("copy bytes for %s: %w", dest, copyErr)
+	}
+	if chmodErr := tmp.Chmod(libraryFileMode); chmodErr != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp for %s: %w", dest, chmodErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		cleanup()
+		return fmt.Errorf("close temp for %s: %w", dest, closeErr)
+	}
+	if renameErr := os.Rename(tmpPath, dest); renameErr != nil {
+		cleanup()
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, dest, renameErr)
+	}
+	return nil
+}
+
+// File modes for files/dirs we create. Match internal/library so the
+// extracted content sits comfortably alongside hand-dropped files.
+const (
+	libraryDirMode  = 0o755
+	libraryFileMode = 0o644
+)

--- a/internal/content/extract.go
+++ b/internal/content/extract.go
@@ -116,6 +116,15 @@ func Extract(r io.Reader, libRoot string, opts ExtractOptions) (Manifest, error)
 // processEntry handles a single tar entry: resolves its destination,
 // validates type/size, and writes it (unless DryRun). Pulled out of
 // Extract to keep the loop body under the cognitive-complexity cap.
+//
+// The path-traversal defence is layered: resolveEntryPath rejects any
+// entry that escapes (../ / leading /) and rebuilds the destination
+// under libRoot/<kind>/. Then directly before each filesystem call we
+// re-derive the cleaned absolute path and confirm it still has
+// libRoot as its prefix. The second check is redundant on a correct
+// resolveEntryPath but lives at the syscall site so CodeQL's
+// zip-slip query and any future reviewer can see the protection
+// inline without chasing the call graph.
 func processEntry(
 	tr *tar.Reader,
 	hdr *tar.Header,
@@ -136,11 +145,16 @@ func processEntry(
 		return nil
 	}
 
+	safeDest, safeErr := ensureUnderRoot(libRoot, dest)
+	if safeErr != nil {
+		return safeErr
+	}
+
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		if !opts.DryRun {
-			if mkErr := os.MkdirAll(dest, libraryDirMode); mkErr != nil {
-				return fmt.Errorf("mkdir %s: %w", dest, mkErr)
+			if mkErr := os.MkdirAll(safeDest, libraryDirMode); mkErr != nil {
+				return fmt.Errorf("mkdir %s: %w", safeDest, mkErr)
 			}
 		}
 		manifest.Directories++
@@ -155,7 +169,7 @@ func processEntry(
 			return fmt.Errorf("%w (running total %d bytes)", ErrBundleTooLarge, *totalBytes)
 		}
 		if !opts.DryRun {
-			if writeErr := writeFile(dest, tr, hdr.Size, overwrite); writeErr != nil {
+			if writeErr := writeFile(libRoot, safeDest, tr, hdr.Size, overwrite); writeErr != nil {
 				return writeErr
 			}
 		}
@@ -167,6 +181,19 @@ func processEntry(
 	default:
 		return fmt.Errorf("%w: %s (typeflag %d)", ErrUnsupportedType, hdr.Name, hdr.Typeflag)
 	}
+}
+
+// ensureUnderRoot is the inline zip-slip guard. Takes the resolved
+// destination and re-verifies it still resolves under libRoot after
+// filepath.Clean strips any . or .. components. Returns the cleaned
+// path on success.
+func ensureUnderRoot(libRoot, dest string) (string, error) {
+	clean := filepath.Clean(dest)
+	rootClean := filepath.Clean(libRoot) + string(filepath.Separator)
+	if !strings.HasPrefix(clean+string(filepath.Separator), rootClean) {
+		return "", fmt.Errorf("%w: %s resolved outside %s", ErrPathEscape, dest, libRoot)
+	}
+	return clean, nil
 }
 
 // resolveEntryPath validates a tar entry path against the library
@@ -196,11 +223,11 @@ func resolveEntryPath(libRoot, name string) (string, library.Kind, string, error
 		return "", kind, "bare kind directory", nil
 	}
 
+	// Build the destination under <libRoot>/<kind>/; the inline
+	// ensureUnderRoot check at every syscall site is what actually
+	// enforces the boundary, so we don't duplicate the prefix check
+	// here.
 	dest := filepath.Join(libRoot, top, filepath.FromSlash(parts[1]))
-	prefix := filepath.Join(libRoot, top) + string(filepath.Separator)
-	if !strings.HasPrefix(dest+string(filepath.Separator), prefix) && dest != filepath.Join(libRoot, top) {
-		return "", "", "", fmt.Errorf("%w: %s resolved to %s", ErrPathEscape, name, dest)
-	}
 	return dest, kind, "", nil
 }
 
@@ -231,7 +258,16 @@ func matchKind(top string) (library.Kind, bool) {
 // writeFile creates or overwrites dest with size bytes from r. Always
 // writes via a temp file in the same dir then atomically renames so a
 // crash mid-extract leaves the previous version intact.
-func writeFile(dest string, r io.Reader, size int64, overwrite bool) error {
+//
+// libRoot is passed solely so we can re-verify dest is still under it
+// inline — defence-in-depth for the path-traversal check that already
+// ran in resolveEntryPath / ensureUnderRoot. The cost is one extra
+// HasPrefix per file; the upside is that any future caller can't
+// bypass the guard by skipping the intermediate validators.
+func writeFile(libRoot, dest string, r io.Reader, size int64, overwrite bool) error {
+	if _, err := ensureUnderRoot(libRoot, dest); err != nil {
+		return err
+	}
 	if !overwrite {
 		if _, statErr := os.Stat(dest); statErr == nil {
 			return nil

--- a/internal/content/extract_test.go
+++ b/internal/content/extract_test.go
@@ -1,0 +1,241 @@
+package content_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/content"
+)
+
+// maxEntrySize mirrors the package-internal cap. Duplicated rather
+// than exported because the cap is an implementation choice the
+// callers shouldn't see, but the oversized-entry test needs to build
+// a header just over it.
+const maxEntrySize int64 = 256 << 20
+
+// tarballEntry is the minimal description of a file we want present in
+// a synthesised test bundle. Body is empty for directories.
+type tarballEntry struct {
+	name string
+	body string
+	dir  bool
+}
+
+func buildTarball(t *testing.T, entries []tarballEntry) []byte {
+	t.Helper()
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name: e.name,
+			Mode: 0o644,
+			Size: int64(len(e.body)),
+		}
+		if e.dir {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Size = 0
+		} else {
+			hdr.Typeflag = tar.TypeReg
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if !e.dir {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("write tar body: %v", err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gz: %v", err)
+	}
+	return raw.Bytes()
+}
+
+func TestExtractRejectsPathTraversal(t *testing.T) {
+	cases := []string{
+		"../escape.yaml",
+		"networks/../../../etc/passwd",
+		"networks/../escape.yaml",
+		"./../escape.yaml",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			tarball := buildTarball(t, []tarballEntry{{name: name, body: "x"}})
+			tmp := t.TempDir()
+			_, err := content.Extract(bytes.NewReader(tarball), tmp, content.ExtractOptions{})
+			if !errors.Is(err, content.ErrPathEscape) && !errors.Is(err, content.ErrUnknownKind) {
+				t.Fatalf("expected ErrPathEscape or ErrUnknownKind for %q, got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestExtractRejectsUnknownTopLevel(t *testing.T) {
+	tarball := buildTarball(t, []tarballEntry{
+		{name: "secrets/passwd", body: "root:x:0:0::/:/bin/sh"},
+	})
+	_, err := content.Extract(bytes.NewReader(tarball), t.TempDir(), content.ExtractOptions{})
+	if !errors.Is(err, content.ErrUnknownKind) {
+		t.Fatalf("expected ErrUnknownKind, got %v", err)
+	}
+}
+
+func TestExtractAcceptsValidBundle(t *testing.T) {
+	tarball := buildTarball(t, []tarballEntry{
+		{name: "networks/", dir: true},
+		{name: "networks/example.yaml", body: "devices: []\n"},
+		{name: "walks/router.walk", body: "1.3.6.1 = STRING: \"x\"\n"},
+		{name: "pcaps/sample.pcap", body: "fake-pcap-bytes"},
+	})
+	root := t.TempDir()
+	manifest, err := content.Extract(bytes.NewReader(tarball), root, content.ExtractOptions{})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if manifest.Files != 3 {
+		t.Errorf("files: got %d want 3", manifest.Files)
+	}
+	if manifest.PerKind["networks"] != 1 {
+		t.Errorf("networks count: got %d want 1", manifest.PerKind["networks"])
+	}
+	for _, rel := range []string{"networks/example.yaml", "walks/router.walk", "pcaps/sample.pcap"} {
+		if _, statErr := os.Stat(filepath.Join(root, rel)); statErr != nil {
+			t.Errorf("expected %s on disk: %v", rel, statErr)
+		}
+	}
+}
+
+func TestExtractDryRunWritesNothing(t *testing.T) {
+	tarball := buildTarball(t, []tarballEntry{
+		{name: "networks/x.yaml", body: "x"},
+	})
+	root := t.TempDir()
+	manifest, err := content.Extract(bytes.NewReader(tarball), root, content.ExtractOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if manifest.Files != 1 {
+		t.Errorf("manifest still counts the file: got %d", manifest.Files)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "networks/x.yaml")); !os.IsNotExist(statErr) {
+		t.Errorf("dry run wrote a file: %v", statErr)
+	}
+}
+
+func TestExtractSkipExistingPreservesFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "networks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	preExisting := filepath.Join(root, "networks", "x.yaml")
+	if err := os.WriteFile(preExisting, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tarball := buildTarball(t, []tarballEntry{{name: "networks/x.yaml", body: "FROM_BUNDLE"}})
+	opts := content.ExtractOptions{SkipExisting: true}
+	if _, err := content.Extract(bytes.NewReader(tarball), root, opts); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(preExisting)
+	if string(got) != "ORIGINAL" {
+		t.Errorf("SkipExisting did not preserve original: got %q", got)
+	}
+
+	if _, err := content.Extract(bytes.NewReader(tarball), root, content.ExtractOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = os.ReadFile(preExisting)
+	if string(got) != "FROM_BUNDLE" {
+		t.Errorf("default overwrite did not replace original: got %q", got)
+	}
+}
+
+func TestExtractRejectsOversizedEntry(t *testing.T) {
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     "networks/huge.yaml",
+		Typeflag: tar.TypeReg,
+		Size:     maxEntrySize + 1,
+		Mode:     0o644,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Logf("close tar (expected error since bytes were not written): %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gz: %v", err)
+	}
+	_, err := content.Extract(bytes.NewReader(raw.Bytes()), t.TempDir(), content.ExtractOptions{})
+	if !errors.Is(err, content.ErrEntryTooLarge) {
+		t.Fatalf("want ErrEntryTooLarge, got %v", err)
+	}
+}
+
+func TestExtractRejectsSymlinkEntries(t *testing.T) {
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     "networks/link",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/etc/passwd",
+		Mode:     0o644,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gz: %v", err)
+	}
+	_, err := content.Extract(bytes.NewReader(raw.Bytes()), t.TempDir(), content.ExtractOptions{})
+	if !errors.Is(err, content.ErrUnsupportedType) {
+		t.Fatalf("want ErrUnsupportedType, got %v", err)
+	}
+}
+
+func TestExtractRoundTripPreservesContent(t *testing.T) {
+	want := "name: example\ndevices: []\n"
+	tarball := buildTarball(t, []tarballEntry{{name: "networks/x.yaml", body: want}})
+	root := t.TempDir()
+	if _, err := content.Extract(bytes.NewReader(tarball), root, content.ExtractOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "networks/x.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("round-trip mismatch.\n want %q\n  got %q", want, got)
+	}
+}
+
+// Sanity: the test helper itself should produce a valid bundle.
+func TestBuildTarballYieldsValidGzip(t *testing.T) {
+	bs := buildTarball(t, []tarballEntry{{name: "networks/x.yaml", body: "x"}})
+	gz, err := gzip.NewReader(bytes.NewReader(bs))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	if _, readErr := io.ReadAll(gz); readErr != nil {
+		t.Fatalf("read all: %v", readErr)
+	}
+}

--- a/internal/content/inventory.go
+++ b/internal/content/inventory.go
@@ -1,0 +1,91 @@
+package content
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/krisarmstrong/niac-go/internal/library"
+)
+
+// Inventory is the per-kind summary `niac content list` prints. One
+// entry per library kind, even when zero files are present, so the
+// output table always has the same shape.
+type Inventory struct {
+	Root  string
+	Kinds []KindStats
+	Total KindStats
+}
+
+// KindStats is the count + size of files under a single library kind.
+type KindStats struct {
+	Kind  library.Kind
+	Files int
+	Bytes int64
+}
+
+// Scan walks the library at root and returns per-kind file counts and
+// byte totals. A missing kind subdir is treated as empty; any other
+// error surfaces so the caller knows the inventory is incomplete
+// instead of silently under-reporting.
+func Scan(root string) (Inventory, error) {
+	abs, absErr := filepath.Abs(root)
+	if absErr != nil {
+		return Inventory{}, fmt.Errorf("resolve library root: %w", absErr)
+	}
+
+	inv := Inventory{Root: abs}
+	for _, kind := range library.AllKinds() {
+		stats := KindStats{Kind: kind}
+		dir := filepath.Join(abs, string(kind))
+
+		walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, perEntryErr error) error {
+			if perEntryErr != nil {
+				if os.IsNotExist(perEntryErr) && path == dir {
+					// Library subdir hasn't been created yet — treat as empty.
+					return filepath.SkipDir
+				}
+				return fmt.Errorf("walk entry %s: %w", path, perEntryErr)
+			}
+			if d.IsDir() {
+				return nil
+			}
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return fmt.Errorf("stat entry %s: %w", path, infoErr)
+			}
+			stats.Files++
+			stats.Bytes += info.Size()
+			return nil
+		})
+		if walkErr != nil {
+			return inv, fmt.Errorf("walk %s: %w", dir, walkErr)
+		}
+
+		inv.Kinds = append(inv.Kinds, stats)
+		inv.Total.Files += stats.Files
+		inv.Total.Bytes += stats.Bytes
+	}
+	return inv, nil
+}
+
+// HumanBytes renders a byte count in a compact human-friendly form
+// (1.2 GB, 340 MB, 18 KB). Used by the CLI list output. Kept here so
+// both the CLI and any future API handler share the same formatting.
+func HumanBytes(n int64) string {
+	suffixes := []struct {
+		threshold int64
+		unit      string
+	}{
+		{1 << 40, "TB"},
+		{1 << 30, "GB"},
+		{1 << 20, "MB"},
+		{1 << 10, "KB"},
+	}
+	for _, s := range suffixes {
+		if n >= s.threshold {
+			return fmt.Sprintf("%.1f %s", float64(n)/float64(s.threshold), s.unit)
+		}
+	}
+	return fmt.Sprintf("%d B", n)
+}


### PR DESCRIPTION
## Summary
Second leg of the on-disk library plan from #548. PR 1 ([e7fc7f2](https://github.com/krisarmstrong/niac-go/commit/e7fc7f2)) put the library plumbing on disk; this PR adds the CLI users will run to populate it without dragging files by hand.

## New surfaces

\`\`\`
niac content install [--bundle path | --url url | --version vX.Y.Z]
                     [--root <path>] [--dry-run] [--skip-existing]
niac content list    [--root <path>]
niac content update  [--root <path>] [--dry-run] [--skip-existing]
\`\`\`

Source resolution for \`install\` (first match wins):
1. \`--bundle <path>\` — local tarball (offline-friendly)
2. \`--url <url>\` — explicit HTTP(S)
3. \`--version <vX.Y.Z>\` — pull from the matching GitHub release
4. (default) — pull the bundle for the running binary's version

## internal/content package

Shared between this CLI and the future UI upload handler (#548 PR 3).

- **\`extract.go\`** — gzip-tar reader with strict path-traversal protection. Every entry is normalised, rejected if it tries to escape via \`..\`, and re-rooted under \`<library>/<kind>/\` before any file is touched. Top-level dirs must match \`library.AllKinds()\` (\`networks\`, \`walks\`, \`pcaps\`); anything else returns \`ErrUnknownKind\`. Caps: 256 MiB per entry, 4 GiB per bundle. Symlinks are rejected. Writes go through \`os.CreateTemp\` + \`os.Rename\` so a crashed extract leaves the previous version intact.
- **\`download.go\`** — HTTP GET with single-pass sha256, matching the \`.tar.gz.sha256\` sidecar that niac releases publish. Mismatch returns \`ErrChecksumMismatch\` + partial-file cleanup. Sidecar 404 is non-fatal but surfaces \`ChecksumReason\` so the CLI can warn. 10-min request timeout; 1 KiB cap on the sidecar read.
- **\`inventory.go\`** — walks \`<root>/{networks,walks,pcaps}\` and returns per-kind file count + bytes for \`niac content list\`.

## Tests

Cover: path-traversal (4 variants), unknown top-level, oversized entry, symlink rejection, dry-run, skip-existing vs. overwrite, round-trip preservation, checksum match/mismatch/missing, and empty-version validation. All in \`content_test\` (external) package per the testpackage lint rule.

## Why this ships before the release-tarball pipeline

\`--bundle\` and \`--url\` paths work today for offline + mirror installs, which is enough to validate the CLI end-to-end. The default-URL path is ready the moment we cut the first content release (separate work, captured under #548 PR 3 design notes).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/content/... ./cmd/niac/...\` passes
- [x] \`golangci-lint run ./internal/content/... ./cmd/niac/...\` 0 issues
- [x] Smoke: \`niac content --help\`, \`niac content install --help\` render correctly
- [ ] Smoke: extract a hand-built tarball into a temp dir with \`niac content install --bundle <file> --root <tmp>\`
- [ ] Smoke: \`niac content list --root <tmp>\` shows the installed files

Refs: #548