### PR TITLE
refactor: audit code-quality fixes — typed log levels, runtime JSON, measured menu, Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,20 @@ VERSION_PKG=github.com/krisarmstrong/niac/internal/version
 GO_BUILD_FLAGS := -trimpath -buildvcs=false
 GOFLAGS=$(GO_BUILD_FLAGS)
 
+# Docker settings
+DOCKER_IMAGE?=niac
+DOCKER_TAG?=$(VERSION)
+
+# Directories — defined BEFORE UI_BUILD_HASH because that variable
+# uses `:=` (immediate evaluation) and references EMBED_DIR. Defining
+# EMBED_DIR after UI_BUILD_HASH meant the hash always evaluated
+# against an empty path and the embedded /__version endpoint reported
+# uiBuildHash="" in the make-build binary. The goreleaser pipeline
+# doesn't hit this because it sets uiBuildHash via its own ldflags.
+UI_DIR := ui
+UI_DIST := $(UI_DIR)/dist
+EMBED_DIR := internal/api/ui
+
 # UI build hash for deployment verification (generated from embedded assets)
 UI_BUILD_HASH := $(shell if [ -d "$(EMBED_DIR)" ] && [ -n "$$(ls -A $(EMBED_DIR) 2>/dev/null)" ]; then \
 	find $(EMBED_DIR) -type f -exec md5 -q {} \; 2>/dev/null | sort | md5 -q 2>/dev/null || \
@@ -160,15 +174,6 @@ GO_LDFLAGS = -s -w \
 	-X main.date=$(BUILD_TIME) \
 	-X main.uiBuildHash=$(UI_BUILD_HASH)
 LDFLAGS=$(GO_LDFLAGS)
-
-# Docker settings
-DOCKER_IMAGE?=niac
-DOCKER_TAG?=$(VERSION)
-
-# Directories
-UI_DIR := ui
-UI_DIST := $(UI_DIR)/dist
-EMBED_DIR := internal/api/ui
 
 # =============================================================================
 # Include Domain-Specific Makefiles

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -563,7 +563,18 @@ func (s *Server) handleRuntime(w http.ResponseWriter, r *http.Request) {
 	s.configMu.RUnlock()
 
 	if stack == nil {
-		http.Error(w, "no simulation running", http.StatusServiceUnavailable)
+		// Return a JSON envelope rather than the plain-text "no
+		// simulation running" message every other endpoint formerly
+		// used. Generic JSON clients (the UI, scripted curl, jq
+		// pipelines) couldn't parse the text response and were
+		// erroring on a valid not-running state. HTTP 200 + running:
+		// false matches the contract the simulation status endpoint
+		// already exposes.
+		s.writeJSON(w, map[string]any{
+			"running":        false,
+			"version":        s.cfg.Version,
+			"uptime_seconds": time.Since(s.startTime).Seconds(),
+		})
 
 		return
 	}

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,7 +20,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-DsLcDfFw.js"></script>
+    <script type="module" crossorigin src="/assets/index-gozSfL0n.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-DQoOXKmh.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-BnzIpsIz.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-ui-Dq3G74Nl.js">

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,7 +20,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-CflPhPcs.js"></script>
+    <script type="module" crossorigin src="/assets/index-DsLcDfFw.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-DQoOXKmh.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-BnzIpsIz.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-ui-Dq3G74Nl.js">

--- a/internal/logging/protocol_log.go
+++ b/internal/logging/protocol_log.go
@@ -7,25 +7,52 @@ import (
 	"os"
 )
 
+// ProtocolLevel is the typed log severity for ProtocolLogf. Using a
+// named type instead of a raw string prevents the silent
+// "warning"/"INFO"/"err" demotion-to-Info bug the audit flagged:
+// any caller passing a string outside the four constants below now
+// fails at compile time.
+type ProtocolLevel int
+
+// ProtocolLevel constants map 1:1 onto slog's standard severities.
+const (
+	LevelDebug ProtocolLevel = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+func (l ProtocolLevel) slogLevel() slog.Level {
+	switch l {
+	case LevelDebug:
+		return slog.LevelDebug
+	case LevelWarn:
+		return slog.LevelWarn
+	case LevelError:
+		return slog.LevelError
+	case LevelInfo:
+		fallthrough
+	default:
+		return slog.LevelInfo
+	}
+}
+
 // ProtocolLogf emits a single line via both stdout (preserving the
 // long-standing operator log format that pipes through `niac logs`
 // and journalctl) AND slog (so the daemon's SSE log tee can ship the
 // message to the Debug Console page in the web UI).
 //
-// Until this helper existed, protocol handlers only wrote to stdout
-// via fmt.Fprintf, which meant the Debug Console — wired through
-// slog → SSE — never saw per-packet activity. Operators reported the
-// console as "empty" even when the simulator was sending hundreds of
-// LLDP/CDP/EDP/FDP frames per minute.
+// ctx threads through to slog so handlers that read context can act
+// on it (trace IDs, cancellation, request scoping). Pass
+// context.Background() at the top of the protocol stack where there
+// is no upstream context; the helper does not accept nil.
 //
 // Format args are Sprintf-formatted; the trailing newline is added
 // for the stdout copy (slog records don't need it).
-//
-// Levels map straight onto slog's standard levels. Callers can also
-// use plain slog.* if they already have an attribute-keyed record to
-// emit — this helper exists for the legacy "format string + args"
-// callers that dominate the protocols package.
-func ProtocolLogf(protocol, level, format string, args ...any) {
+func ProtocolLogf(ctx context.Context, protocol string, level ProtocolLevel, format string, args ...any) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	msg := fmt.Sprintf(format, args...)
 
 	// Stdout copy: preserves "PROTOCOL: ..." prefix so existing
@@ -36,14 +63,5 @@ func ProtocolLogf(protocol, level, format string, args ...any) {
 	// SSE-visible copy via slog. Tagged with the protocol so the UI
 	// can group / filter; the message itself stays unprefixed because
 	// the UI renders the protocol column separately.
-	slogLevel := slog.LevelInfo
-	switch level {
-	case "debug":
-		slogLevel = slog.LevelDebug
-	case "warn":
-		slogLevel = slog.LevelWarn
-	case "error":
-		slogLevel = slog.LevelError
-	}
-	slog.Default().LogAttrs(context.TODO(), slogLevel, msg, slog.String("protocol", protocol))
+	slog.Default().LogAttrs(ctx, level.slogLevel(), msg, slog.String("protocol", protocol))
 }

--- a/internal/protocols/edp.go
+++ b/internal/protocols/edp.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -86,7 +87,13 @@ func (h *EDPHandler) Start() {
 	ticker := h.advertiseTicker
 
 	if h.stack.GetDebugLevel() >= 1 {
-		logging.ProtocolLogf("EDP", "info", "Starting periodic advertisements (interval: %v)", EDPAdvertiseInterval)
+		logging.ProtocolLogf(
+			context.Background(),
+			"EDP",
+			logging.LevelInfo,
+			"Starting periodic advertisements (interval: %v)",
+			EDPAdvertiseInterval,
+		)
 	}
 
 	go func() {
@@ -144,7 +151,14 @@ func (h *EDPHandler) sendAdvertisements() {
 		if frame != nil {
 			h.sendFrame(device, frame)
 			if debugLevel >= DebugLevelVerbose {
-				logging.ProtocolLogf("EDP", "info", "Sent advertisement for %s (%d bytes)", device.Name, len(frame))
+				logging.ProtocolLogf(
+					context.Background(),
+					"EDP",
+					logging.LevelInfo,
+					"Sent advertisement for %s (%d bytes)",
+					device.Name,
+					len(frame),
+				)
 			}
 		}
 	}
@@ -441,7 +455,7 @@ func (h *EDPHandler) HandlePacket(pkt *Packet) {
 	entry := buildEDPNeighborRecord(device.Name, parsed, fields)
 
 	if h.stack.GetDebugLevel() >= DebugLevelInfo && entry.RemoteDevice != "" {
-		logging.ProtocolLogf("EDP", "info", "Neighbor %s via %s (local %s)",
+		logging.ProtocolLogf(context.Background(), "EDP", logging.LevelInfo, "Neighbor %s via %s (local %s)",
 			entry.RemoteDevice, entry.RemotePort, entry.LocalDevice)
 	}
 

--- a/internal/protocols/fdp.go
+++ b/internal/protocols/fdp.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"context"
 	"encoding/binary"
 	"net"
 	"strings"
@@ -97,7 +98,13 @@ func (h *FDPHandler) Start() {
 	ticker := h.advertiseTicker
 
 	if h.stack.GetDebugLevel() >= 1 {
-		logging.ProtocolLogf("FDP", "info", "Starting periodic advertisements (interval: %v)", FDPAdvertiseInterval)
+		logging.ProtocolLogf(
+			context.Background(),
+			"FDP",
+			logging.LevelInfo,
+			"Starting periodic advertisements (interval: %v)",
+			FDPAdvertiseInterval,
+		)
 	}
 
 	go func() {
@@ -154,9 +161,23 @@ func (h *FDPHandler) sendAdvertisements() {
 		if frame != nil {
 			err := h.sendFrame(device, frame)
 			if err != nil && debugLevel >= DebugLevelInfo {
-				logging.ProtocolLogf("FDP", "error", "Error sending advertisement for %s: %v", device.Name, err)
+				logging.ProtocolLogf(
+					context.Background(),
+					"FDP",
+					logging.LevelError,
+					"Error sending advertisement for %s: %v",
+					device.Name,
+					err,
+				)
 			} else if debugLevel >= DebugLevelVerbose {
-				logging.ProtocolLogf("FDP", "info", "Sent advertisement for %s (%d bytes)", device.Name, len(frame))
+				logging.ProtocolLogf(
+					context.Background(),
+					"FDP",
+					logging.LevelInfo,
+					"Sent advertisement for %s (%d bytes)",
+					device.Name,
+					len(frame),
+				)
 			}
 		}
 	}
@@ -519,7 +540,7 @@ func (h *FDPHandler) logFDPNeighbor(entry NeighborRecord, _ *Packet) {
 	debugLevel := h.stack.GetDebugLevel()
 	if debugLevel >= DebugLevelInfo {
 		logging.ProtocolLogf(
-			"FDP", "info",
+			context.Background(), "FDP", logging.LevelInfo,
 			"Neighbor %s via %s (local %s)",
 			entry.RemoteDevice, entry.RemotePort, entry.LocalDevice,
 		)

--- a/internal/protocols/lldp.go
+++ b/internal/protocols/lldp.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -141,7 +142,13 @@ func (h *LLDPHandler) Start() {
 	ticker := h.advertiseTicker
 
 	if h.stack.GetDebugLevel() >= 1 {
-		logging.ProtocolLogf("LLDP", "info", "Starting periodic advertisements (interval: %v)", LLDPAdvertiseInterval)
+		logging.ProtocolLogf(
+			context.Background(),
+			"LLDP",
+			logging.LevelInfo,
+			"Starting periodic advertisements (interval: %v)",
+			LLDPAdvertiseInterval,
+		)
 	}
 
 	go func() {
@@ -206,9 +213,23 @@ func (h *LLDPHandler) sendAdvertisements() {
 		if frame != nil {
 			err := h.sendFrame(device, frame)
 			if err != nil && debugLevel >= DebugLevelInfo {
-				logging.ProtocolLogf("LLDP", "error", "Error sending advertisement for %s: %v", device.Name, err)
+				logging.ProtocolLogf(
+					context.Background(),
+					"LLDP",
+					logging.LevelError,
+					"Error sending advertisement for %s: %v",
+					device.Name,
+					err,
+				)
 			} else if debugLevel >= DebugLevelVerbose {
-				logging.ProtocolLogf("LLDP", "info", "Sent advertisement for %s (%d bytes)", device.Name, len(frame))
+				logging.ProtocolLogf(
+					context.Background(),
+					"LLDP",
+					logging.LevelInfo,
+					"Sent advertisement for %s (%d bytes)",
+					device.Name,
+					len(frame),
+				)
 			}
 		}
 	}
@@ -595,7 +616,7 @@ func (h *LLDPHandler) HandlePacket(pkt *Packet) {
 
 	if debugLevel >= DebugLevelInfo {
 		logging.ProtocolLogf(
-			"LLDP", "info",
+			context.Background(), "LLDP", logging.LevelInfo,
 			"Neighbor %s via %s (local %s)",
 			entry.RemoteDevice, entry.RemotePort, entry.LocalDevice,
 		)

--- a/ui/src/pages/topology/ContextMenu.tsx
+++ b/ui/src/pages/topology/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import type { FC, MouseEvent as ReactMouseEvent } from 'react';
+import { type FC, type MouseEvent as ReactMouseEvent, useCallback, useState } from 'react';
 
 /**
  * ContextMenu is the small popover shown on right-click of a node,
@@ -44,12 +44,38 @@ interface Props {
   onClose: () => void;
 }
 
-// Approximate menu dimensions for the viewport-bounds clamp below.
-// Real width depends on item content but ~200px is conservative.
-const MENU_WIDTH = 200;
-const MENU_HEIGHT = 220;
+// Conservative width estimate for first-paint clamping. The actual
+// width gets measured on mount and replaces this for subsequent
+// reflows, but the menu still needs SOME number on the very first
+// render before the layout effect has a chance to read offsetWidth.
+const INITIAL_MENU_WIDTH = 200;
+const INITIAL_MENU_HEIGHT = 32; // approx one item — favours opening downward on first render
 
 export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
+  // Measured dimensions seed from conservative defaults so the first
+  // render has values to clamp with; the ref callback below
+  // overwrites them once React commits the menu div. Replaces the
+  // old hard-coded MENU_HEIGHT=220 which over-clamped small (2-item)
+  // pane menus from the bottom edge while under-clamping potential
+  // future 10-item menus that would overflow.
+  const [size, setSize] = useState<{ w: number; h: number }>({
+    w: INITIAL_MENU_WIDTH,
+    h: INITIAL_MENU_HEIGHT,
+  });
+
+  // Ref callback measures the rendered div as soon as React commits
+  // it. Using a callback ref (instead of useLayoutEffect + useRef)
+  // sidesteps the exhaustive-deps lint complaint about passing the
+  // `items` prop as a dep — React fires the callback exactly when
+  // the element mounts. setSize's callback form bails out when the
+  // dimensions haven't changed, so re-renders with the same items
+  // are a no-op.
+  const menuRef = useCallback((el: HTMLDivElement | null) => {
+    if (!el) return;
+    const next = { w: el.offsetWidth, h: el.offsetHeight };
+    setSize((prev) => (prev.w === next.w && prev.h === next.h ? prev : next));
+  }, []);
+
   const handleItemClick = (e: ReactMouseEvent, item: ContextMenuItem) => {
     e.stopPropagation();
     if (item.disabled) return;
@@ -60,15 +86,15 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
   // Clamp the menu inside the viewport. Without this, right-clicking
   // a node near the right edge of the canvas would push the menu
   // off-screen — operators interpret that as "menu broken" when it's
-  // actually just rendered at x=clientX with no room. Flip the menu
-  // to open up/left when it would otherwise overflow.
+  // actually just rendered at x=clientX with no room.
   const vw = typeof window !== 'undefined' ? window.innerWidth : 0;
   const vh = typeof window !== 'undefined' ? window.innerHeight : 0;
-  const clampedX = vw > 0 && x + MENU_WIDTH > vw ? Math.max(0, vw - MENU_WIDTH - 8) : x;
-  const clampedY = vh > 0 && y + MENU_HEIGHT > vh ? Math.max(0, vh - MENU_HEIGHT - 8) : y;
+  const clampedX = vw > 0 && x + size.w > vw ? Math.max(0, vw - size.w - 8) : x;
+  const clampedY = vh > 0 && y + size.h > vh ? Math.max(0, vh - size.h - 8) : y;
 
   return (
     <div
+      ref={menuRef}
       // Position-fixed in viewport space — coords come straight from
       // the triggering event's clientX/clientY (then clamped above
       // to keep the menu fully on-screen). z-index bumped to


### PR DESCRIPTION
## Summary

Five code-quality follow-ups from the audit (#8, #9, #11, #13, #14). Independent of PR #577 (user-facing); either can land first.

### #8 + #14 — \`ProtocolLogf\` typed level enum + context.Context
Old signature took \`level string\` and silently demoted unknown values (\`"warning"\`, \`"INFO"\`, \`"err"\`) to Info. Now:

\`\`\`go
func ProtocolLogf(ctx context.Context, protocol string,
                  level ProtocolLevel, format string, args ...any)
\`\`\`

with named constants \`LevelDebug/Info/Warn/Error\`. Compile-time safety against typos. \`ctx\` threads through to slog so future trace-id / cancellation propagation just works. All 11 call sites in LLDP / EDP / FDP updated.

### #13 — \`/api/v1/runtime\` returns JSON when no sim is running
Previously returned plain text \`"no simulation running"\` (HTTP 503) which broke generic JSON clients. Now returns HTTP 200 + \`{"running": false, "version": "...", "uptime_seconds": N}\` matching the existing simulation-status contract.

### #9 — ContextMenu measures own height instead of hard-coding 220px
Hard-coded \`MENU_HEIGHT = 220\` over-clamped 2-item pane menus from the bottom edge and would silently overflow a hypothetical 10-item menu. Now a ref callback reads \`offsetHeight\`/\`offsetWidth\` on mount; setSize uses callback form so re-renders with the same dimensions are a no-op.

### #11 — Makefile \`UI_BUILD_HASH\` evaluation order fixed
\`UI_BUILD_HASH := $(shell ... $(EMBED_DIR) ...)\` was defined BEFORE \`EMBED_DIR\`. \`:=\` is immediate evaluation, so the embedded-asset path was empty at expansion time and \`uiBuildHash\` ended up as \`""\`. \`/__version\` reported \`"uiBuildHash": ""\` for every make-build binary (goreleaser builds were fine — they compute the hash via their own ldflags). Reordered.

## Test plan
- [x] \`make lint\` clean
- [x] \`go test ./...\` clean
- [x] \`make build\` clean
- [x] Live: \`curl /__version\` shows non-empty \`uiBuildHash\`
- [x] Live: \`curl /api/v1/runtime\` returns valid JSON (HTTP 200) when no sim