### PR TITLE
chore(ci): customize labeler.yml issue componentMap for niac

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -51,15 +51,16 @@ jobs:
             const title = issue.title || '';
             const labelsToAdd = [];
 
-            // Component mapping from form dropdown
+            // Component mapping from form dropdown — niac-specific.
             const componentMap = {
               'API/Backend': 'component: api',
               'UI/Frontend': 'component: ui',
-              'Network Discovery': 'component: discovery',
-              'WiFi Survey': 'component: wifi',
-              'Speed Test / iPerf': 'component: iperf',
-              'DHCP Detection': 'component: dhcp',
-              'Authentication': 'component: auth',
+              'SNMP': 'component: snmp',
+              'LLDP/CDP': 'component: protocols',
+              'Protocol Simulation': 'component: protocols',
+              'Device Simulation': 'component: device',
+              'Templates': 'component: templates',
+              'PCAP Capture/Replay': 'component: capture',
               'Configuration': 'component: config',
               'Installation/Deployment': 'area: build',
               'Documentation': 'area: docs',


### PR DESCRIPTION
labeler.yml was copied from seed verbatim during the P2-7 workflow alignment; the inline issue-labeling componentMap had seed-specific component names ("Network Discovery", "WiFi Survey", "Speed Test / iPerf") that never matched niac's issue forms, so the issue-labeler silently no-op'd.

Replace with niac-appropriate categories: SNMP, LLDP/CDP, Protocol Simulation, Device Simulation, Templates, PCAP Capture/Replay. Priority and severity maps are project-agnostic and kept as-is.