### PR TITLE
ci: use native ubuntu-24.04-arm runner for arm64 container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,21 +27,19 @@ env:
 jobs:
   docker:
     name: Build container (linux/${{ matrix.platform }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        platform: [amd64, arm64]
+        include:
+          - platform: amd64
+            runner: ubuntu-latest
+          - platform: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
-      - name: Set up QEMU
-        if: matrix.platform == 'arm64'
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0


### PR DESCRIPTION
## Summary

Replace QEMU emulation with GitHub-hosted native ARM runners for the arm64 container build matrix entry.

QEMU adds ~5-10 min per arm64 build by emulating ARM instructions on amd64 hardware. Native `ubuntu-24.04-arm` runners execute on real ARM silicon — typically 3-10x faster.

### Changes
- Move matrix from `platform: [amd64, arm64]` to `include:` syntax with per-platform runner mapping
- Remove `docker/setup-qemu-action` step (no longer needed)
- amd64 stays on `ubuntu-latest`, arm64 moves to `ubuntu-24.04-arm`

Same change applied to seed and stem `container.yml` (already merged to their main branches).

## Test plan
- [ ] CI passes (container build for both amd64 and arm64)
- [ ] arm64 build noticeably faster than prior QEMU runs