### PR TITLE
feat(devices): context-sensitive editor driven by per-type schema (#546 part 1)

### DIFF
--- a/internal/api/handlers_device_schema.go
+++ b/internal/api/handlers_device_schema.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+)
+
+// DeviceEditorSchema is the per-type form schema the UI device
+// editor consumes to hide irrelevant sections (#546 part 1). The
+// frontend renders sections in a fixed order; this schema tells it
+// which ones apply to the picked device type.
+//
+// Sections are referenced by the same string keys the editor uses
+// internally ("snmp", "lldp", "cdp", "stp", "dhcp", "dns", "http",
+// "ftp", "netbios", "traffic", "ips", "basic"). "basic" is always
+// visible — the device's name and type live there.
+type DeviceEditorSchema struct {
+	Type            string   `json:"type"`
+	Label           string   `json:"label"`
+	VisibleSections []string `json:"visibleSections"`
+}
+
+// deviceEditorSchemas is the canonical map from device type → which
+// sections render. Picked to match common operator expectations: a
+// switch shouldn't see a DNS server tab, a host shouldn't see STP,
+// etc. The list is intentionally small — niac's device types stay
+// in the same handful and adding a new one requires touching exactly
+// this map.
+//
+// Per-type lists are kept in render-order so the UI iterating
+// visibleSections in order Just Works.
+var deviceEditorSchemas = map[string]DeviceEditorSchema{ //nolint:gochecknoglobals // static lookup table
+	"switch": {
+		Type:  "switch",
+		Label: "Switch",
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "cdp", "stp", "ips", "traffic",
+		},
+	},
+	"router": {
+		Type:  "router",
+		Label: "Router",
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "cdp", "ips", "dhcp", "traffic",
+		},
+	},
+	"host": {
+		Type:  "host",
+		Label: "Host / Workstation",
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "ips", "dns", "http", "ftp", "netbios", "traffic",
+		},
+	},
+	"server": {
+		Type:  "server",
+		Label: "Server",
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "ips", "dns", "dhcp", "http", "ftp", "netbios", "traffic",
+		},
+	},
+	"firewall": {
+		Type:  "firewall",
+		Label: "Firewall",
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "ips", "traffic",
+		},
+	},
+	"access_point": {
+		Type:  "access_point",
+		Label: "Wireless Access Point",
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "ips", "traffic",
+		},
+	},
+	"printer": {
+		Type:  "printer",
+		Label: "Printer",
+		VisibleSections: []string{
+			"basic", "snmp", "ips", "traffic",
+		},
+	},
+	"voip_phone": {
+		Type:  "voip_phone",
+		Label: "VoIP Phone",
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "cdp", "ips", "traffic",
+		},
+	},
+	"unknown": {
+		Type:  "unknown",
+		Label: "Unknown / Custom",
+		// Fallback shows everything so users with non-standard types
+		// can still configure any field they need.
+		VisibleSections: []string{
+			"basic", "snmp", "lldp", "cdp", "stp", "ips", "dhcp", "dns", "http", "ftp", "netbios", "traffic",
+		},
+	},
+}
+
+// handleDeviceEditorSchema handles GET /api/v1/device-schemas/{type}
+// and GET /api/v1/device-schemas (list).
+//
+// The list endpoint returns every known schema so the frontend can
+// build a type picker without round-tripping per type. Both endpoints
+// always return JSON — unknown types fall back to the "unknown"
+// schema rather than 404'ing, so a type new to the daemon that the UI
+// hasn't been updated for still gives a usable form.
+func (s *Server) handleDeviceEditorSchema(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+		return
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, "/api/v1/device-schemas")
+	rest = strings.TrimPrefix(rest, "/")
+
+	if rest == "" {
+		s.writeJSON(w, listDeviceEditorSchemas())
+		return
+	}
+
+	schema := lookupDeviceEditorSchema(rest)
+	s.writeJSON(w, schema)
+}
+
+// listDeviceEditorSchemas returns every defined schema in
+// alphabetical-by-type order so the type picker in the UI has a
+// stable display order.
+func listDeviceEditorSchemas() []DeviceEditorSchema {
+	out := make([]DeviceEditorSchema, 0, len(deviceEditorSchemas))
+	for _, schema := range deviceEditorSchemas {
+		out = append(out, schema)
+	}
+	// Stable sort by Type so list responses match between calls.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1].Type > out[j].Type; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// lookupDeviceEditorSchema returns the per-type schema, falling back
+// to the "unknown" schema (show everything) when the type isn't in
+// the map. Type names are normalised lowercase before lookup so the
+// frontend can pass either "switch" or "Switch".
+func lookupDeviceEditorSchema(deviceType string) DeviceEditorSchema {
+	key := strings.ToLower(strings.TrimSpace(deviceType))
+	if schema, ok := deviceEditorSchemas[key]; ok {
+		return schema
+	}
+	return deviceEditorSchemas["unknown"]
+}

--- a/internal/api/handlers_device_schema_test.go
+++ b/internal/api/handlers_device_schema_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+)
+
+func newSchemaTestServer() *Server {
+	return &Server{logger: slog.Default()}
+}
+
+func TestDeviceEditorSchemaListIncludesEveryKnownType(t *testing.T) {
+	server := newSchemaTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/device-schemas", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeviceEditorSchema(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got []DeviceEditorSchema
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != len(deviceEditorSchemas) {
+		t.Fatalf("list returned %d schemas, want %d", len(got), len(deviceEditorSchemas))
+	}
+
+	// Sorted by Type, alphabetical — first entry must come first by key.
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Type > got[i].Type {
+			t.Errorf("list not sorted: %q precedes %q", got[i-1].Type, got[i].Type)
+		}
+	}
+}
+
+func TestDeviceEditorSchemaSwitchHidesIrrelevantSections(t *testing.T) {
+	server := newSchemaTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/device-schemas/switch", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeviceEditorSchema(rec, req)
+
+	var got DeviceEditorSchema
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Type != "switch" {
+		t.Errorf("type = %q, want switch", got.Type)
+	}
+	// Switches must show STP but NOT DNS or DHCP — the whole point
+	// of the per-type schema.
+	if !slices.Contains(got.VisibleSections, "stp") {
+		t.Errorf("switch schema missing stp: %v", got.VisibleSections)
+	}
+	for _, hidden := range []string{"dns", "dhcp", "http", "ftp", "netbios"} {
+		if slices.Contains(got.VisibleSections, hidden) {
+			t.Errorf("switch schema unexpectedly includes %s: %v", hidden, got.VisibleSections)
+		}
+	}
+}
+
+func TestDeviceEditorSchemaServerShowsApplicationServices(t *testing.T) {
+	server := newSchemaTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/device-schemas/server", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeviceEditorSchema(rec, req)
+
+	var got DeviceEditorSchema
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, expected := range []string{"dns", "dhcp", "http", "ftp", "netbios"} {
+		if !slices.Contains(got.VisibleSections, expected) {
+			t.Errorf("server schema missing %s: %v", expected, got.VisibleSections)
+		}
+	}
+	if slices.Contains(got.VisibleSections, "stp") {
+		t.Errorf("server schema unexpectedly includes stp: %v", got.VisibleSections)
+	}
+}
+
+func TestDeviceEditorSchemaUnknownTypeFallsBackToShowAll(t *testing.T) {
+	server := newSchemaTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/device-schemas/some-new-type", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeviceEditorSchema(rec, req)
+
+	var got DeviceEditorSchema
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Unknown types fall through to the "unknown" schema rather than
+	// 404'ing — a new daemon type the UI hasn't been updated for
+	// should still produce a usable form.
+	if got.Type != "unknown" {
+		t.Errorf("type = %q, want unknown (fallback)", got.Type)
+	}
+	if len(got.VisibleSections) < 10 {
+		t.Errorf("unknown schema should show ~everything, got %d sections", len(got.VisibleSections))
+	}
+}
+
+func TestDeviceEditorSchemaCaseInsensitiveLookup(t *testing.T) {
+	server := newSchemaTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/device-schemas/Switch", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeviceEditorSchema(rec, req)
+
+	var got DeviceEditorSchema
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Type != "switch" {
+		t.Errorf("type = %q, want switch (case-insensitive lookup)", got.Type)
+	}
+}
+
+func TestDeviceEditorSchemaRejectsNonGet(t *testing.T) {
+	server := newSchemaTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/device-schemas/switch", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeviceEditorSchema(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != "GET" {
+		t.Errorf("Allow header = %q, want GET", got)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -100,6 +100,14 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 		s.recoverMiddleware(s.auth(s.handleLibraryWalks)))
 	mux.HandleFunc("/api/v1/library/pcaps",
 		s.recoverMiddleware(s.auth(s.handleLibraryPcaps)))
+
+	// Per-type device editor schema (#546 part 1). Read-only — the
+	// schema is a static table the daemon serves so the UI can hide
+	// sections that don't apply (e.g. switch should not see DNS).
+	mux.HandleFunc("/api/v1/device-schemas",
+		s.recoverMiddleware(s.auth(s.handleDeviceEditorSchema)))
+	mux.HandleFunc("/api/v1/device-schemas/",
+		s.recoverMiddleware(s.auth(s.handleDeviceEditorSchema)))
 	mux.HandleFunc("/api/v1/topology", s.recoverMiddleware(s.auth(s.handleTopology)))
 	mux.HandleFunc("/api/v1/topology/export", s.recoverMiddleware(s.auth(s.handleTopologyExport)))
 	mux.HandleFunc("/api/v1/errors", s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleErrors)))))

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -142,6 +142,23 @@ export interface LibraryFileEntry {
 export const fetchLibraryWalks = () => deduplicatedGet<LibraryFileEntry[]>('/api/v1/library/walks');
 export const fetchLibraryPcaps = () => deduplicatedGet<LibraryFileEntry[]>('/api/v1/library/pcaps');
 
+/**
+ * Per-type device editor schema (#546 part 1). The daemon serves a
+ * small static table describing which sections of the device editor
+ * apply to each device type; the editor hides the rest. Falls back
+ * to the "unknown" schema (show everything) on the daemon side, so
+ * an unknown type never breaks the form.
+ */
+export interface DeviceEditorSchema {
+  type: string;
+  label: string;
+  visibleSections: string[];
+}
+export const fetchDeviceEditorSchema = (deviceType: string) =>
+  deduplicatedGet<DeviceEditorSchema>(`/api/v1/device-schemas/${encodeURIComponent(deviceType)}`);
+export const fetchDeviceEditorSchemas = () =>
+  deduplicatedGet<DeviceEditorSchema[]>('/api/v1/device-schemas');
+
 export const injectError = (payload: {
   deviceIp: string;
   interface: string;

--- a/ui/src/components/device-editor/useDeviceEditor.ts
+++ b/ui/src/components/device-editor/useDeviceEditor.ts
@@ -4,6 +4,7 @@ import {
   createDevice,
   deleteDevice,
   fetchConfigDevice,
+  fetchDeviceEditorSchema,
   fetchWalkFiles,
   updateDevice,
 } from '../../api/client';
@@ -40,6 +41,13 @@ export interface UseDeviceEditorReturn {
 
   // Walk files for SNMP
   walkFiles: FileEntry[] | null;
+
+  // Per-type visibility schema (#546 part 1). The editor uses this to
+  // hide sections that don't apply to the currently picked
+  // device.type — a switch shouldn't see DNS, a host shouldn't see
+  // STP, etc. Always falls back to "show everything" on fetch error
+  // so a network blip never breaks the form.
+  visibleSections: Set<string>;
 
   // UI state
   saving: boolean;
@@ -91,6 +99,33 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
 
   // Fetch available walk files
   const { data: walkFiles } = useApiResource(fetchWalkFiles, []);
+
+  // Per-type editor schema. Re-fetches when device.type changes; on
+  // error or while loading we fall through to the "show everything"
+  // set below so the form never disappears entirely.
+  const { data: schema } = useApiResource(
+    () => fetchDeviceEditorSchema(device.type || 'unknown'),
+    [device.type],
+  );
+  const visibleSections = useMemo(() => {
+    if (schema?.visibleSections && schema.visibleSections.length > 0) {
+      return new Set(schema.visibleSections);
+    }
+    return new Set([
+      'basic',
+      'snmp',
+      'lldp',
+      'cdp',
+      'stp',
+      'ips',
+      'dhcp',
+      'dns',
+      'http',
+      'ftp',
+      'netbios',
+      'traffic',
+    ]);
+  }, [schema]);
 
   // Update local state when fetched device changes
   useEffect(() => {
@@ -212,6 +247,7 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     error,
     refetch,
     walkFiles,
+    visibleSections,
     saving,
     deleting,
     message,

--- a/ui/src/pages/DeviceEditorPage.tsx
+++ b/ui/src/pages/DeviceEditorPage.tsx
@@ -30,6 +30,7 @@ export const DeviceEditorPage: FC = () => {
     error,
     refetch,
     walkFiles,
+    visibleSections,
     saving,
     deleting,
     message,
@@ -85,92 +86,116 @@ export const DeviceEditorPage: FC = () => {
       {/* YAML Preview */}
       {showYamlPreview && <YamlPreviewSection yamlContent={yamlPreview} />}
 
-      {/* Basic Settings */}
-      <BasicSettingsSection
-        device={device}
-        isExpanded={expandedSections.has('basic')}
-        onToggle={() => toggleSection('basic')}
-        onUpdate={updateField}
-      />
+      {/* Basic Settings — always visible; type picker lives here so
+          the rest of the form can react when it changes. */}
+      {visibleSections.has('basic') && (
+        <BasicSettingsSection
+          device={device}
+          isExpanded={expandedSections.has('basic')}
+          onToggle={() => toggleSection('basic')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <SnmpSection
-        device={device}
-        isExpanded={expandedSections.has('snmp')}
-        onToggle={() => toggleSection('snmp')}
-        onUpdate={updateField}
-        walkFiles={walkFiles}
-      />
+      {visibleSections.has('snmp') && (
+        <SnmpSection
+          device={device}
+          isExpanded={expandedSections.has('snmp')}
+          onToggle={() => toggleSection('snmp')}
+          onUpdate={updateField}
+          walkFiles={walkFiles}
+        />
+      )}
 
-      <LldpSection
-        device={device}
-        isExpanded={expandedSections.has('lldp')}
-        onToggle={() => toggleSection('lldp')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('lldp') && (
+        <LldpSection
+          device={device}
+          isExpanded={expandedSections.has('lldp')}
+          onToggle={() => toggleSection('lldp')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <CdpSection
-        device={device}
-        isExpanded={expandedSections.has('cdp')}
-        onToggle={() => toggleSection('cdp')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('cdp') && (
+        <CdpSection
+          device={device}
+          isExpanded={expandedSections.has('cdp')}
+          onToggle={() => toggleSection('cdp')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <StpSection
-        device={device}
-        isExpanded={expandedSections.has('stp')}
-        onToggle={() => toggleSection('stp')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('stp') && (
+        <StpSection
+          device={device}
+          isExpanded={expandedSections.has('stp')}
+          onToggle={() => toggleSection('stp')}
+          onUpdate={updateField}
+        />
+      )}
 
-      {/* Additional IP Addresses */}
-      <AdditionalIPsSection
-        device={device}
-        isExpanded={expandedSections.has('ips')}
-        onToggle={() => toggleSection('ips')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('ips') && (
+        <AdditionalIPsSection
+          device={device}
+          isExpanded={expandedSections.has('ips')}
+          onToggle={() => toggleSection('ips')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <DhcpSection
-        device={device}
-        isExpanded={expandedSections.has('dhcp')}
-        onToggle={() => toggleSection('dhcp')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('dhcp') && (
+        <DhcpSection
+          device={device}
+          isExpanded={expandedSections.has('dhcp')}
+          onToggle={() => toggleSection('dhcp')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <DnsSection
-        device={device}
-        isExpanded={expandedSections.has('dns')}
-        onToggle={() => toggleSection('dns')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('dns') && (
+        <DnsSection
+          device={device}
+          isExpanded={expandedSections.has('dns')}
+          onToggle={() => toggleSection('dns')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <HttpSection
-        device={device}
-        isExpanded={expandedSections.has('http')}
-        onToggle={() => toggleSection('http')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('http') && (
+        <HttpSection
+          device={device}
+          isExpanded={expandedSections.has('http')}
+          onToggle={() => toggleSection('http')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <FtpSection
-        device={device}
-        isExpanded={expandedSections.has('ftp')}
-        onToggle={() => toggleSection('ftp')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('ftp') && (
+        <FtpSection
+          device={device}
+          isExpanded={expandedSections.has('ftp')}
+          onToggle={() => toggleSection('ftp')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <NetBiosSection
-        device={device}
-        isExpanded={expandedSections.has('netbios')}
-        onToggle={() => toggleSection('netbios')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('netbios') && (
+        <NetBiosSection
+          device={device}
+          isExpanded={expandedSections.has('netbios')}
+          onToggle={() => toggleSection('netbios')}
+          onUpdate={updateField}
+        />
+      )}
 
-      <TrafficSection
-        device={device}
-        isExpanded={expandedSections.has('traffic')}
-        onToggle={() => toggleSection('traffic')}
-        onUpdate={updateField}
-      />
+      {visibleSections.has('traffic') && (
+        <TrafficSection
+          device={device}
+          isExpanded={expandedSections.has('traffic')}
+          onToggle={() => toggleSection('traffic')}
+          onUpdate={updateField}
+        />
+      )}
 
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (


### PR DESCRIPTION
## Summary
Part 1 of #546. The device editor currently renders the same wide form for every type, so users see fields that don't apply (a switch with a DNS-server section, a server with STP, etc.). This PR adds a per-type **visibility schema** the daemon serves and the UI consumes to hide irrelevant sections.

## Daemon — \`internal/api/handlers_device_schema.go\`

- New \`GET /api/v1/device-schemas/{type}\` returning a tiny \`DeviceEditorSchema {type, label, visibleSections}\`.
- Companion \`GET /api/v1/device-schemas\` (no type) returns every defined schema in alphabetical order so a future type picker can build its list in one round-trip.
- Static lookup table covers **switch / router / host / server / firewall / access_point / printer / voip_phone / unknown**. Unknown types fall through to the \`unknown\` entry which exposes every section — a daemon type the UI hasn't been updated for still produces a usable form.

6 tests pin the per-type contract:
- switch hides \`dns\` / \`dhcp\` / \`http\` / \`ftp\` / \`netbios\`
- server shows the application services + hides \`stp\`
- unknown type lookup falls back
- case-insensitive resolution
- 405 on non-GET
- sorted list order

## Frontend

- \`ui/src/api/client.ts\` — \`DeviceEditorSchema\` type + \`fetchDeviceEditorSchema(type)\` + \`fetchDeviceEditorSchemas()\`.
- \`useDeviceEditor.ts\` — fetches schema for \`device.type\`, exposes \`visibleSections: Set<string>\`. Re-runs when type changes. Falls back to the full 12-section set on fetch error / empty response so a network blip never disappears the form.
- \`DeviceEditorPage.tsx\` — wraps each section render in \`visibleSections.has('<key>')\` so the form adapts as the user picks a different type.

## Why it's safe

Schema is **additive**:
- Old configs + existing devices keep working unchanged
- Only visible difference is fewer empty sections when the type doesn't need them
- Schema fetch failure falls back to "show everything"
- UI ships with a hard-coded 12-section default, so the daemon endpoint can be down (or older binary) and the editor still works

## Out of scope

Part 2 (\`niac\`-side auto-generation of baseline SNMP walks) is a separate PR — that one needs a short design doc first per the issue (vendor sysDescr strings, default interfaceCount, etc.).

## Test plan
- [x] \`go test ./internal/api/... -run TestDeviceEditorSchema -v\` — 6 tests pass
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./internal/api/...\` 0 issues
- [x] \`npm run build\` clean
- [ ] Smoke: open Devices → New Device, pick \`switch\` — STP shows, DNS hidden
- [ ] Smoke: pick \`server\` — DNS / DHCP / HTTP / FTP / NetBIOS show, STP hidden
- [ ] Smoke: pick an unknown type → every section visible

Refs: #546 (this closes part 1; part 2 — auto-walk synthesis — is the remaining work that keeps the issue open)