### PR TITLE
test(library): cover open/list/read/write/delete + metadata + name validation

### DIFF
--- a/internal/library/library_test.go
+++ b/internal/library/library_test.go
@@ -1,0 +1,297 @@
+package library_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/library"
+)
+
+// sampleYAML is the minimum YAML the WriteNetwork validator accepts:
+// it must contain a "devices:" section. Body is otherwise irrelevant.
+const sampleYAML = `# Description: example test network
+# Use Case: integration testing
+devices:
+  - name: r1
+    type: router
+`
+
+// openTempLibrary returns a fresh Library rooted at t.TempDir(). The
+// starter pack auto-unpacks into networks/ on first Open. Tests that
+// want a fully empty library should call ListNetworks → DeleteNetwork
+// for every entry, or simply work around the starter content.
+func openTempLibrary(t *testing.T) *library.Library {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("NIAC_LIBRARY_ROOT", root)
+	lib, err := library.Open(root)
+	if err != nil {
+		t.Fatalf("open library: %v", err)
+	}
+	return lib
+}
+
+func TestOpenCreatesLayout(t *testing.T) {
+	root := t.TempDir()
+	if _, err := library.Open(root); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for _, sub := range []string{"networks", "walks", "pcaps"} {
+		info, err := os.Stat(filepath.Join(root, sub))
+		if err != nil {
+			t.Errorf("expected subdir %s: %v", sub, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s is not a directory", sub)
+		}
+	}
+}
+
+func TestOpenBootstrapsStarterPack(t *testing.T) {
+	lib := openTempLibrary(t)
+	entries, err := lib.ListNetworks()
+	if err != nil {
+		t.Fatalf("list networks: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected starter pack to unpack into networks/, got 0 entries")
+	}
+	starterCount := 0
+	for _, e := range entries {
+		if e.Source == library.SourceStarter {
+			starterCount++
+		}
+	}
+	if starterCount == 0 {
+		t.Errorf("expected at least one SourceStarter entry, got %d entries with no starter source", len(entries))
+	}
+}
+
+func TestOpenSkipsBootstrapWhenNetworksHasContent(t *testing.T) {
+	root := t.TempDir()
+	// Pre-create networks/ with a user file before Open. Bootstrap
+	// must NOT touch that dir.
+	if err := os.MkdirAll(filepath.Join(root, "networks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userFile := filepath.Join(root, "networks", "user.yaml")
+	if err := os.WriteFile(userFile, []byte(sampleYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lib, err := library.Open(root)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	entries, err := lib.ListNetworks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only the user file should be present; the starter pack should
+	// have been skipped.
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 entry (the pre-existing user file), got %d: %v", len(entries), entries)
+	}
+	if entries[0].Name != "user" {
+		t.Errorf("expected name=user, got %s", entries[0].Name)
+	}
+	if entries[0].Source != library.SourceUser {
+		t.Errorf("expected source=user, got %s", entries[0].Source)
+	}
+}
+
+func TestWriteNetworkRoundTrip(t *testing.T) {
+	lib := openTempLibrary(t)
+	if err := lib.WriteNetwork("my-net", sampleYAML); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	doc, err := lib.ReadNetwork("my-net")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if doc.Name != "my-net" {
+		t.Errorf("name: got %q want my-net", doc.Name)
+	}
+	if !strings.Contains(doc.Content, "devices:") {
+		t.Errorf("content roundtrip lost devices: section: %q", doc.Content)
+	}
+	if doc.Format != "yaml" {
+		t.Errorf("format: got %q want yaml", doc.Format)
+	}
+}
+
+func TestWriteNetworkRejectsInvalidName(t *testing.T) {
+	lib := openTempLibrary(t)
+	cases := []string{
+		"../escape",
+		"with/slash",
+		".hidden",
+		"",
+		"has space",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := lib.WriteNetwork(name, sampleYAML)
+			if !errors.Is(err, library.ErrInvalidName) {
+				t.Errorf("want ErrInvalidName for %q, got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestWriteNetworkRejectsEmptyOrBrokenContent(t *testing.T) {
+	lib := openTempLibrary(t)
+	if err := lib.WriteNetwork("empty", ""); !errors.Is(err, library.ErrEmptyContent) {
+		t.Errorf("empty: want ErrEmptyContent, got %v", err)
+	}
+	// Missing the required `devices:` section is treated as
+	// effectively empty so the picker doesn't surface broken rows.
+	if err := lib.WriteNetwork("no-devices", "# just a comment\n"); !errors.Is(err, library.ErrEmptyContent) {
+		t.Errorf("no devices: want ErrEmptyContent, got %v", err)
+	}
+}
+
+func TestReadNetworkMissing(t *testing.T) {
+	lib := openTempLibrary(t)
+	_, err := lib.ReadNetwork("does-not-exist")
+	if !errors.Is(err, library.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestReadNetworkInvalidName(t *testing.T) {
+	lib := openTempLibrary(t)
+	_, err := lib.ReadNetwork("../etc/passwd")
+	if !errors.Is(err, library.ErrInvalidName) {
+		t.Errorf("want ErrInvalidName, got %v", err)
+	}
+}
+
+func TestDeleteNetworkRefusesStarter(t *testing.T) {
+	lib := openTempLibrary(t)
+	entries, err := lib.ListNetworks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var starter string
+	for _, e := range entries {
+		if e.Source == library.SourceStarter {
+			starter = e.Name
+			break
+		}
+	}
+	if starter == "" {
+		t.Skip("no starter networks present; nothing to test")
+	}
+	err = lib.DeleteNetwork(starter)
+	if err == nil {
+		t.Fatalf("expected starter delete to be refused, got nil")
+	}
+	if !strings.Contains(err.Error(), "starter") {
+		t.Errorf("error should mention starter, got %v", err)
+	}
+}
+
+func TestDeleteNetworkRemovesUserFile(t *testing.T) {
+	lib := openTempLibrary(t)
+	if err := lib.WriteNetwork("doomed", sampleYAML); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.DeleteNetwork("doomed"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := lib.ReadNetwork("doomed"); !errors.Is(err, library.ErrNotFound) {
+		t.Errorf("after delete, expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestListFilesWalksAndPcaps(t *testing.T) {
+	lib := openTempLibrary(t)
+	root := lib.Root()
+
+	// Plant fixtures under walks/ (with one vendor subdir) and pcaps/.
+	if err := os.MkdirAll(filepath.Join(root, "walks", "cisco"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	walks := map[string]string{
+		"walks/cisco/c3900.walk": "1.3.6.1 = STRING: x\n",
+		"walks/router.walk":      "1.3.6.1 = STRING: y\n",
+	}
+	for rel, body := range walks {
+		path := filepath.Join(root, rel)
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pcap := filepath.Join(root, "pcaps", "sample.pcap")
+	if err := os.WriteFile(pcap, []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	walkEntries, err := lib.ListFiles(library.KindWalks)
+	if err != nil {
+		t.Fatalf("list walks: %v", err)
+	}
+	if len(walkEntries) != 2 {
+		t.Errorf("walks count = %d, want 2 (%v)", len(walkEntries), walkEntries)
+	}
+	// Sorted by name; cisco/ subdir comes before bare files.
+	if walkEntries[0].Name != "cisco/c3900.walk" {
+		t.Errorf("walks[0] = %s, want cisco/c3900.walk", walkEntries[0].Name)
+	}
+
+	pcapEntries, err := lib.ListFiles(library.KindPcaps)
+	if err != nil {
+		t.Fatalf("list pcaps: %v", err)
+	}
+	if len(pcapEntries) != 1 || pcapEntries[0].Name != "sample.pcap" {
+		t.Errorf("pcaps = %v, want [sample.pcap]", pcapEntries)
+	}
+}
+
+func TestListFilesRejectsNetworksKind(t *testing.T) {
+	lib := openTempLibrary(t)
+	_, err := lib.ListFiles(library.KindNetworks)
+	if !errors.Is(err, library.ErrUnsupportedKind) {
+		t.Errorf("want ErrUnsupportedKind for KindNetworks, got %v", err)
+	}
+}
+
+func TestDefaultRootHonoursEnv(t *testing.T) {
+	t.Setenv("NIAC_LIBRARY_ROOT", "/tmp/custom-niac-library-root")
+	got := library.DefaultRoot()
+	if got != "/tmp/custom-niac-library-root" {
+		t.Errorf("DefaultRoot = %q, want /tmp/custom-niac-library-root", got)
+	}
+}
+
+func TestSubDir(t *testing.T) {
+	lib := openTempLibrary(t)
+	root := lib.Root()
+
+	walksDir := lib.SubDir(library.KindWalks)
+	if !strings.HasSuffix(walksDir, "walks") {
+		t.Errorf("SubDir(walks) = %q, want suffix walks", walksDir)
+	}
+	if !strings.HasPrefix(walksDir, root) {
+		t.Errorf("SubDir(walks) = %q must be under root %q", walksDir, root)
+	}
+}
+
+func TestAllKindsStability(t *testing.T) {
+	got := library.AllKinds()
+	want := []library.Kind{library.KindNetworks, library.KindWalks, library.KindPcaps}
+	if len(got) != len(want) {
+		t.Fatalf("AllKinds len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("AllKinds[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/library/metadata_internal_test.go
+++ b/internal/library/metadata_internal_test.go
@@ -1,0 +1,127 @@
+package library
+
+import "testing"
+
+// metadata.go's parseHeaderMetadata is package-private; tested from
+// inside the package since the API surface (NetworkEntry.Description /
+// NetworkEntry.UseCase) folds many edge cases together. Tested
+// directly so each parsing branch is hit deterministically.
+
+func TestParseHeaderMetadataExplicitFields(t *testing.T) {
+	content := []byte(`# Description: Three-router lab
+# Use Case: Verify OSPF area boundary
+# Some other note
+devices:
+  - name: r1
+`)
+	desc, uc := parseHeaderMetadata(content)
+	if desc != "Three-router lab" {
+		t.Errorf("description = %q, want Three-router lab", desc)
+	}
+	if uc != "Verify OSPF area boundary" {
+		t.Errorf("use case = %q, want Verify OSPF area boundary", uc)
+	}
+}
+
+func TestParseHeaderMetadataFallsBackToFirstComment(t *testing.T) {
+	// No explicit Description: line — first non-empty comment wins.
+	content := []byte(`# Quick smoke test
+# Use Case: Just a sanity run
+devices:
+`)
+	desc, uc := parseHeaderMetadata(content)
+	if desc != "Quick smoke test" {
+		t.Errorf("description = %q, want Quick smoke test", desc)
+	}
+	if uc != "Just a sanity run" {
+		t.Errorf("use case = %q, want Just a sanity run", uc)
+	}
+}
+
+func TestParseHeaderMetadataIgnoresBody(t *testing.T) {
+	// Comments inside the YAML body should NOT pollute metadata —
+	// scanning stops at the first non-comment line.
+	content := []byte(`# Real header line
+devices:
+  # this comment is inside the body and must be ignored
+  - name: r1
+`)
+	desc, _ := parseHeaderMetadata(content)
+	if desc != "Real header line" {
+		t.Errorf("description = %q, want Real header line", desc)
+	}
+}
+
+func TestParseHeaderMetadataEmpty(t *testing.T) {
+	desc, uc := parseHeaderMetadata(nil)
+	if desc != "" || uc != "" {
+		t.Errorf("nil content: desc=%q, uc=%q (want both empty)", desc, uc)
+	}
+	desc, uc = parseHeaderMetadata([]byte(""))
+	if desc != "" || uc != "" {
+		t.Errorf("empty content: desc=%q, uc=%q (want both empty)", desc, uc)
+	}
+}
+
+func TestParseHeaderMetadataPrefixIsCaseInsensitive(t *testing.T) {
+	// matchPrefix lowercases both sides; verify a lowercase header
+	// still gets picked up. Documented behaviour — there's a real
+	// "# description: …" line in the wild from converted templates.
+	content := []byte(`# description: ospf transit
+devices:
+`)
+	desc, _ := parseHeaderMetadata(content)
+	if desc != "ospf transit" {
+		t.Errorf("description = %q, want ospf transit", desc)
+	}
+}
+
+func TestIsYAMLFilename(t *testing.T) {
+	cases := map[string]bool{
+		"foo.yaml":  true,
+		"foo.yml":   true,
+		"FOO.YAML":  false, // case-sensitive on purpose; daemon writes lowercase
+		"foo.json":  false,
+		"":          false,
+		"foo":       false,
+		"foo.yaml/": false,
+	}
+	for name, want := range cases {
+		if got := isYAMLFilename(name); got != want {
+			t.Errorf("isYAMLFilename(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestValidateName(t *testing.T) {
+	// Validates the rules documented on the validateName helper:
+	// only [a-zA-Z0-9._-]; no slashes, no leading dot, no ".." anywhere.
+	ok := []string{
+		"foo",
+		"foo-bar",
+		"foo_bar",
+		"foo.bar",
+		"a1B2c3",
+		"3-router-network",
+	}
+	bad := []string{
+		"",
+		".hidden",
+		"..",
+		"../escape",
+		"a/b",
+		"a\\b",
+		"has space",
+		"emoji-🥲",
+	}
+	for _, n := range ok {
+		if err := validateName(n); err != nil {
+			t.Errorf("validateName(%q) unexpected error: %v", n, err)
+		}
+	}
+	for _, n := range bad {
+		if err := validateName(n); err == nil {
+			t.Errorf("validateName(%q) should have errored", n)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Closes #382.

\`internal/library\` shipped in #549 with zero test files. This PR fills that gap (0% → 80.7% package coverage) and verifies the overall line-weighted coverage is now 55.1% — well above the 40% minimum that #382 called out.

## What's covered

**External tests** (\`library_test.go\` in \`package library_test\`):
- \`Open\` creates the three-subdir layout
- \`Open\` auto-bootstraps the starter pack on an empty \`networks/\`
- \`Open\` leaves a populated \`networks/\` strictly alone
- \`WriteNetwork\` → \`ReadNetwork\` round-trip preserves content
- \`WriteNetwork\` rejects path-traversal / slashes / leading-dot / empty / spaces
- \`WriteNetwork\` rejects empty content + content missing \`devices:\` section
- \`ReadNetwork\` missing → \`ErrNotFound\`; bad name → \`ErrInvalidName\`
- \`DeleteNetwork\` refuses starter sources, removes user files cleanly
- \`ListFiles\` for walks (with vendor subdir) + pcaps; rejects \`KindNetworks\`
- \`DefaultRoot\` honours \`NIAC_LIBRARY_ROOT\` env
- \`SubDir\` / \`Root\` / \`AllKinds\` spot checks

**Internal tests** (\`metadata_internal_test.go\` in \`package library\`):
- \`parseHeaderMetadata\` explicit Description / Use Case lines
- Falls back to first non-empty comment when Description missing
- Stops at first non-comment line (body comments ignored)
- Case-insensitive prefix matching
- \`isYAMLFilename\` boundary cases (.yaml, .yml, .YAML, .json, empty)
- \`validateName\` positive + negative cases

## Coverage proof

\`\`\`
$ go test -cover ./internal/library/...
ok  github.com/krisarmstrong/niac-go/internal/library  0.027s  coverage: 80.7% of statements

$ go tool cover -func=/tmp/total.cov | tail -1
total: (statements) 55.1%
\`\`\`

The remaining 19% in \`internal/library\` is mostly filesystem-error paths that would need fault injection (e.g. \`os.MkdirAll\` failing) to exercise — not worth the brittleness for a marginal coverage gain.

## Test plan
- [x] \`go test ./internal/library/...\` passes
- [x] \`go test ./...\` passes
- [x] \`golangci-lint run ./internal/library/...\` 0 issues