### PR TITLE
fix(release): goreleaser publish needs --skip=validate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,14 @@ jobs:
         env:
           UI_BUILD_HASH: ${{ needs.build-ui.outputs.ui_hash }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: goreleaser release --clean
+        # --skip=validate matches what `--snapshot` does on the dry-run
+        # path. Needed because the UI build downloaded into
+        # internal/api/ui/ overwrites tracked stubs (index.html with
+        # the prior bundle's hashed asset references), which goreleaser
+        # otherwise flags as "git is in a dirty state". PR-level CI
+        # already validates the same content via the dry-run snapshot
+        # in the parallel-rollout era, so trusting it here is safe.
+        run: goreleaser release --clean --skip=validate
 
       - name: Upload dry-run artifact bundle for inspection
         if: inputs.dry_run


### PR DESCRIPTION
## Summary
First real (non-dry-run) goreleaser publish on v0.67.0 ([run 25976166106](https://github.com/krisarmstrong/niac-go/actions/runs/25976166106)) failed at the dirty-tree validation step with:

\`\`\`
git is in a dirty state
 M internal/api/ui/index.html
\`\`\`

That file is a tracked stub (the embedded SPA shell with vite's content-hashed asset references). The build-ui job downloads the freshly-built bundle into \`internal/api/ui/\` before goreleaser runs, which overwrites the stub with the new hash-suffixed asset names. goreleaser's validate pipe sees that as repo modification and refuses to publish.

Dry-run (\`--snapshot\`) skips validate implicitly, which is why every parallel-rollout dry-run passed cleanly. Real publish needs the same behaviour explicitly via \`--skip=validate\`.

## Alternatives considered
- **Reset the dirty files before goreleaser**: would lose the freshly-built UI, breaking the embed
- **Untrack \`internal/api/ui/index.html\` entirely**: correct long-term cleanup but invasive — other consumers reference the tracked path during \`go test\` runs
- **\`--skip=validate\`** (chosen): trusts CI to have caught real validation issues before tag. PR-level checks already run \`goreleaser check\` on every push, so the publish path is safe to trust

## Recovery
After this merges, re-tag (v0.67.1) to trigger a fresh run. The artifacts produced by the failed v0.67.0 run never made it to the release page so there's nothing to clean up there.

## Test plan
- [ ] Merge
- [ ] \`git tag -a v0.67.1 -m "v0.67.1 — re-trigger release after publish fix" && git push origin v0.67.1\`
- [ ] Watch the resulting release run produce signed + SBOM'd artifacts on the GitHub release page