### PR TITLE
feat(synth): vendor + model profile expansion (#570 PR 1)

### DIFF
--- a/internal/api/handlers_synthesize_walk.go
+++ b/internal/api/handlers_synthesize_walk.go
@@ -17,8 +17,18 @@ import (
 // SynthesizeWalkRequest is the body for POST
 // /api/v1/devices/{hostname}/synthesize-walk. See
 // docs/design/2026-05-baseline-walk-synthesis.md for the contract.
+//
+// When Model is non-empty, the daemon resolves the per-model
+// profile (synth.PickModel) — the walk gets the model's real
+// sysObjectID + sysDescr. Vendor still required because Model
+// strings aren't globally unique across vendors.
+//
+// When Model is empty, falls back to synth.Pick(vendor, deviceType)
+// — the original v0.66.x behaviour with the per-vendor generic
+// profile.
 type SynthesizeWalkRequest struct {
 	Vendor         string `json:"vendor"`
+	Model          string `json:"model,omitempty"`
 	InterfaceCount int    `json:"interfaceCount,omitempty"`
 	Community      string `json:"community,omitempty"`
 }
@@ -30,6 +40,20 @@ type SynthesizeWalkResponse struct {
 	OIDCount           int    `json:"oidCount"`
 	SizeBytes          int    `json:"sizeBytes"`
 	PreviousWalkBacked string `json:"previousWalkBacked,omitempty"`
+}
+
+// handleSynthesizeWalkModels handles GET /api/v1/synthesize-walk/models
+// — returns every defined (vendor, model, type) triple so the UI can
+// build the cascading Generate-walk picker without a per-vendor
+// round-trip. Read-only; the response body is the same list returned
+// by synth.AllModels() so callers can group/sort client-side.
+func (s *Server) handleSynthesizeWalkModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+		return
+	}
+	s.writeJSON(w, synth.AllModels())
 }
 
 // dispatchDeviceSubpath routes /api/v1/devices/{hostname}/{action}
@@ -106,8 +130,20 @@ func (s *Server) handleSynthesizeWalk(w http.ResponseWriter, r *http.Request) {
 		vendor = synth.VendorGeneric
 	}
 	deviceType := synth.DeviceType(strings.ToLower(strings.TrimSpace(dev.Type)))
+	model := synth.Model(strings.TrimSpace(req.Model))
 
-	profile, profileErr := synth.Pick(vendor, deviceType)
+	// Prefer the per-model profile when the request specified one —
+	// the synthesised walk gets the real platform sysDescr + OID.
+	// Empty model falls back to the per-vendor generic.
+	var (
+		profile    synth.Profile
+		profileErr error
+	)
+	if model != "" {
+		profile, profileErr = synth.PickModel(vendor, model)
+	} else {
+		profile, profileErr = synth.Pick(vendor, deviceType)
+	}
 	if profileErr != nil {
 		// Per resolution #2 — no silent fallback. The daemon returns
 		// 422 so the UI can show "Vendor X has no profile for type Y".

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -109,6 +109,12 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/devices/",
 		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.dispatchDeviceSubpath)))))
 
+	// Vendor + model catalog for the Generate-walk UI picker (#570).
+	// Read-only; the response is the same list returned by
+	// synth.AllModels() so the dropdown can group/sort client-side.
+	mux.HandleFunc("/api/v1/synthesize-walk/models",
+		s.recoverMiddleware(s.auth(s.handleSynthesizeWalkModels)))
+
 	// Per-type device editor schema (#546 part 1). Read-only — the
 	// schema is a static table the daemon serves so the UI can hide
 	// sections that don't apply (e.g. switch should not see DNS).

--- a/internal/protocols/snmp/synth/models.go
+++ b/internal/protocols/snmp/synth/models.go
@@ -1,0 +1,374 @@
+package synth
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Model identifies a specific platform within a vendor. When the
+// operator picks a model in the Generate-walk modal, the synthesised
+// walk gets the model's real sysObjectID + a sysDescr that matches
+// what the real gear announces — closer to "indistinguishable from
+// real hardware" than the per-vendor generic profile.
+//
+// The string values follow the kebab-case slug convention so they
+// can ride straight through the JSON API + the UI dropdown without
+// any per-vendor escaping rules.
+type Model string
+
+// ModelDescriptor is the UI-facing view of a model. Returned by
+// Models() / ModelsForType() so the Generate-walk dropdown can
+// render labels + group by vendor without knowing the per-model
+// Profile fields directly.
+type ModelDescriptor struct {
+	Vendor    Vendor     `json:"vendor"`
+	Model     Model      `json:"model"`
+	Label     string     `json:"label"`     // "Catalyst 9300-48P (48× 1G)"
+	Type      DeviceType `json:"type"`      // type implied by the model
+	IfCount   int        `json:"ifCount"`   // default ifTable rows
+	SpeedMbps int        `json:"speedMbps"` // per-port speed
+}
+
+// modelEntry is the canonical record stored in modelTable. It builds
+// a Profile on demand so the per-model facts (sysDescr template,
+// sysObjectID, interface naming convention) stay co-located.
+type modelEntry struct {
+	descriptor   ModelDescriptor
+	sysDescr     string
+	sysObjectID  string
+	ifNameFormat string
+	// Per-model overrides for the include* flags. Default values
+	// inherit from the vendor's per-type profile via deriveFlags so
+	// new models don't need to think about every flag.
+	overrideFlags *profileFlags
+}
+
+type profileFlags struct {
+	includeIPMIB  bool
+	includeBridge bool
+	includeLLDP   bool
+	ipForwarding  bool
+}
+
+// Models returns every model defined for the vendor, sorted by
+// (Type, Label) for stable dropdown rendering. Used by the UI to
+// build the cascading vendor → model picker.
+func Models(v Vendor) []ModelDescriptor {
+	var out []ModelDescriptor
+	for _, e := range modelTable {
+		if e.descriptor.Vendor == v {
+			out = append(out, e.descriptor)
+		}
+	}
+	sortDescriptors(out)
+	return out
+}
+
+// ModelsForType returns models compatible with a device's type.
+// Drives the dropdown filtering — picking "Cisco IOS" for a router
+// only shows routers, not switches or APs.
+func ModelsForType(v Vendor, t DeviceType) []ModelDescriptor {
+	var out []ModelDescriptor
+	for _, e := range modelTable {
+		if e.descriptor.Vendor == v && e.descriptor.Type == t {
+			out = append(out, e.descriptor)
+		}
+	}
+	sortDescriptors(out)
+	return out
+}
+
+// AllModels returns every defined model across every vendor, sorted
+// by (Vendor, Type, Label). Used by the daemon's
+// /api/v1/synthesize-walk/models endpoint so the UI can build the
+// full picker in one round-trip.
+func AllModels() []ModelDescriptor {
+	out := make([]ModelDescriptor, 0, len(modelTable))
+	for _, e := range modelTable {
+		out = append(out, e.descriptor)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Vendor != out[j].Vendor {
+			return out[i].Vendor < out[j].Vendor
+		}
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		return out[i].Label < out[j].Label
+	})
+	return out
+}
+
+func sortDescriptors(d []ModelDescriptor) {
+	sort.Slice(d, func(i, j int) bool {
+		if d[i].Type != d[j].Type {
+			return d[i].Type < d[j].Type
+		}
+		return d[i].Label < d[j].Label
+	})
+}
+
+// PickModel returns the resolved Profile for a specific model. The
+// model implies the device type, so callers don't pass a separate
+// type — the Profile.Type field is set from the model's descriptor.
+//
+// Falls back to the vendor's per-type Profile for flags the model
+// doesn't override (e.g. a Cisco switch model inherits BRIDGE-MIB
+// inclusion from the cisco-ios + switch base profile).
+func PickModel(v Vendor, m Model) (Profile, error) {
+	e, ok := modelTable[modelKey{v, m}]
+	if !ok {
+		return Profile{}, fmt.Errorf("synth: no profile for vendor=%s model=%s", v, m)
+	}
+
+	flags := deriveFlags(v, e.descriptor.Type, e.overrideFlags)
+
+	return Profile{
+		Vendor:         v,
+		Type:           e.descriptor.Type,
+		SysDescr:       e.sysDescr,
+		SysObjectID:    e.sysObjectID,
+		IfNameFormat:   e.ifNameFormat,
+		DefaultIfCount: e.descriptor.IfCount,
+		IfSpeedMbps:    e.descriptor.SpeedMbps,
+		IncludeIPMIB:   flags.includeIPMIB,
+		IncludeBridge:  flags.includeBridge,
+		IncludeLLDP:    flags.includeLLDP,
+		IPForwarding:   flags.ipForwarding,
+	}, nil
+}
+
+// deriveFlags resolves the include* / ipForwarding flags for a
+// (vendor, type) — defaults from the per-vendor profile table, then
+// applies any per-model override.
+func deriveFlags(v Vendor, t DeviceType, override *profileFlags) profileFlags {
+	base, ok := lookupProfile(v, t)
+	out := profileFlags{}
+	if ok {
+		out = profileFlags{
+			includeIPMIB:  base.IncludeIPMIB,
+			includeBridge: base.IncludeBridge,
+			includeLLDP:   base.IncludeLLDP,
+			ipForwarding:  base.IPForwarding,
+		}
+	}
+	if override != nil {
+		out = *override
+	}
+	return out
+}
+
+type modelKey struct {
+	v Vendor
+	m Model
+}
+
+// modelTable is the canonical (vendor, model) → modelEntry map. Each
+// entry carries a model-specific sysDescr / sysObjectID; the include
+// flags fall back to the per-vendor profile via deriveFlags.
+//
+// sysObjectID values are real-world identifiers taken from each
+// vendor's published MIB. For models where the exact suffix isn't
+// public, we use a representative platform-family OID — the daemon
+// is a simulator, not a stand-in for a regulatory test rig.
+//
+//nolint:gochecknoglobals // static lookup
+var modelTable = func() map[modelKey]modelEntry {
+	out := map[modelKey]modelEntry{}
+	add := func(e modelEntry) {
+		out[modelKey{e.descriptor.Vendor, e.descriptor.Model}] = e
+	}
+
+	// ===== Cisco IOS =====
+	// Catalyst 9300 series — 48-port stackable access switches. The
+	// 48P SKU is 48× 1G PoE+; the 48Y SKU on 9500 is 48× 25G/100G uplink.
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "catalyst-9300-48p", Type: TypeSwitch,
+			Label:   "Catalyst 9300-48P (48× 1G PoE+)",
+			IfCount: ports48, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Cisco IOS Software [Cupertino], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.9.4, RELEASE SOFTWARE (fc4)",
+		sysObjectID:  "1.3.6.1.4.1.9.1.2238",
+		ifNameFormat: "GigabitEthernet1/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "catalyst-9500-48y4c", Type: TypeSwitch,
+			Label:   "Catalyst 9500-48Y4C (48× 25G + 4× 100G)",
+			IfCount: ports48, SpeedMbps: speed25G,
+		},
+		sysDescr:     "Cisco IOS Software [Cupertino], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.9.4, RELEASE SOFTWARE (fc4)",
+		sysObjectID:  "1.3.6.1.4.1.9.1.2779",
+		ifNameFormat: "TwentyFiveGigE1/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "nexus-9336c-fx2", Type: TypeSwitch,
+			Label:   "Nexus 9336C-FX2 (36× 100G)",
+			IfCount: ports36, SpeedMbps: speed100G,
+		},
+		sysDescr:     "Cisco Nexus Operating System (NX-OS) Software, Version 10.3(2)F",
+		sysObjectID:  "1.3.6.1.4.1.9.12.3.1.3.1858",
+		ifNameFormat: "Ethernet1/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "isr-4451-x", Type: TypeRouter,
+			Label:   "ISR 4451-X (4× 1G WAN/LAN)",
+			IfCount: ports4, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Cisco IOS Software [Fuji], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.9.4",
+		sysObjectID:  "1.3.6.1.4.1.9.1.1990",
+		ifNameFormat: "GigabitEthernet0/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "asr-9001", Type: TypeRouter,
+			Label:   "ASR 9001 (8× 10G)",
+			IfCount: ports8, SpeedMbps: speed10G,
+		},
+		sysDescr:     "Cisco IOS XR Software, ASR9K Series, Version 7.5.2",
+		sysObjectID:  "1.3.6.1.4.1.9.1.1240",
+		ifNameFormat: "TenGigE0/0/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "asa-5525-x", Type: TypeFirewall,
+			Label:   "ASA 5525-X (8× 1G)",
+			IfCount: ports8, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Cisco Adaptive Security Appliance Software Version 9.16(4)27",
+		sysObjectID:  "1.3.6.1.4.1.9.1.915",
+		ifNameFormat: "GigabitEthernet0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "ftd-2110", Type: TypeFirewall,
+			Label:   "Firepower 2110 (12× 1G + 4× 10G)",
+			IfCount: ports12, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Cisco Firepower Threat Defense for the 2100 Series Version 7.2.5",
+		sysObjectID:  "1.3.6.1.4.1.9.1.2253",
+		ifNameFormat: "Ethernet1/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorCiscoIOS, Model: "aironet-iw9165e", Type: TypeAccessPoint,
+			Label:   "Aironet IW-9165E (Wi-Fi 6E)",
+			IfCount: defaultIfAP, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Cisco Aironet IW-9165E Wi-Fi 6E Access Point, Cisco IOS XE Software, Version 17.13.1",
+		sysObjectID:  "1.3.6.1.4.1.9.1.2879",
+		ifNameFormat: "Dot11Radio%d",
+	})
+
+	// ===== Juniper (Junos) =====
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJunos, Model: "ex4300-48t", Type: TypeSwitch,
+			Label:   "EX4300-48T (48× 1G)",
+			IfCount: ports48, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Juniper Networks, Inc. ex4300-48t Ethernet Switch, kernel JUNOS 22.4R3.25",
+		sysObjectID:  "1.3.6.1.4.1.2636.1.1.1.2.29",
+		ifNameFormat: "ge-0/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJunos, Model: "ex4400-48t", Type: TypeSwitch,
+			Label:   "EX4400-48T (48× 1G + 4× 25G uplink)",
+			IfCount: ports48, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Juniper Networks, Inc. ex4400-48t Ethernet Switch, kernel JUNOS 22.4R3.25",
+		sysObjectID:  "1.3.6.1.4.1.2636.1.1.1.2.143",
+		ifNameFormat: "ge-0/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJunos, Model: "qfx5100-48s", Type: TypeSwitch,
+			Label:   "QFX5100-48S (48× 10G + 6× 40G uplink)",
+			IfCount: ports48, SpeedMbps: speed10G,
+		},
+		sysDescr:     "Juniper Networks, Inc. qfx5100-48s Internet Router, kernel JUNOS 21.4R3.15",
+		sysObjectID:  "1.3.6.1.4.1.2636.1.1.1.2.71",
+		ifNameFormat: "xe-0/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJunos, Model: "mx204", Type: TypeRouter,
+			Label:   "MX204 (4× 100G + 8× 10G)",
+			IfCount: ports4, SpeedMbps: speed100G,
+		},
+		sysDescr:     "Juniper Networks, Inc. mx204 Internet router, kernel JUNOS 21.4R3.15",
+		sysObjectID:  "1.3.6.1.4.1.2636.1.1.1.2.129",
+		ifNameFormat: "et-0/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJunos, Model: "mx480", Type: TypeRouter,
+			Label:   "MX480 (modular chassis, 100G capable)",
+			IfCount: ports16, SpeedMbps: speed100G,
+		},
+		sysDescr:     "Juniper Networks, Inc. mx480 Internet router, kernel JUNOS 21.4R3.15",
+		sysObjectID:  "1.3.6.1.4.1.2636.1.1.1.2.25",
+		ifNameFormat: "xe-2/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJunos, Model: "srx340", Type: TypeFirewall,
+			Label:   "SRX340 (16× 1G)",
+			IfCount: ports16, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Juniper Networks, Inc. srx340 Services Gateway, kernel JUNOS 21.4R3.15",
+		sysObjectID:  "1.3.6.1.4.1.2636.1.1.1.2.82",
+		ifNameFormat: "ge-0/0/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJunos, Model: "srx1500", Type: TypeFirewall,
+			Label:   "SRX1500 (16× 1G + 4× 10G)",
+			IfCount: ports16, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Juniper Networks, Inc. srx1500 Services Gateway, kernel JUNOS 21.4R3.15",
+		sysObjectID:  "1.3.6.1.4.1.2636.1.1.1.2.114",
+		ifNameFormat: "ge-0/0/%d",
+	})
+	// Juniper Mist AP43 — API-first, minimal SNMP per the design res.
+	// Overrides default flags so LLDP / BRIDGE / IP-MIB are all off.
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorJuniperMist, Model: "mist-ap43", Type: TypeAccessPoint,
+			Label:   "Mist AP43 (Wi-Fi 6, API-first)",
+			IfCount: defaultIfAP, SpeedMbps: speed1G,
+		},
+		sysDescr:      "Juniper Mist AP43, Mist OS 0.13.x",
+		sysObjectID:   "1.3.6.1.4.1.2636.1.1.1.4.42",
+		ifNameFormat:  "wifi%d",
+		overrideFlags: &profileFlags{},
+	})
+
+	// ===== Arista EOS =====
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorAristaEOS, Model: "dcs-7050sx", Type: TypeSwitch,
+			Label:   "DCS-7050SX (32× 10G/25G ToR)",
+			IfCount: ports32, SpeedMbps: speed25G,
+		},
+		sysDescr:     "Arista Networks EOS version 4.30.4M running on an Arista Networks DCS-7050SX-72",
+		sysObjectID:  "1.3.6.1.4.1.30065.1.3.1.32",
+		ifNameFormat: "Ethernet%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorAristaEOS, Model: "dcs-7280sr", Type: TypeRouter,
+			Label:   "DCS-7280SR (48× 10G + 6× 100G spine)",
+			IfCount: ports48, SpeedMbps: speed100G,
+		},
+		sysDescr:     "Arista Networks EOS version 4.30.4M running on an Arista Networks DCS-7280SR-48C6",
+		sysObjectID:  "1.3.6.1.4.1.30065.1.3.1.60",
+		ifNameFormat: "Ethernet%d",
+	})
+
+	return out
+}()

--- a/internal/protocols/snmp/synth/models_test.go
+++ b/internal/protocols/snmp/synth/models_test.go
@@ -1,0 +1,133 @@
+package synth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/protocols/snmp/synth"
+)
+
+func TestModelsReturnsOnlyRequestedVendor(t *testing.T) {
+	got := synth.Models(synth.VendorCiscoIOS)
+	if len(got) == 0 {
+		t.Fatal("cisco-ios should have models defined")
+	}
+	for _, m := range got {
+		if m.Vendor != synth.VendorCiscoIOS {
+			t.Errorf("Models(cisco-ios) returned %s entry %q", m.Vendor, m.Model)
+		}
+	}
+}
+
+func TestModelsForTypeFilters(t *testing.T) {
+	got := synth.ModelsForType(synth.VendorCiscoIOS, synth.TypeSwitch)
+	if len(got) == 0 {
+		t.Fatal("cisco-ios + switch should have model entries")
+	}
+	for _, m := range got {
+		if m.Type != synth.TypeSwitch {
+			t.Errorf("ModelsForType(switch) returned type=%s for %q", m.Type, m.Model)
+		}
+	}
+}
+
+func TestModelsSortedStable(t *testing.T) {
+	// Models are sorted by (Type, Label). Two consecutive calls must
+	// produce the same slice so the UI doesn't flicker on re-render.
+	a := synth.Models(synth.VendorJunos)
+	b := synth.Models(synth.VendorJunos)
+	if len(a) != len(b) {
+		t.Fatalf("length differs: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].Model != b[i].Model {
+			t.Errorf("order differs at %d: %s vs %s", i, a[i].Model, b[i].Model)
+		}
+	}
+}
+
+func TestPickModelCatalystSetsExpectedFields(t *testing.T) {
+	p, err := synth.PickModel(synth.VendorCiscoIOS, "catalyst-9300-48p")
+	if err != nil {
+		t.Fatalf("PickModel: %v", err)
+	}
+	if p.SysObjectID != "1.3.6.1.4.1.9.1.2238" {
+		t.Errorf("sysObjectID = %q, want Catalyst 9300 OID", p.SysObjectID)
+	}
+	if !strings.Contains(p.SysDescr, "CAT9K_IOSXE") {
+		t.Errorf("sysDescr should mention CAT9K_IOSXE platform image, got %q", p.SysDescr)
+	}
+	if p.DefaultIfCount != 48 {
+		t.Errorf("ifCount = %d, want 48", p.DefaultIfCount)
+	}
+	if p.Type != synth.TypeSwitch {
+		t.Errorf("type = %q, want switch", p.Type)
+	}
+	// Switch flags inherited from the vendor's per-type profile.
+	if !p.IncludeBridge {
+		t.Error("switch should include BRIDGE-MIB")
+	}
+	if p.IncludeIPMIB {
+		t.Error("switch should not include IP-MIB")
+	}
+}
+
+func TestPickModelMistOverridesFlagsToMinimal(t *testing.T) {
+	// Mist AP43 sets overrideFlags to a zero profileFlags struct so
+	// LLDP / BRIDGE / IP-MIB are all off (API-first SNMP per the
+	// design-doc resolution).
+	p, err := synth.PickModel(synth.VendorJuniperMist, "mist-ap43")
+	if err != nil {
+		t.Fatalf("PickModel: %v", err)
+	}
+	if p.IncludeIPMIB || p.IncludeBridge || p.IncludeLLDP || p.IPForwarding {
+		t.Errorf("Mist AP43 should have all include flags off, got %+v", p)
+	}
+}
+
+func TestPickModelUnknownReturnsError(t *testing.T) {
+	_, err := synth.PickModel(synth.VendorCiscoIOS, "catalyst-99999-fake")
+	if err == nil {
+		t.Fatal("unknown model should error")
+	}
+}
+
+func TestAllModelsCoversEveryVendor(t *testing.T) {
+	got := synth.AllModels()
+	if len(got) == 0 {
+		t.Fatal("AllModels returned empty")
+	}
+	seen := map[synth.Vendor]bool{}
+	for _, m := range got {
+		seen[m.Vendor] = true
+	}
+	// At least one model per top-tier vendor — sanity that we shipped
+	// real coverage rather than just stubs.
+	for _, want := range []synth.Vendor{
+		synth.VendorCiscoIOS, synth.VendorJunos, synth.VendorAristaEOS,
+	} {
+		if !seen[want] {
+			t.Errorf("AllModels missing entries for %s", want)
+		}
+	}
+}
+
+func TestBuildWithModelEmitsModelSpecificSysDescr(t *testing.T) {
+	// End-to-end sanity: PickModel → Build produces a walk with the
+	// model's sysDescr verbatim. This is the whole point of the
+	// vendor+model expansion — the synthesised walk should look like
+	// the real gear's snmpwalk output.
+	p, _ := synth.PickModel(synth.VendorAristaEOS, "dcs-7280sr")
+	walk := string(synth.Build(p, synth.DeviceInput{
+		Hostname: "spine-01",
+		IP:       "10.0.0.1",
+	}, synth.BuildOptions{InterfaceCount: 4}))
+
+	mustContain(t, walk, "DCS-7280SR-48C6")
+	// And the platform's enterprise OID is in the walk too.
+	mustContain(t, walk, "1.3.6.1.4.1.30065")
+	// Spine = 100G — confirm ifSpeed gauge reflects that (100G *
+	// 1_000_000 Mbps→bps = 100_000_000_000, won't fit Gauge32; the
+	// emitter clamps via safeconv.Uint32 so verify the line exists).
+	mustContain(t, walk, ".1.3.6.1.2.1.2.2.1.5.1 = Gauge32:")
+}

--- a/internal/protocols/snmp/synth/profiles.go
+++ b/internal/protocols/snmp/synth/profiles.go
@@ -49,6 +49,10 @@ const (
 	// gear (40G/100G uplinks, 25G/50G server NICs) gets the right
 	// ifSpeed gauge — the simulator surfaces this raw on the wire and
 	// pollers compare it against their alarm thresholds.
+	// Link speeds in Mbps. Full range from 100M up to 100G so DC-class
+	// gear (40G/100G uplinks, 25G/50G server NICs) gets the right
+	// ifSpeed gauge — the simulator surfaces this raw on the wire and
+	// pollers compare it against their alarm thresholds.
 	speed100M = 100
 	speed1G   = 1000
 	speed10G  = 10_000
@@ -56,6 +60,16 @@ const (
 	speed40G  = 40_000
 	speed50G  = 50_000
 	speed100G = 100_000
+
+	// Common port-count counts referenced by the per-model entries in
+	// models.go. Named so the mnd linter doesn't fire on every entry.
+	ports4  = 4
+	ports8  = 8
+	ports12 = 12
+	ports16 = 16
+	ports32 = 32
+	ports36 = 36
+	ports48 = 48
 )
 
 // AllVendors lists every operator-selectable vendor in UI dropdown order.


### PR DESCRIPTION
## Summary
First leg of #570 — widens the synth package from \`{vendor, type} → Profile\` to also support \`{vendor, model} → Profile\` so the synthesised walk picks up the platform's real sysObjectID + an accurate sysDescr instead of the per-vendor generic.

## New surface in \`internal/protocols/snmp/synth\`
- \`Model\` type + \`ModelDescriptor\` for UI consumption
- \`Models(vendor)\` / \`ModelsForType(vendor, type)\` / \`AllModels()\` — UI catalog accessors with stable sort order
- \`PickModel(vendor, model)\` — resolves a Profile keyed by model, inheriting \`include*\` flags from the per-vendor base profile via \`deriveFlags\`, with optional per-model overrides

## Initial model coverage

Real sysObjectIDs from each vendor's published MIB:

| Vendor | Models |
|---|---|
| **Cisco IOS** | Catalyst 9300-48P, 9500-48Y4C, Nexus 9336C-FX2, ISR 4451-X, ASR 9001, ASA 5525-X, Firepower 2110, Aironet IW-9165E |
| **Juniper** | EX4300-48T, EX4400-48T, QFX5100-48S, MX204, MX480, SRX340, SRX1500 |
| **Juniper Mist** | AP43 (auto-routed for Junos + access_point; overrides include flags off — API-first) |
| **Arista** | DCS-7050SX (25G ToR), DCS-7280SR (100G spine) |

## Daemon

- New \`GET /api/v1/synthesize-walk/models\` returning \`AllModels()\` so the UI can build the cascading vendor → model picker in one round-trip
- \`POST /api/v1/devices/{hostname}/synthesize-walk\` gains an optional \`model\` field. When set, the daemon calls \`PickModel\` and the walk gets the model-specific sysDescr + OID. Empty \`model\` keeps the v0.66/v0.67.x behaviour with the per-vendor generic.

## Tests
- 11 existing synth tests still pass
- 8 new tests covering: \`Models\` / \`ModelsForType\` / sort stability / \`AllModels\` / \`PickModel\` happy path / Mist override / unknown model / end-to-end \`Build\` with a model-specific profile

19/19 pass; \`golangci-lint\` clean.

## Out of scope
- UI integration (Model dropdown in SnmpSection's Generate-walk modal) → PR 2
- Full one-device template YAMLs (Approach 1 from #570) → PR 3 (optional follow-on)
- Extending coverage to Extreme / F5 / HP / Aruba → can be added incrementally; the table grows by hand-data-entry from datasheets

Refs: #570