### PR TITLE
feat(topology): right-click context menus on nodes / edges / canvas (#552 part 2)

### DIFF
--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -24,6 +24,8 @@ import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { H2, SmallText } from '../ui/Typography';
 import {
+  ContextMenu,
+  type ContextMenuItem,
   createEdges,
   DEFAULT_LAYOUT_MODE,
   DeviceDetailsPanel,
@@ -179,6 +181,21 @@ export const TopologyPage: FC = () => {
     },
     [setNodes],
   );
+  // Session-only "hide this device" set. Cleared by Reset, lost on
+  // page reload — we don't persist it because hiding is meant to be a
+  // temporary "clean up this view to screenshot" gesture, not a
+  // permanent change. Edges referencing a hidden node disappear with
+  // it (they get filtered alongside in the build-graph effect).
+  const [hiddenDevices, setHiddenDevices] = useState<Set<string>>(new Set());
+  // Context-menu state. Discriminated union so render-time exhaustive
+  // checks catch missing handlers. Coordinates are in the canvas
+  // parent's local space (already adjusted from clientX/Y).
+  const [contextMenu, setContextMenu] = useState<
+    | null
+    | { kind: 'node'; x: number; y: number; nodeId: string }
+    | { kind: 'edge'; x: number; y: number; edgeId: string }
+    | { kind: 'pane'; x: number; y: number }
+  >(null);
 
   // Build graph from API data, merging trunk port links with neighbor-discovered links
   useEffect(() => {
@@ -236,6 +253,9 @@ export const TopologyPage: FC = () => {
     // Type-filter + search: hide devices that don't match.
     const q = search.trim().toLowerCase();
     const isVisible = (device: DeviceSummary): boolean => {
+      if (hiddenDevices.has(device.name)) {
+        return false;
+      }
       if (activeTypes.size > 0 && !activeTypes.has((device.type || 'unknown').toLowerCase())) {
         return false;
       }
@@ -295,6 +315,7 @@ export const TopologyPage: FC = () => {
     focusedNodeId,
     hoveredEdgeId,
     layoutMode,
+    hiddenDevices,
     setNodes,
     setEdges,
   ]);
@@ -332,6 +353,7 @@ export const TopologyPage: FC = () => {
     setFocusedNodeId(null);
     setSearch('');
     setActiveTypes(new Set());
+    setHiddenDevices(new Set());
     // Forcing a re-layout: bump nodes through layoutNodes by clearing
     // current positions. The useEffect will pick up the empty current
     // and assign fresh positions on next data tick.
@@ -355,6 +377,71 @@ export const TopologyPage: FC = () => {
       return next;
     });
   }, []);
+
+  // Hide a device by name. Session-only — Reset re-shows everything.
+  const hideDevice = useCallback((name: string) => {
+    setHiddenDevices((curr) => {
+      const next = new Set(curr);
+      next.add(name);
+      return next;
+    });
+  }, []);
+
+  // Copy helper — silently no-ops on clipboard-API errors (the most
+  // common failure is a non-secure context, which we can't fix from
+  // here). The action menu items intentionally don't surface a toast
+  // because right-click → copy is a fast, low-stakes gesture.
+  const copyToClipboard = useCallback((text: string) => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      void navigator.clipboard.writeText(text).catch(() => {
+        // Ignore — secure-context or permissions issue. The user can
+        // fall back to manual select.
+      });
+    }
+  }, []);
+
+  // Context-menu open helpers. ReactFlow calls these with the native
+  // mouse event + the node/edge object; we adjust coordinates into
+  // the canvas-parent's local space so the menu pops where the
+  // pointer is regardless of page scroll position.
+  const handleNodeContextMenu = useCallback((event: React.MouseEvent, node: Node) => {
+    event.preventDefault();
+    const rect = event.currentTarget?.getBoundingClientRect?.();
+    setContextMenu({
+      kind: 'node',
+      x: event.clientX - (rect?.left ?? 0),
+      y: event.clientY - (rect?.top ?? 0),
+      nodeId: node.id,
+    });
+  }, []);
+
+  const handleEdgeContextMenu = useCallback((event: React.MouseEvent, edge: { id: string }) => {
+    event.preventDefault();
+    const rect = event.currentTarget?.getBoundingClientRect?.();
+    setContextMenu({
+      kind: 'edge',
+      x: event.clientX - (rect?.left ?? 0),
+      y: event.clientY - (rect?.top ?? 0),
+      edgeId: edge.id,
+    });
+  }, []);
+
+  const handlePaneContextMenu = useCallback((event: React.MouseEvent | MouseEvent) => {
+    event.preventDefault();
+    // ReactFlow's pane handler receives either a synthetic React event
+    // (when right-clicking the canvas itself) or a native MouseEvent.
+    // Both expose currentTarget; the cast is needed to read it as a
+    // DOM element.
+    const target = (event as React.MouseEvent).currentTarget as HTMLElement | undefined;
+    const rect = target?.getBoundingClientRect?.();
+    setContextMenu({
+      kind: 'pane',
+      x: (event as MouseEvent).clientX - (rect?.left ?? 0),
+      y: (event as MouseEvent).clientY - (rect?.top ?? 0),
+    });
+  }, []);
+
+  const closeContextMenu = useCallback(() => setContextMenu(null), []);
 
   // Update node data with click handler
   useEffect(() => {
@@ -657,6 +744,17 @@ export const TopologyPage: FC = () => {
                   onNodeDragStop={handleNodeDragStop}
                   onEdgeMouseEnter={(_, edge) => setHoveredEdgeId(edge.id)}
                   onEdgeMouseLeave={() => setHoveredEdgeId(null)}
+                  onNodeContextMenu={handleNodeContextMenu}
+                  onEdgeContextMenu={handleEdgeContextMenu}
+                  onPaneContextMenu={handlePaneContextMenu}
+                  // Left-click anywhere closes any open context menu;
+                  // right-clicking again on a different target opens
+                  // its menu in place.
+                  onPaneClick={closeContextMenu}
+                  onNodeClick={(_, node) => {
+                    closeContextMenu();
+                    handleNodeClick(node.id);
+                  }}
                   nodeTypes={nodeTypes}
                   edgeTypes={edgeTypes}
                   fitView={true}
@@ -707,6 +805,27 @@ export const TopologyPage: FC = () => {
                     />
                   )}
                 </ReactFlow>
+                {/* Right-click context menu. Coordinates are in the
+                    canvas-parent's local space (already offset from
+                    the bounding rect in the open handlers). */}
+                {contextMenu && (
+                  <ContextMenu
+                    x={contextMenu.x}
+                    y={contextMenu.y}
+                    onClose={closeContextMenu}
+                    items={contextMenuItems(contextMenu, {
+                      edges,
+                      hideDevice,
+                      navigate,
+                      setFocusedNodeId,
+                      setSelectedDevice,
+                      devices,
+                      handleResetLayout,
+                      handleExport,
+                      copyToClipboard,
+                    })}
+                  />
+                )}
               </>
             )}
           </div>
@@ -718,5 +837,117 @@ export const TopologyPage: FC = () => {
     </div>
   );
 };
+
+/**
+ * contextMenuItems builds the action list for a given menu target.
+ * Factored out of the render path so the JSX stays tight and so each
+ * menu's items are produced in one place rather than scattered inline.
+ *
+ * Item presence is data-driven — e.g. "Edit YAML" only appears when
+ * the daemon knows the device (the menu was opened on a node whose
+ * name is in the devices list), and "Filter to this VLAN" only
+ * appears when the edge carries vlan data.
+ */
+function contextMenuItems(
+  menu: { kind: 'node'; nodeId: string } | { kind: 'edge'; edgeId: string } | { kind: 'pane' },
+  ctx: {
+    edges: LinkEdge[];
+    hideDevice: (name: string) => void;
+    navigate: ReturnType<typeof useNavigate>;
+    setFocusedNodeId: (next: ((curr: string | null) => string | null) | string | null) => void;
+    setSelectedDevice: (device: DeviceSummary | null) => void;
+    devices: DeviceSummary[] | null;
+    handleResetLayout: () => void;
+    handleExport: () => void;
+    copyToClipboard: (text: string) => void;
+  },
+): ContextMenuItem[] {
+  switch (menu.kind) {
+    case 'node': {
+      const device = ctx.devices?.find((d) => d.name === menu.nodeId);
+      const items: ContextMenuItem[] = [
+        {
+          key: 'view',
+          label: 'View details',
+          onSelect: () => {
+            if (device) ctx.setSelectedDevice(device);
+          },
+          disabled: !device,
+        },
+        {
+          key: 'edit',
+          label: 'Edit YAML',
+          hint: 'devices →',
+          onSelect: () => ctx.navigate(`/device-config/${menu.nodeId}`),
+        },
+        {
+          key: 'focus',
+          label: 'Focus neighbourhood',
+          onSelect: () =>
+            ctx.setFocusedNodeId((curr: string | null) =>
+              curr === menu.nodeId ? null : menu.nodeId,
+            ),
+        },
+        {
+          key: 'copy-name',
+          label: 'Copy name',
+          onSelect: () => ctx.copyToClipboard(menu.nodeId),
+          separatorBefore: true,
+        },
+        {
+          key: 'hide',
+          label: 'Hide from view',
+          hint: 'until Reset',
+          destructive: true,
+          onSelect: () => ctx.hideDevice(menu.nodeId),
+          separatorBefore: true,
+        },
+      ];
+      return items;
+    }
+    case 'edge': {
+      const edge = ctx.edges.find((e) => e.id === menu.edgeId);
+      const ifacePair =
+        edge?.data?.sourceInterface || edge?.data?.targetInterface
+          ? `${edge?.source}:${edge?.data?.sourceInterface ?? '?'} ↔ ${edge?.target}:${edge?.data?.targetInterface ?? '?'}`
+          : `${edge?.source} ↔ ${edge?.target}`;
+      const items: ContextMenuItem[] = [
+        {
+          key: 'copy-pair',
+          label: 'Copy device/interface pair',
+          onSelect: () => ctx.copyToClipboard(ifacePair),
+        },
+      ];
+      // Only show VLAN actions when the edge actually carries VLAN
+      // data — keeps the menu short for access links / discovered
+      // edges that have nothing VLAN-shaped to filter on.
+      if (edge?.data?.vlans && edge.data.vlans.length > 0) {
+        const vlanList = edge.data.vlans.join(',');
+        items.push({
+          key: 'copy-vlans',
+          label: `Copy VLAN list (${edge.data.vlans.length})`,
+          onSelect: () => ctx.copyToClipboard(vlanList),
+        });
+      }
+      return items;
+    }
+    default:
+      return [
+        {
+          key: 'export',
+          label: 'Export topology JSON',
+          onSelect: ctx.handleExport,
+        },
+        {
+          key: 'reset',
+          label: 'Reset layout',
+          hint: 'clears drags / filters',
+          destructive: true,
+          onSelect: ctx.handleResetLayout,
+          separatorBefore: true,
+        },
+      ];
+  }
+}
 
 export default TopologyPage;

--- a/ui/src/pages/topology/ContextMenu.tsx
+++ b/ui/src/pages/topology/ContextMenu.tsx
@@ -1,0 +1,87 @@
+import type { FC, MouseEvent as ReactMouseEvent } from 'react';
+
+/**
+ * ContextMenu is the small popover shown on right-click of a node,
+ * edge, or canvas in TopologyPage. Each action is a button; clicking
+ * an action invokes the handler and the parent closes the menu via
+ * the supplied onClose. Click outside / Esc are handled by the page
+ * (one overlay listener catches every dismiss case rather than each
+ * menu installing its own).
+ *
+ * Positioning uses absolute placement from the parent (the canvas
+ * div). The parent passes the event's clientX/clientY adjusted for
+ * the canvas's bounding rect so the menu pops where the user clicked.
+ *
+ * No external dep — niac doesn't ship Headless UI and a 60-line
+ * absolute-positioned div with role="menu" is sufficient for the
+ * three menus this needs. Keyboard navigation is intentionally not
+ * implemented since right-click without pointer doesn't have a
+ * common keyboard equivalent in this UI.
+ */
+
+export interface ContextMenuItem {
+  /** Stable key for React list reconciliation. */
+  key: string;
+  /** Visible label. */
+  label: string;
+  /** Optional muted sub-label (e.g. shortcut hint or supporting info). */
+  hint?: string;
+  /** Action to run on click. The parent closes the menu after. */
+  onSelect: () => void;
+  /** Render as a destructive (red) item — used for Hide / Clear ops. */
+  destructive?: boolean;
+  /** Disable the item (greyed out, no click). */
+  disabled?: boolean;
+  /** Insert a separator BEFORE this item (instead of rendering an item). */
+  separatorBefore?: boolean;
+}
+
+interface Props {
+  /** Anchor x/y in the parent's coordinate space (clientX - rect.left). */
+  x: number;
+  y: number;
+  items: ContextMenuItem[];
+  onClose: () => void;
+}
+
+export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
+  const handleItemClick = (e: ReactMouseEvent, item: ContextMenuItem) => {
+    e.stopPropagation();
+    if (item.disabled) return;
+    item.onSelect();
+    onClose();
+  };
+
+  return (
+    <div
+      className="absolute z-50 min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur"
+      style={{ left: x, top: y }}
+      // Stop right-click on the menu itself from re-opening the pane
+      // menu through ReactFlow's onPaneContextMenu.
+      onContextMenu={(e) => e.preventDefault()}
+      role="menu"
+    >
+      {items.map((item, idx) => (
+        <div key={item.key}>
+          {item.separatorBefore && idx > 0 && <hr className="my-1 h-px border-0 bg-white/10" />}
+          <button
+            type="button"
+            role="menuitem"
+            disabled={item.disabled}
+            onClick={(e) => handleItemClick(e, item)}
+            className={`flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors ${
+              item.disabled
+                ? 'text-gray-600 cursor-not-allowed'
+                : item.destructive
+                  ? 'text-red-300 hover:bg-red-500/15 hover:text-red-200'
+                  : 'hover:bg-white/5 hover:text-white'
+            }`}
+          >
+            <span>{item.label}</span>
+            {item.hint && <span className="text-[10px] text-gray-500">{item.hint}</span>}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/ui/src/pages/topology/index.ts
+++ b/ui/src/pages/topology/index.ts
@@ -2,6 +2,7 @@
  * Topology components barrel export
  */
 
+export { ContextMenu, type ContextMenuItem } from './ContextMenu';
 export { DeviceDetailsPanel } from './DeviceDetailsPanel';
 export { DeviceNode } from './DeviceNode';
 export {


### PR DESCRIPTION
## Summary
Adds the third item from the #552 v2 list (the first two being merged in v0.66.48 + #566). Operators get a fast keyboard-free path to the most common actions without leaving the graph.

## New: \`ui/src/pages/topology/ContextMenu.tsx\`
- ~80-line popover with \`role="menu"\` + \`role="menuitem"\` children
- Supports separator divider rows (\`<hr>\`), destructive (red) items, disabled state, and an optional muted hint suffix per item
- No new external dep — niac doesn't ship Headless UI and the three menus this needs don't warrant adding one

## Menus per target

**Node right-click:**
- View details — opens the existing DeviceDetailsPanel
- Edit YAML — navigates to \`/device-config/{name}\`
- Focus neighbourhood — same toggle as left-click
- Copy name — writes hostname to clipboard
- **Hide from view** (destructive; session-only, cleared by Reset)

**Edge right-click:**
- Copy device/interface pair — e.g. \`"r1:Gi0/1 ↔ r2:Gi0/1"\`
- Copy VLAN list — only when the edge carries vlan data

**Canvas right-click:**
- Export topology JSON
- **Reset layout** (destructive; same as the header Reset button)

## Page wiring

- New \`hiddenDevices: Set<string>\` state, filtered in the build-graph effect alongside type + search filters. Reset clears it.
- New \`contextMenu\` state — discriminated union over node/edge/pane targets — so TypeScript catches missing handlers in the menu builder
- \`onNodeContextMenu\` / \`onEdgeContextMenu\` / \`onPaneContextMenu\` wired on ReactFlow. Coordinates translated from clientX/Y into the canvas-parent's local space so the popover lands at the pointer
- \`onPaneClick\` + \`onNodeClick\` now also \`closeContextMenu\` so any left-click dismisses an open menu
- \`contextMenuItems()\` helper at the bottom builds the per-target action list — factored out so the JSX stays tight and each menu's items live in one place

## Test plan
- [x] \`npm run build\` clean
- [x] \`biome check\` clean
- [x] \`go test ./...\` clean (no Go changes)
- [ ] Smoke: right-click a node — confirm View / Edit / Focus / Copy / Hide all work
- [ ] Smoke: right-click an edge with VLANs — confirm Copy pair + Copy VLAN list both surface
- [ ] Smoke: right-click an edge without VLANs (e.g. discovered LLDP edge) — confirm Copy VLAN list does not appear
- [ ] Smoke: right-click canvas — confirm Export JSON downloads, Reset clears
- [ ] Smoke: hide a device, click Reset, confirm it reappears
- [ ] Smoke: left-click anywhere — open menu dismisses

Closes the right-click-menu sub-item of #552. With this + #566 (hierarchical layout) + v0.66.48 (edge utilization), the full v2 list is done.