### PR TITLE
feat: vendor catalog +3, Debug Console default-on, Refresh race fix, device metadata

### DIFF
--- a/docs/schemas/niac.schema.json
+++ b/docs/schemas/niac.schema.json
@@ -257,6 +257,12 @@
             "$ref": "#/$defs/PortChannel"
           },
           "type": "array"
+        },
+        "properties": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -118,12 +118,30 @@ func (s *Server) handleDevices(w http.ResponseWriter, _ *http.Request) {
 	devices := make([]map[string]any, 0, len(cfg.Devices))
 	for i := range cfg.Devices {
 		dev := &cfg.Devices[i]
-		devices = append(devices, map[string]any{
+		entry := map[string]any{
 			"name":      dev.Name,
 			"type":      dev.Type,
 			"ips":       ipAddressesToStrings(dev.IPAddresses),
 			"protocols": getDeviceProtocols(dev),
-		})
+		}
+		// Surface MAC + vendor properties so the UI device list can
+		// show the same information the new vendor templates encode
+		// in their YAML. Previously only name/type/ips/protocols
+		// reached the UI; the vendor template pack's metadata was
+		// invisible to operators browsing /devices.
+		if len(dev.MACAddress) > 0 {
+			entry["mac"] = dev.MACAddress.String()
+		}
+		if len(dev.Properties) > 0 {
+			entry["properties"] = dev.Properties
+			if v, ok := dev.Properties["vendor"]; ok && v != "" {
+				entry["vendor"] = v
+			}
+			if m, ok := dev.Properties["model"]; ok && m != "" {
+				entry["model"] = m
+			}
+		}
+		devices = append(devices, entry)
 	}
 
 	s.writeJSON(w, devices)

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,7 +20,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-BwfLxCEA.js"></script>
+    <script type="module" crossorigin src="/assets/index-CflPhPcs.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-DQoOXKmh.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-BnzIpsIz.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-ui-Dq3G74Nl.js">

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -86,13 +86,20 @@ func convertPortChannels(in []converter.PortChannel) []PortChannel {
 	return out
 }
 
-// createBaseDevice creates a device with default values.
+// createBaseDevice creates a device with default values. The YAML
+// properties block (free-form vendor metadata: vendor/model/os/etc.)
+// is copied in first so subsequent special-case writes (vlan,
+// custom_mibs_count) extend it rather than dropping the originals.
 func createBaseDevice(yamlDevice converter.Device) Device {
+	props := make(map[string]string, len(yamlDevice.Properties))
+	for k, v := range yamlDevice.Properties {
+		props[k] = v
+	}
 	return Device{
 		Name:       yamlDevice.Name,
 		Type:       inferYAMLDeviceType(yamlDevice),
 		Interfaces: make([]Interface, 0),
-		Properties: make(map[string]string),
+		Properties: props,
 		SNMPConfig: SNMPConfig{
 			Community: DefaultSNMPCommunity,
 			SysName:   yamlDevice.Name,

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -85,6 +85,12 @@ type Device struct {
 	IPerf3        *IPerf3Config        `yaml:"iperf3,omitempty"`         // v1.25.0
 	TrunkPorts    []TrunkPort          `yaml:"trunk_ports,omitempty"`    // v1.23.0 — topology link declarations
 	PortChannels  []PortChannel        `yaml:"port_channels,omitempty"`  // v1.23.0 — LAG bundling
+	// Properties is a free-form vendor-metadata block used by the
+	// vendor template pack (cmd/niac/templates/vendor-templates) to
+	// carry vendor / model / OS / port-config strings into the
+	// device list. Keys are author-defined; consumers treat unknown
+	// keys as informational.
+	Properties map[string]string `yaml:"properties,omitempty"`
 }
 
 // TrunkPort declares a VLAN-tagged trunk link to a neighbouring device.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -30,8 +30,15 @@ var (
 )
 
 const (
-	// DefaultDebugLevel is the default debug level for capture engine.
-	DefaultDebugLevel = 0
+	// DefaultDebugLevel is the default debug level for the capture
+	// engine + protocol stack. Set to 1 (DebugLevelBasic) so the
+	// per-protocol "Starting periodic advertisements" lines and
+	// neighbor-discovery info messages reach the Debug Console out
+	// of the box. Without this the SSE log tee (PR #574) is wired
+	// correctly but operators see an empty Debug Console because
+	// every ProtocolLogf call gates on debugLevel >= 1. Per-packet
+	// verbose logging still requires raising the level explicitly.
+	DefaultDebugLevel = 1
 )
 
 // Config holds daemon configuration.

--- a/internal/protocols/snmp/synth/models.go
+++ b/internal/protocols/snmp/synth/models.go
@@ -370,5 +370,61 @@ var modelTable = func() map[modelKey]modelEntry {
 		ifNameFormat: "Ethernet%d",
 	})
 
+	// ===== Aruba (AOS-CX + Instant) =====
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorAruba, Model: "cx-6300m-48g", Type: TypeSwitch,
+			Label:   "Aruba CX 6300M-48G (48× 1G PoE + 4× 25G)",
+			IfCount: ports48, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Aruba JL663A 6300M 48G CL4 PoE 4SFP56 Swch, AOS-CX 10.13.1000",
+		sysObjectID:  "1.3.6.1.4.1.47196.4.1.1.3.123",
+		ifNameFormat: "1/1/%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorAruba, Model: "iap-505", Type: TypeAccessPoint,
+			Label:   "Aruba Instant AP-505 (Wi-Fi 6)",
+			IfCount: ports4, SpeedMbps: speed1G,
+		},
+		sysDescr:     "Aruba AP-505 (RW), ArubaOS 8.11.1.0",
+		sysObjectID:  "1.3.6.1.4.1.14823.1.2.96",
+		ifNameFormat: "eth%d",
+	})
+
+	// ===== Extreme (EXOS) =====
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorExtreme, Model: "x440-g2-48t", Type: TypeSwitch,
+			Label:   "Extreme X440-G2-48t (48× 1G + 4× SFP, EDP+LLDP)",
+			IfCount: ports48, SpeedMbps: speed1G,
+		},
+		sysDescr:     "ExtremeXOS (X440G2-48t) version 31.7.1.4",
+		sysObjectID:  "1.3.6.1.4.1.1916.2.140",
+		ifNameFormat: "%d",
+	})
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorExtreme, Model: "x670-g2-48x", Type: TypeSwitch,
+			Label:   "Extreme X670-G2-48x (48× 10G SFP+ + 4× 40G)",
+			IfCount: ports48, SpeedMbps: speed10G,
+		},
+		sysDescr:     "ExtremeXOS (X670G2-48x) version 31.7.1.4",
+		sysObjectID:  "1.3.6.1.4.1.1916.2.139",
+		ifNameFormat: "%d",
+	})
+
+	// ===== HP / Aruba ProCurve =====
+	add(modelEntry{
+		descriptor: ModelDescriptor{
+			Vendor: VendorHP, Model: "procurve-2530-48", Type: TypeSwitch,
+			Label:   "HP ProCurve 2530-48 (48× 1G + 4× SFP)",
+			IfCount: ports48, SpeedMbps: speed1G,
+		},
+		sysDescr:     "HP ProCurve J9853A 2530-48 Switch, revision YA.16.10.0019",
+		sysObjectID:  "1.3.6.1.4.1.11.2.3.7.11.150",
+		ifNameFormat: "%d",
+	})
+
 	return out
 }()

--- a/internal/protocols/snmp/synth/profiles.go
+++ b/internal/protocols/snmp/synth/profiles.go
@@ -24,6 +24,9 @@ const (
 	VendorCiscoIOS  Vendor = "cisco-ios"
 	VendorJunos     Vendor = "junos"
 	VendorAristaEOS Vendor = "arista-eos"
+	VendorAruba     Vendor = "aruba"
+	VendorExtreme   Vendor = "extreme"
+	VendorHP        Vendor = "hp"
 	VendorGeneric   Vendor = "generic"
 	// VendorJuniperMist is the Mist-acquisition AP line. API-first, so
 	// the synthesised walk is minimal (system group + bare ifTable).
@@ -77,7 +80,7 @@ const (
 //
 //nolint:gochecknoglobals // static lookup
 var AllVendors = []Vendor{
-	VendorCiscoIOS, VendorJunos, VendorAristaEOS, VendorGeneric,
+	VendorCiscoIOS, VendorJunos, VendorAristaEOS, VendorAruba, VendorExtreme, VendorHP, VendorGeneric,
 }
 
 // DeviceType is the niac device.type string. Kept as a typed alias
@@ -283,6 +286,80 @@ var profileTable = func() map[profileKey]Profile {
 		withFlags(
 			arista("DCS-7280SR", "60", "Ethernet%d", defaultIfRouter, speed100G),
 			true, false, true, true,
+		),
+	)
+
+	// ---- Aruba (AOS-CX) ----
+	// CX 6300M = 48×1G campus access, AP-505 = Wi-Fi 6 indoor AP.
+	aruba := func(platform, oidSuffix, ifFmt string, n, speedMbps int) Profile {
+		return Profile{
+			SysDescr: fmt.Sprintf(
+				"Aruba JL663A %s, AOS-CX 10.13.1000", platform,
+			),
+			SysObjectID:    "1.3.6.1.4.1.47196.4.1.1.3." + oidSuffix,
+			IfNameFormat:   ifFmt,
+			DefaultIfCount: n,
+			IfSpeedMbps:    speedMbps,
+		}
+	}
+	add(
+		VendorAruba,
+		TypeSwitch,
+		withFlags(
+			aruba("6300M 48G PoE", "123", "1/1/%d", defaultIfSwitch, speed1G),
+			false, true, true, false,
+		),
+	)
+	add(
+		VendorAruba,
+		TypeAccessPoint,
+		withFlags(
+			aruba("AP-505", "96", "eth%d", defaultIfAP, speed1G),
+			false, false, true, false,
+		),
+	)
+
+	// ---- Extreme (EXOS) ----
+	// Extreme also runs EDP — flag stays set so the per-device emitter
+	// knows to populate the (minimal) extremeEdpNeighbor table.
+	extreme := func(platform, oidSuffix string, n, speedMbps int) Profile {
+		return Profile{
+			SysDescr: fmt.Sprintf(
+				"ExtremeXOS (%s) version 31.7.1.4", platform,
+			),
+			SysObjectID:    "1.3.6.1.4.1.1916.2." + oidSuffix,
+			IfNameFormat:   "%d", // EXOS uses bare port numbers
+			DefaultIfCount: n,
+			IfSpeedMbps:    speedMbps,
+		}
+	}
+	add(
+		VendorExtreme,
+		TypeSwitch,
+		withFlags(
+			extreme("X440G2-48t", "140", defaultIfSwitch, speed1G),
+			false, true, true, false,
+		),
+	)
+
+	// ---- HP / Aruba ProCurve (legacy ProCurve line) ----
+	hp := func(platform, oidSuffix string, n, speedMbps int) Profile {
+		return Profile{
+			SysDescr: fmt.Sprintf(
+				"HP ProCurve %s Switch, revision YA.16.10.0019", platform,
+			),
+			SysObjectID:    "1.3.6.1.4.1.11.2.3.7.11." + oidSuffix,
+			IfNameFormat:   "%d",
+			DefaultIfCount: n,
+			IfSpeedMbps:    speedMbps,
+		}
+	}
+	add(
+		VendorHP,
+		TypeSwitch,
+		withFlags(
+			hp("J9853A 2530-48", "150", defaultIfSwitch, speed1G),
+			false, true, true, false,
 		),
 	)
 

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -27,6 +27,14 @@ export interface DeviceSummary {
   type: string;
   ips: string[];
   protocols: string[];
+  /** Hardware MAC, lowercase-colon-separated; omitted when device has none. */
+  mac?: string;
+  /** Vendor key from the device's `properties.vendor` (e.g. "cisco"). */
+  vendor?: string;
+  /** Model from the device's `properties.model` (e.g. "C9300-48P"). */
+  model?: string;
+  /** Arbitrary device properties from the YAML config. */
+  properties?: Record<string, string>;
 }
 
 export interface HistoryRecord {

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -486,20 +486,29 @@ export const TopologyPage: FC = () => {
     URL.revokeObjectURL(url);
   }, [nodes, edges]);
 
-  // Refresh data by refetching from the API. We also bump the reset
+  // Refresh data by refetching from the API. We bump the reset
   // counter so the build-graph effect re-runs even when the data
-  // payload is identical — otherwise repeat clicks looked like no-ops
-  // because devices/topology references stayed the same and the
-  // effect's dep array didn't change. Force-fit at the end re-frames
-  // the canvas so the click visibly does something.
+  // payload is identical — otherwise repeat clicks looked like
+  // no-ops because devices/topology references stayed the same.
+  // Critical: await ALL refetches before scheduling fitView. Earlier
+  // versions used a fixed 150ms setTimeout and on slow networks
+  // the fitView fired against stale node positions, then the new
+  // data landed and the canvas snapped to a different frame —
+  // looked broken. requestAnimationFrame gives React one paint to
+  // commit the new layout before we re-frame.
   const handleRefresh = useCallback(() => {
-    refetchTopology();
-    refetchDevices();
-    refetchNeighbors();
     setResetCounter((n) => n + 1);
-    window.setTimeout(() => {
-      rfInstance.current?.fitView({ padding: 0.2, duration: 300 });
-    }, 150);
+    Promise.all([refetchTopology(), refetchDevices(), refetchNeighbors()])
+      .catch(() => {
+        // Refetch errors surface through the per-hook error states;
+        // nothing to do here besides making sure we still try the
+        // refit (better than freezing on a transient network blip).
+      })
+      .finally(() => {
+        window.requestAnimationFrame(() => {
+          rfInstance.current?.fitView({ padding: 0.2, duration: 300 });
+        });
+      });
   }, [refetchTopology, refetchDevices, refetchNeighbors]);
 
   const loading = topologyLoading || devicesLoading;


### PR DESCRIPTION
## Summary

Four user-facing audit follow-ups from the post-#576 review.

### #1 — Synth catalog expanded with Aruba / Extreme / HP
- 3 new \`Vendor\` constants + \`AllVendors\` entries.
- \`profileTable\` adds Aruba (CX 6300M + AP-505), Extreme (X440-G2), HP (ProCurve 2530-48) — all with real sysObjectIDs.
- \`models.go\` registers 5 explicit per-model entries so \`PickModel\` resolves the matching vendor-templates pack entries.
- **Live**: \`/api/v1/synthesize-walk/models\` 18 → **23 models across all 7 vendors** (was falling back to Generic for aruba/extreme/hp).

### #6 — DefaultDebugLevel raised 0 → 1
PR #574 wired the SSE log tee correctly but Debug Console stayed empty because every \`ProtocolLogf\` call gates on \`debugLevel >= 1\`. Now the per-protocol "Starting periodic advertisements" + neighbor-info lines reach the console out of the box. Verified via daemon log: \`level=INFO msg="Starting periodic advertisements (interval: 30s)" protocol=LLDP\`.

### #7 — Refresh button race
\`handleRefresh\` awaited NO refetches before scheduling a 150ms \`setTimeout\` for fitView; on slow networks fitView fired against stale positions and the new data landed afterward. Now:

\`\`\`tsx
Promise.all([refetchTopology(), refetchDevices(), refetchNeighbors()])
  .finally(() => requestAnimationFrame(() => rfInstance.current?.fitView(...)));
\`\`\`

### #12 — DeviceSummary surfaces MAC + vendor + model + properties
Root cause: \`converter.Device\` didn't have a \`Properties\` yaml tag, so the entire \`properties:\` block in YAML was silently dropped during parsing. Vendor templates' \`{vendor, model, os, ports}\` metadata was invisible all the way down. Fixed:
- \`converter.Device.Properties map[string]string\` with yaml tag
- \`createBaseDevice\` copies through
- \`handleDevices\` emits \`mac\` / \`vendor\` / \`model\` / \`properties\` when present
- TS \`DeviceSummary\` extended

**Live verified output for catalyst-9300-48p**:
\`\`\`json
{
  "name": "cat9300-48p-01", "type": "switch", "mac": "00:1b:2c:01:01:01",
  "vendor": "cisco", "model": "C9300-48P",
  "properties": {"vendor": "cisco", "model": "C9300-48P", "os": "IOS-XE", "ports": "..."}
}
\`\`\`

## Test plan
- [x] \`make lint\` clean
- [x] \`go test ./...\` clean
- [x] \`make build\` clean
- [x] Live: 23 synth models across 7 vendors
- [x] Live: device list shows mac+vendor+model+properties for a vendor template instantiation
- [x] Daemon log shows protocol-startup lines via slog (Debug Console will receive them)