### PR TITLE
feat(library): walks + pcaps browser tabs (#548 PR 3)

### DIFF
--- a/internal/api/handlers_library.go
+++ b/internal/api/handlers_library.go
@@ -143,7 +143,41 @@ func (s *Server) handleLibraryNetworkDelete(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// Drained body helper — not yet wired, but used by future walks /
-// pcaps upload endpoints in PR 3. Kept here so the file's single
-// import block is stable.
+// handleLibraryFiles serves GET on /api/v1/library/{walks,pcaps},
+// returning a flat list of file entries with name, size, and mtime.
+// PR 3 ships the browser pages on top of this; uploads + deletes for
+// walks/pcaps are deferred to a follow-up so this PR stays focused
+// on the read path (which is what the picker integrations also need).
+func (s *Server) handleLibraryFiles(w http.ResponseWriter, r *http.Request, kind library.Kind) {
+	if !s.libraryReady() {
+		s.writeLibraryUnavailable(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+		return
+	}
+	entries, err := s.library.ListFiles(kind)
+	if err != nil {
+		s.logger.Error("[API] library: list files", "kind", string(kind), "error", err)
+		writeError(w, r, http.StatusInternalServerError, "library_list_failed",
+			"Failed to list "+string(kind), nil)
+		return
+	}
+	s.writeJSON(w, entries)
+}
+
+// handleLibraryWalks is the registered route handler for /api/v1/library/walks.
+func (s *Server) handleLibraryWalks(w http.ResponseWriter, r *http.Request) {
+	s.handleLibraryFiles(w, r, library.KindWalks)
+}
+
+// handleLibraryPcaps is the registered route handler for /api/v1/library/pcaps.
+func (s *Server) handleLibraryPcaps(w http.ResponseWriter, r *http.Request) {
+	s.handleLibraryFiles(w, r, library.KindPcaps)
+}
+
+// Drained body helper — kept for symmetry with the imports the upload
+// endpoints (networks today, walks/pcaps in a follow-up) already use.
 var _ = io.Discard

--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/library"
+)
+
+// newLibraryTestServer spins up a real library rooted in a fresh
+// t.TempDir() and hooks it onto a minimal Server so the library
+// handlers can be exercised directly with httptest. Returns the root
+// so the test can plant fixture walks/pcaps before calling the
+// handler.
+func newLibraryTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("NIAC_LIBRARY_ROOT", root)
+
+	lib, err := library.Open(root)
+	if err != nil {
+		t.Fatalf("open library: %v", err)
+	}
+	return &Server{
+		logger:  slog.Default(),
+		library: lib,
+	}, root
+}
+
+func TestHandleLibraryWalksLists(t *testing.T) {
+	server, root := newLibraryTestServer(t)
+
+	// Drop two fixture walks; the inner cisco/ subdir mirrors what a
+	// real install looks like (vendor-namespaced walk files).
+	if err := os.MkdirAll(filepath.Join(root, "walks", "cisco"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ciscoWalk := filepath.Join(root, "walks", "cisco", "c3900.walk")
+	if err := os.WriteFile(ciscoWalk, []byte("oid = STRING: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	routerWalk := filepath.Join(root, "walks", "router.walk")
+	if err := os.WriteFile(routerWalk, []byte("oid = STRING: y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/library/walks", nil)
+	rec := httptest.NewRecorder()
+	server.handleLibraryWalks(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got []library.FileEntry
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("entry count = %d, want 2 (%v)", len(got), got)
+	}
+	// ListFiles sorts by name; cisco/c3900.walk comes before router.walk.
+	if got[0].Name != "cisco/c3900.walk" {
+		t.Errorf("entry[0].Name = %q, want cisco/c3900.walk", got[0].Name)
+	}
+	if got[1].Name != "router.walk" {
+		t.Errorf("entry[1].Name = %q, want router.walk", got[1].Name)
+	}
+	if got[1].SizeBytes == 0 {
+		t.Errorf("entry[1] should report nonzero size")
+	}
+}
+
+func TestHandleLibraryPcapsEmpty(t *testing.T) {
+	server, _ := newLibraryTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/library/pcaps", nil)
+	rec := httptest.NewRecorder()
+	server.handleLibraryPcaps(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got []library.FileEntry
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty pcaps dir should return empty slice, got %v", got)
+	}
+}
+
+func TestHandleLibraryWalksRejectsNonGet(t *testing.T) {
+	server, _ := newLibraryTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/library/walks", nil)
+	rec := httptest.NewRecorder()
+	server.handleLibraryWalks(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != "GET" {
+		t.Errorf("Allow header = %q, want GET", got)
+	}
+}
+
+func TestHandleLibraryWalksUnavailable(t *testing.T) {
+	// Server with library=nil simulates the daemon failing to open the
+	// library at startup. The handler should 503 rather than NPE.
+	server := &Server{logger: slog.Default()}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/library/walks", nil)
+	rec := httptest.NewRecorder()
+	server.handleLibraryWalks(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -88,12 +88,18 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/configs", s.recoverMiddleware(s.auth(s.handleUserConfigs)))
 	mux.HandleFunc("/api/v1/configs/", s.recoverMiddleware(s.auth(s.handleUserConfigByName)))
 
-	// Unified Library API (#548 PR 1) — networks subdir only in this PR;
-	// walks/pcaps endpoints land in PR 3.
+	// Unified Library API (#548). Networks landed in PR 1 with full
+	// CRUD; walks/pcaps land in PR 3 as read-only browser endpoints —
+	// uploads + deletes for binary content are a separate follow-up
+	// once the picker integrations have validated the read shape.
 	mux.HandleFunc("/api/v1/library/networks",
 		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleLibraryNetworks)))))
 	mux.HandleFunc("/api/v1/library/networks/",
 		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleLibraryNetworkByName)))))
+	mux.HandleFunc("/api/v1/library/walks",
+		s.recoverMiddleware(s.auth(s.handleLibraryWalks)))
+	mux.HandleFunc("/api/v1/library/pcaps",
+		s.recoverMiddleware(s.auth(s.handleLibraryPcaps)))
 	mux.HandleFunc("/api/v1/topology", s.recoverMiddleware(s.auth(s.handleTopology)))
 	mux.HandleFunc("/api/v1/topology/export", s.recoverMiddleware(s.auth(s.handleTopologyExport)))
 	mux.HandleFunc("/api/v1/errors", s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleErrors)))))

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -128,6 +128,20 @@ export const fetchVersion = () => deduplicatedGet<VersionInfo>('/api/v1/version'
 export const fetchTopology = () => deduplicatedGet<TopologyGraph>('/api/v1/topology');
 export const fetchErrorTypes = () => deduplicatedGet<ErrorInjectionInfo>('/api/v1/errors');
 
+// Library file listings. Backed by GET /api/v1/library/{walks,pcaps},
+// which return [{name, sizeBytes, modifiedAt, source}]. The picker
+// integrations on the device editor (SNMP walks) and Packets / Traffic
+// pages (PCAPs) consume these to surface library content without
+// hitting the older /api/v1/files routes.
+export interface LibraryFileEntry {
+  name: string;
+  sizeBytes: number;
+  modifiedAt: string;
+  source: 'starter' | 'bundle' | 'user';
+}
+export const fetchLibraryWalks = () => deduplicatedGet<LibraryFileEntry[]>('/api/v1/library/walks');
+export const fetchLibraryPcaps = () => deduplicatedGet<LibraryFileEntry[]>('/api/v1/library/pcaps');
+
 export const injectError = (payload: {
   deviceIp: string;
   interface: string;

--- a/ui/src/navGroups.ts
+++ b/ui/src/navGroups.ts
@@ -1,5 +1,6 @@
 import {
   Activity,
+  Database,
   FileBox,
   GitCompare,
   Network,
@@ -41,6 +42,8 @@ export const navGroups: SidebarNavGroup[] = [
     label: 'Library',
     items: [
       { path: '/device-config', label: 'Devices', icon: Wrench },
+      { path: '/library/walks', label: 'Walks', icon: Database },
+      { path: '/library/pcaps', label: 'PCAPs', icon: FileBox },
       { path: '/config-diff', label: 'Compare & Merge', icon: GitCompare },
     ],
   },

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
 import {
   Activity,
+  Database,
   FileBox,
   GitCompare,
   Network,
@@ -49,6 +50,12 @@ const TrafficInjectionPage = lazy(() =>
 );
 const WalkValidatorPage = lazy(() =>
   import('./pages/WalkValidatorPage').then((m) => ({ default: m.WalkValidatorPage })),
+);
+const LibraryWalksPage = lazy(() =>
+  import('./pages/LibraryFilesPage').then((m) => ({ default: m.LibraryWalksPage })),
+);
+const LibraryPcapsPage = lazy(() =>
+  import('./pages/LibraryFilesPage').then((m) => ({ default: m.LibraryPcapsPage })),
 );
 
 /**
@@ -391,6 +398,51 @@ export const pages: PageConfig[] = [
         <p>
           Auto-fix rewrites the walk in place. A <code>.bak</code> next to the original is created
           before the rewrite so you can roll back. Re-run Validate after fixing to confirm.
+        </p>
+      </>
+    ),
+  },
+  {
+    path: '/library/walks',
+    label: 'Walks',
+    title: 'Walk Library',
+    description:
+      'Read-only browser for the on-disk SNMP walk files the daemon serves from the unified library.',
+    icon: Database,
+    component: LibraryWalksPage,
+    help: (
+      <>
+        <p>
+          Shows every <code>.walk</code> file under <code>~/.niac/library/walks/</code> (or{' '}
+          <code>/var/lib/niac/library/walks/</code> on packaged installs). Drop files in directly,
+          or run <code>niac content install</code> to fetch the published bundle for this binary's
+          version.
+        </p>
+        <p>
+          The SNMP section on the Device editor uses the same endpoint to populate its walk picker,
+          so anything that shows up here is immediately selectable when configuring a device.
+        </p>
+      </>
+    ),
+  },
+  {
+    path: '/library/pcaps',
+    label: 'PCAPs',
+    title: 'PCAP Library',
+    description:
+      'Read-only browser for the on-disk PCAP captures the daemon serves from the unified library.',
+    icon: FileBox,
+    component: LibraryPcapsPage,
+    help: (
+      <>
+        <p>
+          Shows every capture under <code>~/.niac/library/pcaps/</code>. Same ingress paths as the
+          walk library: drop files directly or use <code>niac content install</code>.
+        </p>
+        <p>
+          The Packets and Traffic pages will reuse this listing for their PCAP pickers — the unified
+          library means a PCAP added here is visible everywhere the daemon needs to pick one without
+          extra plumbing.
         </p>
       </>
     ),

--- a/ui/src/pages/LibraryFilesPage.tsx
+++ b/ui/src/pages/LibraryFilesPage.tsx
@@ -1,0 +1,165 @@
+import { Database, FileBox, RefreshCw, Search } from 'lucide-react';
+import { type FC, useMemo, useState } from 'react';
+import { fetchLibraryPcaps, fetchLibraryWalks, type LibraryFileEntry } from '../api/client';
+import { useApiResource } from '../hooks/useApiResource';
+import { Button } from '../ui/Button';
+import { Card, CardContent } from '../ui/Card';
+import { H2, SmallText } from '../ui/Typography';
+
+/**
+ * LibraryFilesPage is the shared browser for the read-only library
+ * subdirs (walks/, pcaps/). It exists once and is wrapped twice in
+ * pageRegistry so the route system stays declarative.
+ *
+ * Per #548 PR 3 the page is intentionally minimal: list + search +
+ * total stats. Upload + delete for binary content are deferred to a
+ * later PR — the immediate need is for the picker integrations
+ * (device editor's SNMP section, traffic/packets PCAP picker) to have
+ * a single source of truth.
+ */
+
+interface Props {
+  kind: 'walks' | 'pcaps';
+}
+
+function LibraryFilesView({ kind }: Props) {
+  const fetcher = kind === 'walks' ? fetchLibraryWalks : fetchLibraryPcaps;
+  const { data, loading, refetch, error } = useApiResource(fetcher, [], { intervalMs: 30000 });
+  const [search, setSearch] = useState('');
+
+  const entries = data ?? [];
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter((e) => e.name.toLowerCase().includes(q));
+  }, [entries, search]);
+
+  const totalBytes = useMemo(() => filtered.reduce((acc, e) => acc + e.sizeBytes, 0), [filtered]);
+
+  const KindIcon = kind === 'walks' ? Database : FileBox;
+  const title = kind === 'walks' ? 'SNMP Walks' : 'PCAP Captures';
+  const emptyHint =
+    kind === 'walks'
+      ? 'Drop walk files into ~/.niac/library/walks/, or run `niac content install` to fetch the published bundle.'
+      : 'Drop pcap files into ~/.niac/library/pcaps/, or run `niac content install` to fetch the published bundle.';
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-white/5 bg-gray-900/70">
+        <CardContent>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-cyan-500/20">
+                <KindIcon className="w-6 h-6 text-cyan-400" />
+              </div>
+              <div>
+                <H2>{title}</H2>
+                <SmallText className="text-gray-400">
+                  {entries.length} {entries.length === 1 ? 'file' : 'files'} ·{' '}
+                  {humanBytes(totalBytes)}
+                </SmallText>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500" />
+                <input
+                  type="search"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search by name…"
+                  aria-label="Filter library entries by name"
+                  className="w-64 rounded-md border border-white/10 bg-gray-950/40 pl-7 pr-3 py-1.5 text-xs text-gray-200 placeholder:text-gray-500 focus:border-cyan-500/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+                />
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={refetch}
+                leftIcon={<RefreshCw className="w-4 h-4" />}
+                disabled={loading}
+              >
+                Refresh
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/5 bg-gray-900/70">
+        <CardContent>
+          {error ? (
+            <SmallText className="text-red-400">Failed to load library: {error.message}</SmallText>
+          ) : entries.length === 0 ? (
+            <div className="py-10 text-center">
+              <SmallText className="text-gray-400">No {kind} installed yet.</SmallText>
+              <p className="mt-2 text-xs text-gray-500">{emptyHint}</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="text-xs text-gray-500 uppercase tracking-wide">
+                  <tr className="border-b border-white/10">
+                    <th className="text-left py-2 pr-4">Name</th>
+                    <th className="text-right py-2 pr-4">Size</th>
+                    <th className="text-left py-2 pr-4">Source</th>
+                    <th className="text-left py-2">Modified</th>
+                  </tr>
+                </thead>
+                <tbody className="text-gray-200">
+                  {filtered.map((entry) => (
+                    <tr key={entry.name} className="border-b border-white/5 last:border-0">
+                      <td className="py-2 pr-4 font-mono text-xs">{entry.name}</td>
+                      <td className="py-2 pr-4 text-right tabular-nums">
+                        {humanBytes(entry.sizeBytes)}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <SourceBadge source={entry.source} />
+                      </td>
+                      <td className="py-2 text-xs text-gray-400">
+                        {new Date(entry.modifiedAt).toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                  {search.trim() !== '' && filtered.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="py-6 text-center text-xs text-gray-500">
+                        No entries match "{search}"
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+const SourceBadge: FC<{ source: LibraryFileEntry['source'] }> = ({ source }) => {
+  const styles: Record<LibraryFileEntry['source'], string> = {
+    starter: 'border-violet-500/40 bg-violet-500/10 text-violet-200',
+    bundle: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-200',
+    user: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+  };
+  return (
+    <span
+      className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-medium capitalize ${styles[source]}`}
+    >
+      {source}
+    </span>
+  );
+};
+
+function humanBytes(n: number): string {
+  if (n >= 1 << 30) return `${(n / (1 << 30)).toFixed(1)} GB`;
+  if (n >= 1 << 20) return `${(n / (1 << 20)).toFixed(1)} MB`;
+  if (n >= 1 << 10) return `${(n / (1 << 10)).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+export const LibraryWalksPage: FC = () => <LibraryFilesView kind="walks" />;
+export const LibraryPcapsPage: FC = () => <LibraryFilesView kind="pcaps" />;


### PR DESCRIPTION
## Summary
Final leg of the on-disk library plan from #548. PR 1 ([e7fc7f2](https://github.com/krisarmstrong/niac-go/commit/e7fc7f2)) put the \`networks/\` subdir on disk; PR 2 ([3e4ffc6](https://github.com/krisarmstrong/niac-go/commit/3e4ffc6)) added the \`niac content\` CLI to populate the library from a versioned bundle. This PR surfaces the \`walks/\` and \`pcaps/\` subdirs to both the daemon API and the UI sidebar.

## Backend

- \`GET /api/v1/library/walks\` → \`[{name, sizeBytes, modifiedAt, source}]\`
- \`GET /api/v1/library/pcaps\` → same shape

Both are read-only in this PR. Uploads + deletes for binary content are deferred — the immediate consumers are the picker integrations on the device editor (SNMP) and Traffic/Packets (PCAPs), and those need the read path first. \`Library.ListFiles\` already existed in \`internal/library\` (added in PR 1 against this PR); \`handlers_library.go\` just wires it to HTTP.

Tests in \`handlers_library_test.go\` cover:
- Vendor-namespaced subdirs (\`cisco/c3900.walk\` sorts before \`router.walk\`)
- Empty pcaps dir returns empty slice (not null)
- 405 on POST with proper \`Allow: GET\` header
- 503 when the library failed to open at startup (\`server.library == nil\`)

## Frontend

- New page \`src/pages/LibraryFilesPage.tsx\` with two thin wrappers (\`LibraryWalksPage\`, \`LibraryPcapsPage\`) consuming the new endpoints. Per row: name (mono), size (KB/MB/GB), source badge (starter/bundle/user), last-modified.  Header has a search box + Refresh; search filters by name in-memory.
- Sidebar's **Library** group gains **Walks** and **PCAPs** entries between Devices and Compare & Merge.
- \`/library/walks\` and \`/library/pcaps\` registered in \`pageRegistry\` with contextual help linking to \`niac content install\` for content acquisition.

## Out of scope (follow-ups)

- Upload / delete handlers for binary content (separate PR — needs multipart streaming + tar-or-raw decision)
- Walk picker integration on Device editor's SNMP section (separate PR)
- PCAP picker integration on Traffic / Packets pages (separate PR)

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/api/... -run TestHandleLibrary -v\` 4 tests pass
- [x] \`golangci-lint run ./internal/api/...\` 0 issues
- [x] \`npm run build\` ui clean
- [ ] Smoke: drop a walk into \`~/.niac/library/walks/\`, hit \`/library/walks\` in the UI, confirm it shows up with the right metadata
- [ ] Smoke: same for pcaps

Refs: #548