### PR TITLE
feat(library): migrate walks pickers + daemon validator fallback (#556 partial)

### DIFF
--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -122,3 +122,56 @@ func TestHandleLibraryWalksUnavailable(t *testing.T) {
 		t.Errorf("status = %d, want 503", rec.Code)
 	}
 }
+
+// TestValidateWalkFilePathFallsBackToLibrary verifies that #556's
+// resolver tries the library walks dir as a fallback when the file
+// isn't in the legacy allow-list dir. Without this, the new picker
+// integrations would send library-relative names that the walk
+// validator would reject.
+func TestValidateWalkFilePathFallsBackToLibrary(t *testing.T) {
+	server, root := newLibraryTestServer(t)
+
+	// Plant a walk in the library/walks dir but NOT in the cfgPath
+	// allow-list dir (server.configPath returns "" → falls back to
+	// cwd; we don't drop the walk there).
+	walkPath := filepath.Join(root, "walks", "lib-only.walk")
+	if err := os.WriteFile(walkPath, []byte("oid = STRING: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := server.validateWalkFilePath("lib-only.walk")
+	if err != nil {
+		t.Fatalf("validateWalkFilePath: %v", err)
+	}
+	if got != walkPath {
+		t.Errorf("resolved path = %q, want %q", got, walkPath)
+	}
+}
+
+// TestValidateWalkFilePathPreservesConfigDirPriority verifies that a
+// walk available in BOTH the config dir and the library resolves to
+// the config-dir copy — the legacy bare-filename behaviour in YAML
+// configs must keep working unchanged.
+func TestValidateWalkFilePathPreservesConfigDirPriority(t *testing.T) {
+	server, root := newLibraryTestServer(t)
+	cfgDir := t.TempDir()
+	// configPath() reads from server.cfg.ConfigPath; set it.
+	server.cfg.ConfigPath = filepath.Join(cfgDir, "config.yaml")
+
+	const filename = "shared.walk"
+	if err := os.WriteFile(filepath.Join(cfgDir, filename), []byte("oid = STRING: cfg\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "walks", filename), []byte("oid = STRING: lib\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := server.validateWalkFilePath(filename)
+	if err != nil {
+		t.Fatalf("validateWalkFilePath: %v", err)
+	}
+	want := filepath.Join(cfgDir, filename)
+	if got != want {
+		t.Errorf("resolved path = %q, want config-dir copy %q", got, want)
+	}
+}

--- a/internal/api/walk.go
+++ b/internal/api/walk.go
@@ -15,6 +15,11 @@ import (
 
 // SECURITY FIX #154, #166: Secure path validation for walk files
 // validateWalkFilePath ensures the file path is safe and doesn't traverse outside allowed directories.
+// Walks are resolved in two passes: first the legacy config-dir / cwd
+// allow-list (kept for backward compatibility with bare filenames in
+// the running config), then the unified library walks dir
+// (~/.niac/library/walks/) so the new picker integrations (#556) can
+// send library-relative names like "cisco/c3900.walk".
 func (s *Server) validateWalkFilePath(filename string) (string, error) {
 	if filename == "" {
 		return "", errors.New("filename cannot be empty")
@@ -25,43 +30,76 @@ func (s *Server) validateWalkFilePath(filename string) (string, error) {
 		return "", errors.New("filename contains invalid characters")
 	}
 
-	allowedDir, err := s.resolveWalkAllowedDir()
+	allowedDirs, err := s.resolveWalkAllowedDirs()
 	if err != nil {
 		return "", err
 	}
 
-	absPath := cleanPath
-	if !filepath.IsAbs(cleanPath) {
-		absPath = filepath.Join(allowedDir, cleanPath)
-	}
-	absPath = filepath.Clean(absPath)
+	// Try each allowed dir in order. First one that produces a path
+	// passing all checks wins. If a dir produces a path that fails on
+	// "file not found", fall through to the next dir; any other error
+	// (extension, traversal) short-circuits.
+	var lastNotFound error
+	for _, allowedDir := range allowedDirs {
+		absPath := cleanPath
+		if !filepath.IsAbs(cleanPath) {
+			absPath = filepath.Join(allowedDir, cleanPath)
+		}
+		absPath = filepath.Clean(absPath)
 
-	if traversalErr := ensureWalkPathWithin(absPath, allowedDir, filename); traversalErr != nil {
-		return "", traversalErr
+		if traversalErr := ensureWalkPathWithin(absPath, allowedDir, filename); traversalErr != nil {
+			// "access denied" against THIS dir doesn't preclude finding
+			// the file under a different dir. Keep going.
+			lastNotFound = traversalErr
+			continue
+		}
+		if statErr := checkWalkFileExists(absPath, filename); statErr != nil {
+			lastNotFound = statErr
+			continue
+		}
+		if extErr := validateWalkExtension(absPath); extErr != nil {
+			// Extension errors aren't dir-specific — surface immediately.
+			return "", extErr
+		}
+		return absPath, nil
 	}
 
-	if statErr := checkWalkFileExists(absPath, filename); statErr != nil {
-		return "", statErr
+	if lastNotFound != nil {
+		return "", lastNotFound
 	}
-
-	if extErr := validateWalkExtension(absPath); extErr != nil {
-		return "", extErr
-	}
-
-	return absPath, nil
+	return "", fmt.Errorf("walk file not found: %s", filename)
 }
 
-// resolveWalkAllowedDir returns the directory walk files must reside under.
-func (s *Server) resolveWalkAllowedDir() (string, error) {
+// resolveWalkAllowedDirs returns the ordered list of directories walk
+// files may live under. The first entry is the legacy config-dir / cwd
+// surface; the second is the library walks/ subdir when the library
+// opened successfully. Order matters — config-dir wins so a walk
+// referenced relative to the running config behaves the same as
+// before this change.
+func (s *Server) resolveWalkAllowedDirs() ([]string, error) {
+	var dirs []string
+
 	cfgPath := s.configPath()
 	if cfgPath != "" {
-		return filepath.Dir(cfgPath), nil
+		dirs = append(dirs, filepath.Dir(cfgPath))
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine allowed directory: %w", err)
+		}
+		dirs = append(dirs, cwd)
 	}
-	allowedDir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine allowed directory: %w", err)
+
+	// Library walks dir — only added when the library opened cleanly.
+	// Library failure is non-fatal for the daemon as a whole, and
+	// silently omitting it here matches that posture: clients hitting
+	// /api/v1/library/walks already see 503, so this is just one more
+	// place that surface is unavailable.
+	if s.library != nil {
+		dirs = append(dirs, s.library.SubDir("walks"))
 	}
-	return allowedDir, nil
+
+	return dirs, nil
 }
 
 // ensureWalkPathWithin verifies that absPath resolves under allowedDir (following symlinks).

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -1,8 +1,14 @@
 import { FileCog, Server } from 'lucide-react';
 import { type ChangeEvent, type FC, memo, useEffect, useState } from 'react';
-import { fetchConfig, fetchDevices, fetchFiles, updateConfig } from '../api/client';
+import {
+  fetchConfig,
+  fetchDevices,
+  fetchLibraryWalks,
+  type LibraryFileEntry,
+  updateConfig,
+} from '../api/client';
 import { isApiError } from '../api/errors';
-import type { DeviceSummary, FileEntry } from '../api/types';
+import type { DeviceSummary } from '../api/types';
 import { POLL_INTERVALS } from '../constants/polling';
 import { iconSizes } from '../constants/sizes';
 import { useApiResource } from '../hooks/useApiResource';
@@ -157,7 +163,7 @@ const ConfigEditorCard: FC = () => {
   const { data, loading, error } = useApiResource(fetchConfig, [], {
     intervalMs: POLL_INTERVALS.verySlow,
   });
-  const { data: walkFiles } = useApiResource(() => fetchFiles('walks'), [], {
+  const { data: walkFiles } = useApiResource(fetchLibraryWalks, [], {
     intervalMs: POLL_INTERVALS.verySlow,
   });
   const [value, setValue] = useState('');
@@ -206,14 +212,14 @@ const ConfigEditorCard: FC = () => {
     }
   };
 
-  const handleWalkCopy = async (path: string) => {
+  const handleWalkCopy = async (name: string) => {
     try {
-      await copyToClipboard(path);
-      setStatus({ tone: 'success', message: `Copied ${path}` });
+      await copyToClipboard(name);
+      setStatus({ tone: 'success', message: `Copied ${name}` });
     } catch (err) {
       setStatus({
         tone: 'error',
-        message: getErrorMessage(err) || 'Unable to copy path',
+        message: getErrorMessage(err) || 'Unable to copy walk name',
       });
     }
   };
@@ -295,7 +301,7 @@ const ConfigEditorCard: FC = () => {
  * Walk File Browser - Browse available SNMP walks
  */
 const WalkFileBrowser: FC<{
-  files: FileEntry[];
+  files: LibraryFileEntry[];
   onCopy: (path: string) => void;
 }> = ({ files, onCopy }) => {
   if (files.length === 0) {
@@ -307,15 +313,15 @@ const WalkFileBrowser: FC<{
       <div className="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-white/10 bg-gray-950/50 p-2 text-sm text-gray-300">
         {files.map((file) => (
           <div
-            key={file.path}
+            key={file.name}
             className="flex items-center justify-between gap-2 rounded-lg border border-white/5 bg-gray-900/50 px-3 py-2"
           >
             <div>
               <p className="text-white">{file.name}</p>
-              <SmallText className="text-gray-500">{file.path}</SmallText>
+              <SmallText className="text-gray-500 capitalize">{file.source}</SmallText>
             </div>
-            <Button size="sm" variant="outline" onClick={() => onCopy(file.path)}>
-              Copy path
+            <Button size="sm" variant="outline" onClick={() => onCopy(file.name)}>
+              Copy name
             </Button>
           </div>
         ))}

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -1,6 +1,6 @@
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { fetchFiles, fixWalk, validateWalk } from '../api/client';
-import type { FileEntry, WalkValidationIssue, WalkValidationResponse } from '../api/types';
+import { fetchLibraryWalks, fixWalk, type LibraryFileEntry, validateWalk } from '../api/client';
+import type { WalkValidationIssue, WalkValidationResponse } from '../api/types';
 import { Card, CardContent } from '../ui/Card';
 
 type Severity = 'error' | 'warning' | 'info';
@@ -24,7 +24,7 @@ const severityCounts = (issues: WalkValidationIssue[]): Record<Severity, number>
 };
 
 export const WalkValidatorPage: FC = () => {
-  const [files, setFiles] = useState<FileEntry[]>([]);
+  const [files, setFiles] = useState<LibraryFileEntry[]>([]);
   const [filesError, setFilesError] = useState<string | null>(null);
   const [filesLoading, setFilesLoading] = useState(true);
 
@@ -35,17 +35,21 @@ export const WalkValidatorPage: FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<'idle' | 'validating' | 'fixing'>('idle');
 
-  // Hydrate the file dropdown from /api/v1/files?kind=walks.
+  // Hydrate the file dropdown from /api/v1/library/walks. The daemon's
+  // walk validator (validateWalkFilePath) falls back to the library
+  // walks dir when the file isn't in the legacy config-dir allow-list,
+  // so we can send library-relative names like "cisco/c3900.walk"
+  // unchanged.
   useEffect(() => {
     let cancelled = false;
     setFilesLoading(true);
-    fetchFiles('walks')
+    fetchLibraryWalks()
       .then((entries) => {
         if (cancelled) return;
         setFiles(entries);
         setFilesError(null);
         if (entries.length > 0 && !selectedFile) {
-          setSelectedFile(entries[0].path);
+          setSelectedFile(entries[0].name);
         }
       })
       .catch((err: Error) => {
@@ -111,7 +115,7 @@ export const WalkValidatorPage: FC = () => {
                 {filesLoading && <option>Loading…</option>}
                 {!filesLoading && files.length === 0 && <option>No walks found</option>}
                 {files.map((f) => (
-                  <option key={f.path} value={f.path}>
+                  <option key={f.name} value={f.name}>
                     {f.name} ({Math.round(f.sizeBytes / 1024)} KB)
                   </option>
                 ))}


### PR DESCRIPTION
## Summary
First half of #556 — picker integrations that follow from the library plan landing in v0.66.41–v0.66.43. The walks pickers in WalkValidatorPage and DevicesPage now read from the unified library endpoint instead of the legacy \`/api/v1/files?kind=walks\` surface.

## Daemon — \`internal/api/walk.go\`

- \`resolveWalkAllowedDir\` → **\`resolveWalkAllowedDirs\`** returning an ordered list: config-dir / cwd first, then the library walks dir (\`~/.niac/library/walks/\`) when the library opened cleanly.
- \`validateWalkFilePath\` tries each allowed dir in order. The first to produce a passing path wins; "not found" / "access denied" against one dir falls through to the next, while extension or null-byte errors short-circuit immediately. This preserves the legacy bare-filename-in-YAML behaviour (config-dir wins when a walk is in both places) while unlocking library-relative names like \`cisco/c3900.walk\` that the new UI pickers send.
- Two new tests pin the ordering invariant:
  - \`TestValidateWalkFilePathFallsBackToLibrary\` — file only in library/walks resolves correctly
  - \`TestValidateWalkFilePathPreservesConfigDirPriority\` — file in both places resolves to config-dir copy

## UI

- **\`WalkValidatorPage.tsx\`** — picker swaps from \`fetchFiles('walks')\` to \`fetchLibraryWalks\`. Option value is the bare library-relative name, which the daemon resolves through the new validator fallback above.
- **\`DevicesPage.tsx\`** — same migration for the SNMP walks browser. Each row gains a source badge (starter / bundle / user) inline with the walk name so the user can see content provenance at a glance. "Copy path" became "Copy name" since the value is now a library-relative key, not a filesystem path.

## Out of scope (follow-up)

PCAP picker (\`ReplayControlPanel\`) migration deferred. The pcap path validator has its own security history (security fix #162) and warrants a focused review separate from this change. **#556 stays open until that lands** as a third PR.

## Test plan
- [x] \`go test ./internal/api/... -run "TestValidateWalk|TestHandleLibrary" -v\` — 6 tests pass
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./internal/api/...\` 0 issues
- [x] \`npm run build\` clean
- [ ] Smoke: drop a walk into \`~/.niac/library/walks/\`, pick it in the Walk Validator page, confirm validate/fix complete normally
- [ ] Smoke: open Running Devices, confirm the SNMP walks browser lists library walks with source badges

Refs: #556 (this is the walks half — pcap migration is the remaining work that keeps the issue open)