### PR TITLE
feat(topology): edge thickness + colour by utilization (#552 part 1)

### DIFF
--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -166,7 +166,13 @@ export interface TopologyLink {
   speed?: string;
   duplex?: string;
   status?: string;
-  utilization?: number;
+  /** Link utilization, 0–100. Source = the daemon's json:"utilization_percent"
+   *  on api.TopologyLink; the request layer's snake→camel converter rewrites
+   *  the wire field to utilizationPercent. Today the daemon emits 0 for
+   *  every link (counter wiring is a separate work item); when live counters
+   *  land, the topology page already styles edges based on this value
+   *  (thickness + amber/red tint at high utilisation). */
+  utilizationPercent?: number;
 }
 
 export interface ErrorType {

--- a/ui/src/pages/topology/TrunkEdge.tsx
+++ b/ui/src/pages/topology/TrunkEdge.tsx
@@ -176,6 +176,9 @@ const EdgeTooltip: FC<{ x: number; y: number; data: LinkEdgeData }> = ({ x, y, d
   if (data.linkType) {
     rows.push(['Type', data.linkType]);
   }
+  if (typeof data.utilizationPercent === 'number' && data.utilizationPercent > 0) {
+    rows.push(['Utilisation', `${data.utilizationPercent.toFixed(0)} %`]);
+  }
   rows.push([
     'Source',
     data.discovered ? 'Discovered (LLDP/CDP/EDP/FDP)' : 'Declared (trunk_ports)',

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -225,16 +225,23 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
     data.targetInterface = link.targetInterface;
     data.vlans = link.vlans;
     data.discovered = link.discovered;
+    data.utilizationPercent = link.utilizationPercent;
 
-    const edgeColor = getEdgeColor(data);
+    const baseColor = getEdgeColor(data);
+    const { stroke, strokeWidth: utilWidth } = utilizationStyle(data.utilizationPercent, baseColor);
     // Trunk + LAG links are bidirectional by nature (both sides send
     // and receive on the same wire) — show arrows on both ends. A
     // plain access link still uses a single end-arrow to indicate the
     // "source declared this" direction.
     const bidirectional = data.linkType === 'trunk' || data.linkType === 'lag';
+    // Stroke width = max(base-by-direction, utilisation-driven). High
+    // utilisation should visibly thicken even an access link; trunks
+    // start at 3 px so they don't shrink when utilisation is unknown.
+    const baseWidth = bidirectional ? 3 : 2;
+    const strokeWidth = Math.max(baseWidth, utilWidth);
     const marker = {
       type: MarkerType.ArrowClosed,
-      color: edgeColor,
+      color: stroke,
       width: 14,
       height: 14,
     };
@@ -249,8 +256,8 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
       type: 'trunk',
       animated: bidirectional,
       style: {
-        stroke: edgeColor,
-        strokeWidth: bidirectional ? 3 : 2,
+        stroke,
+        strokeWidth,
       },
       markerEnd: marker,
       ...(bidirectional ? { markerStart: marker } : {}),
@@ -262,4 +269,40 @@ export function createEdges(links: TopologyLink[]): LinkEdge[] {
       data,
     };
   });
+}
+
+/**
+ * utilizationStyle maps a 0–100 utilisation percent to a stroke
+ * width + colour tint. Buckets match the design table in #552:
+ *
+ *   0 – 24   : default colour, base width (no change)
+ *   25 – 59  : default colour, 3 px
+ *   60 – 84  : amber, 4 px
+ *   85+      : red, 5 px
+ *
+ * When utilisation is undefined or 0, we return the unmodified base
+ * colour + the smallest non-zero width sentinel (0) so the caller's
+ * Math.max picks the direction-based default. Callers MUST take
+ * Math.max(baseWidth, returned-width).
+ */
+function utilizationStyle(
+  utilisation: number | undefined,
+  baseColor: string,
+): { stroke: string; strokeWidth: number } {
+  if (utilisation === undefined || utilisation <= 0) {
+    return { stroke: baseColor, strokeWidth: 0 };
+  }
+  if (utilisation < 25) {
+    return { stroke: baseColor, strokeWidth: 0 };
+  }
+  if (utilisation < 60) {
+    return { stroke: baseColor, strokeWidth: 3 };
+  }
+  if (utilisation < 85) {
+    // amber-500 — keeps in-house palette consistent with existing
+    // status tints elsewhere in the UI.
+    return { stroke: '#f59e0b', strokeWidth: 4 };
+  }
+  // red-500 for >= 85 %.
+  return { stroke: '#ef4444', strokeWidth: 5 };
 }

--- a/ui/src/pages/topology/types.ts
+++ b/ui/src/pages/topology/types.ts
@@ -47,6 +47,10 @@ export interface LinkEdgeData extends Record<string, unknown> {
    *  ReactFlow's onEdgeMouseEnter / Leave at the page level; the
    *  TrunkEdge component renders the rich tooltip while true. */
   hovered?: boolean;
+  /** Link utilization, 0–100. When set, drives a stroke-width and
+   *  colour-tint adjustment in createEdges so saturating links pop
+   *  visually. Undefined or 0 → default styling. */
+  utilizationPercent?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
First of the three #552 follow-ups. Visual change only — the daemon already returns \`link.utilizationPercent\` on \`api.TopologyLink\` (today always 0 because counter wiring is a separate work item), so this PR is purely UI surfacing that lights up the moment counters arrive.

## What changes

### \`layout.ts\` — \`createEdges\`
Threads \`link.utilizationPercent\` into \`LinkEdgeData\` and feeds it through a new \`utilizationStyle()\` helper that maps 0–100 % into a stroke width + colour bucket per the design table in #552:

| Utilisation | Stroke width | Colour     |
|------------:|-------------:|:-----------|
|   0 – 24 %  | base         | default    |
|  25 – 59 %  | 3 px         | default    |
|  60 – 84 %  | 4 px         | amber-500  |
|  85 % +     | 5 px         | red-500    |

Stroke width is \`Math.max(direction-based-base, utilisation)\` so trunks don't shrink when utilisation is unknown.

### \`TrunkEdge.tsx\`
Hover tooltip gains a **Utilisation: N %** row when the value is > 0.

### Types
- \`api-response-types.ts\` — rename stub field \`TopologyLink.utilization\` → \`utilizationPercent\` so it matches the daemon's \`utilization_percent\` after the request layer's snake→camel conversion. Adds a docstring explaining the wire contract.
- \`topology/types.ts\` — \`LinkEdgeData\` gains \`utilizationPercent\` so \`TrunkEdge\` can render the tooltip row.

## Scope

Visual presentation only. Counter wiring on the daemon side is captured as a follow-up — until that lands, the styling stays a no-op for real data but is ready to light up the moment counters arrive.

## Test plan
- [x] \`npm run build\` clean
- [x] \`go test ./...\` clean (no Go changes; daemon-side field was already present)
- [ ] Smoke: hand-edit a topology link's utilizationPercent in browser devtools, confirm stroke width/colour buckets activate at 25 / 60 / 85
- [ ] Smoke: hover an edge with utilisation > 0, confirm "Utilisation: N %" row appears in tooltip

Refs: #552 (PR 1 of 3; PRs 2 = right-click menu, 3 = layout modes)