### PR TITLE
fix(release): goreleaser archive paths match actual deploy/ filenames

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -154,9 +154,16 @@ archives:
         dst: templates/snmp
       - src: examples/vendors/*.yaml
         dst: templates/vendors
-      # launchd plist for macOS users who run niac as a service.
-      - src: deploy/launchd/com.mustardseednetworks.niac.plist
-        dst: launchd/com.mustardseednetworks.niac.plist
+      # launchd plist + helper scripts for macOS users who run niac
+      # as a service. (Actual filename is com.niac.plist, NOT the
+      # fully-qualified bundle id — there's no namespacing convention
+      # in the existing deploy/launchd tree to match seed's.)
+      - src: deploy/launchd/com.niac.plist
+        dst: launchd/com.niac.plist
+      - src: deploy/launchd/install.sh
+        dst: launchd/install.sh
+      - src: deploy/launchd/uninstall.sh
+        dst: launchd/uninstall.sh
 
   - id: windows-archive
     ids: [niac-windows]
@@ -177,7 +184,10 @@ archives:
         dst: templates/snmp
       - src: examples/vendors/*.yaml
         dst: templates/vendors
-      - src: deploy/windows/install.ps1
+      # Windows install/build script (actual name is build.ps1; we
+      # surface it as install.ps1 inside the zip so end users see a
+      # consistent installer name across platforms).
+      - src: deploy/windows/build.ps1
         dst: install.ps1
 
 # Linux .deb + .rpm via nfpm (built into goreleaser). Port of .nfpm.yaml —


### PR DESCRIPTION
## Summary
First goreleaser dry-run ([run 25974520693](https://github.com/krisarmstrong/niac-go/actions/runs/25974520693)) failed at the archive step because two src globs referenced files that don't exist in this repo:

\`\`\`
deploy/launchd/com.mustardseednetworks.niac.plist   ← doesn't exist
deploy/windows/install.ps1                           ← doesn't exist
\`\`\`

The \`.mustardseednetworks.\` namespacing was carried over from seed mechanically; niac's launchd tree has no such convention. Actual filenames:

\`\`\`
deploy/launchd/com.niac.plist
deploy/launchd/install.sh + uninstall.sh
deploy/windows/build.ps1
\`\`\`

## Changes
- macOS archives now bundle the real \`com.niac.plist\` plus the existing \`install.sh\` / \`uninstall.sh\` helper scripts that ship next to it.
- Windows archives map source \`build.ps1\` → destination \`install.ps1\` so end users see a consistent installer filename across platforms.

## Validation
- [x] \`goreleaser check\` clean
- [ ] Re-run \`gh workflow run release-goreleaser.yml -f dry_run=true\` after merge; expect the archive step to pass and the run to progress to nfpm / sign / sbom

No semantic changes — config still parallel-rollout, still workflow_dispatch-only.