### PR TITLE
fix(topology+protocols): toolbar Reset/Refresh, Debug Console plumbing, layout polish

### DIFF
--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,12 +20,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-VKJwksfJ.js"></script>
+    <script type="module" crossorigin src="/assets/index-BbIjeAej.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-DQoOXKmh.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-BnzIpsIz.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-ui-DxDhPCA2.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-codemirror-BjllbsfA.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BxYsHYze.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-C7iW6b3x.css">
   </head>
   <body>
     <div id="root"></div>

--- a/internal/logging/protocol_log.go
+++ b/internal/logging/protocol_log.go
@@ -1,0 +1,49 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// ProtocolLogf emits a single line via both stdout (preserving the
+// long-standing operator log format that pipes through `niac logs`
+// and journalctl) AND slog (so the daemon's SSE log tee can ship the
+// message to the Debug Console page in the web UI).
+//
+// Until this helper existed, protocol handlers only wrote to stdout
+// via fmt.Fprintf, which meant the Debug Console — wired through
+// slog → SSE — never saw per-packet activity. Operators reported the
+// console as "empty" even when the simulator was sending hundreds of
+// LLDP/CDP/EDP/FDP frames per minute.
+//
+// Format args are Sprintf-formatted; the trailing newline is added
+// for the stdout copy (slog records don't need it).
+//
+// Levels map straight onto slog's standard levels. Callers can also
+// use plain slog.* if they already have an attribute-keyed record to
+// emit — this helper exists for the legacy "format string + args"
+// callers that dominate the protocols package.
+func ProtocolLogf(protocol, level, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+
+	// Stdout copy: preserves "PROTOCOL: ..." prefix so existing
+	// log-scraping tools (operator's grep / journalctl filters) keep
+	// working without surprise.
+	_, _ = fmt.Fprintf(os.Stdout, "%s: %s\n", protocol, msg)
+
+	// SSE-visible copy via slog. Tagged with the protocol so the UI
+	// can group / filter; the message itself stays unprefixed because
+	// the UI renders the protocol column separately.
+	slogLevel := slog.LevelInfo
+	switch level {
+	case "debug":
+		slogLevel = slog.LevelDebug
+	case "warn":
+		slogLevel = slog.LevelWarn
+	case "error":
+		slogLevel = slog.LevelError
+	}
+	slog.Default().LogAttrs(context.TODO(), slogLevel, msg, slog.String("protocol", protocol))
+}

--- a/internal/protocols/edp.go
+++ b/internal/protocols/edp.go
@@ -4,12 +4,12 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/krisarmstrong/niac-go/internal/config"
+	"github.com/krisarmstrong/niac-go/internal/logging"
 	"github.com/krisarmstrong/niac-go/internal/safeconv"
 )
 
@@ -86,7 +86,7 @@ func (h *EDPHandler) Start() {
 	ticker := h.advertiseTicker
 
 	if h.stack.GetDebugLevel() >= 1 {
-		_, _ = fmt.Fprintf(os.Stdout, "EDP: Starting periodic advertisements (interval: %v)\n", EDPAdvertiseInterval)
+		logging.ProtocolLogf("EDP", "info", "Starting periodic advertisements (interval: %v)", EDPAdvertiseInterval)
 	}
 
 	go func() {
@@ -144,7 +144,7 @@ func (h *EDPHandler) sendAdvertisements() {
 		if frame != nil {
 			h.sendFrame(device, frame)
 			if debugLevel >= DebugLevelVerbose {
-				_, _ = fmt.Fprintf(os.Stdout, "EDP: Sent advertisement for %s (%d bytes)\n", device.Name, len(frame))
+				logging.ProtocolLogf("EDP", "info", "Sent advertisement for %s (%d bytes)", device.Name, len(frame))
 			}
 		}
 	}
@@ -441,7 +441,7 @@ func (h *EDPHandler) HandlePacket(pkt *Packet) {
 	entry := buildEDPNeighborRecord(device.Name, parsed, fields)
 
 	if h.stack.GetDebugLevel() >= DebugLevelInfo && entry.RemoteDevice != "" {
-		_, _ = fmt.Fprintf(os.Stdout, "EDP: Neighbor %s via %s (local %s)\n",
+		logging.ProtocolLogf("EDP", "info", "Neighbor %s via %s (local %s)",
 			entry.RemoteDevice, entry.RemotePort, entry.LocalDevice)
 	}
 

--- a/internal/protocols/fdp.go
+++ b/internal/protocols/fdp.go
@@ -2,14 +2,13 @@ package protocols
 
 import (
 	"encoding/binary"
-	"fmt"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/krisarmstrong/niac-go/internal/config"
+	"github.com/krisarmstrong/niac-go/internal/logging"
 	"github.com/krisarmstrong/niac-go/internal/safeconv"
 )
 
@@ -98,7 +97,7 @@ func (h *FDPHandler) Start() {
 	ticker := h.advertiseTicker
 
 	if h.stack.GetDebugLevel() >= 1 {
-		_, _ = fmt.Fprintf(os.Stdout, "FDP: Starting periodic advertisements (interval: %v)\n", FDPAdvertiseInterval)
+		logging.ProtocolLogf("FDP", "info", "Starting periodic advertisements (interval: %v)", FDPAdvertiseInterval)
 	}
 
 	go func() {
@@ -155,9 +154,9 @@ func (h *FDPHandler) sendAdvertisements() {
 		if frame != nil {
 			err := h.sendFrame(device, frame)
 			if err != nil && debugLevel >= DebugLevelInfo {
-				_, _ = fmt.Fprintf(os.Stdout, "FDP: Error sending advertisement for %s: %v\n", device.Name, err)
+				logging.ProtocolLogf("FDP", "error", "Error sending advertisement for %s: %v", device.Name, err)
 			} else if debugLevel >= DebugLevelVerbose {
-				_, _ = fmt.Fprintf(os.Stdout, "FDP: Sent advertisement for %s (%d bytes)\n", device.Name, len(frame))
+				logging.ProtocolLogf("FDP", "info", "Sent advertisement for %s (%d bytes)", device.Name, len(frame))
 			}
 		}
 	}
@@ -519,12 +518,10 @@ func (h *FDPHandler) buildFDPNeighborRecord(device *config.Device, data *fdpTLVD
 func (h *FDPHandler) logFDPNeighbor(entry NeighborRecord, _ *Packet) {
 	debugLevel := h.stack.GetDebugLevel()
 	if debugLevel >= DebugLevelInfo {
-		_, _ = fmt.Fprintf(
-			os.Stdout,
-			"FDP: Neighbor %s via %s (local %s)\n",
-			entry.RemoteDevice,
-			entry.RemotePort,
-			entry.LocalDevice,
+		logging.ProtocolLogf(
+			"FDP", "info",
+			"Neighbor %s via %s (local %s)",
+			entry.RemoteDevice, entry.RemotePort, entry.LocalDevice,
 		)
 	}
 }

--- a/internal/protocols/lldp.go
+++ b/internal/protocols/lldp.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/gopacket/gopacket/layers"
 
 	"github.com/krisarmstrong/niac-go/internal/config"
+	"github.com/krisarmstrong/niac-go/internal/logging"
 	"github.com/krisarmstrong/niac-go/internal/safeconv"
 )
 
@@ -141,7 +141,7 @@ func (h *LLDPHandler) Start() {
 	ticker := h.advertiseTicker
 
 	if h.stack.GetDebugLevel() >= 1 {
-		_, _ = fmt.Fprintf(os.Stdout, "LLDP: Starting periodic advertisements (interval: %v)\n", LLDPAdvertiseInterval)
+		logging.ProtocolLogf("LLDP", "info", "Starting periodic advertisements (interval: %v)", LLDPAdvertiseInterval)
 	}
 
 	go func() {
@@ -206,9 +206,9 @@ func (h *LLDPHandler) sendAdvertisements() {
 		if frame != nil {
 			err := h.sendFrame(device, frame)
 			if err != nil && debugLevel >= DebugLevelInfo {
-				_, _ = fmt.Fprintf(os.Stdout, "LLDP: Error sending advertisement for %s: %v\n", device.Name, err)
+				logging.ProtocolLogf("LLDP", "error", "Error sending advertisement for %s: %v", device.Name, err)
 			} else if debugLevel >= DebugLevelVerbose {
-				_, _ = fmt.Fprintf(os.Stdout, "LLDP: Sent advertisement for %s (%d bytes)\n", device.Name, len(frame))
+				logging.ProtocolLogf("LLDP", "info", "Sent advertisement for %s (%d bytes)", device.Name, len(frame))
 			}
 		}
 	}
@@ -594,12 +594,10 @@ func (h *LLDPHandler) HandlePacket(pkt *Packet) {
 	}
 
 	if debugLevel >= DebugLevelInfo {
-		_, _ = fmt.Fprintf(
-			os.Stdout,
-			"LLDP: Neighbor %s via %s (local %s)\n",
-			entry.RemoteDevice,
-			entry.RemotePort,
-			entry.LocalDevice,
+		logging.ProtocolLogf(
+			"LLDP", "info",
+			"Neighbor %s via %s (local %s)",
+			entry.RemoteDevice, entry.RemotePort, entry.LocalDevice,
 		)
 	}
 

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -8,10 +8,11 @@ import {
   type NodeTypes,
   Panel,
   ReactFlow,
+  type ReactFlowInstance,
   useEdgesState,
   useNodesState,
 } from '@xyflow/react';
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '@xyflow/react/dist/style.css';
 import { Network, Radar, RefreshCw } from 'lucide-react';
@@ -151,8 +152,29 @@ export const TopologyPage: FC = () => {
     | { kind: 'pane'; x: number; y: number }
   >(null);
 
-  // Build graph from API data, merging trunk port links with neighbor-discovered links
+  // ReactFlow instance handle — captured on init so we can call
+  // fitView() programmatically when the simulation changes
+  // underneath us (different config loaded → new device set).
+  // Without this, switching templates left the canvas zoomed in
+  // on wherever the prior layout had pushed the viewport, and
+  // operators interpreted that as a stale render.
+  const rfInstance = useRef<ReactFlowInstance<DeviceNodeType, LinkEdge> | null>(null);
+  // Bumped by handleResetLayout (declared later) to force the
+  // build-graph useEffect to re-run immediately instead of waiting
+  // for the next 15-second data poll. Declared up here so the
+  // useEffect's dep array can reference it without TDZ trouble.
+  const [resetCounter, setResetCounter] = useState(0);
+  // Hash of the current device-name set. When this changes we
+  // force a fitView so the new map fills the canvas cleanly.
+  const lastDeviceSetSig = useRef<string>('');
+
+  // Build graph from API data, merging trunk port links with neighbor-discovered links.
+  // resetCounter is intentionally read but not branched on — Reset
+  // bumps it to force this effect to re-run with the same upstream
+  // data, restoring the fresh-layout positions after Reset clears
+  // the cached positions in localStorage.
   useEffect(() => {
+    void resetCounter;
     if (!(devices && topology)) {
       return;
     }
@@ -270,6 +292,7 @@ export const TopologyPage: FC = () => {
     hoveredEdgeId,
     layoutMode,
     hiddenDevices,
+    resetCounter,
     setNodes,
     setEdges,
   ]);
@@ -300,6 +323,13 @@ export const TopologyPage: FC = () => {
   // Reset Layout — wipes the saved drag positions + clears focus and
   // search/filter state. The next data-poll effect re-runs layoutNodes
   // from scratch, putting every device on the fresh grid slot.
+  // resetCounter declared up with the other refs/state. handleResetLayout
+  // bumps it to force the build-graph useEffect to re-run immediately
+  // instead of waiting for the next 15-second data poll. The previous
+  // Reset implementation set positions to {x:0, y:0} hoping the effect
+  // would notice — but (0,0) is a valid coordinate, so the effect's
+  // "existing ?? saved ?? fresh" fallback kept the (0,0) and visibly
+  // did nothing.
   const handleResetLayout = useCallback(() => {
     if (typeof window !== 'undefined') {
       window.localStorage.removeItem(TOPOLOGY_POSITIONS_KEY);
@@ -308,11 +338,14 @@ export const TopologyPage: FC = () => {
     setSearch('');
     setActiveTypes(new Set());
     setHiddenDevices(new Set());
-    // Forcing a re-layout: bump nodes through layoutNodes by clearing
-    // current positions. The useEffect will pick up the empty current
-    // and assign fresh positions on next data tick.
-    setNodes((current) => current.map((node) => ({ ...node, position: { x: 0, y: 0 } })));
-  }, [setNodes]);
+    setNodes([]);
+    setEdges([]);
+    setResetCounter((n) => n + 1);
+    // Re-frame the canvas after the fresh layout settles.
+    window.setTimeout(() => {
+      rfInstance.current?.fitView({ padding: 0.2, duration: 400 });
+    }, 150);
+  }, [setNodes, setEdges]);
 
   // The set of unique device types currently in the graph — drives the
   // filter chip row. Sorted for stable button order.
@@ -396,6 +429,27 @@ export const TopologyPage: FC = () => {
     );
   }, [handleNodeClick, setNodes]);
 
+  // When the underlying simulation changes (different config →
+  // different device set), force a fitView so the canvas re-frames
+  // around the new graph instead of staying zoomed in on whatever
+  // the previous layout had pushed the viewport to. Detected via a
+  // sorted-name signature hash; same names = same sim = no re-fit.
+  useEffect(() => {
+    if (!devices || devices.length === 0) return;
+    const sig = devices
+      .map((d) => d.name)
+      .sort()
+      .join('|');
+    if (sig === lastDeviceSetSig.current) return;
+    lastDeviceSetSig.current = sig;
+    // Defer one tick so layoutNodes has populated the new positions
+    // before fitView measures them.
+    const t = window.setTimeout(() => {
+      rfInstance.current?.fitView({ padding: 0.2, duration: 400 });
+    }, 50);
+    return () => window.clearTimeout(t);
+  }, [devices]);
+
   // onConnect is a no-op: edges come from the backend and are not user-editable
   const onConnect = useCallback((_params: Connection) => {
     // Intentionally empty - topology edges are derived from device configs
@@ -432,11 +486,20 @@ export const TopologyPage: FC = () => {
     URL.revokeObjectURL(url);
   }, [nodes, edges]);
 
-  // Refresh data by refetching from the API
+  // Refresh data by refetching from the API. We also bump the reset
+  // counter so the build-graph effect re-runs even when the data
+  // payload is identical — otherwise repeat clicks looked like no-ops
+  // because devices/topology references stayed the same and the
+  // effect's dep array didn't change. Force-fit at the end re-frames
+  // the canvas so the click visibly does something.
   const handleRefresh = useCallback(() => {
     refetchTopology();
     refetchDevices();
     refetchNeighbors();
+    setResetCounter((n) => n + 1);
+    window.setTimeout(() => {
+      rfInstance.current?.fitView({ padding: 0.2, duration: 300 });
+    }, 150);
   }, [refetchTopology, refetchDevices, refetchNeighbors]);
 
   const loading = topologyLoading || devicesLoading;
@@ -538,16 +601,19 @@ export const TopologyPage: FC = () => {
               </Button>
               {view === 'graph' && (
                 <>
-                  {/* Actions dropdown — replaces the standalone Export
-                      button so PNG / JSON / Reset all live in one
-                      place. Also gives keyboard-only users the same
-                      actions exposed via right-click on the canvas. */}
-                  <ActionsMenu
+                  {/* Reset is always-visible — it's a recovery action
+                      (snap drags / filters back to defaults) and
+                      operators reach for it often enough that hiding
+                      it inside a menu got friction reports. */}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleResetLayout}
                     disabled={nodes.length === 0}
-                    onExportPNG={handleExportPNG}
-                    onExportJSON={handleExport}
-                    onReset={handleResetLayout}
-                  />
+                    title="Clear hand-dragged positions, search, and type filters"
+                  >
+                    Reset
+                  </Button>
                   <Button
                     variant={showLabels ? 'outline' : 'ghost'}
                     size="sm"
@@ -556,6 +622,14 @@ export const TopologyPage: FC = () => {
                   >
                     Labels
                   </Button>
+                  {/* Export is the only menu — PNG vs JSON is a real
+                      two-option choice, but Reset + Labels + Layout
+                      are direct buttons / pills for fast iteration. */}
+                  <ActionsMenu
+                    disabled={nodes.length === 0}
+                    onExportPNG={handleExportPNG}
+                    onExportJSON={handleExport}
+                  />
                   {/* Layout-mode picker — one pill per mode. The active
                       pill is highlighted; clicking another re-runs the
                       layout and persists the choice. Hierarchical is the
@@ -703,6 +777,9 @@ export const TopologyPage: FC = () => {
                   onNodeClick={(_, node) => {
                     closeContextMenu();
                     handleNodeClick(node.id);
+                  }}
+                  onInit={(instance) => {
+                    rfInstance.current = instance;
                   }}
                   nodeTypes={nodeTypes}
                   edgeTypes={edgeTypes}

--- a/ui/src/pages/topology/ActionsMenu.tsx
+++ b/ui/src/pages/topology/ActionsMenu.tsx
@@ -3,13 +3,14 @@ import { type FC, useEffect, useState } from 'react';
 import { Button } from '../../ui/Button';
 
 /**
- * ActionsMenu is the small "Actions ▾" dropdown in the topology
- * header — the keyboard-accessible mirror of the canvas right-click
- * menu. Opens on click, closes on outside-click or Escape.
+ * ActionsMenu is the small "Export ▾" dropdown in the topology
+ * header. Two options: PNG (image render of the canvas via
+ * html-to-image) and JSON (the structured topology graph).
  *
- * No new external dep needed; a focusable button + a click-outside
- * listener is enough for three menu items. If we ever grow more
- * complex menus, Headless UI is the next step up.
+ * Originally also carried "Reset layout" but that turned out to be
+ * a recovery action operators reach for too often — Reset is now a
+ * direct toolbar button. This menu stays small + scoped to "save
+ * this view somewhere".
  *
  * Lives in its own file so TopologyPage.tsx stays under the
  * file-size red-flag threshold (800 lines).
@@ -18,8 +19,7 @@ export const ActionsMenu: FC<{
   disabled?: boolean;
   onExportPNG: () => void;
   onExportJSON: () => void;
-  onReset: () => void;
-}> = ({ disabled, onExportPNG, onExportJSON, onReset }) => {
+}> = ({ disabled, onExportPNG, onExportJSON }) => {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -56,7 +56,7 @@ export const ActionsMenu: FC<{
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        Actions
+        Export
       </Button>
       {open && (
         <div
@@ -80,16 +80,6 @@ export const ActionsMenu: FC<{
           >
             <span>Export topology JSON</span>
             <span className="text-[10px] text-gray-500">data</span>
-          </button>
-          <hr className="my-1 h-px border-0 bg-white/10" />
-          <button
-            type="button"
-            role="menuitem"
-            onClick={handle(onReset)}
-            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-red-300 transition-colors hover:bg-red-500/15 hover:text-red-200"
-          >
-            <span>Reset layout</span>
-            <span className="text-[10px] text-gray-500">drags + filters</span>
           </button>
         </div>
       )}

--- a/ui/src/pages/topology/ContextMenu.tsx
+++ b/ui/src/pages/topology/ContextMenu.tsx
@@ -44,6 +44,11 @@ interface Props {
   onClose: () => void;
 }
 
+// Approximate menu dimensions for the viewport-bounds clamp below.
+// Real width depends on item content but ~200px is conservative.
+const MENU_WIDTH = 200;
+const MENU_HEIGHT = 220;
+
 export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
   const handleItemClick = (e: ReactMouseEvent, item: ContextMenuItem) => {
     e.stopPropagation();
@@ -52,17 +57,26 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
     onClose();
   };
 
+  // Clamp the menu inside the viewport. Without this, right-clicking
+  // a node near the right edge of the canvas would push the menu
+  // off-screen — operators interpret that as "menu broken" when it's
+  // actually just rendered at x=clientX with no room. Flip the menu
+  // to open up/left when it would otherwise overflow.
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 0;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 0;
+  const clampedX = vw > 0 && x + MENU_WIDTH > vw ? Math.max(0, vw - MENU_WIDTH - 8) : x;
+  const clampedY = vh > 0 && y + MENU_HEIGHT > vh ? Math.max(0, vh - MENU_HEIGHT - 8) : y;
+
   return (
     <div
       // Position-fixed in viewport space — coords come straight from
-      // the triggering event's clientX/clientY. Earlier attempts used
-      // absolute positioning relative to the canvas-parent, but
-      // ReactFlow's context-menu callbacks pass an event whose
-      // currentTarget is the node/edge element (not the canvas
-      // container), so subtracting that rect produced
-      // node-relative coords that pushed the menu off-screen.
-      className="fixed z-50 min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur"
-      style={{ left: x, top: y }}
+      // the triggering event's clientX/clientY (then clamped above
+      // to keep the menu fully on-screen). z-index bumped to
+      // [9999] because the topology page sits inside a stacking
+      // context (the Card chrome creates one) and z-50 lost to
+      // ReactFlow's own overlay elements in earlier versions.
+      className="fixed z-[9999] min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur"
+      style={{ left: clampedX, top: clampedY }}
       // Stop right-click on the menu itself from re-opening the pane
       // menu through ReactFlow's onPaneContextMenu.
       onContextMenu={(e) => e.preventDefault()}

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -10,12 +10,17 @@ import { linkSpeedColors } from './types';
 
 /**
  * LayoutMode selects which positioning algorithm `layoutNodes` runs.
- * Hierarchical is the default — concentric rings are visually noisy
- * once you have more than a handful of devices, and the dagre-driven
- * layered layout matches how operators draw network diagrams on a
- * whiteboard.
+ * Hierarchical is the default — it matches how operators draw network
+ * diagrams on a whiteboard (core top, access bottom). Grid is the
+ * fallback for small device sets or when the operator wants a flat
+ * connectivity-agnostic view.
+ *
+ * Concentric was tried in earlier versions but operators found it
+ * hard to read — rings around the most-connected device collapse on
+ * small graphs and become a tangle past ~6 nodes. Removed in favour
+ * of just the two modes that work.
  */
-export type LayoutMode = 'hierarchical' | 'concentric' | 'grid';
+export type LayoutMode = 'hierarchical' | 'grid';
 
 export const DEFAULT_LAYOUT_MODE: LayoutMode = 'hierarchical';
 
@@ -25,11 +30,6 @@ export const LAYOUT_MODES: { mode: LayoutMode; label: string; description: strin
     mode: 'hierarchical',
     label: 'Hierarchical',
     description: 'Layered top-down — core at top, access at bottom',
-  },
-  {
-    mode: 'concentric',
-    label: 'Concentric',
-    description: 'Rings around the most-connected device',
   },
   {
     mode: 'grid',
@@ -52,11 +52,6 @@ const NODE_GAP_Y = 100;
 // ~260 px wide) doesn't obscure the first column of cards.
 const LAYOUT_LEFT_OFFSET = 280;
 const LAYOUT_TOP_OFFSET = 40;
-
-// Minimum radius for the concentric-ring layout. Must be large enough
-// that a node on the inner ring doesn't overlap the centre node — i.e.
-// > one card-width plus padding. The previous 180 wasn't enough.
-const CONCENTRIC_MIN_RADIUS = 320;
 
 /**
  * layoutNodes returns ReactFlow node positions according to the
@@ -82,8 +77,6 @@ export function layoutNodes(
   switch (mode) {
     case 'grid':
       return gridLayout(devices);
-    case 'concentric':
-      return concentricLayout(devices, links);
     default:
       return hierarchicalLayout(devices, links);
   }
@@ -174,71 +167,6 @@ function hierarchicalLayout(devices: DeviceSummary[], links: TopologyLink[]): De
       id: device.name,
       type: 'device',
       position: { x, y },
-      data: makeData(device),
-    };
-  });
-}
-
-/**
- * concentricLayout puts the most-connected device at the centre and
- * arranges the rest in degree-ordered rings. Kept for users who
- * prefer it; not the default because rings collapse on small graphs
- * and become hard to read on bigger ones.
- */
-function concentricLayout(devices: DeviceSummary[], links: TopologyLink[]): DeviceNode[] {
-  // ≤4 devices: rings would overlap. Fall through to grid.
-  if (devices.length <= 4) {
-    return gridLayout(devices);
-  }
-
-  // Build adjacency for degree calculation.
-  const adjacency = new Map<string, Set<string>>();
-  for (const device of devices) {
-    adjacency.set(device.name, new Set());
-  }
-  for (const link of links) {
-    adjacency.get(link.source)?.add(link.target);
-    adjacency.get(link.target)?.add(link.source);
-  }
-  const degrees = new Map<string, number>();
-  for (const [name, neighbors] of adjacency) {
-    degrees.set(name, neighbors.size);
-  }
-  const sorted = [...devices].sort(
-    (a, b) => (degrees.get(b.name) || 0) - (degrees.get(a.name) || 0),
-  );
-
-  const nodeMap = new Map<string, { x: number; y: number }>();
-  const centerX = 400;
-  const centerY = 300;
-  let currentRadius = 0;
-  let angleOffset = 0;
-  let nodesInRing = 1;
-  let ringIndex = 0;
-  for (const device of sorted) {
-    if (ringIndex >= nodesInRing) {
-      ringIndex = 0;
-      currentRadius += CONCENTRIC_MIN_RADIUS;
-      angleOffset += Math.PI / 6;
-      nodesInRing = Math.max(1, Math.floor((2 * Math.PI * currentRadius) / 280));
-    }
-    const angle = (2 * Math.PI * ringIndex) / nodesInRing + angleOffset;
-    nodeMap.set(device.name, {
-      x: centerX + currentRadius * Math.cos(angle),
-      y: centerY + currentRadius * Math.sin(angle),
-    });
-    ringIndex++;
-  }
-
-  return devices.map((device, index) => {
-    const pos = nodeMap.get(device.name) || {
-      x: 100 + (index % 5) * 200,
-      y: 100 + Math.floor(index / 5) * 150,
-    };
-    return {
-      id: device.name,
-      type: 'device',
-      position: pos,
       data: makeData(device),
     };
   });


### PR DESCRIPTION
## Summary

Operator-reported follow-ups after v0.67.1 / #573 testing:

- **Reset and Refresh now visibly do something.** The old Reset wrote positions to `{0,0}` that the position-preservation chain (`existing ?? saved ?? fresh`) treated as valid, so the canvas didn't move. Refresh refetched identical data so the build-graph effect's dep array never changed. Fix: bump a `resetCounter` in the effect deps, clear cached positions + localStorage, and call `rfInstance.fitView()` after a paint tick.
- **Right-click context menu** moved to position-fixed in viewport space with a viewport-bounds clamp and z-index bump, so it can't render off-screen near canvas edges or get covered by ReactFlow overlays.
- **Removed the concentric layout** (visually unreadable at >10 nodes) and removed the **minimap** (no operator value at this scale). Hierarchical spacing widened.
- **Toolbar flattened**: Reset direct, Layout pills inline, Labels toggle direct; only Export stays a dropdown.
- **Debug Console** now actually receives protocol activity. New `internal/logging.ProtocolLogf` helper tees per-packet lines to both stdout (preserving operator log format) *and* slog (so the daemon's SSE log tee delivers them to the UI). Migrated all LLDP/EDP/FDP `fmt.Fprintf(os.Stdout, ...)` sites.

## Test plan
- [ ] Click Reset on a populated topology → canvas re-frames with fresh layout, drags wiped
- [ ] Click Refresh → canvas re-frames; data still consistent
- [ ] Right-click a node near right or bottom canvas edge → menu stays fully on-screen
- [ ] Switch between Hierarchical / Grid layouts → both render cleanly
- [ ] Open Debug Console with a running sim → LLDP / EDP (if enabled per device) / FDP (if enabled) lines appear in real time
- [ ] Export PNG and Export JSON both produce valid files