### PR TITLE
fix(ci): grant security-events: write (restores broken niac main CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,13 @@ jobs:
   security:
     name: Security Scanning
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # github/codeql-action/upload-sarif@v4 requires security-events: write
+      # to push results to the Security tab (regressed from a default-on
+      # permission in earlier versions). Trivy and gosec both use this
+      # action to upload SARIF.
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
After PR #581 merged the gh-actions group bump (which pulled codeql-action up to v4), niac main CI fails on Security Scanning with:

```
Resource not accessible by integration
```

The newer codeql-action/upload-sarif requires explicit `security-events: write` permission; seed and stem's equivalent job already had it (so they're fine), niac was missing it.

Adding the explicit permissions block restores SARIF uploads from gosec + Trivy. Fixes niac main CI.