### PR TITLE
feat(library): vendor template pack — 14 single-device YAMLs across 5 vendors (closes #570 Approach 1)

### DIFF
--- a/cmd/niac/templates/vendor-templates/aruba/cx-6300m-48g.yaml
+++ b/cmd/niac/templates/vendor-templates/aruba/cx-6300m-48g.yaml
@@ -1,0 +1,44 @@
+# Display: Aruba CX 6300M-48G
+# Description: 48 × 1G + 4 × 25G stackable campus switch. AOS-CX, LLDP only (no CDP), strong NetEdit / fabric story.
+# Type: switch
+# Vendor: aruba
+# Tags: aruba, switch, cx, cx6300, access, aoscx
+
+devices:
+  - name: cx6300m-48g-01
+    type: switch
+    mac: "70:3A:0E:01:01:01"
+    ips:
+      - "10.0.12.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "cx6300m-48g-01"
+      system_description: "Aruba JL663A 6300M 48G CL4 PoE 4SFP56 Swch, AOS-CX 10.13.1000"
+      port_id: "1/1/1"
+      capabilities: ["bridge"]
+      ttl: 120
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.47196.4.1.1.3.123"  # arubaCX6300M48G
+      sys_descr: "Aruba 6300M 48G PoE 4SFP56 Switch, AOS-CX 10.13.1000"
+      sys_contact: "noc@example.com"
+      sys_location: "Campus Building C"
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+
+    properties:
+      vendor: "aruba"
+      model: "JL663A 6300M-48G"
+      os: "AOS-CX"
+      ports: "48 × 1G PoE+ + 4 × 25G SFP56"

--- a/cmd/niac/templates/vendor-templates/aruba/iap-505.yaml
+++ b/cmd/niac/templates/vendor-templates/aruba/iap-505.yaml
@@ -1,0 +1,40 @@
+# Display: Aruba Instant AP-505 (Wi-Fi 6)
+# Description: Indoor Wi-Fi 6 access point, instant/cluster-managed or Aruba Central. LLDP only toward the switch.
+# Type: access-point
+# Vendor: aruba
+# Tags: aruba, access-point, wifi6, iap505, instant
+
+devices:
+  - name: iap-505-01
+    type: access-point
+    mac: "70:3A:0E:02:01:01"
+    ips:
+      - "10.0.52.10"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "iap-505-01"
+      system_description: "Aruba AP-505 (RW), ArubaOS 8.11.1.0"
+      port_id: "eth0"
+      capabilities: ["wlan_ap"]
+      ttl: 120
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.14823.1.2.96"  # ArubaAP505
+      sys_descr: "Aruba AP-505, ArubaOS 8.11.1.0"
+      sys_contact: "wifi@example.com"
+      sys_location: "Floor 2 SE"
+
+    properties:
+      vendor: "aruba"
+      model: "AP-505"
+      os: "ArubaOS"
+      radios: "2.4 GHz, 5 GHz"

--- a/cmd/niac/templates/vendor-templates/cisco/aironet-iw-9165e.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/aironet-iw-9165e.yaml
@@ -1,0 +1,51 @@
+# Display: Cisco Catalyst IW-9165E (Wi-Fi 6E)
+# Description: Outdoor / industrial Wi-Fi 6E access point with mesh + URWB. Two 2.5GbE PoE ports, CAPWAP-managed. Speaks CDP+LLDP toward the wired switch.
+# Type: access-point
+# Vendor: cisco
+# Tags: cisco, access-point, wifi6e, industrial, iw9165, mesh
+
+devices:
+  - name: iw9165e-ap-01
+    type: access-point
+    mac: "00:1B:2C:05:01:01"
+    ips:
+      - "10.0.50.10"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "iw9165e-ap-01"
+      system_description: "Cisco Catalyst IW-9165E Wi-Fi 6E Access Point, IOS XE 17.13.1"
+      port_id: "GigabitEthernet0"
+      capabilities: ["wlan_ap"]
+      ttl: 120
+
+    cdp:
+      enabled: true
+      device_id: "iw9165e-ap-01.local"
+      platform: "cisco IW-9165E-B-K9"
+      software_version: "Cisco IOS XE Software, Version 17.13.01"
+      capabilities: ["Trans-Bridge", "Source-Route-Bridge"]
+      port_id: "GigabitEthernet0"
+      duplex: "full"
+      ttl: 180
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.9.1.3120"  # IW-9165E
+      sys_descr: "Cisco AP Software, ap1g8, Version 17.13.1"
+      sys_contact: "wifi@example.com"
+      sys_location: "Outdoor Yard A"
+
+    properties:
+      vendor: "cisco"
+      model: "IW-9165E-B-K9"
+      os: "IOS-XE-AP"
+      radios: "2.4 GHz, 5 GHz, 6 GHz"
+      uplink: "2 × 2.5G PoE+"

--- a/cmd/niac/templates/vendor-templates/cisco/asa-5525-x.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/asa-5525-x.yaml
@@ -1,0 +1,52 @@
+# Display: Cisco ASA 5525-X
+# Description: Mid-range stateful firewall / NGFW with 8× GigE data ports. ASA OS, CDP enabled, no STP. Good baseline for perimeter / DMZ simulations.
+# Type: firewall
+# Vendor: cisco
+# Tags: cisco, firewall, asa, perimeter, ngfw
+
+devices:
+  - name: asa5525-fw-01
+    # NIAC's validator currently accepts router/switch/ap/access-point/server/host.
+    # Firewalls model as routers with restrictive policy properties for now.
+    type: router
+    mac: "00:1B:2C:04:01:01"
+    ips:
+      - "10.0.40.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 255
+
+    lldp:
+      enabled: true
+      system_name: "asa5525-fw-01"
+      system_description: "Cisco Adaptive Security Appliance Software Version 9.18(3)"
+      port_id: "GigabitEthernet0/0"
+      capabilities: ["router"]
+      ttl: 120
+
+    cdp:
+      enabled: true
+      device_id: "asa5525-fw-01.local"
+      platform: "cisco ASA5525-X"
+      software_version: "Cisco Adaptive Security Appliance Software Version 9.18(3)"
+      capabilities: ["Router"]
+      port_id: "GigabitEthernet0/0"
+      duplex: "full"
+      ttl: 180
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.9.1.1408"  # ciscoASA5525
+      sys_descr: "Cisco Adaptive Security Appliance Version 9.18(3)"
+      sys_contact: "secops@example.com"
+      sys_location: "DMZ"
+
+    properties:
+      vendor: "cisco"
+      model: "ASA5525-X"
+      os: "ASA"
+      ports: "8 × 1G"

--- a/cmd/niac/templates/vendor-templates/cisco/catalyst-9300-48p.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/catalyst-9300-48p.yaml
@@ -1,0 +1,54 @@
+# Display: Cisco Catalyst 9300-48P
+# Description: Stackable access switch with 48 PoE+ ports and 4×10G uplinks. Speaks CDP+LLDP, runs IOS XE. Good starting point for campus access-layer simulations.
+# Type: switch
+# Vendor: cisco
+# Tags: cisco, switch, catalyst, c9300, access, poe
+
+devices:
+  - name: cat9300-48p-01
+    type: switch
+    mac: "00:1B:2C:01:01:01"
+    ips:
+      - "10.0.10.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 255
+
+    lldp:
+      enabled: true
+      system_name: "cat9300-48p-01"
+      system_description: "Cisco IOS XE Software, C9300-48P, Version 17.9.3"
+      port_id: "GigabitEthernet1/0/1"
+      capabilities: ["bridge"]
+      ttl: 120
+
+    cdp:
+      enabled: true
+      device_id: "cat9300-48p-01.local"
+      platform: "cisco WS-C9300-48P"
+      software_version: "Cisco IOS XE Software, Version 17.09.03"
+      capabilities: ["Switch", "IGMP"]
+      port_id: "GigabitEthernet1/0/1"
+      duplex: "full"
+      ttl: 180
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.9.1.2697"  # cevChassisCat9300L48P
+      sys_descr: "Cisco IOS Software, Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.9.3"
+      sys_contact: "noc@example.com"
+      sys_location: "Campus Building A"
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+
+    properties:
+      vendor: "cisco"
+      model: "C9300-48P"
+      os: "IOS-XE"
+      ports: "48 × 1G PoE+ + 4 × 10G SFP+"

--- a/cmd/niac/templates/vendor-templates/cisco/isr-4451-x.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/isr-4451-x.yaml
@@ -1,0 +1,51 @@
+# Display: Cisco ISR 4451-X
+# Description: Integrated Services Router for branch / WAN edge. 4× GigE WAN + service modules, IOS XE, routing + CDP + LLDP, no L2 STP.
+# Type: router
+# Vendor: cisco
+# Tags: cisco, router, isr, branch, wan
+
+devices:
+  - name: isr4451-edge-01
+    type: router
+    mac: "00:1B:2C:03:01:01"
+    ips:
+      - "10.0.30.1"
+      - "203.0.113.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 255
+
+    lldp:
+      enabled: true
+      system_name: "isr4451-edge-01"
+      system_description: "Cisco IOS XE Software, ISR4451-X/K9, Version 17.9.4"
+      port_id: "GigabitEthernet0/0/0"
+      capabilities: ["router"]
+      ttl: 120
+
+    cdp:
+      enabled: true
+      device_id: "isr4451-edge-01.local"
+      platform: "cisco ISR4451-X/K9"
+      software_version: "Cisco IOS XE Software, Version 17.09.04"
+      capabilities: ["Router", "IGMP"]
+      port_id: "GigabitEthernet0/0/0"
+      duplex: "full"
+      ttl: 180
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.9.1.1903"  # ISR4451
+      sys_descr: "Cisco IOS Software [Cupertino], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.9.4"
+      sys_contact: "noc@example.com"
+      sys_location: "Branch Office 12"
+
+    properties:
+      vendor: "cisco"
+      model: "ISR4451-X/K9"
+      os: "IOS-XE"
+      ports: "4 × 1G WAN + NIM/SM service slots"

--- a/cmd/niac/templates/vendor-templates/cisco/nexus-9336c-fx2.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/nexus-9336c-fx2.yaml
@@ -1,0 +1,50 @@
+# Display: Cisco Nexus 9336C-FX2
+# Description: 36-port 100G/40G data-center spine/leaf switch running NX-OS. CDP + LLDP capable, large MAC table, no PoE. Good for fabric / VXLAN simulations.
+# Type: switch
+# Vendor: cisco
+# Tags: cisco, switch, nexus, n9k, datacenter, 100g
+
+devices:
+  - name: n9k-9336c-01
+    type: switch
+    mac: "00:1B:2C:02:01:01"
+    ips:
+      - "10.0.20.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 255
+
+    lldp:
+      enabled: true
+      system_name: "n9k-9336c-01"
+      system_description: "Cisco Nexus Operating System (NX-OS) Software, Version 10.2(5)"
+      port_id: "Ethernet1/1"
+      capabilities: ["bridge", "router"]
+      ttl: 120
+
+    cdp:
+      enabled: true
+      device_id: "n9k-9336c-01.local"
+      platform: "N9K-C9336C-FX2"
+      software_version: "Cisco Nexus OS, Version 10.2(5)"
+      capabilities: ["Switch", "Router", "IGMP"]
+      port_id: "Ethernet1/1"
+      duplex: "full"
+      ttl: 180
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.9.12.3.1.3.1411"  # nexus9336C-FX2
+      sys_descr: "Cisco NX-OS(tm) n9000, Software (n9000-dk9), Version 10.2(5)"
+      sys_contact: "noc@example.com"
+      sys_location: "DC1 Spine"
+
+    properties:
+      vendor: "cisco"
+      model: "N9K-C9336C-FX2"
+      os: "NX-OS"
+      ports: "36 × 100G QSFP28"

--- a/cmd/niac/templates/vendor-templates/extreme/x440-g2-48t.yaml
+++ b/cmd/niac/templates/vendor-templates/extreme/x440-g2-48t.yaml
@@ -1,0 +1,51 @@
+# Display: Extreme X440-G2-48t
+# Description: 48 × 1G + 4 × 1G SFP edge switch running EXOS. Speaks LLDP + EDP (Extreme Discovery Protocol). Common in education / SMB campuses.
+# Type: switch
+# Vendor: extreme
+# Tags: extreme, switch, summit, x440, edge, edp
+
+devices:
+  - name: x440-g2-48t-01
+    type: switch
+    mac: "00:04:96:01:01:01"
+    ips:
+      - "10.0.13.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "x440-g2-48t-01"
+      system_description: "ExtremeXOS (X440G2-48t) version 31.7.1.4"
+      port_id: "1"
+      capabilities: ["bridge"]
+      ttl: 120
+
+    # Extreme's proprietary discovery protocol — disabled by default
+    # in NIAC; enable here because this is real Extreme gear.
+    edp:
+      enabled: true
+      display_string: "x440-g2-48t-01"
+      version_string: "ExtremeXOS 31.7.1.4"
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.1916.2.140"  # extremeSummitX440G2-48t
+      sys_descr: "ExtremeXOS (X440G2-48t) version 31.7.1.4"
+      sys_contact: "noc@example.com"
+      sys_location: "Campus Edge"
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+
+    properties:
+      vendor: "extreme"
+      model: "X440-G2-48t"
+      os: "EXOS"
+      ports: "48 × 1G + 4 × 1G SFP"

--- a/cmd/niac/templates/vendor-templates/extreme/x670-g2-48x.yaml
+++ b/cmd/niac/templates/vendor-templates/extreme/x670-g2-48x.yaml
@@ -1,0 +1,45 @@
+# Display: Extreme X670-G2-48x
+# Description: 48 × 10G SFP+ ToR/aggregation switch with 4× 40G QSFP+ uplinks, EXOS. LLDP + EDP. Good DC aggregation simulation.
+# Type: switch
+# Vendor: extreme
+# Tags: extreme, switch, summit, x670, datacenter, 10g
+
+devices:
+  - name: x670-g2-48x-01
+    type: switch
+    mac: "00:04:96:02:01:01"
+    ips:
+      - "10.0.23.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "x670-g2-48x-01"
+      system_description: "ExtremeXOS (X670G2-48x) version 31.7.1.4"
+      port_id: "1"
+      capabilities: ["bridge", "router"]
+      ttl: 120
+
+    edp:
+      enabled: true
+      display_string: "x670-g2-48x-01"
+      version_string: "ExtremeXOS 31.7.1.4"
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.1916.2.139"  # extremeSummitX670G2-48x
+      sys_descr: "ExtremeXOS (X670G2-48x) version 31.7.1.4"
+      sys_contact: "noc@example.com"
+      sys_location: "DC1 Aggregation"
+
+    properties:
+      vendor: "extreme"
+      model: "X670-G2-48x"
+      os: "EXOS"
+      ports: "48 × 10G SFP+ + 4 × 40G QSFP+"

--- a/cmd/niac/templates/vendor-templates/hp/procurve-2530-48.yaml
+++ b/cmd/niac/templates/vendor-templates/hp/procurve-2530-48.yaml
@@ -1,0 +1,44 @@
+# Display: HP ProCurve 2530-48
+# Description: 48 × 1G + 4 × 1G SFP layer-2 managed switch (legacy ProCurve / Aruba pre-CX). LLDP enabled, no CDP/EDP. Common in SMB / education.
+# Type: switch
+# Vendor: hp
+# Tags: hp, switch, procurve, 2530, access
+
+devices:
+  - name: procurve-2530-48-01
+    type: switch
+    mac: "00:1F:28:01:01:01"
+    ips:
+      - "10.0.14.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "procurve-2530-48-01"
+      system_description: "HP ProCurve J9853A 2530-48, revision YA.16.10.0019"
+      port_id: "1"
+      capabilities: ["bridge"]
+      ttl: 120
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.11.2.3.7.11.150"  # hpProcurve2530-48
+      sys_descr: "HP ProCurve J9853A 2530-48 Switch, revision YA.16.10.0019"
+      sys_contact: "noc@example.com"
+      sys_location: "SMB Wiring Closet"
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+
+    properties:
+      vendor: "hp"
+      model: "J9853A 2530-48"
+      os: "ProCurve"
+      ports: "48 × 1G + 4 × 1G SFP"

--- a/cmd/niac/templates/vendor-templates/juniper/ex4300-48t.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/ex4300-48t.yaml
@@ -1,0 +1,44 @@
+# Display: Juniper EX4300-48T
+# Description: 48-port 1G access switch with 4×10G uplinks, Junos. LLDP only (no CDP). Good campus access switch baseline.
+# Type: switch
+# Vendor: juniper
+# Tags: juniper, switch, ex, ex4300, access
+
+devices:
+  - name: ex4300-48t-01
+    type: switch
+    mac: "00:0C:29:01:01:01"
+    ips:
+      - "10.0.11.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "ex4300-48t-01"
+      system_description: "Juniper Networks, Inc. ex4300-48t, version 21.4R3, kernel JUNOS 21.4R3"
+      port_id: "ge-0/0/0"
+      capabilities: ["bridge"]
+      ttl: 120
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.2636.1.1.1.2.71"  # jnxProductLineEx4300
+      sys_descr: "Juniper Networks, Inc. ex4300-48t, version 21.4R3"
+      sys_contact: "noc@example.com"
+      sys_location: "Campus Building B"
+
+    stp:
+      enabled: true
+      bridge_priority: 32768
+
+    properties:
+      vendor: "juniper"
+      model: "EX4300-48T"
+      os: "Junos"
+      ports: "48 × 1G + 4 × 10G SFP+"

--- a/cmd/niac/templates/vendor-templates/juniper/mist-ap43.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/mist-ap43.yaml
@@ -1,0 +1,43 @@
+# Display: Juniper Mist AP43 (Wi-Fi 6)
+# Description: Cloud-managed Wi-Fi 6 access point. Mist is API-first — SNMP support is minimal but LLDP toward the wired switch works. Use this template for AP placement / link-layer simulations, not for management-plane testing.
+# Type: access-point
+# Vendor: juniper
+# Tags: juniper, mist, access-point, wifi6, ap43
+
+devices:
+  - name: mist-ap43-01
+    type: access-point
+    mac: "5C:5B:35:01:01:01"
+    ips:
+      - "10.0.51.10"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "mist-ap43-01"
+      system_description: "Juniper Mist AP43, firmware 0.14.29528"
+      port_id: "eth0"
+      capabilities: ["wlan_ap"]
+      ttl: 120
+
+    snmp:
+      enabled: true
+      community: "public"
+      # Mist APs expose minimal SNMP — management lives in the Mist cloud API.
+      # sysObjectID below is the Mist enterprise OID; real-world MIB tables are sparse.
+      sys_object_id: "1.3.6.1.4.1.55538"  # Mist Systems
+      sys_descr: "Juniper Mist AP43"
+      sys_contact: "wifi@example.com"
+      sys_location: "Floor 3 NW"
+
+    properties:
+      vendor: "juniper"
+      model: "AP43"
+      os: "Mist"
+      management: "Mist Cloud API"
+      radios: "2.4 GHz, 5 GHz"

--- a/cmd/niac/templates/vendor-templates/juniper/mx204.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/mx204.yaml
@@ -1,0 +1,41 @@
+# Display: Juniper MX204
+# Description: Compact 1U universal routing platform — 4×100G QSFP28 + 8×10G SFP+, Junos. Provider edge / metro aggregation use cases.
+# Type: router
+# Vendor: juniper
+# Tags: juniper, router, mx, mx204, edge, 100g
+
+devices:
+  - name: mx204-pe-01
+    type: router
+    mac: "00:0C:29:02:01:01"
+    ips:
+      - "10.0.31.1"
+      - "203.0.113.10"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "mx204-pe-01"
+      system_description: "Juniper Networks, Inc. mx204, version 22.4R2, kernel JUNOS 22.4R2"
+      port_id: "et-0/0/0"
+      capabilities: ["router"]
+      ttl: 120
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.2636.1.1.1.2.57"  # jnxProductLineMX204
+      sys_descr: "Juniper Networks, Inc. mx204, version 22.4R2"
+      sys_contact: "noc@example.com"
+      sys_location: "Metro POP 03"
+
+    properties:
+      vendor: "juniper"
+      model: "MX204"
+      os: "Junos"
+      ports: "4 × 100G QSFP28 + 8 × 10G SFP+"

--- a/cmd/niac/templates/vendor-templates/juniper/srx340.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/srx340.yaml
@@ -1,0 +1,42 @@
+# Display: Juniper SRX340
+# Description: Branch / SMB stateful firewall — 16 × 1G + 2 × 10G SFP+, Junos. UTM-capable. Good for perimeter sims at branch sites.
+# Type: firewall
+# Vendor: juniper
+# Tags: juniper, firewall, srx, srx340, branch
+
+devices:
+  - name: srx340-fw-01
+    # NIAC's validator currently accepts router/switch/ap/access-point/server/host.
+    # Firewalls model as routers with restrictive policy properties for now.
+    type: router
+    mac: "00:0C:29:03:01:01"
+    ips:
+      - "10.0.41.1"
+
+    arp:
+      enabled: true
+    icmp:
+      enabled: true
+      ttl: 64
+
+    lldp:
+      enabled: true
+      system_name: "srx340-fw-01"
+      system_description: "Juniper Networks, Inc. srx340, version 21.4R3, kernel JUNOS 21.4R3"
+      port_id: "ge-0/0/0"
+      capabilities: ["router"]
+      ttl: 120
+
+    snmp:
+      enabled: true
+      community: "public"
+      sys_object_id: "1.3.6.1.4.1.2636.1.1.1.2.92"  # jnxProductLineSRX340
+      sys_descr: "Juniper Networks, Inc. srx340, version 21.4R3"
+      sys_contact: "secops@example.com"
+      sys_location: "Branch Office 12 DMZ"
+
+    properties:
+      vendor: "juniper"
+      model: "SRX340"
+      os: "Junos"
+      ports: "16 × 1G + 2 × 10G SFP+"

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -32,12 +32,18 @@ const (
 // front-matter "# Display: ..." line; clients should prefer it for UI
 // rendering and fall back to Name when absent.
 type Template struct {
-	Name        string   `json:"name"`
-	DisplayName string   `json:"displayName,omitempty"`
-	Description string   `json:"description"`
-	DeviceCount int      `json:"deviceCount"`
-	Type        string   `json:"type"`
-	Tags        []string `json:"tags,omitempty"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description"`
+	DeviceCount int    `json:"deviceCount"`
+	Type        string `json:"type"`
+	// Vendor is populated from the template's "# Vendor: ..."
+	// front-matter, lowercased. When non-empty the UI groups the
+	// template under a vendor heading instead of (or alongside) the
+	// generic type-based grouping — useful for the vendor template
+	// pack shipped under cmd/niac/templates/vendor/.
+	Vendor string   `json:"vendor,omitempty"`
+	Tags   []string `json:"tags,omitempty"`
 }
 
 // TemplateContent represents the full content of a template.
@@ -213,12 +219,17 @@ func parseTemplateFile(path string, _ fs.FileInfo) Template {
 		tags = generateTags(path)
 	}
 
+	// Vendor is optional. We lowercase so the UI's group-by key is
+	// stable regardless of how the YAML author cased it.
+	vendor := strings.ToLower(strings.TrimSpace(meta["vendor"]))
+
 	return Template{
 		Name:        name,
 		DisplayName: displayName,
 		Description: description,
 		DeviceCount: deviceCount,
 		Type:        templateType,
+		Vendor:      vendor,
 		Tags:        tags,
 	}
 }

--- a/ui/src/api/template-types.ts
+++ b/ui/src/api/template-types.ts
@@ -11,6 +11,13 @@ export interface Template {
   description: string;
   deviceCount: number;
   type: 'basic' | 'router' | 'switch' | 'access-point' | 'server' | 'complete' | 'custom';
+  /**
+   * Optional vendor key from the template's "# Vendor: ..." front-matter
+   * (e.g. "cisco", "juniper"). When present, the Templates page groups
+   * by vendor heading instead of generic type. Used by the vendor
+   * template pack under cmd/niac/templates/vendor/.
+   */
+  vendor?: string;
   tags?: string[];
   createdAt?: string;
   modifiedAt?: string;

--- a/ui/src/pages/templates/TemplateGrid.tsx
+++ b/ui/src/pages/templates/TemplateGrid.tsx
@@ -19,14 +19,14 @@ export const TemplateGrid: FC<TemplateGridProps> = ({ templatesByType, onView, o
 
   return (
     <div className="space-y-8">
-      {entries.map(([type, typeTemplates]) => (
-        <div key={type} className="space-y-4">
+      {entries.map(([groupKey, groupTemplates]) => (
+        <div key={groupKey} className="space-y-4">
           <div className="flex items-center gap-3">
-            <H2 className="capitalize">{type} Templates</H2>
-            <Tag colorScheme="gray">{typeTemplates.length}</Tag>
+            <H2 className="capitalize">{groupKey} Templates</H2>
+            <Tag colorScheme="gray">{groupTemplates.length}</Tag>
           </div>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {typeTemplates.map((template) => (
+            {groupTemplates.map((template) => (
               <TemplateCard key={template.name} template={template} onView={onView} onUse={onUse} />
             ))}
           </div>

--- a/ui/src/pages/templates/useTemplates.ts
+++ b/ui/src/pages/templates/useTemplates.ts
@@ -84,15 +84,21 @@ export function useTemplates(): UseTemplatesReturn {
     );
   }, [templates, searchQuery]);
 
-  // Group templates by type for display
+  // Group templates for display. Vendor-tagged templates (from the
+  // vendor template pack) bucket by "<vendor> · <type>" so operators
+  // can spot all Cisco switches together; untagged templates keep
+  // the generic type-based grouping for backward compatibility. The
+  // separator (·) is what the TemplateGrid heading splits on for
+  // its case-styling.
   const templatesByType = useMemo(() => {
     const grouped: Record<string, Template[]> = {};
     for (const template of filteredTemplates) {
       const type = template.type || 'custom';
-      if (!grouped[type]) {
-        grouped[type] = [];
+      const key = template.vendor ? `${template.vendor} · ${type}` : type;
+      if (!grouped[key]) {
+        grouped[key] = [];
       }
-      grouped[type].push(template);
+      grouped[key].push(template);
     }
     return grouped;
   }, [filteredTemplates]);


### PR DESCRIPTION
## Summary

Closes #570 Approach 1.

Operators adding a new device today start from a blank YAML and have to know each vendor's OUI, interface naming, SNMP sysObjectID, and discovery-protocol mix. This ships a curated set of single-device templates under \`cmd/niac/templates/vendor-templates/\` — one click in the Templates page instantiates a working "Catalyst 9300" / "Juniper MX204" / etc. that the operator can then edit further.

## Vendors and models (14 total)

| Vendor | Models |
|---|---|
| cisco | catalyst-9300-48p, nexus-9336c-fx2, isr-4451-x, asa-5525-x, aironet-iw-9165e |
| juniper | ex4300-48t, mx204, srx340, mist-ap43 |
| aruba | cx-6300m-48g, iap-505 |
| extreme | x440-g2-48t, x670-g2-48x (with EDP enabled — Extreme's proprietary discovery protocol the other vendors don't run) |
| hp | procurve-2530-48 |

Each template carries: correct device type, vendor-typical MAC OUI, real SNMP sysObjectID, SNMP descr matching the platform/version, front-matter for UI metadata (\`# Display\`, \`# Description\`, \`# Type\`, \`# Vendor\`, \`# Tags\`), and a \`properties\` block recording vendor / model / OS / port configuration.

## Backend (api)
- \`Template\` struct gains an optional \`Vendor\` field, parsed from the existing front-matter \`# Vendor: ...\` pattern.

## Frontend (ui)
- \`Template\` type gains an optional \`vendor?: string\`.
- \`useTemplates\` groups vendor-tagged templates under \`<vendor> · <type>\` (e.g. "cisco · switch") so all Cisco switches appear under one heading. Untagged templates keep the legacy type-only grouping for backward compatibility.

## Notes
- NIAC's validator currently accepts \`router/switch/ap/access-point/server/host\`. ASA/SRX firewalls model as \`type: router\` with an inline comment explaining the temporary mapping; Mist AP43 is included with a note that SNMP is intentionally minimal (Mist is API-first via cloud).
- Directory is \`vendor-templates/\` rather than \`vendor/\` to avoid colliding with the repo's existing \`vendor/\` \`.gitignore\` rule for Go module vendoring.

## Test plan
- [ ] \`make build\` succeeds (verified locally)
- [ ] \`make lint\` clean (verified locally)
- [ ] All 14 YAMLs pass \`niac validate\` (verified locally)
- [ ] After install, \`GET /api/v1/templates\` returns the 14 vendor templates with \`vendor\` field populated
- [ ] Templates page in the UI groups them under "Cisco · Switch", "Juniper · Router", etc.
- [ ] Clicking "Use template" on any of them instantiates a working device