### PR TITLE
fix(topology+protocols): six operator-reported issues + traffic broken

### DIFF
--- a/internal/api/handlers_library.go
+++ b/internal/api/handlers_library.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/krisarmstrong/niac-go/internal/library"
@@ -165,7 +167,121 @@ func (s *Server) handleLibraryFiles(w http.ResponseWriter, r *http.Request, kind
 			"Failed to list "+string(kind), nil)
 		return
 	}
+
+	// Fall through to candidate directories when the library subdir
+	// is empty. Without this, freshly-installed daemons return [] for
+	// /api/v1/library/pcaps even with example pcaps right there in
+	// the repo — and the Traffic page picker stays empty. Once an
+	// operator drops files into ~/.niac/library/{walks,pcaps}/ the
+	// fallback stops firing (library content wins).
+	//
+	// Candidates (in priority order):
+	//   1. Sim-config-relative dir (legacy collectFiles path, only
+	//      meaningful when a sim is running)
+	//   2. examples/captures/ relative to cwd (bundled in the repo)
+	//   3. examples/pcaps/ relative to cwd (older example layout)
+	if len(entries) == 0 {
+		if legacy, legacyErr := s.collectFiles(string(kind)); legacyErr == nil && len(legacy) > 0 {
+			s.writeJSON(w, libraryEntriesFromLegacy(legacy))
+			return
+		}
+		for _, candidate := range fallbackDirsForKind(kind) {
+			if extras := scanDirForExtensions(candidate, extensionsForKind(kind)); len(extras) > 0 {
+				s.writeJSON(w, extras)
+				return
+			}
+		}
+	}
 	s.writeJSON(w, entries)
+}
+
+// fallbackDirsForKind returns the ordered list of directories to scan
+// when the library subdir for `kind` is empty. Order matters — first
+// non-empty hit wins.
+func fallbackDirsForKind(kind library.Kind) []string {
+	switch kind {
+	case library.KindPcaps:
+		return []string{"examples/captures", "examples/pcaps"}
+	case library.KindWalks:
+		return []string{"examples/walks", "examples/device_walks_sanitized", "examples/device_walks"}
+	case library.KindNetworks:
+		// networks have their own bootstrap path (starter pack copies
+		// into the library on first run) and the live editor / picker
+		// flow doesn't need a cold-start fallback. Return nil so the
+		// caller treats it as "no candidates" rather than panicking.
+		return nil
+	default:
+		return nil
+	}
+}
+
+// extensionsForKind is the per-kind file extension allow-list used by
+// the candidate-dir scanner.
+func extensionsForKind(kind library.Kind) []string {
+	switch kind {
+	case library.KindPcaps:
+		return []string{".pcap", ".pcapng", ".cap"}
+	case library.KindWalks:
+		return []string{".walk", ".snmpwalk", ".txt"}
+	case library.KindNetworks:
+		// see fallbackDirsForKind — networks don't use this codepath.
+		return nil
+	default:
+		return nil
+	}
+}
+
+// scanDirForExtensions walks dir non-recursively, returning entries
+// whose extension matches one of `exts`. Errors (missing dir, perm
+// issues) are swallowed — the caller treats this as best-effort
+// fallback content.
+func scanDirForExtensions(dir string, exts []string) []library.FileEntry {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	allowed := make(map[string]bool, len(exts))
+	for _, e := range exts {
+		allowed[e] = true
+	}
+	var out []library.FileEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !allowed[strings.ToLower(filepath.Ext(e.Name()))] {
+			continue
+		}
+		info, statErr := e.Info()
+		if statErr != nil {
+			continue
+		}
+		out = append(out, library.FileEntry{
+			Name:       e.Name(),
+			SizeBytes:  info.Size(),
+			ModifiedAt: info.ModTime().UTC(),
+			Source:     library.SourceUser,
+		})
+	}
+	return out
+}
+
+// libraryEntriesFromLegacy converts the legacy collectFiles result
+// shape (FileEntry with path / name / sizeBytes / modifiedAt) into
+// the library.FileEntry shape (name / sizeBytes / modifiedAt /
+// source). The legacy entries get source="user" since they originated
+// from the operator's filesystem layout, not the library bootstrap.
+func libraryEntriesFromLegacy(in []FileEntry) []library.FileEntry {
+	out := make([]library.FileEntry, len(in))
+	for i, e := range in {
+		out[i] = library.FileEntry{
+			Name:       e.Name,
+			SizeBytes:  e.SizeBytes,
+			ModifiedAt: e.Modified,
+			Source:     library.SourceUser,
+		}
+	}
+	return out
 }
 
 // handleLibraryWalks is the registered route handler for /api/v1/library/walks.

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,12 +20,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-DeN2_m22.js"></script>
-    <link rel="modulepreload" crossorigin href="/assets/vendor-react-BoJ-pB7h.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-DtDwoORA.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-CNjH12JY.js">
+    <script type="module" crossorigin src="/assets/index-VKJwksfJ.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/vendor-react-DQoOXKmh.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-BnzIpsIz.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-DxDhPCA2.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-codemirror-BjllbsfA.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-B6jpQMrx.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BxYsHYze.css">
   </head>
   <body>
     <div id="root"></div>

--- a/internal/protocols/cdp.go
+++ b/internal/protocols/cdp.go
@@ -165,8 +165,14 @@ func (h *CDPHandler) sendAdvertisements() {
 			continue
 		}
 
-		// Skip if CDP is explicitly disabled for this device
-		if device.CDPConfig != nil && !device.CDPConfig.Enabled {
+		// CDP is Cisco-proprietary. We require explicit opt-in
+		// (CDPConfig != nil && Enabled) so non-Cisco devices in
+		// mixed-vendor configs don't announce themselves on a
+		// protocol they'd never actually run. Closes the
+		// "every device emits CDP" bug observed via the Neighbors
+		// page in v0.67.x. (LLDP — the IEEE standard — still
+		// defaults on for switch/router/AP via lldp.go.)
+		if device.CDPConfig == nil || !device.CDPConfig.Enabled {
 			continue
 		}
 

--- a/internal/protocols/edp.go
+++ b/internal/protocols/edp.go
@@ -128,8 +128,14 @@ func (h *EDPHandler) sendAdvertisements() {
 			continue
 		}
 
-		// Skip if EDP is explicitly disabled for this device
-		if device.EDPConfig != nil && !device.EDPConfig.Enabled {
+		// EDP is Extreme-proprietary. Most real-world devices don't
+		// emit it — only ExtremeWare/EXOS hardware does. We require
+		// explicit opt-in (EDPConfig != nil && Enabled) so Cisco /
+		// Juniper / generic devices in mixed-vendor configs don't
+		// announce themselves on a protocol they'd never actually run.
+		// Closes the "every device emits EDP" bug observed via the
+		// Neighbors page in v0.67.x.
+		if device.EDPConfig == nil || !device.EDPConfig.Enabled {
 			continue
 		}
 

--- a/internal/protocols/fdp.go
+++ b/internal/protocols/fdp.go
@@ -140,8 +140,13 @@ func (h *FDPHandler) sendAdvertisements() {
 			continue
 		}
 
-		// Skip if FDP is explicitly disabled for this device
-		if device.FDPConfig != nil && !device.FDPConfig.Enabled {
+		// FDP is Foundry/Brocade-proprietary. Like EDP, real-world
+		// gear from any other vendor doesn't speak it, so we require
+		// explicit opt-in (FDPConfig != nil && Enabled) to avoid
+		// every simulated device spamming FDP advertisements regardless
+		// of vendor. Closes the "every device emits FDP" bug observed
+		// via the Neighbors page in v0.67.x.
+		if device.FDPConfig == nil || !device.FDPConfig.Enabled {
 			continue
 		}
 

--- a/internal/protocols/lldp.go
+++ b/internal/protocols/lldp.go
@@ -103,6 +103,20 @@ type LLDPHandler struct {
 }
 
 // NewLLDPHandler creates a new LLDP handler.
+// lldpDefaultEnabledForType reports whether LLDP advertisements
+// should be emitted by default when LLDPConfig is nil. Switches,
+// routers, APs, firewalls, and VoIP phones all run LLDP out of the
+// box on real hardware; hosts and servers don't unless explicitly
+// configured.
+func lldpDefaultEnabledForType(deviceType string) bool {
+	switch strings.ToLower(deviceType) {
+	case "switch", "router", "access_point", "firewall", "voip_phone":
+		return true
+	default:
+		return false
+	}
+}
+
 func NewLLDPHandler(stack *Stack) *LLDPHandler {
 	return &LLDPHandler{
 		stack:    stack,
@@ -169,8 +183,21 @@ func (h *LLDPHandler) sendAdvertisements() {
 			continue
 		}
 
-		// Skip if LLDP is explicitly disabled for this device
-		if device.LLDPConfig != nil && !device.LLDPConfig.Enabled {
+		// LLDP is the IEEE 802.1AB standard — every modern
+		// network-infra device (switch / router / AP / firewall /
+		// VoIP phone) speaks it. Hosts and servers generally don't
+		// run it absent explicit opt-in, so default to the
+		// infra-device subset and let everything else require
+		// LLDPConfig.Enabled=true to participate.
+		//
+		// Companion to the CDP/EDP/FDP opt-in tightening: keeps the
+		// Neighbors page honest by not announcing LLDP from a generic
+		// Linux server that real-world wouldn't speak it.
+		if !lldpDefaultEnabledForType(device.Type) {
+			if device.LLDPConfig == nil || !device.LLDPConfig.Enabled {
+				continue
+			}
+		} else if device.LLDPConfig != nil && !device.LLDPConfig.Enabled {
 			continue
 		}
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,6 +19,7 @@
         "@types/dagre": "0.7.53",
         "@xyflow/react": "12.10.2",
         "dagre": "0.8.5",
+        "html-to-image": "1.11.13",
         "immer": "11.1.6",
         "lucide-react": "0.562.0",
         "react": "19.2.5",
@@ -3269,6 +3270,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/http-proxy-agent": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "@types/dagre": "0.7.53",
     "@xyflow/react": "12.10.2",
     "dagre": "0.8.5",
+    "html-to-image": "1.11.13",
     "immer": "11.1.6",
     "lucide-react": "0.562.0",
     "react": "19.2.5",

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -4,7 +4,6 @@ import {
   type Connection,
   Controls,
   type EdgeTypes,
-  MiniMap,
   type Node,
   type NodeTypes,
   Panel,
@@ -15,29 +14,32 @@ import {
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '@xyflow/react/dist/style.css';
-import { Download, Layers, Network, Radar, RefreshCw } from 'lucide-react';
+import { Network, Radar, RefreshCw } from 'lucide-react';
 import { fetchDevices, fetchNeighbors, fetchTopology } from '../api/client';
 import type { DeviceSummary } from '../api/types';
-import { topologyDeviceColors as deviceColors } from '../constants/device-types';
 import { useApiResource } from '../hooks/useApiResource';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { H2, SmallText } from '../ui/Typography';
 import {
+  ActionsMenu,
   ContextMenu,
-  type ContextMenuItem,
+  contextMenuItems,
   createEdges,
-  DEFAULT_LAYOUT_MODE,
   DeviceDetailsPanel,
   DeviceNode,
-  type DeviceNodeData,
   type DeviceNodeType,
   LAYOUT_MODES,
   type LayoutMode,
   type LinkEdge,
   layoutNodes,
   NeighborsView,
+  readSavedLayoutMode,
+  readSavedPositions,
+  TOPOLOGY_POSITIONS_KEY,
   TopologyLegend,
+  writeSavedLayoutMode,
+  writeSavedPositions,
 } from './topology';
 import { TrunkEdge } from './topology/TrunkEdge';
 
@@ -56,56 +58,9 @@ const edgeTypes: EdgeTypes = {
   trunk: TrunkEdge,
 };
 
-// Where we stash user-dragged node positions so they survive page
-// reloads. Keyed by device name → {x, y}. SSR-safe — no-ops if window
-// is undefined.
-const TOPOLOGY_POSITIONS_KEY = 'niac.topology.positions';
-// Layout mode persistence key — survives page reload like positions
-// do. Only valid values from LAYOUT_MODES are honoured; anything else
-// falls back to DEFAULT_LAYOUT_MODE.
-const TOPOLOGY_LAYOUT_MODE_KEY = 'niac.topology.layoutMode';
-
-function readSavedPositions(): Record<string, { x: number; y: number }> {
-  if (typeof window === 'undefined') return {};
-  try {
-    const raw = window.localStorage.getItem(TOPOLOGY_POSITIONS_KEY);
-    if (!raw) return {};
-    return JSON.parse(raw) as Record<string, { x: number; y: number }>;
-  } catch {
-    return {};
-  }
-}
-
-function writeSavedPositions(positions: Record<string, { x: number; y: number }>) {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(TOPOLOGY_POSITIONS_KEY, JSON.stringify(positions));
-  } catch {
-    // Quota / privacy mode — silently skip; positions will reset on reload.
-  }
-}
-
-function readSavedLayoutMode(): LayoutMode {
-  if (typeof window === 'undefined') return DEFAULT_LAYOUT_MODE;
-  try {
-    const raw = window.localStorage.getItem(TOPOLOGY_LAYOUT_MODE_KEY);
-    if (LAYOUT_MODES.some((m) => m.mode === raw)) {
-      return raw as LayoutMode;
-    }
-  } catch {
-    // SSR / quota — fall through.
-  }
-  return DEFAULT_LAYOUT_MODE;
-}
-
-function writeSavedLayoutMode(mode: LayoutMode) {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(TOPOLOGY_LAYOUT_MODE_KEY, mode);
-  } catch {
-    // No-op on quota / privacy mode.
-  }
-}
+// Persistence helpers (positions + layout mode) live in
+// ./topology/persistence.ts so this file stays under the 800-line
+// file-size red-flag threshold.
 
 /**
  * TopologyPage renders the network graph with the device-node and
@@ -135,10 +90,9 @@ export const TopologyPage: FC = () => {
   const [edges, setEdges, onEdgesChange] = useEdgesState<LinkEdge>([]);
   const [selectedDevice, setSelectedDevice] = useState<DeviceSummary | null>(null);
   const [showLegend, setShowLegend] = useState(true);
-  // Minimap defaults off — it's distracting for small graphs and most
-  // users will pan with the mouse anyway. Toggle on via the header
-  // button when working with larger topologies.
-  const [showMinimap, setShowMinimap] = useState(false);
+  // Minimap removed in this version — it was always toggle-off by
+  // default and operators didn't use it; the ReactFlow Controls
+  // (fit-view + zoom buttons) already cover navigation on big graphs.
   // showLabels controls whether TrunkEdge renders its per-side
   // interface labels + the middle VLAN/speed label. On by default
   // for clarity; toggle off via the header to see clean lines only.
@@ -404,41 +358,27 @@ export const TopologyPage: FC = () => {
   // mouse event + the node/edge object; we adjust coordinates into
   // the canvas-parent's local space so the menu pops where the
   // pointer is regardless of page scroll position.
+  // Context-menu handlers pass clientX/Y straight through to a
+  // position:fixed menu. Earlier attempts offset by the event's
+  // currentTarget rect — but ReactFlow's callbacks set currentTarget
+  // to the node/edge/pane element itself (not the canvas container),
+  // so the subtraction produced node-relative coords and the menu
+  // popped off-screen. Viewport-fixed is simpler and matches how
+  // every OS-native context menu behaves.
   const handleNodeContextMenu = useCallback((event: React.MouseEvent, node: Node) => {
     event.preventDefault();
-    const rect = event.currentTarget?.getBoundingClientRect?.();
-    setContextMenu({
-      kind: 'node',
-      x: event.clientX - (rect?.left ?? 0),
-      y: event.clientY - (rect?.top ?? 0),
-      nodeId: node.id,
-    });
+    setContextMenu({ kind: 'node', x: event.clientX, y: event.clientY, nodeId: node.id });
   }, []);
 
   const handleEdgeContextMenu = useCallback((event: React.MouseEvent, edge: { id: string }) => {
     event.preventDefault();
-    const rect = event.currentTarget?.getBoundingClientRect?.();
-    setContextMenu({
-      kind: 'edge',
-      x: event.clientX - (rect?.left ?? 0),
-      y: event.clientY - (rect?.top ?? 0),
-      edgeId: edge.id,
-    });
+    setContextMenu({ kind: 'edge', x: event.clientX, y: event.clientY, edgeId: edge.id });
   }, []);
 
   const handlePaneContextMenu = useCallback((event: React.MouseEvent | MouseEvent) => {
     event.preventDefault();
-    // ReactFlow's pane handler receives either a synthetic React event
-    // (when right-clicking the canvas itself) or a native MouseEvent.
-    // Both expose currentTarget; the cast is needed to read it as a
-    // DOM element.
-    const target = (event as React.MouseEvent).currentTarget as HTMLElement | undefined;
-    const rect = target?.getBoundingClientRect?.();
-    setContextMenu({
-      kind: 'pane',
-      x: (event as MouseEvent).clientX - (rect?.left ?? 0),
-      y: (event as MouseEvent).clientY - (rect?.top ?? 0),
-    });
+    const me = event as MouseEvent;
+    setContextMenu({ kind: 'pane', x: me.clientX, y: me.clientY });
   }, []);
 
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
@@ -501,11 +441,35 @@ export const TopologyPage: FC = () => {
 
   const loading = topologyLoading || devicesLoading;
 
-  // Minimap node color function
-  const getMinimapNodeColor = useCallback((node: Node) => {
-    const nodeData = node.data as DeviceNodeData;
-    const nodeType = typeof nodeData?.type === 'string' ? nodeData.type.toLowerCase() : 'unknown';
-    return deviceColors[nodeType] || deviceColors.unknown;
+  // PNG export. Captures the ReactFlow viewport via the .react-flow
+  // root element; html-to-image walks the DOM, inlines computed
+  // styles, and rasterises to PNG. We snapshot at 2× pixel ratio so
+  // the image scales cleanly on Retina/4K screens.
+  const handleExportPNG = useCallback(async () => {
+    const root = document.querySelector<HTMLElement>('.react-flow');
+    if (!root) return;
+    try {
+      const { toPng } = await import('html-to-image');
+      const dataUrl = await toPng(root, {
+        pixelRatio: 2,
+        backgroundColor: '#0a0a0a',
+        cacheBust: true,
+        // Skip the ReactFlow controls + minimap chrome — viewers want
+        // the diagram, not the UI scaffolding.
+        filter: (node) =>
+          !(node instanceof HTMLElement) || !node.classList?.contains?.('react-flow__panel'),
+      });
+      const link = document.createElement('a');
+      link.href = dataUrl;
+      link.download = `niac-topology-${new Date().toISOString().slice(0, 10)}.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (err) {
+      // Best-effort — surface in console rather than a modal since
+      // the PNG path is a convenience, not a primary flow.
+      console.error('Topology PNG export failed:', err); // eslint-disable-line no-console
+    }
   }, []);
 
   return (
@@ -574,23 +538,16 @@ export const TopologyPage: FC = () => {
               </Button>
               {view === 'graph' && (
                 <>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleExport}
-                    leftIcon={<Download className="w-4 h-4" />}
+                  {/* Actions dropdown — replaces the standalone Export
+                      button so PNG / JSON / Reset all live in one
+                      place. Also gives keyboard-only users the same
+                      actions exposed via right-click on the canvas. */}
+                  <ActionsMenu
                     disabled={nodes.length === 0}
-                  >
-                    Export
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleResetLayout}
-                    title="Reset hand-dragged positions + filters back to defaults"
-                  >
-                    Reset
-                  </Button>
+                    onExportPNG={handleExportPNG}
+                    onExportJSON={handleExport}
+                    onReset={handleResetLayout}
+                  />
                   <Button
                     variant={showLabels ? 'outline' : 'ghost'}
                     size="sm"
@@ -598,14 +555,6 @@ export const TopologyPage: FC = () => {
                     title="Toggle interface / VLAN / speed labels on edges"
                   >
                     Labels
-                  </Button>
-                  <Button
-                    variant={showMinimap ? 'outline' : 'ghost'}
-                    size="sm"
-                    onClick={() => setShowMinimap(!showMinimap)}
-                    leftIcon={<Layers className="w-4 h-4" />}
-                  >
-                    Minimap
                   </Button>
                   {/* Layout-mode picker — one pill per mode. The active
                       pill is highlighted; clicking another re-runs the
@@ -773,14 +722,6 @@ export const TopologyPage: FC = () => {
                     color="rgba(255, 255, 255, 0.05)"
                   />
                   <Controls showZoom={true} showFitView={true} showInteractive={false} />
-                  {showMinimap && (
-                    <MiniMap
-                      nodeColor={getMinimapNodeColor}
-                      maskColor="rgba(0, 0, 0, 0.8)"
-                      pannable={true}
-                      zoomable={true}
-                    />
-                  )}
 
                   {/* Legend Panel — only meaningful when there are edges
                       to colour. With zero edges the link-speed key is
@@ -837,117 +778,5 @@ export const TopologyPage: FC = () => {
     </div>
   );
 };
-
-/**
- * contextMenuItems builds the action list for a given menu target.
- * Factored out of the render path so the JSX stays tight and so each
- * menu's items are produced in one place rather than scattered inline.
- *
- * Item presence is data-driven — e.g. "Edit YAML" only appears when
- * the daemon knows the device (the menu was opened on a node whose
- * name is in the devices list), and "Filter to this VLAN" only
- * appears when the edge carries vlan data.
- */
-function contextMenuItems(
-  menu: { kind: 'node'; nodeId: string } | { kind: 'edge'; edgeId: string } | { kind: 'pane' },
-  ctx: {
-    edges: LinkEdge[];
-    hideDevice: (name: string) => void;
-    navigate: ReturnType<typeof useNavigate>;
-    setFocusedNodeId: (next: ((curr: string | null) => string | null) | string | null) => void;
-    setSelectedDevice: (device: DeviceSummary | null) => void;
-    devices: DeviceSummary[] | null;
-    handleResetLayout: () => void;
-    handleExport: () => void;
-    copyToClipboard: (text: string) => void;
-  },
-): ContextMenuItem[] {
-  switch (menu.kind) {
-    case 'node': {
-      const device = ctx.devices?.find((d) => d.name === menu.nodeId);
-      const items: ContextMenuItem[] = [
-        {
-          key: 'view',
-          label: 'View details',
-          onSelect: () => {
-            if (device) ctx.setSelectedDevice(device);
-          },
-          disabled: !device,
-        },
-        {
-          key: 'edit',
-          label: 'Edit YAML',
-          hint: 'devices →',
-          onSelect: () => ctx.navigate(`/device-config/${menu.nodeId}`),
-        },
-        {
-          key: 'focus',
-          label: 'Focus neighbourhood',
-          onSelect: () =>
-            ctx.setFocusedNodeId((curr: string | null) =>
-              curr === menu.nodeId ? null : menu.nodeId,
-            ),
-        },
-        {
-          key: 'copy-name',
-          label: 'Copy name',
-          onSelect: () => ctx.copyToClipboard(menu.nodeId),
-          separatorBefore: true,
-        },
-        {
-          key: 'hide',
-          label: 'Hide from view',
-          hint: 'until Reset',
-          destructive: true,
-          onSelect: () => ctx.hideDevice(menu.nodeId),
-          separatorBefore: true,
-        },
-      ];
-      return items;
-    }
-    case 'edge': {
-      const edge = ctx.edges.find((e) => e.id === menu.edgeId);
-      const ifacePair =
-        edge?.data?.sourceInterface || edge?.data?.targetInterface
-          ? `${edge?.source}:${edge?.data?.sourceInterface ?? '?'} ↔ ${edge?.target}:${edge?.data?.targetInterface ?? '?'}`
-          : `${edge?.source} ↔ ${edge?.target}`;
-      const items: ContextMenuItem[] = [
-        {
-          key: 'copy-pair',
-          label: 'Copy device/interface pair',
-          onSelect: () => ctx.copyToClipboard(ifacePair),
-        },
-      ];
-      // Only show VLAN actions when the edge actually carries VLAN
-      // data — keeps the menu short for access links / discovered
-      // edges that have nothing VLAN-shaped to filter on.
-      if (edge?.data?.vlans && edge.data.vlans.length > 0) {
-        const vlanList = edge.data.vlans.join(',');
-        items.push({
-          key: 'copy-vlans',
-          label: `Copy VLAN list (${edge.data.vlans.length})`,
-          onSelect: () => ctx.copyToClipboard(vlanList),
-        });
-      }
-      return items;
-    }
-    default:
-      return [
-        {
-          key: 'export',
-          label: 'Export topology JSON',
-          onSelect: ctx.handleExport,
-        },
-        {
-          key: 'reset',
-          label: 'Reset layout',
-          hint: 'clears drags / filters',
-          destructive: true,
-          onSelect: ctx.handleResetLayout,
-          separatorBefore: true,
-        },
-      ];
-  }
-}
 
 export default TopologyPage;

--- a/ui/src/pages/topology/ActionsMenu.tsx
+++ b/ui/src/pages/topology/ActionsMenu.tsx
@@ -1,0 +1,98 @@
+import { ChevronDown, Download } from 'lucide-react';
+import { type FC, useEffect, useState } from 'react';
+import { Button } from '../../ui/Button';
+
+/**
+ * ActionsMenu is the small "Actions ▾" dropdown in the topology
+ * header — the keyboard-accessible mirror of the canvas right-click
+ * menu. Opens on click, closes on outside-click or Escape.
+ *
+ * No new external dep needed; a focusable button + a click-outside
+ * listener is enough for three menu items. If we ever grow more
+ * complex menus, Headless UI is the next step up.
+ *
+ * Lives in its own file so TopologyPage.tsx stays under the
+ * file-size red-flag threshold (800 lines).
+ */
+export const ActionsMenu: FC<{
+  disabled?: boolean;
+  onExportPNG: () => void;
+  onExportJSON: () => void;
+  onReset: () => void;
+}> = ({ disabled, onExportPNG, onExportJSON, onReset }) => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Element | null;
+      if (!target?.closest?.('[data-topology-actions]')) setOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('click', onDocClick);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('click', onDocClick);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [open]);
+
+  const handle = (fn: () => void) => () => {
+    fn();
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" data-topology-actions>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        leftIcon={<Download className="w-4 h-4" />}
+        rightIcon={<ChevronDown className="w-3.5 h-3.5" />}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        Actions
+      </Button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-1 min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur z-50"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handle(onExportPNG)}
+            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-white"
+          >
+            <span>Export as PNG</span>
+            <span className="text-[10px] text-gray-500">image</span>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handle(onExportJSON)}
+            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-white"
+          >
+            <span>Export topology JSON</span>
+            <span className="text-[10px] text-gray-500">data</span>
+          </button>
+          <hr className="my-1 h-px border-0 bg-white/10" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handle(onReset)}
+            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-red-300 transition-colors hover:bg-red-500/15 hover:text-red-200"
+          >
+            <span>Reset layout</span>
+            <span className="text-[10px] text-gray-500">drags + filters</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/src/pages/topology/ContextMenu.tsx
+++ b/ui/src/pages/topology/ContextMenu.tsx
@@ -54,7 +54,14 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
 
   return (
     <div
-      className="absolute z-50 min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur"
+      // Position-fixed in viewport space — coords come straight from
+      // the triggering event's clientX/clientY. Earlier attempts used
+      // absolute positioning relative to the canvas-parent, but
+      // ReactFlow's context-menu callbacks pass an event whose
+      // currentTarget is the node/edge element (not the canvas
+      // container), so subtracting that rect produced
+      // node-relative coords that pushed the menu off-screen.
+      className="fixed z-50 min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur"
       style={{ left: x, top: y }}
       // Stop right-click on the menu itself from re-opening the pane
       // menu through ReactFlow's onPaneContextMenu.

--- a/ui/src/pages/topology/NeighborsView.tsx
+++ b/ui/src/pages/topology/NeighborsView.tsx
@@ -43,18 +43,75 @@ export const NeighborsView: FC = () => {
   const [protocolFilter, setProtocolFilter] = useState<ProtocolFilter>('all');
   const [search, setSearch] = useState('');
 
+  // Deduped + filtered view. Real neighbour tables routinely show the
+  // same adjacency announced by multiple protocols (e.g. CDP + LLDP
+  // between two Cisco-or-mixed devices); the daemon emits one row per
+  // (protocol, chassis, port) so the underlying neighbour table can
+  // age each independently, but the human reading the table wants
+  // one row per adjacency with the protocol-set rolled up.
+  //
+  // We collapse on (localDevice, remoteDevice, remotePort) and merge
+  // the protocol strings into a comma-separated list. The "TTL" and
+  // "Last Seen" columns surface the most recent value across the
+  // collapsed group so the row reflects the freshest observation.
   const filtered = useMemo(() => {
     if (!neighbors) return [];
     const q = search.trim().toLowerCase();
-    return neighbors.filter((n) => {
-      if (protocolFilter !== 'all' && n.protocol !== protocolFilter) return false;
-      if (!q) return true;
-      return (
-        n.localDevice.toLowerCase().includes(q) ||
-        n.remoteDevice.toLowerCase().includes(q) ||
-        n.remoteChassisId.toLowerCase().includes(q) ||
-        n.remotePort.toLowerCase().includes(q)
-      );
+    const grouped = new Map<
+      string,
+      {
+        protocols: string[];
+        localDevice: string;
+        remoteDevice: string;
+        remotePort: string;
+        remoteChassisId: string;
+        managementAddress: string;
+        ttl: number;
+        lastSeen: string;
+        // Track the most recent lastSeen so updates win deterministically.
+        lastSeenMs: number;
+      }
+    >();
+    for (const n of neighbors) {
+      if (protocolFilter !== 'all' && n.protocol !== protocolFilter) continue;
+      if (q) {
+        const haystack =
+          `${n.localDevice} ${n.remoteDevice} ${n.remoteChassisId} ${n.remotePort}`.toLowerCase();
+        if (!haystack.includes(q)) continue;
+      }
+      const key = `${n.localDevice}|${n.remoteDevice}|${n.remotePort}`;
+      const tsMs = new Date(n.lastSeen).getTime();
+      const existing = grouped.get(key);
+      if (!existing) {
+        grouped.set(key, {
+          protocols: [n.protocol],
+          localDevice: n.localDevice,
+          remoteDevice: n.remoteDevice,
+          remotePort: n.remotePort,
+          remoteChassisId: n.remoteChassisId,
+          managementAddress: n.managementAddress,
+          ttl: n.ttl,
+          lastSeen: n.lastSeen,
+          lastSeenMs: Number.isFinite(tsMs) ? tsMs : 0,
+        });
+        continue;
+      }
+      if (!existing.protocols.includes(n.protocol)) {
+        existing.protocols.push(n.protocol);
+        existing.protocols.sort();
+      }
+      // Most recent wins for the variable fields.
+      if (Number.isFinite(tsMs) && tsMs > existing.lastSeenMs) {
+        existing.lastSeenMs = tsMs;
+        existing.lastSeen = n.lastSeen;
+        existing.ttl = n.ttl;
+        existing.managementAddress = n.managementAddress || existing.managementAddress;
+        existing.remoteChassisId = n.remoteChassisId || existing.remoteChassisId;
+      }
+    }
+    return [...grouped.values()].sort((a, b) => {
+      if (a.localDevice !== b.localDevice) return a.localDevice.localeCompare(b.localDevice);
+      return a.remoteDevice.localeCompare(b.remoteDevice);
     });
   }, [neighbors, protocolFilter, search]);
 
@@ -145,12 +202,14 @@ export const NeighborsView: FC = () => {
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/5">
-                {filtered.map((n, idx) => (
+                {filtered.map((n) => (
                   <tr
-                    key={`${n.localDevice}-${n.remoteDevice}-${n.protocol}-${idx}`}
+                    key={`${n.localDevice}-${n.remoteDevice}-${n.remotePort}`}
                     className="text-gray-200 hover:bg-gray-950/40"
                   >
-                    <td className="px-4 py-2 font-mono text-xs text-cyan-300">{n.protocol}</td>
+                    <td className="px-4 py-2 font-mono text-xs text-cyan-300">
+                      {n.protocols.join(', ')}
+                    </td>
                     <td className="px-4 py-2">{n.localDevice}</td>
                     <td className="px-4 py-2">{n.remoteDevice}</td>
                     <td className="px-4 py-2 text-gray-400">{n.remotePort || '—'}</td>

--- a/ui/src/pages/topology/contextMenuItems.ts
+++ b/ui/src/pages/topology/contextMenuItems.ts
@@ -1,0 +1,140 @@
+import type { useNavigate } from 'react-router-dom';
+import type { DeviceSummary } from '../../api/types';
+import type { ContextMenuItem } from './ContextMenu';
+import type { LinkEdge } from './types';
+
+/**
+ * Discriminated union of context-menu targets. Render-time exhaustive
+ * checks catch missing handlers in contextMenuItems() below.
+ */
+export type ContextMenuTarget =
+  | { kind: 'node'; nodeId: string }
+  | { kind: 'edge'; edgeId: string }
+  | { kind: 'pane' };
+
+/**
+ * ContextMenuCtx is the bag of callbacks + state a menu item handler
+ * needs to actually do its work — held by TopologyPage and passed in
+ * each time the menu opens so we don't have to plumb ten props
+ * through ContextMenu itself.
+ */
+export interface ContextMenuCtx {
+  edges: LinkEdge[];
+  hideDevice: (name: string) => void;
+  navigate: ReturnType<typeof useNavigate>;
+  setFocusedNodeId: (next: ((curr: string | null) => string | null) | string | null) => void;
+  setSelectedDevice: (device: DeviceSummary | null) => void;
+  devices: DeviceSummary[] | null;
+  handleResetLayout: () => void;
+  handleExport: () => void;
+  copyToClipboard: (text: string) => void;
+}
+
+/**
+ * contextMenuItems builds the action list for a given menu target.
+ * Factored out of the render path so the JSX stays tight and so each
+ * menu's items are produced in one place rather than scattered inline.
+ *
+ * Item presence is data-driven — e.g. "Edit YAML" only appears when
+ * the daemon knows the device (the menu was opened on a node whose
+ * name is in the devices list), and the VLAN action only appears
+ * when the edge carries vlan data.
+ *
+ * Lives in its own file so TopologyPage.tsx stays under the 800-line
+ * file-size red-flag threshold.
+ */
+export function contextMenuItems(menu: ContextMenuTarget, ctx: ContextMenuCtx): ContextMenuItem[] {
+  switch (menu.kind) {
+    case 'node':
+      return nodeMenuItems(menu.nodeId, ctx);
+    case 'edge':
+      return edgeMenuItems(menu.edgeId, ctx);
+    default:
+      return paneMenuItems(ctx);
+  }
+}
+
+function nodeMenuItems(nodeId: string, ctx: ContextMenuCtx): ContextMenuItem[] {
+  const device = ctx.devices?.find((d) => d.name === nodeId);
+  return [
+    {
+      key: 'view',
+      label: 'View details',
+      onSelect: () => {
+        if (device) ctx.setSelectedDevice(device);
+      },
+      disabled: !device,
+    },
+    {
+      key: 'edit',
+      label: 'Edit YAML',
+      hint: 'devices →',
+      onSelect: () => ctx.navigate(`/device-config/${nodeId}`),
+    },
+    {
+      key: 'focus',
+      label: 'Focus neighbourhood',
+      onSelect: () =>
+        ctx.setFocusedNodeId((curr: string | null) => (curr === nodeId ? null : nodeId)),
+    },
+    {
+      key: 'copy-name',
+      label: 'Copy name',
+      onSelect: () => ctx.copyToClipboard(nodeId),
+      separatorBefore: true,
+    },
+    {
+      key: 'hide',
+      label: 'Hide from view',
+      hint: 'until Reset',
+      destructive: true,
+      onSelect: () => ctx.hideDevice(nodeId),
+      separatorBefore: true,
+    },
+  ];
+}
+
+function edgeMenuItems(edgeId: string, ctx: ContextMenuCtx): ContextMenuItem[] {
+  const edge = ctx.edges.find((e) => e.id === edgeId);
+  const ifacePair =
+    edge?.data?.sourceInterface || edge?.data?.targetInterface
+      ? `${edge?.source}:${edge?.data?.sourceInterface ?? '?'} ↔ ${edge?.target}:${edge?.data?.targetInterface ?? '?'}`
+      : `${edge?.source} ↔ ${edge?.target}`;
+  const items: ContextMenuItem[] = [
+    {
+      key: 'copy-pair',
+      label: 'Copy device/interface pair',
+      onSelect: () => ctx.copyToClipboard(ifacePair),
+    },
+  ];
+  // Only show VLAN actions when the edge actually carries VLAN data —
+  // keeps the menu short for access links / discovered edges that
+  // have nothing VLAN-shaped to filter on.
+  if (edge?.data?.vlans && edge.data.vlans.length > 0) {
+    const vlanList = edge.data.vlans.join(',');
+    items.push({
+      key: 'copy-vlans',
+      label: `Copy VLAN list (${edge.data.vlans.length})`,
+      onSelect: () => ctx.copyToClipboard(vlanList),
+    });
+  }
+  return items;
+}
+
+function paneMenuItems(ctx: ContextMenuCtx): ContextMenuItem[] {
+  return [
+    {
+      key: 'export',
+      label: 'Export topology JSON',
+      onSelect: ctx.handleExport,
+    },
+    {
+      key: 'reset',
+      label: 'Reset layout',
+      hint: 'clears drags / filters',
+      destructive: true,
+      onSelect: ctx.handleResetLayout,
+      separatorBefore: true,
+    },
+  ];
+}

--- a/ui/src/pages/topology/index.ts
+++ b/ui/src/pages/topology/index.ts
@@ -2,7 +2,9 @@
  * Topology components barrel export
  */
 
+export { ActionsMenu } from './ActionsMenu';
 export { ContextMenu, type ContextMenuItem } from './ContextMenu';
+export { type ContextMenuTarget, contextMenuItems } from './contextMenuItems';
 export { DeviceDetailsPanel } from './DeviceDetailsPanel';
 export { DeviceNode } from './DeviceNode';
 export {
@@ -13,6 +15,14 @@ export {
   layoutNodes,
 } from './layout';
 export { NeighborsView } from './NeighborsView';
+export {
+  clearSavedPositions,
+  readSavedLayoutMode,
+  readSavedPositions,
+  TOPOLOGY_POSITIONS_KEY,
+  writeSavedLayoutMode,
+  writeSavedPositions,
+} from './persistence';
 export { TopologyHeader } from './TopologyHeader';
 export { TopologyLegend } from './TopologyLegend';
 export type { DeviceNode as DeviceNodeType, DeviceNodeData, LinkEdge, LinkEdgeData } from './types';

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -129,10 +129,19 @@ function gridLayout(devices: DeviceSummary[]): DeviceNode[] {
  */
 function hierarchicalLayout(devices: DeviceSummary[], links: TopologyLink[]): DeviceNode[] {
   const g = new dagre.graphlib.Graph();
+  // Spacing tuned by trial against the kitchen-sink template:
+  //  - nodesep doubled (160 → 320) so siblings on the same rank
+  //    don't crowd each other; the trunk-edge floating labels
+  //    ("Gi0/1 ↔ Gi0/1 · VLANs 1-30") sit comfortably between cards.
+  //  - ranksep tripled (100+60 → 280) so the per-side interface
+  //    labels at each edge endpoint clear the cards above and below.
+  //  - edgesep added so dagre doesn't collapse parallel edges between
+  //    two ranks into a visual stack.
   g.setGraph({
     rankdir: 'TB',
-    nodesep: NODE_GAP_X,
-    ranksep: NODE_GAP_Y + 60,
+    nodesep: NODE_GAP_X * 2,
+    ranksep: NODE_GAP_Y + 180,
+    edgesep: 60,
     marginx: LAYOUT_LEFT_OFFSET,
     marginy: LAYOUT_TOP_OFFSET,
   });

--- a/ui/src/pages/topology/persistence.ts
+++ b/ui/src/pages/topology/persistence.ts
@@ -1,0 +1,69 @@
+import { DEFAULT_LAYOUT_MODE, LAYOUT_MODES, type LayoutMode } from './layout';
+
+/**
+ * localStorage-backed persistence helpers for the topology page.
+ *
+ * Two pieces of state survive page reload:
+ *  1. User-dragged node positions, keyed by device name
+ *  2. The chosen layout mode (hierarchical / concentric / grid)
+ *
+ * All helpers are SSR-safe — they no-op when `window` is undefined.
+ * Lives in its own file so TopologyPage.tsx stays under the
+ * 800-line file-size red-flag threshold.
+ */
+
+export const TOPOLOGY_POSITIONS_KEY = 'niac.topology.positions';
+export const TOPOLOGY_LAYOUT_MODE_KEY = 'niac.topology.layoutMode';
+
+export type SavedPositions = Record<string, { x: number; y: number }>;
+
+export function readSavedPositions(): SavedPositions {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(TOPOLOGY_POSITIONS_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as SavedPositions;
+  } catch {
+    return {};
+  }
+}
+
+export function writeSavedPositions(positions: SavedPositions): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(TOPOLOGY_POSITIONS_KEY, JSON.stringify(positions));
+  } catch {
+    // Quota / privacy mode — silently skip; positions will reset on reload.
+  }
+}
+
+export function clearSavedPositions(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(TOPOLOGY_POSITIONS_KEY);
+  } catch {
+    // No-op on quota / privacy mode.
+  }
+}
+
+export function readSavedLayoutMode(): LayoutMode {
+  if (typeof window === 'undefined') return DEFAULT_LAYOUT_MODE;
+  try {
+    const raw = window.localStorage.getItem(TOPOLOGY_LAYOUT_MODE_KEY);
+    if (LAYOUT_MODES.some((m) => m.mode === raw)) {
+      return raw as LayoutMode;
+    }
+  } catch {
+    // SSR / quota — fall through.
+  }
+  return DEFAULT_LAYOUT_MODE;
+}
+
+export function writeSavedLayoutMode(mode: LayoutMode): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(TOPOLOGY_LAYOUT_MODE_KEY, mode);
+  } catch {
+    // No-op on quota / privacy mode.
+  }
+}


### PR DESCRIPTION
## Summary
Bundles fixes for six topology / Neighbors issues plus the "Traffic broken" report. All independent but small; bundling avoids 6 PRs of churn against the same handful of files.

## Backend — protocols + library fallback

### Protocol defaults (closes the "every device emits every protocol" bug)
The four discovery handlers (\`cdp.go\`, \`lldp.go\`, \`edp.go\`, \`fdp.go\`) all gated on **skip if explicitly disabled**, which meant nil config → send. Cisco devices spammed EDP, Extreme devices spammed CDP, every device sent FDP regardless of vendor.

- **CDP / EDP / FDP**: explicit opt-in only. Won't advertise unless its Config struct is set with \`Enabled: true\`.
- **LLDP**: default-on for infra types (switch / router / AP / firewall / VoIP phone), opt-in for everything else. New \`lldpDefaultEnabledForType\` helper.

### Traffic page picker (Traffic broken)
\`ReplayControlPanel\` reads \`/api/v1/library/pcaps\`. The library is empty by default, so the picker showed nothing even when pcaps lived in \`examples/captures/\`. Fix: when the library subdir is empty, server-side fallback scans candidate dirs (\`examples/captures\` then \`examples/pcaps\` for pcaps; \`examples/walks\` family for walks). Library content wins once present.

## Frontend — Neighbors dedup + topology UI

| # | Issue | Fix |
|---|---|---|
| 1 | Layout scrunched | dagre nodesep doubled (160→320), ranksep tripled (160→280), edgesep added |
| 2 | Right-click menu missing | ContextMenu was using absolute positioning relative to a wrong parent — ReactFlow's context-menu callbacks pass an event whose currentTarget is the node/edge/pane element, not the canvas container. Subtracting that rect produced node-relative coords that pushed the menu off-screen. Fix: position:fixed + clientX/clientY directly |
| 3 | Toolbar Actions menu | New ActionsMenu dropdown (header) mirrors the right-click actions for keyboard users |
| 4 | Minimap useless | Removed entirely (button + state + render + helper + import) |
| 5 | PNG export | Added via \`html-to-image\` (~30KB), 2× pixel ratio. VSDX deferred as a follow-up |
| 6 | Wrong/duplicate neighbors | Backend protocol fix above + NeighborsView dedup by (localDevice, remoteDevice, remotePort) with comma-separated protocol column |

## Refactoring

TopologyPage.tsx was 1028 lines after the additions, over the 800-line red-flag threshold. Extracted three helpers to siblings:
- \`topology/ActionsMenu.tsx\` (the new dropdown)
- \`topology/contextMenuItems.ts\` (per-target menu builders)
- \`topology/persistence.ts\` (localStorage helpers)

TopologyPage.tsx is now 782 lines.

## Validation

Locally rebuilt + restarted daemon + verified against the kitchen-sink template:
- Neighbours table: \`cisco-router-full -> X460-G2-24t-10G4\` now shows EDP only (X460 is Extreme), \`-> brocade-switch-01\` shows FDP only (Brocade) — protocol assignment matches vendor reality
- Library pcaps endpoint: returns all 24 example pcaps when library is empty
- Build clean, all tests pass, 0 lint issues

## Test plan
- [x] \`go test ./...\` passes
- [x] \`golangci-lint run ./internal/...\` 0 issues
- [x] \`npm run build\` clean
- [x] Local sim shows realistic neighbor protocol assignments
- [ ] Smoke: right-click a node — menu appears at cursor
- [ ] Smoke: Actions → Export as PNG → image downloads
- [ ] Smoke: Topology page renders without scrunched cards