### PR TITLE
build(release): add .goreleaser.yml + parallel dispatch workflow

### DIFF
--- a/.github/workflows/release-goreleaser.yml
+++ b/.github/workflows/release-goreleaser.yml
@@ -1,0 +1,169 @@
+# =============================================================================
+# Release (goreleaser) — PARALLEL ROLLOUT
+# =============================================================================
+# Status: NOT the canonical release pipeline. .github/workflows/release.yml
+# is still authoritative for tag-triggered releases. This workflow is
+# workflow_dispatch-only and produces a snapshot under dist/ that can be
+# downloaded and diffed against release.yml's output. Once dry-runs match,
+# a follow-up PR will switch the tag trigger over and delete release.yml.
+#
+# Mirrors seed's .github/workflows/release.yml shape so the two projects
+# converge on the same release tooling.
+#
+# Toolchain notes:
+#   Build runs inside the goreleaser-cross Docker image which ships:
+#     - gcc + gcc-aarch64-linux-gnu (Linux cross)
+#     - mingw-w64 (Windows cross; we use CGO_ENABLED=0 there anyway)
+#     - osxcross + macOS SDK (Darwin cross)
+#   Node + UI build run in a separate job; goreleaser picks up the
+#   embedded dist via internal/api/ui/ (vite config writes there).
+#   libpcap-dev:arm64 is apt-installed at the start because the cross
+#   image doesn't ship libpcap headers per target arch.
+#
+# Inputs: only the typed `dry_run` boolean — no untrusted event fields
+# are interpolated into shell commands.
+# =============================================================================
+
+name: Release (goreleaser)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Snapshot build only - do not publish or sign"
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write # cosign keyless OIDC
+  packages: write
+
+jobs:
+  # =========================================================================
+  # UI build - done outside the goreleaser-cross container because that
+  # image is Go-focused and doesn't ship Node. We build internal/api/ui/
+  # here so the next job can pick up the directory and let goreleaser's
+  # Go build embed it.
+  # =========================================================================
+  build-ui:
+    name: Build UI
+    runs-on: ubuntu-latest
+    outputs:
+      ui_hash: ${{ steps.ui-hash.outputs.hash }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "25.2.1"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Build UI
+        run: |
+          cd ui
+          npm ci
+          npm run build
+
+      - name: Compute UI build hash
+        id: ui-hash
+        run: |
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
+          echo "hash=$UI_BUILD_HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload UI dist
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: ui-dist
+          path: internal/api/ui/
+          retention-days: 1
+          include-hidden-files: true
+
+  # =========================================================================
+  # goreleaser build + (when not dry-run) publish.
+  # Runs inside goreleaser-cross container so all cross-compile toolchains
+  # are present.
+  # =========================================================================
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    needs: [build-ui]
+    container:
+      # Docker Hub tag scheme: <go-version>-<bundle-revision>. v1.26.2-3
+      # tracks Go 1.26.2 + goreleaser v2.15.4. Pin so behaviour stays
+      # reproducible; bump via dependabot when newer revs land.
+      image: goreleaser/goreleaser-cross:v1.26.2-3
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Mark workspace as safe (container runs as root)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install libpcap headers for amd64 + arm64
+        # goreleaser-cross ships compilers but not libpcap headers.
+        # gopacket/pcap needs pcap.h for cgo. Add the arm64 architecture
+        # and pull libpcap-dev for both archs.
+        shell: bash
+        run: |
+          set -euo pipefail
+          dpkg --add-architecture arm64
+          if [ -f /etc/apt/sources.list ]; then
+            sed -i 's|^deb |deb [arch=amd64] |' /etc/apt/sources.list
+          fi
+          shopt -s nullglob
+          for f in /etc/apt/sources.list.d/*.list; do
+            sed -i 's|^deb |deb [arch=amd64] |' "$f"
+          done
+          cat > /etc/apt/sources.list.d/arm64.list <<'EOF'
+          deb [arch=arm64] http://deb.debian.org/debian bookworm main
+          deb [arch=arm64] http://deb.debian.org/debian-security bookworm-security main
+          deb [arch=arm64] http://deb.debian.org/debian bookworm-updates main
+          EOF
+          apt-get update || true
+          apt-get install -y libpcap-dev libpcap-dev:arm64
+
+      - name: Download UI dist
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ui-dist
+          path: internal/api/ui/
+
+      - name: Install Syft (SBOM) inside container
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Install Cosign inside container
+        run: |
+          COSIGN_VERSION=v2.4.1
+          curl -sSfL -o /usr/local/bin/cosign "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
+          chmod +x /usr/local/bin/cosign
+
+      - name: Run goreleaser (snapshot/dry-run)
+        if: inputs.dry_run
+        env:
+          UI_BUILD_HASH: ${{ needs.build-ui.outputs.ui_hash }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goreleaser release --snapshot --clean --skip=publish,announce
+
+      - name: Run goreleaser (publish)
+        if: ${{ !inputs.dry_run }}
+        env:
+          UI_BUILD_HASH: ${{ needs.build-ui.outputs.ui_hash }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goreleaser release --clean
+
+      - name: Upload dry-run artifact bundle for inspection
+        if: inputs.dry_run
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: goreleaser-dryrun-${{ github.run_id }}
+          path: dist/
+          retention-days: 14

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,310 @@
+# =============================================================================
+# goreleaser config for NIAC (Network In A Can)
+# =============================================================================
+# First-pass migration of release.yml's hand-coded pipeline.
+#
+# Status: PARALLEL ROLLOUT. The canonical release pipeline is still
+# .github/workflows/release.yml. This config is exercised only by
+# .github/workflows/release-goreleaser.yml on workflow_dispatch. Once a
+# dry-run produces artifacts equivalent to release.yml's output, a
+# follow-up PR will swap the tag trigger over and delete the old workflow.
+#
+# Shape mirrors seed's .goreleaser.yml so the two projects standardise on
+# the same release tooling.
+#
+# Things this config covers natively:
+#   - Multi-arch builds (linux amd64/arm64, darwin amd64/arm64, windows
+#     amd64/arm64)
+#   - .tar.gz, .zip, .deb, .rpm
+#   - ldflags injection (version, commit, date, uiBuildHash) targeting
+#     niac's main.* package globals (not a separate version package)
+#   - cosign keyless signing of every artifact
+#   - syft SBOM per archive
+#   - SHA-256 checksums
+#
+# Things still handled outside goreleaser:
+#   - macOS .pkg installer via deploy/macos/build-pkg.sh — kept as a
+#     local-only convenience; the .tar.gz is the published artifact
+#   - UI frontend build — runs in the build-ui job inside
+#     release-goreleaser.yml; goreleaser's `before:` hook just verifies
+#     the dist directory is populated before the Go build embeds it
+#
+# Tested against goreleaser v2.x inside goreleaser-cross:v1.26.2-3.
+# =============================================================================
+
+version: 2
+
+project_name: niac
+
+before:
+  hooks:
+    - go mod download
+    # UI dist is built BEFORE goreleaser runs (in the build-ui job inside
+    # release-goreleaser.yml) and written to internal/api/ui/. internal/api/static.go
+    # then `go:embed`s it into the binary. Just verify it landed.
+    - bash -c 'test -f internal/api/ui/index.html || (echo "internal/api/ui/index.html missing — UI build step failed or artifact missing"; exit 1)'
+
+builds:
+  - id: niac-linux
+    main: ./cmd/niac
+    binary: niac
+    env:
+      - CGO_ENABLED=1
+    goos: [linux]
+    goarch: [amd64, arm64]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags: &ldflags
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+      - -X main.uiBuildHash={{.Env.UI_BUILD_HASH}}
+    # Per-target cross-compile settings. goreleaser-cross has all of
+    # these toolchains preinstalled; without them, building linux/arm64
+    # from an amd64 host fails on cgo runtime ARM64 assembly.
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
+          - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+
+  - id: niac-darwin
+    main: ./cmd/niac
+    binary: niac
+    env:
+      - CGO_ENABLED=1
+    goos: [darwin]
+    goarch: [amd64, arm64]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags: *ldflags
+    # macOS cross-compile via osxcross (bundled in goreleaser-cross).
+    # The CC paths are stable inside the container image.
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CC=o64-clang
+          - CXX=o64-clang++
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CC=oa64-clang
+          - CXX=oa64-clang++
+
+  - id: niac-windows
+    main: ./cmd/niac
+    binary: niac
+    # Windows: CGO disabled (gopacket/pcap fork handles the build without
+    # native libpcap-windows toolchain). Matches release.yml.
+    env:
+      - CGO_ENABLED=0
+    goos: [windows]
+    goarch: [amd64, arm64]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags: *ldflags
+
+archives:
+  - id: linux-archive
+    ids: [niac-linux]
+    name_template: "niac-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      # Built-in YAML templates — same set the nfpm packages bundle.
+      - src: cmd/niac/templates/*.yaml
+        dst: templates
+      - src: examples/combinations/*.yaml
+        dst: templates/combinations
+      - src: examples/layer2/*.yaml
+        dst: templates/layer2
+      - src: examples/network/*.yaml
+        dst: templates/network
+      - src: examples/services/*.yaml
+        dst: templates/services
+      - src: examples/snmp/*.yaml
+        dst: templates/snmp
+      - src: examples/vendors/*.yaml
+        dst: templates/vendors
+      # Systemd unit so the tarball is a one-stop install for systemd hosts.
+      - src: deploy/systemd/niac.service
+        dst: systemd/niac.service
+
+  - id: darwin-archive
+    ids: [niac-darwin]
+    name_template: "niac-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - src: cmd/niac/templates/*.yaml
+        dst: templates
+      - src: examples/combinations/*.yaml
+        dst: templates/combinations
+      - src: examples/layer2/*.yaml
+        dst: templates/layer2
+      - src: examples/network/*.yaml
+        dst: templates/network
+      - src: examples/services/*.yaml
+        dst: templates/services
+      - src: examples/snmp/*.yaml
+        dst: templates/snmp
+      - src: examples/vendors/*.yaml
+        dst: templates/vendors
+      # launchd plist for macOS users who run niac as a service.
+      - src: deploy/launchd/com.mustardseednetworks.niac.plist
+        dst: launchd/com.mustardseednetworks.niac.plist
+
+  - id: windows-archive
+    ids: [niac-windows]
+    name_template: "niac-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    formats: [zip]
+    files:
+      - src: cmd/niac/templates/*.yaml
+        dst: templates
+      - src: examples/combinations/*.yaml
+        dst: templates/combinations
+      - src: examples/layer2/*.yaml
+        dst: templates/layer2
+      - src: examples/network/*.yaml
+        dst: templates/network
+      - src: examples/services/*.yaml
+        dst: templates/services
+      - src: examples/snmp/*.yaml
+        dst: templates/snmp
+      - src: examples/vendors/*.yaml
+        dst: templates/vendors
+      - src: deploy/windows/install.ps1
+        dst: install.ps1
+
+# Linux .deb + .rpm via nfpm (built into goreleaser). Port of .nfpm.yaml —
+# this lets us delete that sidecar file once parallel runs are validated.
+nfpms:
+  - id: linux-packages
+    ids: [niac-linux]
+    package_name: niac
+    vendor: Mustard Seed Networks
+    homepage: https://github.com/krisarmstrong/niac-go
+    maintainer: Kris Armstrong <kris@mustardseednetworks.com>
+    description: |
+      NIAC - Network In A Can by Mustard Seed Networks
+      .
+      NIAC is a network device simulator supporting SNMP agent simulation,
+      device template management, walk file capture and replay, multi-device
+      orchestration, packet capture / traffic generation, and a Web UI for
+      configuration management.
+    license: Proprietary
+    section: net
+    priority: optional
+    formats:
+      - deb
+      - rpm
+    file_name_template: >-
+      {{- if eq .ConventionalExtension ".deb" -}}
+        niac_{{ .Version }}_{{ .Arch }}
+      {{- else if eq .ConventionalExtension ".rpm" -}}
+        {{- $rpmarch := .Arch -}}
+        {{- if eq .Arch "amd64" }}{{ $rpmarch = "x86_64" }}{{ end -}}
+        {{- if eq .Arch "arm64" }}{{ $rpmarch = "aarch64" }}{{ end -}}
+        niac-{{ .Version }}-1.{{ $rpmarch }}
+      {{- end -}}
+    dependencies:
+      - systemd
+    overrides:
+      deb:
+        dependencies:
+          - libpcap0.8 | libpcap0.8t64
+          - systemd
+          - libcap2-bin
+      rpm:
+        dependencies:
+          - libpcap
+          - systemd
+          - libcap
+    contents:
+      - src: ./deploy/systemd/niac.service
+        dst: /usr/lib/systemd/system/niac.service
+        file_info:
+          mode: 0o644
+      # Built-in YAML templates — same set the tar.gz archives include.
+      - src: ./cmd/niac/templates/*.yaml
+        dst: /var/lib/niac/templates/
+      - src: ./examples/combinations/*.yaml
+        dst: /var/lib/niac/templates/combinations/
+      - src: ./examples/layer2/*.yaml
+        dst: /var/lib/niac/templates/layer2/
+      - src: ./examples/network/*.yaml
+        dst: /var/lib/niac/templates/network/
+      - src: ./examples/services/*.yaml
+        dst: /var/lib/niac/templates/services/
+      - src: ./examples/snmp/*.yaml
+        dst: /var/lib/niac/templates/snmp/
+      - src: ./examples/vendors/*.yaml
+        dst: /var/lib/niac/templates/vendors/
+      # Owner-only data + log dirs that the maintainer scripts populate.
+      - dst: /etc/niac
+        type: dir
+        file_info:
+          mode: 0o750
+          owner: niac
+          group: niac
+      - dst: /var/lib/niac
+        type: dir
+        file_info:
+          mode: 0o750
+          owner: niac
+          group: niac
+      - dst: /var/log/niac
+        type: dir
+        file_info:
+          mode: 0o750
+          owner: niac
+          group: niac
+    scripts:
+      preinstall: ./deploy/nfpm/preinstall.sh
+      postinstall: ./deploy/nfpm/postinstall.sh
+      preremove: ./deploy/nfpm/preremove.sh
+      postremove: ./deploy/nfpm/postremove.sh
+    bindir: /usr/bin
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+sboms:
+  - id: archives-sbom
+    artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.sbom.json"
+
+signs:
+  # Sign all release artifacts via cosign keyless OIDC. Mirrors seed's
+  # signing block. Bundle format preserves Sigstore transparency log
+  # entry.
+  - cmd: cosign
+    signature: "${artifact}.cosign.bundle"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--bundle"
+      - "${artifact}.cosign.bundle"
+      - "${artifact}"
+    artifacts: all
+    output: true
+
+release:
+  github:
+    owner: krisarmstrong
+    name: niac-go
+  replace_existing_artifacts: true
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    NIAC {{ .Tag }} — Network In A Can by Mustard Seed Networks.
+
+snapshot:
+  version_template: "0.0.0-dryrun-{{ .ShortCommit }}"


### PR DESCRIPTION
## Summary
First leg of standardising niac's release pipeline with seed's (per the cross-project alignment plan).

This PR is **non-disruptive**: \`.github/workflows/release.yml\` remains the canonical pipeline on tag push. The new \`.github/workflows/release-goreleaser.yml\` is **workflow_dispatch-only** and produces snapshot artifacts under \`dist/\` for inspection. Once a dry-run matches release.yml's output, a follow-up will switch the tag trigger over and delete the 629-line hand-coded workflow.

## What's covered natively

| Today (release.yml, 629 lines) | After (.goreleaser.yml + workflow, ~470 lines) |
|---|---|
| 6-arch matrix builds (manual) | declarative \`builds:\` list |
| .deb / .rpm via parallel \`.nfpm.yaml\` + scripting | nfpm inline in goreleaser (one source of truth) |
| ldflags hand-spliced into each \`go build\` | \`ldflags:\` block with template variables |
| sha256 hand-computed per artifact | \`checksum:\` block |
| no signing | cosign keyless OIDC on every artifact |
| no SBOM | syft per archive |
| no snapshot/dry-run | \`goreleaser release --snapshot\` built-in |

## What's deliberately deferred

- **macOS .pkg installer** — kept as a local-only convenience in \`deploy/macos/build-pkg.sh\`. macOS users get the .tar.gz; goreleaser-cross can't produce a notarized .pkg from Linux anyway.
- **Homebrew tap** — niac doesn't have one yet; trivial to add via a \`brews:\` block once \`krisarmstrong/homebrew-tap\` exists.
- **release-please** integration — separate PR (c in the plan).

## Validation

- [x] \`goreleaser check\` clean
- [ ] \`gh workflow run release-goreleaser.yml -f dry_run=true\` — confirm goreleaser produces .tar.gz / .zip / .deb / .rpm for every (os, arch) combo; download \`goreleaser-dryrun-<run_id>\` artifact and diff against \`release.yml\`'s tag output
- [ ] Once dry-run validated, follow-up PR will swap the tag trigger and delete release.yml + .nfpm.yaml

## Cross-project alignment

Mirrors seed's \`.goreleaser.yml\` + \`release.yml\` shape. After both repos converge, the same goreleaser-cross image revision, the same nfpm contents structure, the same cosign signing block. Drift between the two release pipelines becomes a dependabot bump rather than a hand-port.