### PR TITLE
feat(library): migrate pcap replay picker + daemon validator fallback (#556)

### DIFF
--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -175,3 +175,50 @@ func TestValidateWalkFilePathPreservesConfigDirPriority(t *testing.T) {
 		t.Errorf("resolved path = %q, want config-dir copy %q", got, want)
 	}
 }
+
+// TestValidatePcapFilePathFallsBackToLibrary mirrors the walk test:
+// a pcap that lives only under <library>/pcaps/ must still resolve
+// via the legacy validator surface, so the new ReplayControlPanel
+// picker (#556 pcap half) doesn't need a parallel API.
+func TestValidatePcapFilePathFallsBackToLibrary(t *testing.T) {
+	server, root := newLibraryTestServer(t)
+
+	pcapPath := filepath.Join(root, "pcaps", "lib-only.pcap")
+	if err := os.WriteFile(pcapPath, []byte("fake-pcap-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := server.validatePcapFilePath("lib-only.pcap")
+	if err != nil {
+		t.Fatalf("validatePcapFilePath: %v", err)
+	}
+	if got != pcapPath {
+		t.Errorf("resolved path = %q, want %q", got, pcapPath)
+	}
+}
+
+// TestValidatePcapFilePathPreservesConfigDirPriority — same priority
+// guarantee for pcaps as for walks. A pcap present in both places
+// resolves to the config-dir copy.
+func TestValidatePcapFilePathPreservesConfigDirPriority(t *testing.T) {
+	server, root := newLibraryTestServer(t)
+	cfgDir := t.TempDir()
+	server.cfg.ConfigPath = filepath.Join(cfgDir, "config.yaml")
+
+	const filename = "shared.pcap"
+	if err := os.WriteFile(filepath.Join(cfgDir, filename), []byte("cfg-pcap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pcaps", filename), []byte("lib-pcap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := server.validatePcapFilePath(filename)
+	if err != nil {
+		t.Fatalf("validatePcapFilePath: %v", err)
+	}
+	want := filepath.Join(cfgDir, filename)
+	if got != want {
+		t.Errorf("resolved path = %q, want config-dir copy %q", got, want)
+	}
+}

--- a/internal/api/pcap_validation.go
+++ b/internal/api/pcap_validation.go
@@ -232,78 +232,129 @@ func (s *Server) prepareReplayRequest(req ReplayRequest) (ReplayRequest, error) 
 }
 
 // SECURITY FIX #162: validatePcapFilePath ensures the file path is safe.
+// Pcaps are resolved in two passes (mirroring validateWalkFilePath
+// in #558): first the legacy config-dir / cwd allow-list, then the
+// unified library pcaps dir (~/.niac/library/pcaps/) so the new
+// picker integrations from #556 can send library-relative names.
+//
+// Per-dir checks live in tryPcapInDir so this top-level function
+// stays under the cognitive-complexity cap. Soft failures (access
+// denied / not found) propagate via lastErr and fall through to the
+// next allowed dir; hard failures (extension, null byte, dir-not-file)
+// short-circuit out.
 func (s *Server) validatePcapFilePath(filename string) (string, error) {
 	if filename == "" {
 		return "", errors.New("filename cannot be empty")
 	}
 
 	cleanPath := filepath.Clean(filename)
-
 	if strings.ContainsRune(cleanPath, 0) {
 		return "", errors.New("filename contains invalid characters")
 	}
 
-	cfgPath := s.configPath()
-	var allowedDir string
-	if cfgPath != "" {
-		allowedDir = filepath.Dir(cfgPath)
-	} else {
-		var err error
-		allowedDir, err = os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("cannot determine allowed directory: %w", err)
-		}
+	allowedDirs, err := s.resolvePcapAllowedDirs()
+	if err != nil {
+		return "", err
 	}
 
-	var absPath string
+	var lastErr error
+	for _, allowedDir := range allowedDirs {
+		absPath, hardFail, attemptErr := tryPcapInDir(cleanPath, filename, allowedDir)
+		if hardFail {
+			return "", attemptErr
+		}
+		if attemptErr != nil {
+			lastErr = attemptErr
+			continue
+		}
+		return absPath, nil
+	}
+
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("pcap file not found: %s", filename)
+}
+
+// tryPcapInDir resolves cleanPath against allowedDir and returns the
+// validated absolute path on success. The second return is "hard
+// fail" — true when the error is dir-independent (extension, null
+// byte, dir-not-file) and the caller should stop trying other dirs.
+func tryPcapInDir(cleanPath, filename, allowedDir string) (string, bool, error) {
+	absPath := cleanPath
 	if !filepath.IsAbs(cleanPath) {
 		absPath = filepath.Join(allowedDir, cleanPath)
-	} else {
-		absPath = cleanPath
+	}
+	absPath = filepath.Clean(absPath)
+
+	// Inline barrier on the EvalSymlinks/Stat sinks below so static
+	// analysers see the absolute path is bounded before any filesystem
+	// access.
+	if !filepath.IsAbs(absPath) || strings.Contains(absPath, "..") {
+		return "", true, errors.New("pcap file path failed safety check")
 	}
 
-	absPath = filepath.Clean(absPath)
-	// Inline barrier on the EvalSymlinks/Stat sinks below so static analysers
-	// see the absolute path is bounded before any filesystem access.
-	if !filepath.IsAbs(absPath) || strings.Contains(absPath, "..") {
-		return "", errors.New("pcap file path failed safety check")
-	}
-	realPath, err := filepath.EvalSymlinks(absPath)
-	if err != nil {
+	realPath, evalErr := filepath.EvalSymlinks(absPath)
+	if evalErr != nil {
 		realPath = absPath
 	}
-
-	realAllowedDir, err := filepath.EvalSymlinks(allowedDir)
-	if err != nil {
+	realAllowedDir, evalDirErr := filepath.EvalSymlinks(allowedDir)
+	if evalDirErr != nil {
 		realAllowedDir = allowedDir
 	}
-
 	if !strings.HasPrefix(realPath, realAllowedDir+string(filepath.Separator)) &&
 		realPath != realAllowedDir {
-		return "", fmt.Errorf("access denied: file must be within %s", allowedDir)
+		return "", false, fmt.Errorf("access denied: file must be within %s", allowedDir)
 	}
 
-	info, err := os.Stat(absPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("pcap file not found: %s", filename)
+	info, statErr := os.Stat(absPath)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return "", false, fmt.Errorf("pcap file not found: %s", filename)
 		}
-		return "", fmt.Errorf("cannot access pcap file: %w", err)
+		return "", true, fmt.Errorf("cannot access pcap file: %w", statErr)
 	}
 	if info.IsDir() {
-		return "", fmt.Errorf("%w: %s", ErrPathIsADirectory, absPath)
+		return "", true, fmt.Errorf("%w: %s", ErrPathIsADirectory, absPath)
 	}
 
 	ext := strings.ToLower(filepath.Ext(absPath))
 	validExts := map[string]bool{".pcap": true, ".pcapng": true, ".cap": true}
 	if !validExts[ext] {
-		return "", fmt.Errorf(
+		return "", true, fmt.Errorf(
 			"invalid pcap file extension: %s (allowed: .pcap, .pcapng, .cap)",
 			ext,
 		)
 	}
+	return absPath, false, nil
+}
 
-	return absPath, nil
+// resolvePcapAllowedDirs returns the ordered list of directories pcap
+// files may live under. Mirrors resolveWalkAllowedDirs in walk.go —
+// config-dir / cwd first, library pcaps dir second when the library
+// opened cleanly. Library failure stays non-fatal: clients that need
+// pcap content from the library will already hit a 503 on
+// /api/v1/library/pcaps, so silently omitting it here matches the
+// rest of the daemon's posture.
+func (s *Server) resolvePcapAllowedDirs() ([]string, error) {
+	var dirs []string
+
+	cfgPath := s.configPath()
+	if cfgPath != "" {
+		dirs = append(dirs, filepath.Dir(cfgPath))
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine allowed directory: %w", err)
+		}
+		dirs = append(dirs, cwd)
+	}
+
+	if s.library != nil {
+		dirs = append(dirs, s.library.SubDir("pcaps"))
+	}
+
+	return dirs, nil
 }
 
 func (s *Server) writeUploadedFile(data []byte) (string, error) {

--- a/ui/src/components/ReplayControlPanel.tsx
+++ b/ui/src/components/ReplayControlPanel.tsx
@@ -1,5 +1,5 @@
 import { type FC, useState } from 'react';
-import { fetchFiles, fetchReplayStatus, startReplay, stopReplay } from '../api/client';
+import { fetchLibraryPcaps, fetchReplayStatus, startReplay, stopReplay } from '../api/client';
 import { useApiResource } from '../hooks/useApiResource';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
@@ -8,7 +8,12 @@ import { SmallText } from '../ui/Typography';
 import { getErrorMessage } from '../utils/format';
 
 export const ReplayControlPanel: FC = () => {
-  const { data: pcapFiles } = useApiResource(() => fetchFiles('pcaps'), []);
+  // Hydrates from /api/v1/library/pcaps. The daemon's
+  // validatePcapFilePath falls back to ~/.niac/library/pcaps/ when
+  // the file isn't in the legacy config-dir allow-list, so passing
+  // bare library names like "sample.pcap" to startReplay works
+  // without any further translation in the UI.
+  const { data: pcapFiles } = useApiResource(fetchLibraryPcaps, []);
   const { data: replayStatus, refetch: refetchStatus } = useApiResource(fetchReplayStatus, [], {
     intervalMs: 2000,
   });
@@ -112,7 +117,7 @@ export const ReplayControlPanel: FC = () => {
               >
                 <option value="">Select PCAP file...</option>
                 {pcapFiles?.map((file) => (
-                  <option key={file.path} value={file.path}>
+                  <option key={file.name} value={file.name}>
                     {file.name} ({(file.sizeBytes / 1024).toFixed(1)} KB)
                   </option>
                 ))}


### PR DESCRIPTION
## Summary
Closes #556 — the pcap half that matches the walks migration in #558. Same architectural pattern: extend the daemon validator to accept files under the library subdir, then point the picker at the unified library endpoint.

## Daemon — \`internal/api/pcap_validation.go\`

- Extracted **\`resolvePcapAllowedDirs\`** returning an ordered list (config-dir first, \`library/pcaps/\` second when the library opened cleanly). Mirrors \`resolveWalkAllowedDirs\` from #558 so the two validators behave identically.
- \`validatePcapFilePath\` now iterates the allow-list. Soft failures (access denied / not found) fall through to the next dir; hard failures (extension, null byte, dir-not-file) short-circuit out.
- Per-dir attempt extracted into \`tryPcapInDir\` to keep the top-level function under the cognitive-complexity cap and to keep the validator's logic flat.

## UI — \`ui/src/components/ReplayControlPanel.tsx\`

Picker swaps \`fetchFiles('pcaps')\` → \`fetchLibraryPcaps\`. Bare library names like \`sample.pcap\` go straight to \`startReplay\`; the daemon's new validator fallback resolves them to the absolute path under \`~/.niac/library/pcaps/\`.

## Tests

Both added to \`handlers_library_test.go\` alongside the walks-equivalent tests from #558:
- **\`TestValidatePcapFilePathFallsBackToLibrary\`** — file only in \`<library>/pcaps/\` still resolves via the legacy validator surface
- **\`TestValidatePcapFilePathPreservesConfigDirPriority\`** — a file present in both dirs resolves to the config-dir copy, preserving the legacy behaviour for pcaps referenced from running YAML

## Test plan
- [x] \`go test ./internal/api/... -run "TestValidatePcap|TestValidateWalk|TestHandleLibrary" -v\` — 8 tests pass
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./internal/api/...\` 0 issues
- [x] \`npm run build\` clean
- [ ] Smoke: drop a pcap into \`~/.niac/library/pcaps/\`, start replay from the UI picker, confirm it runs
- [ ] Smoke: a pcap referenced by absolute path from the running YAML still replays unchanged

Refs: #556 (this closes it; #558 handled the walks half)