### PR TITLE
refactor(ui): eliminate raw Tailwind palette; use semantic theme tokens (97.7% reduction)

### DIFF
--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,12 +20,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-C_tvHcjQ.js"></script>
+    <script type="module" crossorigin src="/assets/index-SHnGKA7b.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-eeLRIeX4.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-BgvehhUW.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-ui-DWCVT6q4.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-codemirror-C6W6iGZP.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DJf-jlMi.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-CeEOyKCx.css">
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/BpfFilterBar.tsx
+++ b/ui/src/components/BpfFilterBar.tsx
@@ -113,8 +113,8 @@ export const BpfFilterBar: FC = memo(() => {
       <div className="flex items-center gap-2">
         {/* Filter icon and active indicator */}
         <div className="flex items-center gap-1.5 flex-shrink-0">
-          <Filter className={`${iconSizes.md} text-gray-400`} />
-          {isActive && <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />}
+          <Filter className={`${iconSizes.md} text-text-muted`} />
+          {isActive && <CheckCircle2 className="h-3.5 w-3.5 text-status-success" />}
         </div>
 
         {/* Input */}
@@ -127,12 +127,12 @@ export const BpfFilterBar: FC = memo(() => {
           }}
           onKeyDown={handleKeyDown}
           placeholder="BPF filter (e.g. tcp port 80)"
-          className={`flex-1 bg-gray-950/70 border rounded-lg px-3 py-1.5 text-sm font-mono text-white placeholder-gray-500 focus:outline-none focus:ring-1 ${
+          className={`flex-1 bg-bg-base/70 border rounded-lg px-3 py-1.5 text-sm font-mono text-text-primary placeholder-gray-500 focus:outline-none focus:ring-1 ${
             error
-              ? 'border-red-500/60 focus:ring-red-500/40'
+              ? 'border-status-error/60 focus:ring-status-error/40'
               : isActive
-                ? 'border-green-500/40 focus:ring-green-500/40'
-                : 'border-white/10 focus:ring-violet-500/40'
+                ? 'border-status-success/40 focus:ring-green-500/40'
+                : 'border-white/10 focus:ring-brand-500/40'
           }`}
           disabled={isLoading}
         />
@@ -164,15 +164,15 @@ export const BpfFilterBar: FC = memo(() => {
       {/* Error message */}
       {error && (
         <div className="flex items-center gap-1.5 px-1">
-          <AlertCircle className={`${iconSizes.sm} text-red-400 flex-shrink-0`} />
-          <SmallText className="text-red-400">{error}</SmallText>
+          <AlertCircle className={`${iconSizes.sm} text-status-error flex-shrink-0`} />
+          <SmallText className="text-status-error">{error}</SmallText>
         </div>
       )}
 
       {/* Active filter indicator */}
       {isActive && activeFilter && (
         <div className="flex items-center gap-1.5 px-1">
-          <SmallText className="text-green-400">
+          <SmallText className="text-status-success">
             Active: <span className="font-mono">{activeFilter}</span>
           </SmallText>
         </div>
@@ -185,7 +185,7 @@ export const BpfFilterBar: FC = memo(() => {
             key={preset.filter}
             type="button"
             onClick={() => handlePreset(preset.filter)}
-            className="px-2 py-0.5 text-xs rounded bg-gray-800/60 text-gray-400 hover:text-white hover:bg-gray-700/60 border border-white/5 transition-colors"
+            className="px-2 py-0.5 text-xs rounded bg-bg-elevated/60 text-text-muted hover:text-text-primary hover:bg-bg-elevated/60 border border-white/5 transition-colors"
           >
             {preset.label}
           </button>

--- a/ui/src/components/ColoringRulesPanel.tsx
+++ b/ui/src/components/ColoringRulesPanel.tsx
@@ -29,13 +29,13 @@ const RuleRow: FC<{
   const filterError = rule.filter ? validate(rule.filter) : null;
 
   return (
-    <div className="flex items-center gap-2 py-2 px-2 rounded-lg bg-gray-950/40 border border-white/5">
+    <div className="flex items-center gap-2 py-2 px-2 rounded-lg bg-bg-base/40 border border-white/5">
       {/* Enable toggle */}
       <input
         type="checkbox"
         checked={rule.enabled}
         onChange={(e) => onChange({ ...rule, enabled: e.target.checked })}
-        className="rounded border-gray-600 bg-gray-800 text-violet-500 focus:ring-violet-400 focus:ring-offset-gray-900 flex-shrink-0"
+        className="rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-400 focus:ring-offset-gray-900 flex-shrink-0"
       />
 
       {/* Color preview */}
@@ -51,7 +51,7 @@ const RuleRow: FC<{
         type="text"
         value={rule.name}
         onChange={(e) => onChange({ ...rule, name: e.target.value })}
-        className="w-24 bg-transparent border-b border-white/10 text-sm text-white focus:outline-none focus:border-violet-400 px-1"
+        className="w-24 bg-transparent border-b border-white/10 text-sm text-text-primary focus:outline-none focus:border-brand-400 px-1"
         placeholder="Name"
       />
 
@@ -60,10 +60,10 @@ const RuleRow: FC<{
         type="text"
         value={rule.filter}
         onChange={(e) => onChange({ ...rule, filter: e.target.value })}
-        className={`flex-1 bg-transparent border-b text-sm font-mono text-white focus:outline-none px-1 ${
+        className={`flex-1 bg-transparent border-b text-sm font-mono text-text-primary focus:outline-none px-1 ${
           filterError
-            ? 'border-red-500/60 focus:border-red-400'
-            : 'border-white/10 focus:border-violet-400'
+            ? 'border-status-error/60 focus:border-status-error'
+            : 'border-white/10 focus:border-brand-400'
         }`}
         placeholder="Filter expression"
       />
@@ -91,7 +91,7 @@ const RuleRow: FC<{
         type="button"
         onClick={onMoveUp}
         disabled={isFirst}
-        className="p-1 text-gray-500 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
+        className="p-1 text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
         title="Move up"
       >
         <ArrowUp className={iconSizes.sm} />
@@ -100,7 +100,7 @@ const RuleRow: FC<{
         type="button"
         onClick={onMoveDown}
         disabled={isLast}
-        className="p-1 text-gray-500 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
+        className="p-1 text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
         title="Move down"
       >
         <ArrowDown className={iconSizes.sm} />
@@ -110,7 +110,7 @@ const RuleRow: FC<{
       <button
         type="button"
         onClick={onDelete}
-        className="p-1 text-gray-500 hover:text-red-400"
+        className="p-1 text-text-muted hover:text-status-error"
         title="Delete rule"
       >
         <Trash2 className="h-3.5 w-3.5" />
@@ -187,18 +187,22 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-        <div className="w-full max-w-3xl mx-4 bg-gray-900 border border-white/10 rounded-xl shadow-2xl max-h-[80vh] flex flex-col">
+        <div className="w-full max-w-3xl mx-4 bg-bg-surface border border-white/10 rounded-xl shadow-2xl max-h-[80vh] flex flex-col">
           {/* Header */}
           <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
-            <h3 className="text-lg font-semibold text-white">Coloring Rules</h3>
-            <button type="button" onClick={onClose} className="p-1 text-gray-400 hover:text-white">
+            <h3 className="text-lg font-semibold text-text-primary">Coloring Rules</h3>
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-1 text-text-muted hover:text-text-primary"
+            >
               <X className="h-5 w-5" />
             </button>
           </div>
 
           {/* Rules list */}
           <div className="flex-1 overflow-y-auto px-5 py-4 space-y-2">
-            <SmallText className="text-gray-400 mb-3 block">
+            <SmallText className="text-text-muted mb-3 block">
               Rules are evaluated top-to-bottom. First matching rule determines the row color.
             </SmallText>
 
@@ -216,7 +220,7 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
             ))}
 
             {localRules.length === 0 && (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-text-muted">
                 <p>No coloring rules defined.</p>
               </div>
             )}

--- a/ui/src/components/ConversationList.tsx
+++ b/ui/src/components/ConversationList.tsx
@@ -78,9 +78,9 @@ export const ConversationList: FC<ConversationListProps> = memo(
 
     if (conversations.length === 0) {
       return (
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent>
-            <div className="text-center py-8 text-gray-400">
+            <div className="text-center py-8 text-text-muted">
               <p className="text-sm">No TCP/UDP conversations found</p>
               <SmallText>Conversations require packets with port information</SmallText>
             </div>
@@ -90,45 +90,45 @@ export const ConversationList: FC<ConversationListProps> = memo(
     }
 
     return (
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent>
           <div className="mb-3 flex items-center justify-between">
-            <SmallText className="text-gray-400">
+            <SmallText className="text-text-muted">
               {conversations.length} conversation{conversations.length !== 1 ? 's' : ''}
             </SmallText>
-            <SmallText className="text-gray-500">Click a row to filter packets</SmallText>
+            <SmallText className="text-text-muted">Click a row to filter packets</SmallText>
           </div>
 
           <div className="overflow-auto rounded-lg border border-white/5 max-h-[500px]">
             <table className="min-w-full divide-y divide-white/5">
-              <thead className="bg-gray-900/80 sticky top-0 z-10">
+              <thead className="bg-bg-surface/80 sticky top-0 z-10">
                 <tr>
-                  <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                  <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
                     Endpoint A
                   </th>
-                  <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                  <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
                     Endpoint B
                   </th>
                   <th
-                    className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400 cursor-pointer hover:text-violet-300 select-none"
+                    className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
                     onClick={() => handleSort('protocol')}
                   >
                     Protocol{sortIndicator('protocol')}
                   </th>
                   <th
-                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-gray-400 cursor-pointer hover:text-violet-300 select-none"
+                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
                     onClick={() => handleSort('packets')}
                   >
                     Packets{sortIndicator('packets')}
                   </th>
                   <th
-                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-gray-400 cursor-pointer hover:text-violet-300 select-none"
+                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
                     onClick={() => handleSort('bytes')}
                   >
                     Bytes{sortIndicator('bytes')}
                   </th>
                   <th
-                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-gray-400 cursor-pointer hover:text-violet-300 select-none"
+                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
                     onClick={() => handleSort('duration')}
                   >
                     Duration{sortIndicator('duration')}
@@ -161,21 +161,21 @@ const ConversationRow: FC<{
   const duration = getConversationDuration(conversation);
 
   return (
-    <tr onClick={onClick} className="cursor-pointer hover:bg-gray-900/50 transition-colors">
-      <td className="px-3 py-2 text-white text-sm font-mono">{conversation.endpointA}</td>
-      <td className="px-3 py-2 text-white text-sm font-mono">{conversation.endpointB}</td>
+    <tr onClick={onClick} className="cursor-pointer hover:bg-bg-surface/50 transition-colors">
+      <td className="px-3 py-2 text-text-primary text-sm font-mono">{conversation.endpointA}</td>
+      <td className="px-3 py-2 text-text-primary text-sm font-mono">{conversation.endpointB}</td>
       <td className="px-3 py-2">
         <Tag colorScheme={getProtocolColor(conversation.protocol)} className="text-xs">
           {conversation.protocol}
         </Tag>
       </td>
-      <td className="px-3 py-2 text-gray-300 text-sm text-right font-mono">
+      <td className="px-3 py-2 text-text-secondary text-sm text-right font-mono">
         {conversation.packets}
       </td>
-      <td className="px-3 py-2 text-gray-300 text-sm text-right font-mono">
+      <td className="px-3 py-2 text-text-secondary text-sm text-right font-mono">
         {formatBytes(conversation.bytes)}
       </td>
-      <td className="px-3 py-2 text-gray-400 text-sm text-right font-mono">
+      <td className="px-3 py-2 text-text-muted text-sm text-right font-mono">
         {formatDurationSeconds(duration)}
       </td>
     </tr>

--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -74,34 +74,36 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="flex min-h-[400px] flex-col items-center justify-center p-8">
           <div className="mx-auto max-w-md text-center">
             <div className="mb-4 flex justify-center">
-              <div className="rounded-full bg-red-100 p-4 dark:bg-red-900/20">
-                <AlertCircle className={`${iconSizes['3xl']} text-red-600 dark:text-red-400`} />
+              <div className="rounded-full bg-status-error p-4 dark:bg-status-error/20">
+                <AlertCircle
+                  className={`${iconSizes['3xl']} text-status-error dark:text-status-error`}
+                />
               </div>
             </div>
 
-            <h2 className="mb-2 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            <h2 className="mb-2 text-xl font-semibold text-text-muted dark:text-text-primary">
               Something went wrong
             </h2>
 
-            <p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
+            <p className="mb-6 text-sm text-text-disabled dark:text-text-muted">
               An unexpected error occurred. You can try to recover or reload the page.
             </p>
 
             {/* Error details (development only - hidden in production) */}
             {import.meta.env.DEV && this.state.error && (
-              <div className="mb-6 rounded-lg bg-gray-100 p-4 text-left dark:bg-gray-800">
-                <p className="mb-1 text-xs font-medium text-gray-500 dark:text-gray-400">
+              <div className="mb-6 rounded-lg bg-bg-muted p-4 text-left dark:bg-bg-elevated">
+                <p className="mb-1 text-xs font-medium text-text-muted dark:text-text-muted">
                   Error Details:
                 </p>
-                <pre className="overflow-auto text-xs text-red-600 dark:text-red-400">
+                <pre className="overflow-auto text-xs text-status-error dark:text-status-error">
                   {this.state.error.message}
                 </pre>
                 {this.state.errorInfo?.componentStack && (
                   <>
-                    <p className="mb-1 mt-3 text-xs font-medium text-gray-500 dark:text-gray-400">
+                    <p className="mb-1 mt-3 text-xs font-medium text-text-muted dark:text-text-muted">
                       Component Stack:
                     </p>
-                    <pre className="max-h-32 overflow-auto text-xs text-gray-600 dark:text-gray-400">
+                    <pre className="max-h-32 overflow-auto text-xs text-text-disabled dark:text-text-muted">
                       {this.state.errorInfo.componentStack}
                     </pre>
                   </>
@@ -113,7 +115,7 @@ export class ErrorBoundary extends Component<Props, State> {
               <button
                 type="button"
                 onClick={this.handleRetry}
-                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                className="inline-flex items-center gap-2 rounded-lg bg-status-info px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-status-info focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2"
               >
                 <RefreshCw className={iconSizes.md} />
                 Try Again
@@ -121,7 +123,7 @@ export class ErrorBoundary extends Component<Props, State> {
               <button
                 type="button"
                 onClick={this.handleReload}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                className="inline-flex items-center gap-2 rounded-lg border border-border-muted bg-white px-4 py-2 text-sm font-medium text-text-disabled transition-colors hover:bg-bg-muted focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2 dark:border-border-muted dark:bg-bg-elevated dark:text-text-secondary dark:hover:bg-bg-elevated"
               >
                 Reload Page
               </button>
@@ -143,29 +145,31 @@ export class PageErrorBoundary extends ErrorBoundary {
   render(): ReactNode {
     if (this.state.hasError) {
       return (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-6 dark:border-red-800 dark:bg-red-900/10">
+        <div className="rounded-lg border border-status-error bg-status-error p-6 dark:border-status-error dark:bg-status-error/10">
           <div className="flex items-start gap-4">
             <AlertCircle
-              className={`${iconSizes.xl} flex-shrink-0 text-red-600 dark:text-red-400`}
+              className={`${iconSizes.xl} flex-shrink-0 text-status-error dark:text-status-error`}
             />
             <div className="flex-1">
-              <h3 className="text-sm font-medium text-red-800 dark:text-red-200">Page Error</h3>
-              <p className="mt-1 text-sm text-red-700 dark:text-red-300">
+              <h3 className="text-sm font-medium text-status-error dark:text-status-error">
+                Page Error
+              </h3>
+              <p className="mt-1 text-sm text-status-error dark:text-status-error">
                 This page encountered an error. Try navigating to another page or refresh.
               </p>
               <div className="mt-4 flex gap-2">
                 <button
                   type="button"
                   onClick={this.handleRetry}
-                  className="text-sm font-medium text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300"
+                  className="text-sm font-medium text-status-error hover:text-status-error dark:text-status-error dark:hover:text-status-error"
                 >
                   Retry
                 </button>
-                <span className="text-red-300 dark:text-red-600">|</span>
+                <span className="text-status-error dark:text-status-error">|</span>
                 <button
                   type="button"
                   onClick={this.handleReload}
-                  className="text-sm font-medium text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300"
+                  className="text-sm font-medium text-status-error hover:text-status-error dark:text-status-error dark:hover:text-status-error"
                 >
                   Reload
                 </button>

--- a/ui/src/components/ErrorInjectionPanel.tsx
+++ b/ui/src/components/ErrorInjectionPanel.tsx
@@ -119,7 +119,7 @@ export const ErrorInjectionPanel: FC = () => {
                 id="error-device"
                 value={selectedDevice}
                 onChange={(e) => setSelectedDevice(e.target.value)}
-                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
               >
                 <option value="">Select device...</option>
                 {devices?.map((dev) => (
@@ -141,7 +141,7 @@ export const ErrorInjectionPanel: FC = () => {
                 value={selectedInterface}
                 onChange={(e) => setSelectedInterface(e.target.value)}
                 placeholder="e.g., eth0, GigabitEthernet0/1"
-                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
               />
             </div>
 
@@ -154,7 +154,7 @@ export const ErrorInjectionPanel: FC = () => {
                 id="error-type"
                 value={selectedErrorType}
                 onChange={(e) => setSelectedErrorType(e.target.value)}
-                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
               >
                 <option value="">Select error type...</option>
                 {errorInfo?.availableTypes?.map((type: ErrorType) => (
@@ -164,7 +164,7 @@ export const ErrorInjectionPanel: FC = () => {
                 ))}
               </select>
               {selectedErrorType && errorInfo?.availableTypes && (
-                <SmallText className="text-gray-400 mt-1">
+                <SmallText className="text-text-muted mt-1">
                   {
                     errorInfo.availableTypes.find((t: ErrorType) => t.type === selectedErrorType)
                       ?.description
@@ -185,9 +185,9 @@ export const ErrorInjectionPanel: FC = () => {
                 max="100"
                 value={errorValue}
                 onChange={(e) => setErrorValue(Number.parseInt(e.target.value, 10))}
-                className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer"
+                className="w-full h-2 bg-bg-elevated rounded-lg appearance-none cursor-pointer"
               />
-              <SmallText className="text-gray-400">0 = No errors, 100 = Maximum errors</SmallText>
+              <SmallText className="text-text-muted">0 = No errors, 100 = Maximum errors</SmallText>
             </div>
           </div>
 
@@ -196,8 +196,8 @@ export const ErrorInjectionPanel: FC = () => {
             <div
               className={`p-3 rounded ${
                 message.type === 'success'
-                  ? 'bg-green-500/10 text-green-400 border border-green-500/20'
-                  : 'bg-red-500/10 text-red-400 border border-red-500/20'
+                  ? 'bg-status-success/10 text-status-success border border-status-success/20'
+                  : 'bg-status-error/10 text-status-error border border-status-error/20'
               }`}
             >
               {message.text}
@@ -228,7 +228,7 @@ export const ErrorInjectionPanel: FC = () => {
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-gray-700">
+                  <tr className="border-b border-border-default">
                     <th className="text-left py-2 px-2">Device IP</th>
                     <th className="text-left py-2 px-2">Interface</th>
                     <th className="text-left py-2 px-2">Error Type</th>
@@ -242,7 +242,7 @@ export const ErrorInjectionPanel: FC = () => {
                       Object.entries(errorTypes).map(([errorType, value]) => (
                         <tr
                           key={`${deviceIp}-${iface}-${errorType}`}
-                          className="border-b border-gray-800"
+                          className="border-b border-border-default"
                         >
                           <td className="py-2 px-2">{deviceIp}</td>
                           <td className="py-2 px-2">{iface}</td>
@@ -255,7 +255,7 @@ export const ErrorInjectionPanel: FC = () => {
                               type="button"
                               onClick={() => handleClearSpecific(deviceIp, iface)}
                               disabled={isSubmitting}
-                              className="text-blue-400 hover:text-blue-300 text-sm"
+                              className="text-status-info hover:text-status-info text-sm"
                               aria-label={`Clear error on ${deviceIp} ${iface}`}
                             >
                               Clear

--- a/ui/src/components/FilterBar.tsx
+++ b/ui/src/components/FilterBar.tsx
@@ -29,8 +29,8 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
   const borderColor = !value.trim()
     ? 'border-white/10'
     : isValid
-      ? 'border-green-500/60'
-      : 'border-red-500/60';
+      ? 'border-status-success/60'
+      : 'border-status-error/60';
 
   // Update suggestions on input change
   useEffect(() => {
@@ -112,31 +112,33 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
             onBlur={() => setTimeout(() => setIsFocused(false), 200)}
             onKeyDown={handleKeyDown}
             placeholder={placeholder ?? 'Display filter (e.g., ip.src == 10.0.0.1 && tcp)'}
-            className={`w-full rounded-lg border ${borderColor} bg-gray-950/60 px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none font-mono transition-colors`}
+            className={`w-full rounded-lg border ${borderColor} bg-bg-base/60 px-3 py-2 text-sm text-text-primary placeholder-gray-500 focus:outline-none font-mono transition-colors`}
           />
           {validationError && isFocused && (
-            <div className="absolute top-full left-0 mt-1 px-2 py-1 bg-red-900/90 border border-red-500/50 rounded text-xs text-red-200 z-20 max-w-md">
+            <div className="absolute top-full left-0 mt-1 px-2 py-1 bg-status-error/90 border border-status-error/50 rounded text-xs text-status-error z-20 max-w-md">
               {validationError}
             </div>
           )}
 
           {/* Autocomplete dropdown */}
           {suggestions.length > 0 && isFocused && (
-            <div className="absolute top-full left-0 mt-1 w-full bg-gray-900 border border-white/10 rounded-lg shadow-lg z-30 max-h-48 overflow-y-auto">
+            <div className="absolute top-full left-0 mt-1 w-full bg-bg-surface border border-white/10 rounded-lg shadow-lg z-30 max-h-48 overflow-y-auto">
               {suggestions.map((suggestion, idx) => (
                 <button
                   key={suggestion.text}
                   type="button"
-                  className={`w-full text-left px-3 py-1.5 text-sm hover:bg-gray-800 ${
-                    idx === selectedSuggestion ? 'bg-gray-800 text-white' : 'text-gray-300'
+                  className={`w-full text-left px-3 py-1.5 text-sm hover:bg-bg-elevated ${
+                    idx === selectedSuggestion
+                      ? 'bg-bg-elevated text-text-primary'
+                      : 'text-text-secondary'
                   }`}
                   onMouseDown={(e) => {
                     e.preventDefault();
                     applySuggestion(suggestion);
                   }}
                 >
-                  <span className="font-mono text-violet-300">{suggestion.text}</span>
-                  <span className="ml-2 text-gray-500 text-xs">{suggestion.description}</span>
+                  <span className="font-mono text-brand-300">{suggestion.text}</span>
+                  <span className="ml-2 text-text-muted text-xs">{suggestion.description}</span>
                 </button>
               ))}
             </div>
@@ -150,7 +152,7 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
               key={protocol}
               type="button"
               onClick={() => handleQuickInsert(protocol)}
-              className="px-2 py-1 text-xs rounded border border-white/10 text-gray-400 hover:text-white hover:border-white/20 bg-gray-900/50 transition-colors uppercase"
+              className="px-2 py-1 text-xs rounded border border-white/10 text-text-muted hover:text-text-primary hover:border-white/20 bg-bg-surface/50 transition-colors uppercase"
             >
               {protocol}
             </button>

--- a/ui/src/components/HelpDrawer.tsx
+++ b/ui/src/components/HelpDrawer.tsx
@@ -75,18 +75,18 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
           className={cn(drawer.content, drawer.size.lg, 'animate-slide-in-right')}
         >
           {/* Header */}
-          <div className="sticky top-0 bg-gray-900 border-b border-white/10 z-10">
+          <div className="sticky top-0 bg-bg-surface border-b border-white/10 z-10">
             <div className="px-4 py-3 flex items-center justify-between">
               <div className={layout.inline.default}>
-                <HelpCircle className="w-5 h-5 text-violet-400" aria-hidden="true" />
-                <h2 className="text-lg font-semibold text-white">Help</h2>
+                <HelpCircle className="w-5 h-5 text-brand-400" aria-hidden="true" />
+                <h2 className="text-lg font-semibold text-text-primary">Help</h2>
               </div>
               <button
                 type="button"
                 onClick={onClose}
                 className={cn(
                   'p-2 hover:bg-white/10 rounded-lg transition-colors',
-                  'text-gray-400 hover:text-white',
+                  'text-text-muted hover:text-text-primary',
                 )}
                 aria-label="Close help"
               >
@@ -97,7 +97,7 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
             {/* Search */}
             <div className="px-4 pb-3">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
                 <input
                   type="text"
                   placeholder="Search help..."
@@ -105,8 +105,8 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className={cn(
                     'w-full pl-10 pr-4 py-2 bg-white/5 border border-white/10 rounded-lg',
-                    'text-sm text-white placeholder:text-gray-500',
-                    'focus:outline-none focus:ring-2 focus:ring-violet-500/50',
+                    'text-sm text-text-primary placeholder:text-text-muted',
+                    'focus:outline-none focus:ring-2 focus:ring-brand-500/50',
                   )}
                 />
               </div>
@@ -126,8 +126,8 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
                       'flex items-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors',
                       'border-b-2 -mb-[2px]',
                       activeTab === tab.id
-                        ? 'border-violet-500 text-white'
-                        : 'border-transparent text-gray-400 hover:text-white hover:border-white/20',
+                        ? 'border-brand-500 text-text-primary'
+                        : 'border-transparent text-text-muted hover:text-text-primary hover:border-white/20',
                     )}
                   >
                     {tab.icon}

--- a/ui/src/components/HexDumpViewer.tsx
+++ b/ui/src/components/HexDumpViewer.tsx
@@ -83,9 +83,9 @@ const HexRow = memo(
       const isHighlighted =
         highlightStart >= 0 && globalIndex >= highlightStart && globalIndex < highlightEnd;
 
-      let className = isHeader ? 'text-cyan-400' : 'text-gray-300';
+      let className = isHeader ? 'text-status-info' : 'text-text-secondary';
       if (isHighlighted) {
-        className = 'text-yellow-200 bg-yellow-700/40 rounded-sm';
+        className = 'text-status-warning bg-status-warning/40 rounded-sm';
       }
 
       return (
@@ -99,7 +99,9 @@ const HexRow = memo(
     // Pad with spaces if row is not full
     const paddingCount = bytesPerRow - bytes.length;
     const padding =
-      paddingCount > 0 ? <span className="text-gray-700">{'   '.repeat(paddingCount)}</span> : null;
+      paddingCount > 0 ? (
+        <span className="text-text-disabled">{'   '.repeat(paddingCount)}</span>
+      ) : null;
 
     // Build ASCII column
     const asciiChars = bytes.map((byte, idx) => {
@@ -109,9 +111,9 @@ const HexRow = memo(
         highlightStart >= 0 && globalIndex >= highlightStart && globalIndex < highlightEnd;
       const char = byteToChar(byte);
 
-      let asciiClass = isHeader ? 'text-cyan-400' : 'text-gray-300';
+      let asciiClass = isHeader ? 'text-status-info' : 'text-text-secondary';
       if (isHighlighted) {
-        asciiClass = 'text-yellow-200 bg-yellow-700/40';
+        asciiClass = 'text-status-warning bg-status-warning/40';
       }
 
       return (
@@ -124,7 +126,7 @@ const HexRow = memo(
     return (
       <div className="flex font-mono text-xs leading-5">
         {/* Offset column */}
-        <span className="text-violet-400 w-20 flex-shrink-0">{formatOffset(offset)}:</span>
+        <span className="text-brand-400 w-20 flex-shrink-0">{formatOffset(offset)}:</span>
 
         {/* Hex column */}
         <span className="flex-1 min-w-0">
@@ -133,7 +135,7 @@ const HexRow = memo(
         </span>
 
         {/* Separator */}
-        <span className="text-gray-600 mx-2">|</span>
+        <span className="text-text-disabled mx-2">|</span>
 
         {/* ASCII column */}
         <span className="w-16 flex-shrink-0 text-right">{asciiChars}</span>
@@ -185,7 +187,7 @@ export const HexDumpViewer: FC<HexDumpViewerProps> = memo(
 
     if (!rawData) {
       return (
-        <div className="h-full flex items-center justify-center text-gray-400">
+        <div className="h-full flex items-center justify-center text-text-muted">
           <p className="text-sm">Select a packet to view hex dump</p>
         </div>
       );
@@ -198,26 +200,26 @@ export const HexDumpViewer: FC<HexDumpViewerProps> = memo(
         {/* Header with legend */}
         <div className="flex items-center justify-between mb-2 pb-2 border-b border-white/10">
           <div className="flex items-center gap-4 text-xs">
-            <span className="text-gray-400">{totalBytes} bytes</span>
+            <span className="text-text-muted">{totalBytes} bytes</span>
             <div className="flex items-center gap-2">
-              <span className="w-3 h-3 bg-cyan-400/30 rounded" />
-              <span className="text-gray-400">Header</span>
+              <span className="w-3 h-3 bg-status-info/30 rounded" />
+              <span className="text-text-muted">Header</span>
             </div>
             <div className="flex items-center gap-2">
-              <span className="w-3 h-3 bg-gray-300/30 rounded" />
-              <span className="text-gray-400">Payload</span>
+              <span className="w-3 h-3 bg-bg-muted/30 rounded" />
+              <span className="text-text-muted">Payload</span>
             </div>
             {highlightStart >= 0 && (
               <div className="flex items-center gap-2">
-                <span className="w-3 h-3 bg-yellow-700/40 rounded" />
-                <span className="text-gray-400">Selected</span>
+                <span className="w-3 h-3 bg-status-warning/40 rounded" />
+                <span className="text-text-muted">Selected</span>
               </div>
             )}
           </div>
         </div>
 
         {/* Hex dump content */}
-        <div className="flex-1 overflow-y-auto rounded-lg bg-gray-950/70 p-3 border border-white/5">
+        <div className="flex-1 overflow-y-auto rounded-lg bg-bg-base/70 p-3 border border-white/5">
           <div className="space-y-0.5">
             {rows.map((row) => (
               <HexRow

--- a/ui/src/components/LogFilters.tsx
+++ b/ui/src/components/LogFilters.tsx
@@ -78,14 +78,14 @@ export const LogFilters: FC<LogFiltersProps> = memo(
         <div className="flex flex-wrap items-center gap-4">
           {/* Level Filter */}
           <div className="flex items-center gap-2">
-            <label htmlFor="level-filter" className="text-sm text-gray-400">
+            <label htmlFor="level-filter" className="text-sm text-text-muted">
               Level:
             </label>
             <select
               id="level-filter"
               value={levelFilter}
               onChange={handleLevelChange}
-              className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-1.5 text-sm text-white focus:border-violet-400 focus:outline-none"
+              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
               aria-label="Filter by log level"
             >
               {LOG_LEVELS.map((level) => (
@@ -98,14 +98,14 @@ export const LogFilters: FC<LogFiltersProps> = memo(
 
           {/* Protocol Filter */}
           <div className="flex items-center gap-2">
-            <label htmlFor="protocol-filter" className="text-sm text-gray-400">
+            <label htmlFor="protocol-filter" className="text-sm text-text-muted">
               Protocol:
             </label>
             <select
               id="protocol-filter"
               value={protocolFilter}
               onChange={handleProtocolChange}
-              className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-1.5 text-sm text-white focus:border-violet-400 focus:outline-none"
+              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
               aria-label="Filter by protocol"
             >
               {PROTOCOLS.map((protocol) => (
@@ -118,18 +118,18 @@ export const LogFilters: FC<LogFiltersProps> = memo(
 
           {/* Search Input */}
           <div className="flex flex-1 items-center gap-2">
-            <label htmlFor="log-search" className="text-sm text-gray-400">
+            <label htmlFor="log-search" className="text-sm text-text-muted">
               Search:
             </label>
             <div className="relative flex-1 max-w-md">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
               <input
                 id="log-search"
                 type="text"
                 value={searchQuery}
                 onChange={handleSearchChange}
                 placeholder="Filter logs..."
-                className="w-full rounded-lg border border-white/10 bg-gray-950/60 py-1.5 pl-9 pr-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                className="w-full rounded-lg border border-white/10 bg-bg-base/60 py-1.5 pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                 aria-label="Search logs"
               />
             </div>
@@ -145,13 +145,13 @@ export const LogFilters: FC<LogFiltersProps> = memo(
                 type="checkbox"
                 checked={autoScroll}
                 onChange={handleAutoScrollChange}
-                className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-violet-500 focus:ring-violet-500 focus:ring-offset-gray-900"
+                className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500 focus:ring-offset-gray-900"
               />
-              <span className="text-sm text-gray-300">Auto-scroll</span>
+              <span className="text-sm text-text-secondary">Auto-scroll</span>
             </label>
 
             {/* Log Count */}
-            <SmallText className="text-gray-500">
+            <SmallText className="text-text-muted">
               {logCount} log{logCount !== 1 ? 's' : ''} buffered
             </SmallText>
           </div>
@@ -167,7 +167,9 @@ export const LogFilters: FC<LogFiltersProps> = memo(
                   paused ? <Play className={iconSizes.md} /> : <Pause className={iconSizes.md} />
                 }
                 aria-label={paused ? 'Resume log stream' : 'Pause log stream'}
-                className={paused ? 'bg-green-600 hover:bg-green-700 border-green-500' : ''}
+                className={
+                  paused ? 'bg-status-success hover:bg-status-success border-status-success' : ''
+                }
               >
                 {paused ? 'Resume' : 'Pause'}
               </Button>

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -27,37 +27,37 @@ const LEVEL_COLORS: Record<
   { bg: string; text: string; border: string; accent: string }
 > = {
   error: {
-    bg: 'bg-red-500/10',
-    text: 'text-red-400',
-    border: 'border-red-500/30',
-    accent: 'bg-red-500',
+    bg: 'bg-status-error/10',
+    text: 'text-status-error',
+    border: 'border-status-error/30',
+    accent: 'bg-status-error',
   },
   warn: {
-    bg: 'bg-yellow-500/10',
-    text: 'text-yellow-400',
-    border: 'border-yellow-500/30',
-    accent: 'bg-yellow-500',
+    bg: 'bg-status-warning/10',
+    text: 'text-status-warning',
+    border: 'border-status-warning/30',
+    accent: 'bg-status-warning',
   },
   info: {
     bg: 'bg-white/5',
-    text: 'text-gray-200',
+    text: 'text-text-primary',
     border: 'border-white/10',
-    accent: 'bg-blue-500',
+    accent: 'bg-status-info',
   },
   debug: {
-    bg: 'bg-gray-500/10',
-    text: 'text-gray-500',
-    border: 'border-gray-500/20',
-    accent: 'bg-gray-500',
+    bg: 'bg-bg-muted/10',
+    text: 'text-text-muted',
+    border: 'border-border-muted/20',
+    accent: 'bg-bg-muted',
   },
 };
 
 // Level badge colors
 const LEVEL_BADGE_COLORS: Record<LogLevelKey, string> = {
-  error: 'bg-red-500/20 text-red-400 border-red-500/30',
-  warn: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
-  info: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-  debug: 'bg-gray-500/20 text-gray-500 border-gray-500/30',
+  error: 'bg-status-error/20 text-status-error border-status-error/30',
+  warn: 'bg-status-warning/20 text-status-warning border-status-warning/30',
+  info: 'bg-status-info/20 text-status-info border-status-info/30',
+  debug: 'bg-bg-muted/20 text-text-muted border-border-muted/30',
 };
 
 // Format timestamp for display
@@ -115,7 +115,7 @@ function highlightText(text: string, query: string): React.ReactNode {
       offset += part.length;
       if (part.toLowerCase() === query.toLowerCase()) {
         return (
-          <mark key={key} className="bg-yellow-400/40 text-yellow-200 rounded px-0.5">
+          <mark key={key} className="bg-status-warning/40 text-status-warning rounded px-0.5">
             {part}
           </mark>
         );
@@ -199,7 +199,9 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
           className={`flex items-start gap-2 flex-1 text-left ${hasDetails ? 'cursor-pointer' : 'cursor-default'}`}
         >
           {/* Expand indicator */}
-          <span className={`shrink-0 mt-0.5 ${hasDetails ? 'text-gray-500' : 'text-transparent'}`}>
+          <span
+            className={`shrink-0 mt-0.5 ${hasDetails ? 'text-text-muted' : 'text-transparent'}`}
+          >
             {expanded ? (
               <ChevronDown className={iconSizes.md} />
             ) : (
@@ -211,7 +213,7 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
           <span className={`shrink-0 w-1 h-5 rounded-full ${colors.accent}`} />
 
           {/* Timestamp */}
-          <span className="shrink-0 text-gray-500 tabular-nums">
+          <span className="shrink-0 text-text-muted tabular-nums">
             {formatTimestamp(log.timestamp)}
           </span>
 
@@ -223,7 +225,7 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
           </span>
 
           {/* Protocol Badge */}
-          <span className="shrink-0 rounded border border-violet-500/30 bg-violet-500/20 px-1.5 py-0.5 text-xs font-semibold text-violet-400">
+          <span className="shrink-0 rounded border border-brand-500/30 bg-brand-500/20 px-1.5 py-0.5 text-xs font-semibold text-brand-400">
             {log.protocol}
           </span>
 
@@ -234,7 +236,7 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
 
           {/* Source (if available) */}
           {log.source && (
-            <span className="shrink-0 text-gray-600 text-xs font-mono">{log.source}</span>
+            <span className="shrink-0 text-text-disabled text-xs font-mono">{log.source}</span>
           )}
         </button>
 
@@ -242,12 +244,12 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
         <button
           type="button"
           onClick={handleCopy}
-          className="shrink-0 p-1 rounded hover:bg-white/10 text-gray-500 hover:text-gray-300 transition-colors"
+          className="shrink-0 p-1 rounded hover:bg-white/10 text-text-muted hover:text-text-secondary transition-colors"
           title="Copy log entry"
           aria-label="Copy log entry"
         >
           {copied ? (
-            <Check className={`${iconSizes.sm} text-green-400`} />
+            <Check className={`${iconSizes.sm} text-status-success`} />
           ) : (
             <Copy className={iconSizes.sm} />
           )}
@@ -259,25 +261,25 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
         <div className={`px-3 py-3 ${colors.bg} border-t ${colors.border}`}>
           <div className="ml-6 space-y-2">
             {/* Metadata row */}
-            <div className="flex flex-wrap gap-4 text-xs text-gray-500">
+            <div className="flex flex-wrap gap-4 text-xs text-text-muted">
               <span>
-                <strong className="text-gray-400">Time:</strong>{' '}
+                <strong className="text-text-muted">Time:</strong>{' '}
                 {formatFullTimestamp(log.timestamp)}
               </span>
               {log.source && (
                 <span>
-                  <strong className="text-gray-400">Source:</strong> {log.source}
+                  <strong className="text-text-muted">Source:</strong> {log.source}
                 </span>
               )}
               <span>
-                <strong className="text-gray-400">ID:</strong> {log.id}
+                <strong className="text-text-muted">ID:</strong> {log.id}
               </span>
             </div>
 
             {/* Details JSON */}
-            <div className="rounded-lg border border-white/10 bg-gray-950/70 overflow-hidden">
-              <div className="flex items-center justify-between px-3 py-1.5 bg-gray-900/50 border-b border-white/10">
-                <span className="text-xs font-medium text-gray-400">Details</span>
+            <div className="rounded-lg border border-white/10 bg-bg-base/70 overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-1.5 bg-bg-surface/50 border-b border-white/10">
+                <span className="text-xs font-medium text-text-muted">Details</span>
                 <button
                   type="button"
                   onClick={async (e) => {
@@ -286,14 +288,14 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
                       await navigator.clipboard.writeText(formatDetails(log.details));
                     }
                   }}
-                  className="p-1 rounded hover:bg-white/10 text-gray-500 hover:text-gray-300 transition-colors"
+                  className="p-1 rounded hover:bg-white/10 text-text-muted hover:text-text-secondary transition-colors"
                   title="Copy details JSON"
                   aria-label="Copy details JSON"
                 >
                   <Copy className={iconSizes.xs} />
                 </button>
               </div>
-              <pre className="p-3 text-xs font-mono text-gray-300 overflow-x-auto">
+              <pre className="p-3 text-xs font-mono text-text-secondary overflow-x-auto">
                 {formatDetails(log.details ?? {})}
               </pre>
             </div>
@@ -340,17 +342,17 @@ export const LogViewer: FC<LogViewerProps> = memo(({ logs, searchQuery, autoScro
     return (
       <div
         ref={containerRef}
-        className="flex h-96 items-center justify-center rounded-lg border border-white/10 bg-gray-950/50"
+        className="flex h-96 items-center justify-center rounded-lg border border-white/10 bg-bg-base/50"
       >
         <div className="text-center space-y-3">
           <div
-            className={`mx-auto ${iconSizes['3xl']} rounded-full bg-gray-800/50 flex items-center justify-center`}
+            className={`mx-auto ${iconSizes['3xl']} rounded-full bg-bg-elevated/50 flex items-center justify-center`}
           >
-            <Terminal className={`${iconSizes.xl} text-gray-600`} />
+            <Terminal className={`${iconSizes.xl} text-text-disabled`} />
           </div>
           <div>
-            <p className="text-gray-400 font-medium">No logs to display</p>
-            <p className="mt-1 text-sm text-gray-600">
+            <p className="text-text-muted font-medium">No logs to display</p>
+            <p className="mt-1 text-sm text-text-disabled">
               Logs will appear here when the debug console receives data
             </p>
           </div>
@@ -369,12 +371,14 @@ export const LogViewer: FC<LogViewerProps> = memo(({ logs, searchQuery, autoScro
           return (
             <div
               key={level}
-              className={`flex items-center gap-1.5 px-2 py-1 rounded ${colors?.bg || 'bg-gray-500/10'}`}
+              className={`flex items-center gap-1.5 px-2 py-1 rounded ${colors?.bg || 'bg-bg-muted/10'}`}
             >
-              {isError && count > 0 && <AlertCircle className={`${iconSizes.xs} text-red-400`} />}
-              <span className={`${colors?.accent || 'bg-gray-500'} h-2 w-2 rounded-full`} />
-              <span className={`font-medium ${colors?.text || 'text-gray-400'}`}>{level}</span>
-              <span className="text-gray-500">{count}</span>
+              {isError && count > 0 && (
+                <AlertCircle className={`${iconSizes.xs} text-status-error`} />
+              )}
+              <span className={`${colors?.accent || 'bg-bg-muted'} h-2 w-2 rounded-full`} />
+              <span className={`font-medium ${colors?.text || 'text-text-muted'}`}>{level}</span>
+              <span className="text-text-muted">{count}</span>
             </div>
           );
         })}
@@ -383,7 +387,7 @@ export const LogViewer: FC<LogViewerProps> = memo(({ logs, searchQuery, autoScro
       {/* Log Container */}
       <div
         ref={containerRef}
-        className="h-[500px] overflow-y-auto rounded-lg border border-white/10 bg-gray-950/70 scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-gray-700"
+        className="h-[500px] overflow-y-auto rounded-lg border border-white/10 bg-bg-base/70 scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-gray-700"
         role="log"
         aria-label="Debug console log output"
         aria-live="polite"

--- a/ui/src/components/PacketDetails.tsx
+++ b/ui/src/components/PacketDetails.tsx
@@ -30,8 +30,8 @@ const DetailRow = memo(
 
     return (
       <div className="flex items-start gap-2 py-1.5 border-b border-white/5 last:border-0">
-        <SmallText className="text-gray-400 w-24 flex-shrink-0">{label}</SmallText>
-        <span className={`text-sm text-white ${mono ? 'font-mono' : ''}`}>{value}</span>
+        <SmallText className="text-text-muted w-24 flex-shrink-0">{label}</SmallText>
+        <span className={`text-sm text-text-primary ${mono ? 'font-mono' : ''}`}>{value}</span>
       </div>
     );
   },
@@ -49,8 +49,8 @@ const HeadersSection = memo(({ headers }: { headers: Record<string, unknown> | u
 
   return (
     <div className="mt-4">
-      <h4 className="text-sm font-semibold text-gray-300 mb-2">Protocol Headers</h4>
-      <div className="rounded-lg bg-gray-950/50 p-3 border border-white/5">
+      <h4 className="text-sm font-semibold text-text-secondary mb-2">Protocol Headers</h4>
+      <div className="rounded-lg bg-bg-base/50 p-3 border border-white/5">
         {Object.entries(headers).map(([key, value]) => (
           <DetailRow
             key={key}
@@ -77,7 +77,7 @@ HeadersSection.displayName = 'HeadersSection';
 export const PacketDetails: FC<PacketDetailsProps> = memo(({ packet, onFieldSelect }) => {
   if (!packet) {
     return (
-      <div className="h-full flex items-center justify-center text-gray-400">
+      <div className="h-full flex items-center justify-center text-text-muted">
         <p className="text-sm">Select a packet to view details</p>
       </div>
     );
@@ -90,7 +90,7 @@ export const PacketDetails: FC<PacketDetailsProps> = memo(({ packet, onFieldSele
         <Tag colorScheme={getProtocolColor(packet.protocol)} className="text-sm">
           {packet.protocol}
         </Tag>
-        <SmallText className="text-gray-400">{formatBytes(packet.size)}</SmallText>
+        <SmallText className="text-text-muted">{formatBytes(packet.size)}</SmallText>
       </div>
 
       {/* Protocol dissection tree */}
@@ -99,8 +99,8 @@ export const PacketDetails: FC<PacketDetailsProps> = memo(({ packet, onFieldSele
       {/* Summary */}
       {packet.summary && (
         <div className="mt-3 pt-2 border-t border-white/5">
-          <SmallText className="text-gray-500 uppercase text-xs tracking-wide">Summary</SmallText>
-          <p className="text-sm text-gray-300 py-1">{packet.summary}</p>
+          <SmallText className="text-text-muted uppercase text-xs tracking-wide">Summary</SmallText>
+          <p className="text-sm text-text-secondary py-1">{packet.summary}</p>
         </div>
       )}
     </div>

--- a/ui/src/components/PacketList.tsx
+++ b/ui/src/components/PacketList.tsx
@@ -52,8 +52,8 @@ const PacketRow = memo(
       onClick={onClick}
       className={`w-full text-left p-2 rounded-lg border transition-colors ${
         isSelected
-          ? 'border-violet-500/50 bg-violet-900/30'
-          : 'border-white/5 bg-gray-950/50 hover:bg-gray-900/50 hover:border-white/10'
+          ? 'border-brand-500/50 bg-brand-900/30'
+          : 'border-white/5 bg-bg-base/50 hover:bg-bg-surface/50 hover:border-white/10'
       }`}
       style={rowStyle}
     >
@@ -61,16 +61,16 @@ const PacketRow = memo(
         <Tag colorScheme={getProtocolColor(packet.protocol)} className="text-xs">
           {packet.protocol}
         </Tag>
-        <SmallText className="text-gray-400 font-mono text-xs">{formattedTime}</SmallText>
+        <SmallText className="text-text-muted font-mono text-xs">{formattedTime}</SmallText>
       </div>
-      <div className="mt-1 text-sm text-white truncate">
+      <div className="mt-1 text-sm text-text-primary truncate">
         {packet.sourceIp}
         {packet.sourcePort && `:${packet.sourcePort}`}
-        <span className="text-gray-500 mx-1">-&gt;</span>
+        <span className="text-text-muted mx-1">-&gt;</span>
         {packet.destIp}
         {packet.destPort && `:${packet.destPort}`}
       </div>
-      <SmallText className="text-gray-400 truncate block">{packet.summary}</SmallText>
+      <SmallText className="text-text-muted truncate block">{packet.summary}</SmallText>
     </button>
   ),
 );
@@ -89,7 +89,7 @@ export const PacketList: FC<PacketListProps> = memo(
 
     if (packets.length === 0) {
       return (
-        <div className="h-full flex items-center justify-center text-gray-400">
+        <div className="h-full flex items-center justify-center text-text-muted">
           <div className="text-center">
             <p className="text-sm">No packets to display</p>
             <SmallText>Waiting for packet stream...</SmallText>
@@ -103,7 +103,7 @@ export const PacketList: FC<PacketListProps> = memo(
         <button
           type="button"
           onClick={cycleTimeMode}
-          className="text-xs text-gray-500 hover:text-violet-300 mb-1 text-left select-none"
+          className="text-xs text-text-muted hover:text-brand-300 mb-1 text-left select-none"
           title="Click to cycle: Absolute / Relative / Delta"
         >
           Mode: {getTimeDisplayLabel(timeMode)}

--- a/ui/src/components/ProtocolTree.tsx
+++ b/ui/src/components/ProtocolTree.tsx
@@ -34,7 +34,7 @@ export const ProtocolTree: FC<ProtocolTreeProps> = memo(({ packet, onFieldSelect
 
   if (!packet) {
     return (
-      <div className="h-full flex items-center justify-center text-gray-400">
+      <div className="h-full flex items-center justify-center text-text-muted">
         <p className="text-sm">Select a packet to view protocol layers</p>
       </div>
     );
@@ -42,7 +42,7 @@ export const ProtocolTree: FC<ProtocolTreeProps> = memo(({ packet, onFieldSelect
 
   if (layers.length === 0) {
     return (
-      <div className="h-full flex items-center justify-center text-gray-400">
+      <div className="h-full flex items-center justify-center text-text-muted">
         <p className="text-sm">No protocol layers available</p>
       </div>
     );

--- a/ui/src/components/ProtocolTreeLayer.tsx
+++ b/ui/src/components/ProtocolTreeLayer.tsx
@@ -36,11 +36,11 @@ export const ProtocolTreeLayer: FC<ProtocolTreeLayerProps> = memo(({ layer, onFi
         className="flex items-center gap-1 w-full text-left py-0.5 hover:bg-white/5 rounded px-1 -ml-1"
       >
         {isExpanded ? (
-          <ChevronDown className={`${iconSizes.sm} text-gray-500 flex-shrink-0`} />
+          <ChevronDown className={`${iconSizes.sm} text-text-muted flex-shrink-0`} />
         ) : (
-          <ChevronRight className={`${iconSizes.sm} text-gray-500 flex-shrink-0`} />
+          <ChevronRight className={`${iconSizes.sm} text-text-muted flex-shrink-0`} />
         )}
-        <span className="text-violet-300 font-medium">{layer.name}</span>
+        <span className="text-brand-300 font-medium">{layer.name}</span>
       </button>
 
       {isExpanded && (
@@ -53,12 +53,12 @@ export const ProtocolTreeLayer: FC<ProtocolTreeLayerProps> = memo(({ layer, onFi
                 type="button"
                 onClick={() => handleFieldClick(field)}
                 className={`block w-full text-left py-0.5 px-1 -ml-1 rounded text-xs ${
-                  hasRange ? 'hover:bg-yellow-900/30 cursor-pointer' : 'cursor-default'
+                  hasRange ? 'hover:bg-status-warning/30 cursor-pointer' : 'cursor-default'
                 }`}
                 disabled={!hasRange}
               >
-                <span className="text-gray-400">{field.name}: </span>
-                <span className="text-white font-mono">{field.value}</span>
+                <span className="text-text-muted">{field.name}: </span>
+                <span className="text-text-primary font-mono">{field.value}</span>
               </button>
             );
           })}

--- a/ui/src/components/ReplayControlPanel.tsx
+++ b/ui/src/components/ReplayControlPanel.tsx
@@ -82,7 +82,7 @@ export const ReplayControlPanel: FC = () => {
                   <Tag colorScheme="green">Running</Tag>
                   <span className="font-medium">{replayStatus.file}</span>
                 </div>
-                <SmallText className="text-gray-400">
+                <SmallText className="text-text-muted">
                   Started:{' '}
                   {replayStatus.startedAt
                     ? new Date(replayStatus.startedAt).toLocaleString()
@@ -113,7 +113,7 @@ export const ReplayControlPanel: FC = () => {
                 value={selectedFile}
                 onChange={(e) => setSelectedFile(e.target.value)}
                 disabled={replayStatus?.running}
-                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info disabled:opacity-50"
               >
                 <option value="">Select PCAP file...</option>
                 {pcapFiles?.map((file) => (
@@ -138,9 +138,9 @@ export const ReplayControlPanel: FC = () => {
                 onChange={(e) => setLoopMs(Number.parseInt(e.target.value, 10) || 0)}
                 placeholder="0 = no loop"
                 disabled={replayStatus?.running}
-                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info disabled:opacity-50"
               />
-              <SmallText className="text-gray-400">
+              <SmallText className="text-text-muted">
                 0 = Play once, &gt;0 = Loop with delay
               </SmallText>
             </div>
@@ -159,9 +159,9 @@ export const ReplayControlPanel: FC = () => {
                 value={scale}
                 onChange={(e) => setScale(Number.parseFloat(e.target.value) || 1.0)}
                 disabled={replayStatus?.running}
-                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info disabled:opacity-50"
               />
-              <SmallText className="text-gray-400">
+              <SmallText className="text-text-muted">
                 1.0 = Original timing, 2.0 = 2x faster, 0.5 = 2x slower
               </SmallText>
             </div>
@@ -174,8 +174,8 @@ export const ReplayControlPanel: FC = () => {
               aria-live="polite"
               className={`p-3 rounded ${
                 message.type === 'success'
-                  ? 'bg-green-500/10 text-green-400 border border-green-500/20'
-                  : 'bg-red-500/10 text-red-400 border border-red-500/20'
+                  ? 'bg-status-success/10 text-status-success border border-status-success/20'
+                  : 'bg-status-error/10 text-status-error border border-status-error/20'
               }`}
             >
               {message.text}

--- a/ui/src/components/SettingsDrawer.tsx
+++ b/ui/src/components/SettingsDrawer.tsx
@@ -92,17 +92,17 @@ export function SettingsDrawer({
           className={cn(drawer.content, drawer.size.lg, 'animate-slide-in-right')}
         >
           {/* Header */}
-          <div className="sticky top-0 bg-gray-900 border-b border-white/10 px-4 py-3 flex items-center justify-between z-10">
+          <div className="sticky top-0 bg-bg-surface border-b border-white/10 px-4 py-3 flex items-center justify-between z-10">
             <div className={layout.inline.default}>
-              <Settings className="w-5 h-5 text-violet-400" aria-hidden="true" />
-              <h2 className="text-lg font-semibold text-white">Settings</h2>
+              <Settings className="w-5 h-5 text-brand-400" aria-hidden="true" />
+              <h2 className="text-lg font-semibold text-text-primary">Settings</h2>
             </div>
             <button
               type="button"
               onClick={onClose}
               className={cn(
                 'p-2 hover:bg-white/10 rounded-lg transition-colors',
-                'text-gray-400 hover:text-white',
+                'text-text-muted hover:text-text-primary',
               )}
               aria-label="Close settings"
             >
@@ -124,8 +124,8 @@ export function SettingsDrawer({
                     'flex items-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors',
                     'border-b-2 -mb-[2px]',
                     activeTab === tab.id
-                      ? 'border-violet-500 text-white'
-                      : 'border-transparent text-gray-400 hover:text-white hover:border-white/20',
+                      ? 'border-brand-500 text-text-primary'
+                      : 'border-transparent text-text-muted hover:text-text-primary hover:border-white/20',
                   )}
                 >
                   {tab.icon}
@@ -162,8 +162,8 @@ interface SectionProps {
 const Section = ({ title, description, children }: SectionProps): ReactElement => (
   <div className="space-y-3">
     <div>
-      <h3 className="text-sm font-semibold text-white">{title}</h3>
-      {description && <p className="text-xs text-gray-500 mt-0.5">{description}</p>}
+      <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
+      {description && <p className="text-xs text-text-muted mt-0.5">{description}</p>}
     </div>
     <div className="space-y-2">{children}</div>
   </div>
@@ -178,8 +178,8 @@ interface SettingRowProps {
 const SettingRow = ({ label, description, children }: SettingRowProps): ReactElement => (
   <div className="flex items-center justify-between gap-4 py-2 px-3 bg-white/5 rounded-lg">
     <div className="flex-1 min-w-0">
-      <div className="text-sm text-gray-200">{label}</div>
-      {description && <div className="text-xs text-gray-500 truncate">{description}</div>}
+      <div className="text-sm text-text-primary">{label}</div>
+      {description && <div className="text-xs text-text-muted truncate">{description}</div>}
     </div>
     <div className="flex-shrink-0">{children}</div>
   </div>
@@ -204,26 +204,29 @@ function AppearanceSection(): ReactElement {
             className={cn(
               'flex flex-col items-center gap-2 p-3 rounded-lg border transition-all',
               theme === option
-                ? 'border-violet-500 bg-violet-500/10'
+                ? 'border-brand-500 bg-brand-500/10'
                 : 'border-white/10 hover:border-white/20 hover:bg-white/5',
             )}
           >
             <div
               className={cn(
                 'w-8 h-8 rounded-lg flex items-center justify-center',
-                option === 'dark' && 'bg-gray-800',
-                option === 'light' && 'bg-gray-200',
-                option === 'system' && 'bg-gradient-to-br from-gray-200 to-gray-800',
+                option === 'dark' && 'bg-bg-elevated',
+                option === 'light' && 'bg-bg-muted',
+                option === 'system' && 'bg-gradient-to-br from-gray-200 to-bg-elevated',
               )}
             >
               <Monitor
-                className={cn('w-4 h-4', option === 'light' ? 'text-gray-800' : 'text-white')}
+                className={cn(
+                  'w-4 h-4',
+                  option === 'light' ? 'text-text-disabled' : 'text-text-primary',
+                )}
               />
             </div>
             <span
               className={cn(
                 'text-xs font-medium capitalize',
-                theme === option ? 'text-white' : 'text-gray-400',
+                theme === option ? 'text-text-primary' : 'text-text-muted',
               )}
             >
               {option}
@@ -231,7 +234,7 @@ function AppearanceSection(): ReactElement {
           </button>
         ))}
       </div>
-      <p className="text-xs text-gray-500 mt-2">
+      <p className="text-xs text-text-muted mt-2">
         Light mode coming soon. Currently only dark mode is available.
       </p>
     </Section>
@@ -277,9 +280,9 @@ function NetworkSection(): ReactElement {
         description="Available network interfaces for traffic injection"
       >
         <div className="space-y-2">
-          {loading && <p className="text-xs text-gray-500">Loading interfaces...</p>}
+          {loading && <p className="text-xs text-text-muted">Loading interfaces...</p>}
           {!loading && interfaces.length === 0 && (
-            <p className="text-xs text-gray-500">No interfaces found</p>
+            <p className="text-xs text-text-muted">No interfaces found</p>
           )}
           {interfaces.map((iface) => (
             <InterfaceItem
@@ -291,14 +294,14 @@ function NetworkSection(): ReactElement {
             />
           ))}
         </div>
-        <p className="text-xs text-gray-500 mt-2">
+        <p className="text-xs text-text-muted mt-2">
           Interface selection is managed from the Runtime Control page.
         </p>
       </Section>
 
       <Section title="Connection Settings" description="Configure backend connection">
         <SettingRow label="Backend URL" description="NIAC backend server address">
-          <code className="text-xs text-violet-400 bg-violet-500/10 px-2 py-1 rounded">
+          <code className="text-xs text-brand-400 bg-brand-500/10 px-2 py-1 rounded">
             localhost:8080
           </code>
         </SettingRow>
@@ -322,16 +325,18 @@ function InterfaceItem({ name, type, status, ip }: InterfaceItemProps): ReactEle
     <div className="flex items-center justify-between py-2 px-3 bg-white/5 rounded-lg">
       <div className={layout.inline.default}>
         <Network
-          className={cn('w-4 h-4', status === 'active' ? 'text-emerald-500' : 'text-gray-500')}
+          className={cn('w-4 h-4', status === 'active' ? 'text-status-success' : 'text-text-muted')}
         />
         <div>
-          <div className="text-sm text-white font-mono">{name}</div>
-          <div className="text-xs text-gray-500">{type}</div>
+          <div className="text-sm text-text-primary font-mono">{name}</div>
+          <div className="text-xs text-text-muted">{type}</div>
         </div>
       </div>
       <div className="text-right">
-        <div className="text-sm text-gray-300 font-mono">{ip}</div>
-        <div className={cn('text-xs', status === 'active' ? 'text-emerald-400' : 'text-gray-500')}>
+        <div className="text-sm text-text-secondary font-mono">{ip}</div>
+        <div
+          className={cn('text-xs', status === 'active' ? 'text-status-success' : 'text-text-muted')}
+        >
           {status}
         </div>
       </div>
@@ -354,8 +359,8 @@ function DebugSection(): ReactElement {
             value={logLevel}
             onChange={(e) => setLogLevel(e.target.value as typeof logLevel)}
             className={cn(
-              'bg-gray-800 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white',
-              'focus:outline-none focus:ring-2 focus:ring-violet-500/50',
+              'bg-bg-elevated border border-white/10 rounded-lg px-3 py-1.5 text-sm text-text-primary',
+              'focus:outline-none focus:ring-2 focus:ring-brand-500/50',
             )}
           >
             <option value="error">Error</option>
@@ -376,10 +381,10 @@ function DebugSection(): ReactElement {
           )}
         >
           <div>
-            <div className="text-sm text-gray-200">Protocol Debug Levels</div>
-            <div className="text-xs text-gray-500">Configure per-protocol logging</div>
+            <div className="text-sm text-text-primary">Protocol Debug Levels</div>
+            <div className="text-xs text-text-muted">Configure per-protocol logging</div>
           </div>
-          <ChevronRight className="w-4 h-4 text-gray-500" />
+          <ChevronRight className="w-4 h-4 text-text-muted" />
         </button>
 
         <button
@@ -391,10 +396,10 @@ function DebugSection(): ReactElement {
           )}
         >
           <div>
-            <div className="text-sm text-gray-200">Export Diagnostics</div>
-            <div className="text-xs text-gray-500">Download debug information</div>
+            <div className="text-sm text-text-primary">Export Diagnostics</div>
+            <div className="text-xs text-text-muted">Download debug information</div>
           </div>
-          <ChevronRight className="w-4 h-4 text-gray-500" />
+          <ChevronRight className="w-4 h-4 text-text-muted" />
         </button>
       </Section>
     </>
@@ -415,12 +420,12 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
       <Section title="Application">
         <div className="bg-white/5 rounded-lg p-4 space-y-3">
           <div className="flex items-center gap-3">
-            <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-violet-500 to-violet-700 flex items-center justify-center shadow-lg shadow-violet-500/30">
-              <Network className={`${iconSizes.xl} text-white`} />
+            <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center shadow-lg shadow-brand-500/30">
+              <Network className={`${iconSizes.xl} text-text-primary`} />
             </div>
             <div>
-              <h4 className="text-lg font-bold text-white">NIAC</h4>
-              <p className="text-sm text-gray-400">Network Injection & Analysis Console</p>
+              <h4 className="text-lg font-bold text-text-primary">NIAC</h4>
+              <p className="text-sm text-text-muted">Network Injection & Analysis Console</p>
             </div>
           </div>
           <div className="grid grid-cols-2 gap-2 pt-2 border-t border-white/10">
@@ -433,7 +438,7 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
       </Section>
 
       <Section title="Legal">
-        <div className="space-y-2 text-xs text-gray-500">
+        <div className="space-y-2 text-xs text-text-muted">
           <p>Copyright (c) 2025 Mustard Seed Networks. All rights reserved.</p>
           <p>
             NIAC is proprietary software. Unauthorized copying, modification, or distribution is
@@ -454,8 +459,8 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
               'hover:bg-white/10 transition-colors',
             )}
           >
-            <span className="text-sm text-gray-200">GitHub</span>
-            <ChevronRight className="w-4 h-4 text-gray-500" />
+            <span className="text-sm text-text-primary">GitHub</span>
+            <ChevronRight className="w-4 h-4 text-text-muted" />
           </a>
           <a
             href="https://mustardseednetworks.com"
@@ -467,8 +472,8 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
               'hover:bg-white/10 transition-colors',
             )}
           >
-            <span className="text-sm text-gray-200">Website</span>
-            <ChevronRight className="w-4 h-4 text-gray-500" />
+            <span className="text-sm text-text-primary">Website</span>
+            <ChevronRight className="w-4 h-4 text-text-muted" />
           </a>
         </div>
       </Section>
@@ -484,8 +489,8 @@ interface InfoItemProps {
 function InfoItem({ label, value }: InfoItemProps): ReactElement {
   return (
     <div>
-      <div className="text-xs text-gray-500">{label}</div>
-      <div className="text-sm text-white font-mono">{value}</div>
+      <div className="text-xs text-text-muted">{label}</div>
+      <div className="text-sm text-text-primary font-mono">{value}</div>
     </div>
   );
 }

--- a/ui/src/components/StatBlock.tsx
+++ b/ui/src/components/StatBlock.tsx
@@ -12,9 +12,9 @@ interface StatBlockProps {
  */
 export const StatBlock = memo(({ label, value, helper }: StatBlockProps) => (
   <div>
-    <SmallText className="uppercase tracking-wide text-gray-400">{label}</SmallText>
-    <p className="text-3xl font-bold text-white">{value}</p>
-    <SmallText className="text-gray-300">{helper}</SmallText>
+    <SmallText className="uppercase tracking-wide text-text-muted">{label}</SmallText>
+    <p className="text-3xl font-bold text-text-primary">{value}</p>
+    <SmallText className="text-text-secondary">{helper}</SmallText>
   </div>
 ));
 

--- a/ui/src/components/StreamView.tsx
+++ b/ui/src/components/StreamView.tsx
@@ -91,27 +91,27 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-full max-w-4xl mx-4 bg-gray-900 border border-white/10 rounded-xl shadow-2xl max-h-[85vh] flex flex-col">
+      <div className="w-full max-w-4xl mx-4 bg-bg-surface border border-white/10 rounded-xl shadow-2xl max-h-[85vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
           <div>
-            <h3 className="text-lg font-semibold text-white">Follow Stream</h3>
-            <SmallText className="text-gray-400">
+            <h3 className="text-lg font-semibold text-text-primary">Follow Stream</h3>
+            <SmallText className="text-text-muted">
               {packets.length} packets |{' '}
-              <span className="text-blue-400">{totalClientBytes} B client</span> /{' '}
-              <span className="text-red-400">{totalServerBytes} B server</span>
+              <span className="text-status-info">{totalClientBytes} B client</span> /{' '}
+              <span className="text-status-error">{totalServerBytes} B server</span>
             </SmallText>
           </div>
           <div className="flex items-center gap-3">
             {/* Display mode toggle */}
-            <div className="flex rounded-lg border border-white/10 bg-gray-950/50 p-1">
+            <div className="flex rounded-lg border border-white/10 bg-bg-base/50 p-1">
               <button
                 type="button"
                 onClick={() => setDisplayMode('ascii')}
                 className={`px-3 py-1 text-xs rounded-md transition-colors ${
                   displayMode === 'ascii'
-                    ? 'bg-violet-600 text-white'
-                    : 'text-gray-400 hover:text-white'
+                    ? 'bg-brand-600 text-text-primary'
+                    : 'text-text-muted hover:text-text-primary'
                 }`}
               >
                 ASCII
@@ -121,15 +121,19 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
                 onClick={() => setDisplayMode('hex')}
                 className={`px-3 py-1 text-xs rounded-md transition-colors ${
                   displayMode === 'hex'
-                    ? 'bg-violet-600 text-white'
-                    : 'text-gray-400 hover:text-white'
+                    ? 'bg-brand-600 text-text-primary'
+                    : 'text-text-muted hover:text-text-primary'
                 }`}
               >
                 Hex
               </button>
             </div>
 
-            <button type="button" onClick={onClose} className="p-1 text-gray-400 hover:text-white">
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-1 text-text-muted hover:text-text-primary"
+            >
               <X className="h-5 w-5" />
             </button>
           </div>
@@ -138,7 +142,7 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
         {/* Stream content */}
         <div className="flex-1 overflow-y-auto px-5 py-4">
           {segments.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-text-muted">
               <p>No payload data available for this stream</p>
             </div>
           ) : (
@@ -148,8 +152,8 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
                   key={`${segment.timestamp}-${idx}`}
                   className={`px-3 py-1.5 rounded whitespace-pre-wrap break-all ${
                     segment.isClient
-                      ? 'bg-blue-950/30 text-blue-300 border-l-2 border-blue-500'
-                      : 'bg-red-950/30 text-red-300 border-l-2 border-red-500'
+                      ? 'bg-status-info/30 text-status-info border-l-2 border-status-info'
+                      : 'bg-status-error/30 text-status-error border-l-2 border-status-error'
                   }`}
                 >
                   {displayMode === 'ascii' ? hexToAscii(segment.data) : formatHex(segment.data)}

--- a/ui/src/components/TemplateCard.tsx
+++ b/ui/src/components/TemplateCard.tsx
@@ -25,13 +25,13 @@ const typeIcons: Record<Template['type'], FC<{ className?: string }>> = {
 };
 
 const typeColors: Record<Template['type'], string> = {
-  basic: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
-  router: 'bg-orange-500/20 text-orange-300 border-orange-500/30',
-  switch: 'bg-green-500/20 text-green-300 border-green-500/30',
-  'access-point': 'bg-purple-500/20 text-purple-300 border-purple-500/30',
-  server: 'bg-cyan-500/20 text-cyan-300 border-cyan-500/30',
-  firewall: 'bg-red-500/20 text-red-300 border-red-500/30',
-  complete: 'bg-amber-500/20 text-amber-300 border-amber-500/30',
+  basic: 'bg-status-info/20 text-status-info border-status-info/30',
+  router: 'bg-status-warning/20 text-status-warning border-status-warning/30',
+  switch: 'bg-status-success/20 text-status-success border-status-success/30',
+  'access-point': 'bg-brand-500/20 text-brand-300 border-brand-500/30',
+  server: 'bg-status-info/20 text-status-info border-status-info/30',
+  firewall: 'bg-status-error/20 text-status-error border-status-error/30',
+  complete: 'bg-status-warning/20 text-status-warning border-status-warning/30',
   custom: 'bg-pink-500/20 text-pink-300 border-pink-500/30',
 };
 
@@ -40,7 +40,7 @@ export const TemplateCard: FC<TemplateCardProps> = memo(({ template, onView, onU
   const colorClass = typeColors[template.type] || typeColors.custom;
 
   return (
-    <Card className="border-white/5 bg-gray-900/70 hover:border-violet-500/30 transition-colors">
+    <Card className="border-white/5 bg-bg-surface/70 hover:border-brand-500/30 transition-colors">
       <CardContent className="space-y-4">
         {/* Header with icon and type */}
         <div className="flex items-start justify-between">
@@ -54,13 +54,13 @@ export const TemplateCard: FC<TemplateCardProps> = memo(({ template, onView, onU
 
         {/* Template info */}
         <div className="space-y-1">
-          <h3 className="font-semibold text-white text-lg">
+          <h3 className="font-semibold text-text-primary text-lg">
             {template.displayName || template.name}
           </h3>
           {template.displayName && (
-            <SmallText className="text-gray-500 font-mono text-[10px]">{template.name}</SmallText>
+            <SmallText className="text-text-muted font-mono text-[10px]">{template.name}</SmallText>
           )}
-          <SmallText className="text-gray-400 line-clamp-2">
+          <SmallText className="text-text-muted line-clamp-2">
             {template.description || 'No description available'}
           </SmallText>
         </div>

--- a/ui/src/components/TemplatePreviewModal.tsx
+++ b/ui/src/components/TemplatePreviewModal.tsx
@@ -108,7 +108,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         aria-label="Close modal"
       />
       <div
-        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl"
+        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
@@ -116,14 +116,14 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         {/* Modal Header */}
         <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-violet-500/20 p-2">
-              <FileCode className={`${iconSizes.lg} text-violet-300`} />
+            <div className="rounded-lg bg-brand-500/20 p-2">
+              <FileCode className={`${iconSizes.lg} text-brand-300`} />
             </div>
             <div>
-              <h2 id="modal-title" className="text-lg font-semibold text-white">
+              <h2 id="modal-title" className="text-lg font-semibold text-text-primary">
                 {template.name}
               </h2>
-              <SmallText className="text-gray-400">
+              <SmallText className="text-text-muted">
                 {template.description || 'Configuration template preview'}
               </SmallText>
             </div>
@@ -131,7 +131,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
+            className="rounded-lg p-2 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors"
             aria-label="Close modal"
           >
             <X className={iconSizes.lg} />
@@ -139,7 +139,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         </div>
 
         {/* Template metadata */}
-        <div className="flex flex-wrap items-center gap-3 border-b border-white/10 px-6 py-3 bg-gray-950/50">
+        <div className="flex flex-wrap items-center gap-3 border-b border-white/10 px-6 py-3 bg-bg-base/50">
           <Tag colorScheme="purple">
             {template.deviceCount} {template.deviceCount === 1 ? 'device' : 'devices'}
           </Tag>
@@ -162,17 +162,17 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         <div className="max-h-[50vh] overflow-auto p-6">
           {loading && (
             <div className="flex items-center justify-center py-12">
-              <div className="flex items-center gap-3 text-gray-400">
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-violet-500 border-t-transparent" />
+              <div className="flex items-center gap-3 text-text-muted">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
                 <span>Loading template content...</span>
               </div>
             </div>
           )}
 
           {error && (
-            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-red-300">
+            <div className="rounded-lg border border-status-error/30 bg-status-error/10 p-4 text-status-error">
               <p className="font-semibold">Failed to load template</p>
-              <SmallText className="text-red-400">{error.message}</SmallText>
+              <SmallText className="text-status-error">{error.message}</SmallText>
             </div>
           )}
 
@@ -189,7 +189,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         </div>
 
         {/* Modal Footer */}
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-white/10 px-6 py-4 bg-gray-950/50">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-white/10 px-6 py-4 bg-bg-base/50">
           <div className="flex gap-2">
             <Button
               variant="ghost"
@@ -229,7 +229,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
               </Button>
             </div>
             {editError && (
-              <SmallText className="text-red-300" role="alert">
+              <SmallText className="text-status-error" role="alert">
                 {editError}
               </SmallText>
             )}

--- a/ui/src/components/config/DiffViewer.tsx
+++ b/ui/src/components/config/DiffViewer.tsx
@@ -29,7 +29,7 @@ const DiffStatsBar: FC<{
   showMergeControls,
 }) => (
   <div className="flex items-center gap-4 flex-wrap">
-    <SmallText className="text-gray-400">Changes:</SmallText>
+    <SmallText className="text-text-muted">Changes:</SmallText>
     <Tag colorScheme="green" className="text-xs">
       +{additions} additions
     </Tag>
@@ -40,7 +40,7 @@ const DiffStatsBar: FC<{
       {modifications} modified blocks
     </Tag>
     {showMergeControls && (
-      <SmallText className="text-gray-400 ml-auto">
+      <SmallText className="text-text-muted ml-auto">
         {decisionsCount} / {changedBlocksCount} decisions made
       </SmallText>
     )}
@@ -54,12 +54,12 @@ const ColumnHeaders: FC<{
   leftLabel: string;
   rightLabel: string;
 }> = ({ leftLabel, rightLabel }) => (
-  <div className="grid grid-cols-2 gap-px bg-gray-800 rounded-t-lg overflow-hidden">
-    <div className="bg-gray-900/90 px-4 py-2">
-      <SmallText className="text-gray-300 font-semibold">{leftLabel}</SmallText>
+  <div className="grid grid-cols-2 gap-px bg-bg-elevated rounded-t-lg overflow-hidden">
+    <div className="bg-bg-surface/90 px-4 py-2">
+      <SmallText className="text-text-secondary font-semibold">{leftLabel}</SmallText>
     </div>
-    <div className="bg-gray-900/90 px-4 py-2">
-      <SmallText className="text-gray-300 font-semibold">{rightLabel}</SmallText>
+    <div className="bg-bg-surface/90 px-4 py-2">
+      <SmallText className="text-text-secondary font-semibold">{rightLabel}</SmallText>
     </div>
   </div>
 );
@@ -68,7 +68,7 @@ const ColumnHeaders: FC<{
  * Empty state when no content is provided
  */
 const EmptyState: FC = () => (
-  <div className="flex items-center justify-center h-64 text-gray-400">
+  <div className="flex items-center justify-center h-64 text-text-muted">
     <SmallText>Upload files to compare</SmallText>
   </div>
 );
@@ -142,7 +142,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
       <ColumnHeaders leftLabel={leftLabel} rightLabel={rightLabel} />
 
       {/* Diff content */}
-      <div className="rounded-lg border border-white/10 bg-gray-950/50 overflow-hidden max-h-[500px] overflow-y-auto">
+      <div className="rounded-lg border border-white/10 bg-bg-base/50 overflow-hidden max-h-[500px] overflow-y-auto">
         {diffBlocks.map((block) => (
           <DiffBlockComponent
             key={block.id}

--- a/ui/src/components/config/MergeControls.tsx
+++ b/ui/src/components/config/MergeControls.tsx
@@ -109,12 +109,12 @@ export const MergeControls: FC<MergeControlsProps> = ({
   }, [onReset]);
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         {/* Header */}
         <div className="flex items-center justify-between">
           <H2 className="flex items-center gap-2">
-            <FileCheck className={`${iconSizes.lg} text-violet-300`} />
+            <FileCheck className={`${iconSizes.lg} text-brand-300`} />
             Merge Controls
           </H2>
           {stats.totalChanges > 0 && (
@@ -138,15 +138,15 @@ export const MergeControls: FC<MergeControlsProps> = ({
         {stats.totalChanges > 0 && (
           <div className="space-y-2">
             <div className="flex items-center justify-between text-sm">
-              <SmallText className="text-gray-400">Resolution progress</SmallText>
-              <SmallText className="text-gray-300">
+              <SmallText className="text-text-muted">Resolution progress</SmallText>
+              <SmallText className="text-text-secondary">
                 {stats.decisionsCount} / {stats.totalChanges} ({stats.progress}
                 %)
               </SmallText>
             </div>
-            <div className="h-2 rounded-full bg-gray-800 overflow-hidden">
+            <div className="h-2 rounded-full bg-bg-elevated overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-violet-500 to-violet-400 transition-all duration-300"
+                className="h-full bg-gradient-to-r from-brand-500 to-brand-400 transition-all duration-300"
                 style={{ width: `${stats.progress}%` }}
               />
             </div>
@@ -156,7 +156,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
         {/* Decision breakdown */}
         {stats.decisionsCount > 0 && (
           <div className="flex items-center gap-4 flex-wrap">
-            <SmallText className="text-gray-400">Decisions:</SmallText>
+            <SmallText className="text-text-muted">Decisions:</SmallText>
             {stats.leftCount > 0 && (
               <Tag colorScheme="blue" className="text-xs">
                 <ChevronLeft className={`${iconSizes.xs} mr-1`} />
@@ -179,7 +179,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
 
         {/* Quick actions */}
         <div className="space-y-3">
-          <SmallText className="text-gray-400 uppercase tracking-wide font-semibold">
+          <SmallText className="text-text-muted uppercase tracking-wide font-semibold">
             Quick Actions
           </SmallText>
 
@@ -246,7 +246,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
         </div>
 
         {/* Help text */}
-        <SmallText className="text-gray-500">
+        <SmallText className="text-text-muted">
           {stats.totalChanges === 0
             ? 'Upload two YAML config files to start comparing and merging.'
             : stats.isComplete
@@ -327,7 +327,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
         aria-label="Close modal"
       />
       <div
-        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl flex flex-col"
+        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl flex flex-col"
         role="dialog"
         aria-modal="true"
         aria-labelledby="preview-modal-title"
@@ -335,20 +335,20 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
         {/* Modal Header */}
         <div className="flex items-center justify-between border-b border-white/10 px-6 py-4 flex-shrink-0">
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-violet-500/20 p-2">
-              <FileCheck className={`${iconSizes.lg} text-violet-300`} />
+            <div className="rounded-lg bg-brand-500/20 p-2">
+              <FileCheck className={`${iconSizes.lg} text-brand-300`} />
             </div>
             <div>
-              <h2 id="preview-modal-title" className="text-lg font-semibold text-white">
+              <h2 id="preview-modal-title" className="text-lg font-semibold text-text-primary">
                 Merged Configuration Preview
               </h2>
-              <SmallText className="text-gray-400">{lineCount} lines</SmallText>
+              <SmallText className="text-text-muted">{lineCount} lines</SmallText>
             </div>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
+            className="rounded-lg p-2 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors"
             aria-label="Close modal"
           >
             <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -376,7 +376,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
         </div>
 
         {/* Modal Footer */}
-        <div className="flex justify-end gap-3 border-t border-white/10 px-6 py-4 bg-gray-950/50 flex-shrink-0">
+        <div className="flex justify-end gap-3 border-t border-white/10 px-6 py-4 bg-bg-base/50 flex-shrink-0">
           <Button variant="outline" onClick={onClose}>
             Close
           </Button>

--- a/ui/src/components/config/YamlEditor.tsx
+++ b/ui/src/components/config/YamlEditor.tsx
@@ -258,7 +258,7 @@ export const YamlEditor: FC<YamlEditorProps> = ({
   return (
     <section
       ref={containerRef}
-      className={`rounded-xl border border-white/10 bg-gray-950/70 overflow-hidden ${className}`}
+      className={`rounded-xl border border-white/10 bg-bg-base/70 overflow-hidden ${className}`}
       style={containerStyle}
       aria-label="YAML editor"
     />

--- a/ui/src/components/config/diff-viewer/DiffBlock.tsx
+++ b/ui/src/components/config/diff-viewer/DiffBlock.tsx
@@ -36,8 +36,8 @@ const MergeControls: FC<{
   decision?: MergeDecision;
   onDecision: (choice: MergeDecision['choice']) => void;
 }> = ({ decision, onDecision }) => (
-  <div className="flex items-center justify-center gap-2 py-2 px-4 bg-gray-900/80 border-b border-white/10">
-    <SmallText className="text-gray-400 mr-2">Accept:</SmallText>
+  <div className="flex items-center justify-center gap-2 py-2 px-4 bg-bg-surface/80 border-b border-white/10">
+    <SmallText className="text-text-muted mr-2">Accept:</SmallText>
     <Button
       size="sm"
       variant={decision?.choice === 'left' ? undefined : 'outline'}

--- a/ui/src/components/config/diff-viewer/DiffLine.tsx
+++ b/ui/src/components/config/diff-viewer/DiffLine.tsx
@@ -16,10 +16,10 @@ export const DiffLineComponent: FC<DiffLineComponentProps> = memo(({ line, side 
 
   return (
     <div className={`flex ${styles.bg} border-l-2 ${styles.border}`}>
-      <span className="w-12 flex-shrink-0 px-2 py-0.5 text-right text-xs text-gray-500 select-none border-r border-white/5">
+      <span className="w-12 flex-shrink-0 px-2 py-0.5 text-right text-xs text-text-muted select-none border-r border-white/5">
         {lineNum ?? ''}
       </span>
-      <span className="px-1 py-0.5 text-xs text-gray-400 select-none w-4">
+      <span className="px-1 py-0.5 text-xs text-text-muted select-none w-4">
         {line.type === 'added' ? '+' : line.type === 'removed' ? '-' : ' '}
       </span>
       <pre

--- a/ui/src/components/config/diff-viewer/diff-styles.ts
+++ b/ui/src/components/config/diff-viewer/diff-styles.ts
@@ -13,27 +13,27 @@ export function getDiffStyles(type: DiffType): DiffStyleSet {
   switch (type) {
     case 'added':
       return {
-        bg: 'bg-green-500/10',
-        border: 'border-green-500/30',
-        text: 'text-green-300',
+        bg: 'bg-status-success/10',
+        border: 'border-status-success/30',
+        text: 'text-status-success',
       };
     case 'removed':
       return {
-        bg: 'bg-red-500/10',
-        border: 'border-red-500/30',
-        text: 'text-red-300',
+        bg: 'bg-status-error/10',
+        border: 'border-status-error/30',
+        text: 'text-status-error',
       };
     case 'modified':
       return {
-        bg: 'bg-yellow-500/10',
-        border: 'border-yellow-500/30',
-        text: 'text-yellow-300',
+        bg: 'bg-status-warning/10',
+        border: 'border-status-warning/30',
+        text: 'text-status-warning',
       };
     default:
       return {
         bg: '',
         border: 'border-transparent',
-        text: 'text-gray-300',
+        text: 'text-text-secondary',
       };
   }
 }

--- a/ui/src/components/debug/ProtocolDebugLevels.tsx
+++ b/ui/src/components/debug/ProtocolDebugLevels.tsx
@@ -22,30 +22,30 @@ type DebugLevelKey = Lowercase<DebugLevel>;
 
 // Colors for different debug levels
 const LEVEL_COLORS: Record<DebugLevelKey, string> = {
-  off: 'bg-gray-700',
-  error: 'bg-red-600',
-  warn: 'bg-yellow-600',
-  info: 'bg-blue-600',
-  debug: 'bg-green-600',
-  trace: 'bg-purple-600',
+  off: 'bg-bg-elevated',
+  error: 'bg-status-error',
+  warn: 'bg-status-warning',
+  info: 'bg-status-info',
+  debug: 'bg-status-success',
+  trace: 'bg-brand-600',
 };
 
 // Category colors for visual grouping
 const CATEGORY_COLORS: Record<ProtocolCategory, string> = {
-  discovery: 'border-cyan-500/30',
-  switching: 'border-emerald-500/30',
-  routing: 'border-blue-500/30',
-  redundancy: 'border-orange-500/30',
-  multicast: 'border-purple-500/30',
+  discovery: 'border-status-info/30',
+  switching: 'border-status-success/30',
+  routing: 'border-status-info/30',
+  redundancy: 'border-status-warning/30',
+  multicast: 'border-brand-500/30',
   monitoring: 'border-pink-500/30',
 };
 
 const CATEGORY_HEADER_COLORS: Record<ProtocolCategory, string> = {
-  discovery: 'text-cyan-400',
-  switching: 'text-emerald-400',
-  routing: 'text-blue-400',
-  redundancy: 'text-orange-400',
-  multicast: 'text-purple-400',
+  discovery: 'text-status-info',
+  switching: 'text-status-success',
+  routing: 'text-status-info',
+  redundancy: 'text-status-warning',
+  multicast: 'text-brand-400',
   monitoring: 'text-pink-400',
 };
 
@@ -71,9 +71,9 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
   );
 
   return (
-    <div className="rounded-lg border border-white/10 bg-gray-950/50 p-4">
+    <div className="rounded-lg border border-white/10 bg-bg-base/50 p-4">
       <div className="flex items-center justify-between mb-3">
-        <span className="font-semibold text-white">{config.protocol}</span>
+        <span className="font-semibold text-text-primary">{config.protocol}</span>
         <Tag
           colorScheme={
             config.level === 'OFF'
@@ -121,7 +121,7 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
             [&::-webkit-slider-thumb]:bg-white
             [&::-webkit-slider-thumb]:shadow-md
             [&::-webkit-slider-thumb]:border-2
-            [&::-webkit-slider-thumb]:border-violet-400
+            [&::-webkit-slider-thumb]:border-brand-400
             [&::-webkit-slider-thumb]:transition-transform
             [&::-webkit-slider-thumb]:hover:scale-110
             [&::-moz-range-thumb]:h-5
@@ -130,18 +130,18 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
             [&::-moz-range-thumb]:bg-white
             [&::-moz-range-thumb]:shadow-md
             [&::-moz-range-thumb]:border-2
-            [&::-moz-range-thumb]:border-violet-400"
+            [&::-moz-range-thumb]:border-brand-400"
           aria-label={`${config.protocol} debug level`}
           aria-valuetext={config.level}
         />
       </div>
 
       {/* Level labels */}
-      <div className="flex justify-between mt-1 text-xs text-gray-500">
+      <div className="flex justify-between mt-1 text-xs text-text-muted">
         {DEBUG_LEVELS.map((level) => (
           <span
             key={level}
-            className={`${levelIndex === DEBUG_LEVELS.indexOf(level) ? 'text-white font-medium' : ''}`}
+            className={`${levelIndex === DEBUG_LEVELS.indexOf(level) ? 'text-text-primary font-medium' : ''}`}
           >
             {level.substring(0, 3)}
           </span>
@@ -170,7 +170,7 @@ const CategoryGroup: FC<CategoryGroupProps> = memo(
     }
 
     return (
-      <div className={`rounded-xl border ${CATEGORY_COLORS[category]} bg-gray-900/50 p-4`}>
+      <div className={`rounded-xl border ${CATEGORY_COLORS[category]} bg-bg-surface/50 p-4`}>
         <h3
           className={`text-sm font-semibold uppercase tracking-wide mb-4 ${CATEGORY_HEADER_COLORS[category]}`}
         >
@@ -231,22 +231,22 @@ export const ProtocolDebugLevels: FC = () => {
 
   if (loading) {
     return (
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="py-12 text-center">
-          <RefreshCw className={`mx-auto ${iconSizes['2xl']} animate-spin text-gray-400`} />
-          <SmallText className="mt-3 text-gray-400">Loading protocol debug settings...</SmallText>
+          <RefreshCw className={`mx-auto ${iconSizes['2xl']} animate-spin text-text-muted`} />
+          <SmallText className="mt-3 text-text-muted">Loading protocol debug settings...</SmallText>
         </CardContent>
       </Card>
     );
   }
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-6">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Settings2 className={`${iconSizes.xl} text-violet-400`} />
+            <Settings2 className={`${iconSizes.xl} text-brand-400`} />
             <H2>Protocol Debug Levels</H2>
           </div>
 
@@ -291,25 +291,25 @@ export const ProtocolDebugLevels: FC = () => {
         {/* Status Messages */}
         {error && (
           <div
-            className="rounded-lg border border-red-500/30 bg-red-900/20 px-4 py-3 text-sm text-red-300"
+            className="rounded-lg border border-status-error/30 bg-status-error/20 px-4 py-3 text-sm text-status-error"
             role="alert"
           >
             {error}
           </div>
         )}
         {successMessage && (
-          <output className="rounded-lg border border-green-500/30 bg-green-900/20 px-4 py-3 text-sm text-green-300">
+          <output className="rounded-lg border border-status-success/30 bg-status-success/20 px-4 py-3 text-sm text-status-success">
             {successMessage}
           </output>
         )}
         {hasChanges && !error && !successMessage && (
-          <output className="rounded-lg border border-yellow-500/30 bg-yellow-900/20 px-4 py-3 text-sm text-yellow-300">
+          <output className="rounded-lg border border-status-warning/30 bg-status-warning/20 px-4 py-3 text-sm text-status-warning">
             You have unsaved changes
           </output>
         )}
 
         {/* Description */}
-        <SmallText className="text-gray-400">
+        <SmallText className="text-text-muted">
           Adjust debug output verbosity for each network protocol. Higher levels (DEBUG, TRACE)
           produce more detailed logs but may impact performance. Changes take effect immediately
           when saved.
@@ -332,44 +332,44 @@ export const ProtocolDebugLevels: FC = () => {
         </div>
 
         {/* Legend */}
-        <div className="rounded-lg border border-white/10 bg-gray-950/50 p-4">
-          <SmallText className="font-semibold uppercase tracking-wide text-gray-400 mb-3">
+        <div className="rounded-lg border border-white/10 bg-bg-base/50 p-4">
+          <SmallText className="font-semibold uppercase tracking-wide text-text-muted mb-3">
             Level Guide
           </SmallText>
           <div className="flex flex-wrap gap-4 text-sm">
             <div className="flex items-center gap-2">
               <span className={`h-3 w-3 rounded-full ${LEVEL_COLORS.off}`} />
-              <span className="text-gray-300">
+              <span className="text-text-secondary">
                 <strong>OFF</strong> - No output
               </span>
             </div>
             <div className="flex items-center gap-2">
               <span className={`h-3 w-3 rounded-full ${LEVEL_COLORS.error}`} />
-              <span className="text-gray-300">
+              <span className="text-text-secondary">
                 <strong>ERROR</strong> - Critical issues only
               </span>
             </div>
             <div className="flex items-center gap-2">
               <span className={`h-3 w-3 rounded-full ${LEVEL_COLORS.warn}`} />
-              <span className="text-gray-300">
+              <span className="text-text-secondary">
                 <strong>WARN</strong> - Warnings and errors
               </span>
             </div>
             <div className="flex items-center gap-2">
               <span className={`h-3 w-3 rounded-full ${LEVEL_COLORS.info}`} />
-              <span className="text-gray-300">
+              <span className="text-text-secondary">
                 <strong>INFO</strong> - General information
               </span>
             </div>
             <div className="flex items-center gap-2">
               <span className={`h-3 w-3 rounded-full ${LEVEL_COLORS.debug}`} />
-              <span className="text-gray-300">
+              <span className="text-text-secondary">
                 <strong>DEBUG</strong> - Detailed debugging
               </span>
             </div>
             <div className="flex items-center gap-2">
               <span className={`h-3 w-3 rounded-full ${LEVEL_COLORS.trace}`} />
-              <span className="text-gray-300">
+              <span className="text-text-secondary">
                 <strong>TRACE</strong> - Full packet traces
               </span>
             </div>

--- a/ui/src/components/device-editor/AdditionalIPsSection.tsx
+++ b/ui/src/components/device-editor/AdditionalIPsSection.tsx
@@ -38,7 +38,7 @@ export const AdditionalIPsSection: FC<AdditionalIPsSectionProps> = ({
   return (
     <CollapsibleSection title="Additional IP Addresses" isExpanded={isExpanded} onToggle={onToggle}>
       <div className="space-y-4">
-        <SmallText className="text-gray-400">
+        <SmallText className="text-text-muted">
           Add secondary IP addresses for multi-homed or VLAN configurations.
         </SmallText>
         {(device.ips || []).map((ip, index) => (

--- a/ui/src/components/device-editor/DHCPSection.tsx
+++ b/ui/src/components/device-editor/DHCPSection.tsx
@@ -108,8 +108,8 @@ export const DhcpSection: FC<ProtocolSectionProps> = ({
 
           {/* Static Leases */}
           <div className="space-y-3">
-            <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Database className={`${iconSizes.md} text-violet-400`} />
+            <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+              <Database className={`${iconSizes.md} text-brand-400`} />
               Static Leases
             </h4>
             {(device.dhcp.clientLeases || []).map((lease: DHCPLease, index: number) => (

--- a/ui/src/components/device-editor/DNSSection.tsx
+++ b/ui/src/components/device-editor/DNSSection.tsx
@@ -41,8 +41,8 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
         <div className="space-y-6">
           {/* Forward Records (A records) */}
           <div className="space-y-3">
-            <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Globe className={`${iconSizes.md} text-violet-400`} />
+            <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+              <Globe className={`${iconSizes.md} text-brand-400`} />
               Forward Records (A Records)
             </h4>
             {(device.dns.forwardRecords || []).map((record: DNSRecord, index: number) => (
@@ -73,7 +73,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
                   }}
                   placeholder="IP Address"
-                  className="w-40 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none font-mono"
+                  className="w-40 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
                 />
                 <input
                   type="number"
@@ -87,7 +87,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
                   }}
                   placeholder="TTL"
-                  className="w-24 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                  className="w-24 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                 />
                 <Button
                   variant="ghost"
@@ -122,8 +122,8 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
 
           {/* Reverse Records (PTR records) */}
           <div className="space-y-3">
-            <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Globe className={`${iconSizes.md} text-violet-400`} />
+            <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+              <Globe className={`${iconSizes.md} text-brand-400`} />
               Reverse Records (PTR Records)
             </h4>
             {(device.dns.reverseRecords || []).map((record: DNSRecord, index: number) => (
@@ -140,7 +140,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), reverseRecords: records });
                   }}
                   placeholder="IP Address"
-                  className="w-40 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none font-mono"
+                  className="w-40 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
                 />
                 <input
                   type="text"

--- a/ui/src/components/device-editor/DeleteConfirmModal.tsx
+++ b/ui/src/components/device-editor/DeleteConfirmModal.tsx
@@ -25,16 +25,16 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
         aria-label="Close delete confirmation"
       />
       <div
-        className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl"
+        className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
       >
         <div className="p-6 space-y-4">
-          <div className="flex items-center gap-3 text-red-400">
+          <div className="flex items-center gap-3 text-status-error">
             <Trash2 className={iconSizes.xl} />
             <h2 className="text-lg font-semibold">Delete Device</h2>
           </div>
-          <p className="text-gray-300">
+          <p className="text-text-secondary">
             Are you sure you want to delete <strong>{deviceHostname}</strong>? This action cannot be
             undone.
           </p>
@@ -43,7 +43,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
               Cancel
             </Button>
             <Button
-              className="bg-red-600 hover:bg-red-700 text-white"
+              className="bg-status-error hover:bg-status-error text-text-primary"
               onClick={onConfirm}
               disabled={deleting}
             >

--- a/ui/src/components/device-editor/DeviceEditorHeader.tsx
+++ b/ui/src/components/device-editor/DeviceEditorHeader.tsx
@@ -46,22 +46,22 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
   const DeviceIcon = deviceTypeIcons[deviceType as DeviceType] ?? deviceTypeIcons.unknown;
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={onNavigateBack}
-              className="p-2 text-gray-400 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+              className="p-2 text-text-muted hover:text-text-primary hover:bg-white/10 rounded-lg transition-colors"
               title="Back to device list"
             >
               <ArrowLeft className={iconSizes.lg} />
             </button>
-            <DeviceIcon className={`${iconSizes.xl} text-violet-300`} />
+            <DeviceIcon className={`${iconSizes.xl} text-brand-300`} />
             <div>
               <H2>{isNewDevice ? 'New Device' : device.hostname || 'Edit Device'}</H2>
-              <SmallText className="text-gray-400">
+              <SmallText className="text-text-muted">
                 {isNewDevice ? 'Create a new network device' : 'Edit device configuration'}
               </SmallText>
             </div>
@@ -80,7 +80,7 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
                 variant="outline"
                 leftIcon={<Trash2 className={iconSizes.md} />}
                 onClick={onDelete}
-                className="text-red-400 hover:text-red-300 border-red-400/30 hover:border-red-400/50"
+                className="text-status-error hover:text-status-error border-status-error/30 hover:border-status-error/50"
                 disabled={deleting}
               >
                 Delete
@@ -111,8 +111,8 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
           <div
             className={`flex items-center gap-2 rounded-lg p-3 ${
               message.type === 'success'
-                ? 'border border-green-500/30 bg-green-500/10 text-green-300'
-                : 'border border-red-500/30 bg-red-500/10 text-red-300'
+                ? 'border border-status-success/30 bg-status-success/10 text-status-success'
+                : 'border border-status-error/30 bg-status-error/10 text-status-error'
             }`}
             role="alert"
           >

--- a/ui/src/components/device-editor/DeviceEditorStatusView.tsx
+++ b/ui/src/components/device-editor/DeviceEditorStatusView.tsx
@@ -22,10 +22,10 @@ export const DeviceEditorStatusView: FC<DeviceEditorStatusViewProps> = ({
   if (!isNewDevice && loading) {
     return (
       <div className="space-y-6">
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent className="flex items-center justify-center py-12">
-            <div className="flex items-center gap-3 text-gray-400">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-violet-500 border-t-transparent" />
+            <div className="flex items-center gap-3 text-text-muted">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
               <span>Loading device...</span>
             </div>
           </CardContent>
@@ -37,13 +37,13 @@ export const DeviceEditorStatusView: FC<DeviceEditorStatusViewProps> = ({
   if (!isNewDevice && error) {
     return (
       <div className="space-y-6">
-        <Card className="border-red-500/30 bg-red-900/20">
+        <Card className="border-status-error/30 bg-status-error/20">
           <CardContent className="space-y-3">
             <div className="flex items-start gap-3">
-              <AlertCircle className="mt-1 h-5 w-5 text-red-400" />
+              <AlertCircle className="mt-1 h-5 w-5 text-status-error" />
               <div>
-                <p className="font-semibold text-red-200">Failed to Load Device</p>
-                <SmallText className="text-red-300/90">{error.message}</SmallText>
+                <p className="font-semibold text-status-error">Failed to Load Device</p>
+                <SmallText className="text-status-error/90">{error.message}</SmallText>
                 <div className="flex gap-2 mt-3">
                   <Button variant="outline" size="sm" onClick={onRetry}>
                     Retry

--- a/ui/src/components/device-editor/FTPSection.tsx
+++ b/ui/src/components/device-editor/FTPSection.tsx
@@ -75,12 +75,12 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                   }
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-gray-700 rounded-full peer peer-checked:bg-violet-600 peer-focus:ring-2 peer-focus:ring-violet-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.ftp.allowAnonymous ? 'translate-x-4' : ''}`}
                   />
                 </div>
-                <span className="ml-3 text-sm text-gray-300">
+                <span className="ml-3 text-sm text-text-secondary">
                   {device.ftp.allowAnonymous ? 'Enabled' : 'Disabled'}
                 </span>
               </label>
@@ -89,8 +89,8 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
 
           {/* FTP Users */}
           <div className="space-y-3">
-            <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Folder className={`${iconSizes.md} text-violet-400`} />
+            <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+              <Folder className={`${iconSizes.md} text-brand-400`} />
               FTP Users
             </h4>
             {(device.ftp.users || []).map((user: FTPUser, index: number) => (
@@ -110,7 +110,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Username"
-                  className="flex-1 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                  className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                 />
                 <input
                   type="text"
@@ -124,7 +124,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Password"
-                  className="flex-1 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                  className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                 />
                 <input
                   type="text"
@@ -135,7 +135,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Home Directory"
-                  className="flex-1 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none font-mono"
+                  className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
                 />
                 <Button
                   variant="ghost"

--- a/ui/src/components/device-editor/HTTPSection.tsx
+++ b/ui/src/components/device-editor/HTTPSection.tsx
@@ -50,14 +50,14 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
 
           {/* Endpoints */}
           <div className="space-y-3">
-            <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <FileText className={`${iconSizes.md} text-violet-400`} />
+            <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+              <FileText className={`${iconSizes.md} text-brand-400`} />
               Endpoints
             </h4>
             {(device.http.endpoints || []).map((endpoint: HTTPEndpoint, index: number) => (
               <div
                 key={`${endpoint.method || 'GET'}-${endpoint.path || endpoint.statusCode || 'endpoint'}`}
-                className="rounded-lg border border-white/5 bg-gray-950/40 p-4 space-y-3"
+                className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3"
               >
                 <div className="flex gap-2 items-center">
                   <select
@@ -70,7 +70,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       };
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
-                    className="w-24 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+                    className="w-24 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
                   >
                     <option value="GET">GET</option>
                     <option value="POST">POST</option>
@@ -89,7 +89,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="/api/status"
-                    className="flex-1 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none font-mono"
+                    className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
                   />
                   <input
                     type="number"
@@ -103,7 +103,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Status"
-                    className="w-20 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                    className="w-20 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                   />
                   <Button
                     variant="ghost"
@@ -132,7 +132,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Content-Type (e.g., application/json)"
-                    className="w-64 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                    className="w-64 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                   />
                   <input
                     type="text"
@@ -146,7 +146,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Response body"
-                    className="flex-1 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                    className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                   />
                 </div>
               </div>

--- a/ui/src/components/device-editor/NetBIOSSection.tsx
+++ b/ui/src/components/device-editor/NetBIOSSection.tsx
@@ -104,8 +104,8 @@ export const NetBiosSection: FC<ProtocolSectionProps> = ({
 
           {/* Services */}
           <div className="space-y-3">
-            <h4 className="text-sm font-medium text-white flex items-center gap-2">
-              <Network className={`${iconSizes.md} text-violet-400`} />
+            <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+              <Network className={`${iconSizes.md} text-brand-400`} />
               NetBIOS Services
             </h4>
             <div className="flex flex-wrap gap-4">
@@ -128,9 +128,9 @@ export const NetBiosSection: FC<ProtocolSectionProps> = ({
                         });
                       }
                     }}
-                    className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-violet-500"
+                    className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500"
                   />
-                  <span className="text-sm text-gray-300 capitalize">{service}</span>
+                  <span className="text-sm text-text-secondary capitalize">{service}</span>
                 </label>
               ))}
             </div>
@@ -145,9 +145,9 @@ export const NetBiosSection: FC<ProtocolSectionProps> = ({
                     msbrowse: e.target.checked,
                   })
                 }
-                className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-violet-500"
+                className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500"
               />
-              <span className="text-sm text-gray-300">Master Browser (MSBROWSE)</span>
+              <span className="text-sm text-text-secondary">Master Browser (MSBROWSE)</span>
             </label>
           </div>
         </div>

--- a/ui/src/components/device-editor/TrafficSection.tsx
+++ b/ui/src/components/device-editor/TrafficSection.tsx
@@ -48,10 +48,10 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
       {device.traffic?.enabled && (
         <div className="space-y-6">
           {/* ARP Announcements */}
-          <div className="rounded-lg border border-white/5 bg-gray-950/40 p-4 space-y-3">
+          <div className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-white flex items-center gap-2">
-                <Radio className={`${iconSizes.md} text-violet-400`} />
+              <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+                <Radio className={`${iconSizes.md} text-brand-400`} />
                 ARP Announcements
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -70,7 +70,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                   }}
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-gray-700 rounded-full peer peer-checked:bg-violet-600 peer-focus:ring-2 peer-focus:ring-violet-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.arpAnnouncements?.enabled ? 'translate-x-4' : ''}`}
                   />
@@ -93,17 +93,17 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                     });
                   }}
                   min={1}
-                  className="w-32 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                  className="w-32 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                 />
               </FormField>
             )}
           </div>
 
           {/* Periodic Pings */}
-          <div className="rounded-lg border border-white/5 bg-gray-950/40 p-4 space-y-3">
+          <div className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-white flex items-center gap-2">
-                <Radio className={`${iconSizes.md} text-violet-400`} />
+              <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+                <Radio className={`${iconSizes.md} text-brand-400`} />
                 Periodic Pings
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -122,7 +122,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                   }}
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-gray-700 rounded-full peer peer-checked:bg-violet-600 peer-focus:ring-2 peer-focus:ring-violet-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.periodicPings?.enabled ? 'translate-x-4' : ''}`}
                   />
@@ -147,7 +147,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                       });
                     }}
                     min={1}
-                    className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                    className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                   />
                 </FormField>
                 <FormField label="Payload Size (bytes)" helpText="Size of ICMP payload">
@@ -167,7 +167,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                     }}
                     min={0}
                     max={65507}
-                    className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                    className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                   />
                 </FormField>
               </div>
@@ -175,10 +175,10 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
           </div>
 
           {/* Random Traffic */}
-          <div className="rounded-lg border border-white/5 bg-gray-950/40 p-4 space-y-3">
+          <div className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-white flex items-center gap-2">
-                <Radio className={`${iconSizes.md} text-violet-400`} />
+              <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
+                <Radio className={`${iconSizes.md} text-brand-400`} />
                 Random Traffic
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -197,7 +197,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                   }}
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-gray-700 rounded-full peer peer-checked:bg-violet-600 peer-focus:ring-2 peer-focus:ring-violet-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.randomTraffic?.enabled ? 'translate-x-4' : ''}`}
                   />
@@ -224,7 +224,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                         });
                       }}
                       min={1}
-                      className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                      className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                     />
                   </FormField>
                   <FormField label="Packet Count" helpText="Packets per burst">
@@ -245,12 +245,12 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                       }}
                       min={1}
                       max={100}
-                      className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+                      className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
                     />
                   </FormField>
                 </div>
                 <div className="space-y-2">
-                  <h5 className="text-xs font-medium text-gray-400">Traffic Patterns</h5>
+                  <h5 className="text-xs font-medium text-text-muted">Traffic Patterns</h5>
                   <div className="flex flex-wrap gap-4">
                     {(['broadcast_arp', 'multicast', 'udp'] as const).map((pattern) => (
                       <label key={pattern} className="flex items-center gap-2 cursor-pointer">
@@ -284,9 +284,9 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                               });
                             }
                           }}
-                          className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-violet-500"
+                          className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500"
                         />
-                        <span className="text-sm text-gray-300">
+                        <span className="text-sm text-text-secondary">
                           {pattern === 'broadcast_arp'
                             ? 'Broadcast ARP'
                             : pattern === 'multicast'

--- a/ui/src/components/device-editor/YamlPreviewSection.tsx
+++ b/ui/src/components/device-editor/YamlPreviewSection.tsx
@@ -10,7 +10,7 @@ export interface YamlPreviewSectionProps {
 
 export const YamlPreviewSection: FC<YamlPreviewSectionProps> = ({ yamlContent }) => {
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent>
         <H2 className="mb-3 flex items-center gap-2 text-base">
           <span>YAML Preview</span>

--- a/ui/src/components/device-editor/types.ts
+++ b/ui/src/components/device-editor/types.ts
@@ -27,16 +27,16 @@ export interface SNMPSectionProps extends ProtocolSectionProps {
  * Common input class names for device editor forms
  */
 export const inputClassName =
-  'w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none';
+  'w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none';
 
 export const monoInputClassName =
-  'w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none font-mono';
+  'w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono';
 
 export const selectClassName =
-  'w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white focus:border-violet-400 focus:outline-none';
+  'w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none';
 
 export const checkboxClassName =
-  'w-4 h-4 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-violet-500';
+  'w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500';
 
 export const smallInputClassName =
-  'flex-1 rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none font-mono';
+  'flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono';

--- a/ui/src/components/device-list/CloneDeviceModal.tsx
+++ b/ui/src/components/device-list/CloneDeviceModal.tsx
@@ -28,20 +28,23 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
         aria-label="Close clone device modal"
       />
       <div
-        className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl"
+        className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
       >
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
-          <div className="flex items-center gap-3 text-blue-400">
+          <div className="flex items-center gap-3 text-status-info">
             <Copy className={iconSizes.xl} />
             <h2 className="text-lg font-semibold">Clone Device</h2>
           </div>
-          <p className="text-gray-300">
+          <p className="text-text-secondary">
             Create a copy of <strong>{hostname}</strong> with a new name.
           </p>
           <div>
-            <label htmlFor="new-hostname" className="block text-sm font-medium text-gray-300 mb-2">
+            <label
+              htmlFor="new-hostname"
+              className="block text-sm font-medium text-text-secondary mb-2"
+            >
               New Hostname
             </label>
             <input
@@ -49,7 +52,7 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
               type="text"
               value={newHostname}
               onChange={(e) => setNewHostname(e.target.value)}
-              className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
             />
           </div>
           <div className="flex justify-end gap-3 pt-2">

--- a/ui/src/components/device-list/ConfirmDeleteModal.tsx
+++ b/ui/src/components/device-list/ConfirmDeleteModal.tsx
@@ -21,16 +21,16 @@ export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
       aria-label="Close delete confirmation"
     />
     <div
-      className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl"
+      className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
       role="dialog"
       aria-modal="true"
     >
       <div className="p-6 space-y-4">
-        <div className="flex items-center gap-3 text-red-400">
+        <div className="flex items-center gap-3 text-status-error">
           <Trash2 className="h-6 w-6" />
           <h2 className="text-lg font-semibold">Delete Device</h2>
         </div>
-        <p className="text-gray-300">
+        <p className="text-text-secondary">
           Are you sure you want to delete <strong>{hostname}</strong>? This action cannot be undone.
         </p>
         <div className="flex justify-end gap-3 pt-2">

--- a/ui/src/components/device-list/DeviceBulkActions.tsx
+++ b/ui/src/components/device-list/DeviceBulkActions.tsx
@@ -18,8 +18,8 @@ export const DeviceBulkActions: FC<DeviceBulkActionsProps> = ({
   }
 
   return (
-    <div className="flex items-center gap-4 p-3 rounded-lg bg-violet-500/10 border border-violet-500/30">
-      <span className="text-sm text-violet-200">
+    <div className="flex items-center gap-4 p-3 rounded-lg bg-brand-500/10 border border-brand-500/30">
+      <span className="text-sm text-brand-200">
         {selectedCount} device
         {selectedCount !== 1 ? 's' : ''} selected
       </span>
@@ -28,7 +28,7 @@ export const DeviceBulkActions: FC<DeviceBulkActionsProps> = ({
         size="sm"
         leftIcon={<Trash2 className="h-4 w-4" />}
         onClick={onDeleteSelected}
-        className="text-red-400 hover:text-red-300 hover:bg-red-500/20"
+        className="text-status-error hover:text-status-error hover:bg-status-error/20"
       >
         Delete Selected
       </Button>

--- a/ui/src/components/device-list/DeviceCardView.tsx
+++ b/ui/src/components/device-list/DeviceCardView.tsx
@@ -35,9 +35,9 @@ export const DeviceCardView: FC = () => {
         return (
           <div key={device.hostname} className="rounded-2xl">
             <Card
-              className={`group border-white/5 bg-gray-900/70 hover:border-violet-500/30 transition-all h-full ${
+              className={`group border-white/5 bg-bg-surface/70 hover:border-brand-500/30 transition-all h-full ${
                 selectedDevices.has(device.hostname)
-                  ? 'ring-2 ring-violet-500/50 border-violet-500/30'
+                  ? 'ring-2 ring-brand-500/50 border-brand-500/30'
                   : ''
               }`}
             >
@@ -49,7 +49,7 @@ export const DeviceCardView: FC = () => {
                       type="checkbox"
                       checked={selectedDevices.has(device.hostname)}
                       onChange={() => onSelectDevice(device.hostname)}
-                      className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-violet-500 focus:ring-violet-500 cursor-pointer"
+                      className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500 cursor-pointer"
                     />
                     <div className={`p-2 rounded-lg ${colorClasses.bg}`}>
                       <DeviceIcon className={`${iconSizes.lg} ${colorClasses.text}`} />
@@ -63,27 +63,27 @@ export const DeviceCardView: FC = () => {
                 <button
                   type="button"
                   onClick={() => onEdit(device.hostname)}
-                  className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+                  className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-gray-900"
                   aria-label={`Edit device ${device.hostname}`}
                 >
                   {/* Device name and IP */}
                   <div>
-                    <h3 className="font-semibold text-white group-hover:text-violet-300 transition-colors truncate">
+                    <h3 className="font-semibold text-text-primary group-hover:text-brand-300 transition-colors truncate">
                       {device.hostname}
                     </h3>
                     <div className="flex items-center gap-1 mt-1">
-                      <Network className={`${iconSizes.sm} text-gray-500`} />
-                      <span className="text-sm text-gray-400 font-mono">
+                      <Network className={`${iconSizes.sm} text-text-muted`} />
+                      <span className="text-sm text-text-muted font-mono">
                         {device.ip || device.ips?.[0] || 'No IP'}
                       </span>
                       {device.ips && device.ips.length > 1 && (
-                        <span className="text-xs text-gray-500">+{device.ips.length - 1}</span>
+                        <span className="text-xs text-text-muted">+{device.ips.length - 1}</span>
                       )}
                     </div>
                   </div>
 
                   {/* MAC Address */}
-                  <div className="text-xs text-gray-500 font-mono truncate">{device.mac}</div>
+                  <div className="text-xs text-text-muted font-mono truncate">{device.mac}</div>
 
                   {/* Protocols */}
                   <div className="flex flex-wrap gap-1">
@@ -94,7 +94,7 @@ export const DeviceCardView: FC = () => {
                         </Tag>
                       ))
                     ) : (
-                      <span className="text-gray-500 text-xs">No protocols</span>
+                      <span className="text-text-muted text-xs">No protocols</span>
                     )}
                     {deviceProtocols.length > 3 && (
                       <Tag colorScheme="gray" className="text-xs">
@@ -109,7 +109,7 @@ export const DeviceCardView: FC = () => {
                   <button
                     type="button"
                     onClick={() => onEdit(device.hostname)}
-                    className="p-2 text-gray-400 hover:text-violet-300 hover:bg-white/10 rounded-lg transition-colors"
+                    className="p-2 text-text-muted hover:text-brand-300 hover:bg-white/10 rounded-lg transition-colors"
                     title="Edit device"
                   >
                     <Edit3 className={iconSizes.md} />
@@ -117,7 +117,7 @@ export const DeviceCardView: FC = () => {
                   <button
                     type="button"
                     onClick={() => onClone(device.hostname)}
-                    className="p-2 text-gray-400 hover:text-blue-300 hover:bg-white/10 rounded-lg transition-colors"
+                    className="p-2 text-text-muted hover:text-status-info hover:bg-white/10 rounded-lg transition-colors"
                     title="Clone device"
                   >
                     <Copy className={iconSizes.md} />
@@ -125,7 +125,7 @@ export const DeviceCardView: FC = () => {
                   <button
                     type="button"
                     onClick={() => onDelete(device.hostname)}
-                    className="p-2 text-gray-400 hover:text-red-400 hover:bg-white/10 rounded-lg transition-colors"
+                    className="p-2 text-text-muted hover:text-status-error hover:bg-white/10 rounded-lg transition-colors"
                     title="Delete device"
                   >
                     <Trash2 className={iconSizes.md} />

--- a/ui/src/components/device-list/DeviceListHeader.tsx
+++ b/ui/src/components/device-list/DeviceListHeader.tsx
@@ -41,13 +41,13 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
     <div className="flex flex-wrap items-center justify-between gap-4">
       <div>
         <H2 className="flex items-center gap-2">
-          <Server className={`${iconSizes.lg} text-violet-300`} />
+          <Server className={`${iconSizes.lg} text-brand-300`} />
           Device Configuration
         </H2>
-        <P className="text-gray-400 mt-1">
+        <P className="text-text-muted mt-1">
           Manage network device configurations for simulation.
           {deviceCount > 0 && (
-            <output className="ml-2 text-violet-300">{deviceCount} devices</output>
+            <output className="ml-2 text-brand-300">{deviceCount} devices</output>
           )}
         </P>
       </div>
@@ -84,14 +84,14 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
             Data
           </Button>
           {exportMenuOpen && (
-            <div className="absolute right-0 z-10 mt-1 w-44 rounded-lg border border-white/10 bg-gray-900 shadow-lg">
+            <div className="absolute right-0 z-10 mt-1 w-44 rounded-lg border border-white/10 bg-bg-surface shadow-lg">
               <button
                 type="button"
                 onClick={() => {
                   exportDevicesAsJSON(filteredDevices);
                   setExportMenuOpen(false);
                 }}
-                className="block w-full px-3 py-2 text-left text-sm text-gray-200 hover:bg-white/5"
+                className="block w-full px-3 py-2 text-left text-sm text-text-primary hover:bg-white/5"
               >
                 JSON (data only)
               </button>
@@ -101,7 +101,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
                   exportDevicesAsCSV(filteredDevices);
                   setExportMenuOpen(false);
                 }}
-                className="block w-full px-3 py-2 text-left text-sm text-gray-200 hover:bg-white/5"
+                className="block w-full px-3 py-2 text-left text-sm text-text-primary hover:bg-white/5"
               >
                 CSV (data only)
               </button>

--- a/ui/src/components/device-list/DeviceListStates.tsx
+++ b/ui/src/components/device-list/DeviceListStates.tsx
@@ -14,12 +14,12 @@ interface LoadingStateProps {
 export const DeviceListLoadingState: FC<LoadingStateProps> = ({ viewMode }) => {
   if (viewMode === 'table') {
     return (
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="p-0">
           {/* Table header skeleton */}
-          <div className="flex items-center gap-4 border-b border-white/10 px-4 py-3 bg-gray-950/40">
-            <div className="h-4 w-4 rounded bg-gray-700/50" />
-            <div className="flex-1 grid grid-cols-12 gap-4 text-sm font-medium text-gray-400">
+          <div className="flex items-center gap-4 border-b border-white/10 px-4 py-3 bg-bg-base/40">
+            <div className="h-4 w-4 rounded bg-bg-elevated/50" />
+            <div className="flex-1 grid grid-cols-12 gap-4 text-sm font-medium text-text-muted">
               <div className="col-span-3">Hostname</div>
               <div className="col-span-2">Type</div>
               <div className="col-span-2">IP Address</div>
@@ -43,13 +43,13 @@ interface ErrorStateProps {
 
 export const DeviceListErrorState: FC<ErrorStateProps> = ({ error, onRetry }) => {
   return (
-    <Card className="border-red-500/30 bg-red-900/20" role="alert" aria-live="assertive">
+    <Card className="border-status-error/30 bg-status-error/20" role="alert" aria-live="assertive">
       <CardContent className="space-y-3">
         <div className="flex items-start gap-3">
-          <AlertCircle className="mt-1 h-5 w-5 text-red-400" />
+          <AlertCircle className="mt-1 h-5 w-5 text-status-error" />
           <div>
-            <p className="font-semibold text-red-200">Failed to Load Devices</p>
-            <SmallText className="text-red-300/90">{error.message}</SmallText>
+            <p className="font-semibold text-status-error">Failed to Load Devices</p>
+            <SmallText className="text-status-error/90">{error.message}</SmallText>
             <Button variant="outline" size="sm" className="mt-3" onClick={onRetry}>
               Retry
             </Button>
@@ -64,11 +64,11 @@ export const DeviceListEmptyState: FC = () => {
   const navigate = useNavigate();
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="py-12 text-center">
-        <Server className="mx-auto h-12 w-12 text-gray-600" />
+        <Server className="mx-auto h-12 w-12 text-text-disabled" />
         <H2 className="mt-4 mb-2">No Devices Configured</H2>
-        <P className="text-gray-400">
+        <P className="text-text-muted">
           Add your first device to start configuring your network simulation.
         </P>
         <Button
@@ -90,11 +90,11 @@ interface NoResultsStateProps {
 
 export const DeviceListNoResultsState: FC<NoResultsStateProps> = ({ onClearFilters }) => {
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="py-12 text-center">
-        <Search className="mx-auto h-12 w-12 text-gray-600" />
+        <Search className="mx-auto h-12 w-12 text-text-disabled" />
         <H2 className="mt-4 mb-2">No Matching Devices</H2>
-        <P className="text-gray-400">
+        <P className="text-text-muted">
           No devices match your current filters. Try adjusting your search.
         </P>
         <Button variant="outline" className="mt-4" onClick={onClearFilters}>

--- a/ui/src/components/device-list/DeviceSearchFilters.tsx
+++ b/ui/src/components/device-list/DeviceSearchFilters.tsx
@@ -32,19 +32,19 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
     <div className="flex flex-wrap gap-4">
       {/* Search */}
       <div className="relative flex-1 min-w-[250px]">
-        <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+        <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-text-muted" />
         <input
           type="text"
           placeholder="Search by hostname, MAC, or IP..."
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
-          className="w-full rounded-lg border border-white/10 bg-gray-950/60 py-2.5 pl-10 pr-10 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+          className="w-full rounded-lg border border-white/10 bg-bg-base/60 py-2.5 pl-10 pr-10 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
         />
         {searchQuery && (
           <button
             type="button"
             onClick={() => onSearchChange('')}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary"
             aria-label="Clear search"
           >
             <X className="h-4 w-4" />
@@ -54,11 +54,11 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
 
       {/* Type filter */}
       <div className="flex items-center gap-2">
-        <Filter className={`${iconSizes.md} text-gray-400`} />
+        <Filter className={`${iconSizes.md} text-text-muted`} />
         <select
           value={typeFilter}
           onChange={(e) => onTypeFilterChange(e.target.value as DeviceType | 'all')}
-          className="rounded-lg border border-white/10 bg-gray-950/60 py-2 px-3 text-sm text-white focus:border-violet-400 focus:outline-none"
+          className="rounded-lg border border-white/10 bg-bg-base/60 py-2 px-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
         >
           <option value="all">All Types</option>
           {deviceTypes.map((type) => (
@@ -73,7 +73,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
       <select
         value={protocolFilter}
         onChange={(e) => onProtocolFilterChange(e.target.value)}
-        className="rounded-lg border border-white/10 bg-gray-950/60 py-2 px-3 text-sm text-white focus:border-violet-400 focus:outline-none"
+        className="rounded-lg border border-white/10 bg-bg-base/60 py-2 px-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
       >
         <option value="all">All Protocols</option>
         {protocols.map((proto) => (
@@ -84,14 +84,14 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
       </select>
 
       {/* View toggle */}
-      <div className="flex items-center gap-1 p-1 rounded-lg bg-gray-950/60 border border-white/10">
+      <div className="flex items-center gap-1 p-1 rounded-lg bg-bg-base/60 border border-white/10">
         <button
           type="button"
           onClick={() => onViewModeChange('table')}
           className={`p-2 rounded-md transition-colors ${
             viewMode === 'table'
-              ? 'bg-violet-600 text-white'
-              : 'text-gray-400 hover:text-white hover:bg-white/10'
+              ? 'bg-brand-600 text-text-primary'
+              : 'text-text-muted hover:text-text-primary hover:bg-white/10'
           }`}
           title="Table view"
           aria-label="Table view"
@@ -103,8 +103,8 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
           onClick={() => onViewModeChange('cards')}
           className={`p-2 rounded-md transition-colors ${
             viewMode === 'cards'
-              ? 'bg-violet-600 text-white'
-              : 'text-gray-400 hover:text-white hover:bg-white/10'
+              ? 'bg-brand-600 text-text-primary'
+              : 'text-text-muted hover:text-text-primary hover:bg-white/10'
           }`}
           title="Card view"
           aria-label="Card view"

--- a/ui/src/components/device-list/DeviceStatusMessage.tsx
+++ b/ui/src/components/device-list/DeviceStatusMessage.tsx
@@ -21,8 +21,8 @@ export const DeviceStatusMessage: FC<DeviceStatusMessageProps> = ({ message, onD
     <div
       className={`flex items-center gap-2 rounded-lg p-3 ${
         message.type === 'success'
-          ? 'border border-green-500/30 bg-green-500/10 text-green-300'
-          : 'border border-red-500/30 bg-red-500/10 text-red-300'
+          ? 'border border-status-success/30 bg-status-success/10 text-status-success'
+          : 'border border-status-error/30 bg-status-error/10 text-status-error'
       }`}
       role="alert"
     >

--- a/ui/src/components/device-list/DeviceTableView.tsx
+++ b/ui/src/components/device-list/DeviceTableView.tsx
@@ -18,19 +18,19 @@ export const DeviceTableView: FC = () => {
     getDeviceProtocols,
   } = useDeviceList();
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="p-0">
         {/* Table header */}
         <div>
-          <div className="flex items-center gap-4 border-b border-white/10 px-4 py-3 bg-gray-950/40">
+          <div className="flex items-center gap-4 border-b border-white/10 px-4 py-3 bg-bg-base/40">
             <input
               type="checkbox"
               checked={selectedDevices.size === devices.length && devices.length > 0}
               onChange={onSelectAll}
-              className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-violet-500 focus:ring-violet-500"
+              className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500"
               aria-label="Select all devices"
             />
-            <div className="flex-1 grid grid-cols-12 gap-4 text-sm font-medium text-gray-400">
+            <div className="flex-1 grid grid-cols-12 gap-4 text-sm font-medium text-text-muted">
               <div className="col-span-3">Hostname</div>
               <div className="col-span-2">Type</div>
               <div className="col-span-2">IP Address</div>
@@ -56,24 +56,24 @@ export const DeviceTableView: FC = () => {
               <div
                 key={device.hostname}
                 className={`flex items-center gap-4 px-4 py-3 hover:bg-white/5 transition-colors ${
-                  selectedDevices.has(device.hostname) ? 'bg-violet-500/10' : ''
+                  selectedDevices.has(device.hostname) ? 'bg-brand-500/10' : ''
                 }`}
               >
                 <input
                   type="checkbox"
                   checked={selectedDevices.has(device.hostname)}
                   onChange={() => onSelectDevice(device.hostname)}
-                  className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-violet-500 focus:ring-violet-500"
+                  className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500"
                   aria-label={`Select ${device.hostname}`}
                 />
                 <div className="flex-1 grid grid-cols-12 gap-4 items-center">
                   {/* Hostname */}
                   <div className="col-span-3 flex items-center gap-2">
-                    <DeviceIcon className={`${iconSizes.md} text-gray-400`} />
+                    <DeviceIcon className={`${iconSizes.md} text-text-muted`} />
                     <button
                       type="button"
                       onClick={() => onEdit(device.hostname)}
-                      className="text-white hover:text-violet-300 font-medium truncate"
+                      className="text-text-primary hover:text-brand-300 font-medium truncate"
                     >
                       {device.hostname}
                     </button>
@@ -88,11 +88,11 @@ export const DeviceTableView: FC = () => {
 
                   {/* IP */}
                   <div className="col-span-2">
-                    <span className="text-gray-300 text-sm font-mono">
+                    <span className="text-text-secondary text-sm font-mono">
                       {device.ip || device.ips?.[0] || '—'}
                     </span>
                     {device.ips && device.ips.length > 1 && (
-                      <span className="ml-1 text-gray-500 text-xs">+{device.ips.length - 1}</span>
+                      <span className="ml-1 text-text-muted text-xs">+{device.ips.length - 1}</span>
                     )}
                   </div>
 
@@ -105,7 +105,7 @@ export const DeviceTableView: FC = () => {
                         </Tag>
                       ))
                     ) : (
-                      <span className="text-gray-500 text-sm">No protocols</span>
+                      <span className="text-text-muted text-sm">No protocols</span>
                     )}
                     {deviceProtocols.length > 4 && (
                       <Tag colorScheme="gray" className="text-xs">
@@ -119,7 +119,7 @@ export const DeviceTableView: FC = () => {
                     <button
                       type="button"
                       onClick={() => onEdit(device.hostname)}
-                      className="p-2 text-gray-400 hover:text-violet-300 hover:bg-white/5 rounded-lg transition-colors"
+                      className="p-2 text-text-muted hover:text-brand-300 hover:bg-white/5 rounded-lg transition-colors"
                       title="Edit device"
                     >
                       <Edit3 className={iconSizes.md} />
@@ -127,7 +127,7 @@ export const DeviceTableView: FC = () => {
                     <button
                       type="button"
                       onClick={() => onClone(device.hostname)}
-                      className="p-2 text-gray-400 hover:text-blue-300 hover:bg-white/5 rounded-lg transition-colors"
+                      className="p-2 text-text-muted hover:text-status-info hover:bg-white/5 rounded-lg transition-colors"
                       title="Clone device"
                     >
                       <Copy className={iconSizes.md} />
@@ -135,7 +135,7 @@ export const DeviceTableView: FC = () => {
                     <button
                       type="button"
                       onClick={() => onDelete(device.hostname)}
-                      className="p-2 text-gray-400 hover:text-red-400 hover:bg-white/5 rounded-lg transition-colors"
+                      className="p-2 text-text-muted hover:text-status-error hover:bg-white/5 rounded-lg transition-colors"
                       title="Delete device"
                     >
                       <Trash2 className={iconSizes.md} />

--- a/ui/src/components/form/CollapsibleSection.tsx
+++ b/ui/src/components/form/CollapsibleSection.tsx
@@ -23,7 +23,7 @@ export const CollapsibleSection: FC<CollapsibleSectionProps> = ({
   enabled,
   onEnableChange,
 }) => (
-  <Card className="border-white/5 bg-gray-900/70 overflow-hidden">
+  <Card className="border-white/5 bg-bg-surface/70 overflow-hidden">
     <div className="flex items-center justify-between px-6 py-4 hover:bg-white/5 transition-colors">
       <div className="flex items-center gap-3">
         <button
@@ -31,14 +31,14 @@ export const CollapsibleSection: FC<CollapsibleSectionProps> = ({
           onClick={onToggle}
           aria-expanded={isExpanded}
           aria-label={`${title} section, ${isExpanded ? 'expanded' : 'collapsed'}`}
-          className="flex items-center gap-3 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-violet-500 rounded-lg px-1 -ml-1"
+          className="flex items-center gap-3 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500 rounded-lg px-1 -ml-1"
         >
           {isExpanded ? (
-            <ChevronDown className={`${iconSizes.md} text-gray-400`} />
+            <ChevronDown className={`${iconSizes.md} text-text-muted`} />
           ) : (
-            <ChevronRight className={`${iconSizes.md} text-gray-400`} />
+            <ChevronRight className={`${iconSizes.md} text-text-muted`} />
           )}
-          <h3 className="font-semibold text-white">{title}</h3>
+          <h3 className="font-semibold text-text-primary">{title}</h3>
           {required && (
             <Tag colorScheme="red" className="text-xs">
               Required
@@ -54,7 +54,7 @@ export const CollapsibleSection: FC<CollapsibleSectionProps> = ({
                 onChange={(e) => onEnableChange(e.target.checked)}
                 className="sr-only peer"
               />
-              <div className="w-9 h-5 bg-gray-700 rounded-full peer peer-checked:bg-violet-600 peer-focus:ring-2 peer-focus:ring-violet-500 transition-colors">
+              <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
                 <div
                   className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${enabled ? 'translate-x-4' : ''}`}
                 />

--- a/ui/src/components/form/FormField.tsx
+++ b/ui/src/components/form/FormField.tsx
@@ -23,27 +23,27 @@ export const FormField: FC<FormFieldProps> = ({
     {htmlFor ? (
       <label
         htmlFor={htmlFor}
-        className="flex items-center gap-2 text-sm font-medium text-gray-300 mb-2"
+        className="flex items-center gap-2 text-sm font-medium text-text-secondary mb-2"
       >
         {label}
-        {required && <span className="text-red-400">*</span>}
+        {required && <span className="text-status-error">*</span>}
         {helpText && (
           <span className="relative group">
-            <HelpCircle className={`${iconSizes.sm} text-gray-500 cursor-help`} />
-            <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-gray-800 text-gray-200 text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
+            <HelpCircle className={`${iconSizes.sm} text-text-muted cursor-help`} />
+            <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-bg-elevated text-text-primary text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
               {helpText}
             </span>
           </span>
         )}
       </label>
     ) : (
-      <div className="flex items-center gap-2 text-sm font-medium text-gray-300 mb-2">
+      <div className="flex items-center gap-2 text-sm font-medium text-text-secondary mb-2">
         {label}
-        {required && <span className="text-red-400">*</span>}
+        {required && <span className="text-status-error">*</span>}
         {helpText && (
           <span className="relative group">
-            <HelpCircle className={`${iconSizes.sm} text-gray-500 cursor-help`} />
-            <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-gray-800 text-gray-200 text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
+            <HelpCircle className={`${iconSizes.sm} text-text-muted cursor-help`} />
+            <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-bg-elevated text-text-primary text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
               {helpText}
             </span>
           </span>

--- a/ui/src/components/help-drawer/FeaturesSection.tsx
+++ b/ui/src/components/help-drawer/FeaturesSection.tsx
@@ -27,9 +27,9 @@ export function FeaturesSection({ searchQuery }: FeaturesSectionProps): ReactEle
 
   return (
     <div className="space-y-3">
-      <h3 className="text-sm font-semibold text-white">Quick Reference</h3>
+      <h3 className="text-sm font-semibold text-text-primary">Quick Reference</h3>
       {filteredFeatures.length === 0 ? (
-        <p className="text-sm text-gray-500 py-4 text-center">No features match your search.</p>
+        <p className="text-sm text-text-muted py-4 text-center">No features match your search.</p>
       ) : (
         <div className="space-y-2">
           {filteredFeatures.map((feature) => (
@@ -50,7 +50,7 @@ function FeatureCard({ feature }: FeatureCardProps): ReactElement {
     <div className="bg-white/5 rounded-lg p-3 hover:bg-white/10 transition-colors">
       <div className={layout.flex.between}>
         <div className={layout.inline.default}>
-          <h4 className="text-sm font-medium text-white">{feature.title}</h4>
+          <h4 className="text-sm font-medium text-text-primary">{feature.title}</h4>
           {feature.badge && (
             <span
               className={cn(
@@ -63,9 +63,9 @@ function FeatureCard({ feature }: FeatureCardProps): ReactElement {
             </span>
           )}
         </div>
-        <code className="text-xs text-gray-500">{feature.path}</code>
+        <code className="text-xs text-text-muted">{feature.path}</code>
       </div>
-      <p className="text-xs text-gray-400 mt-1">{feature.description}</p>
+      <p className="text-xs text-text-muted mt-1">{feature.description}</p>
     </div>
   );
 }

--- a/ui/src/components/help-drawer/GlossarySection.tsx
+++ b/ui/src/components/help-drawer/GlossarySection.tsx
@@ -47,15 +47,15 @@ export function GlossarySection({ searchQuery }: GlossarySectionProps): ReactEle
   return (
     <div className="space-y-6">
       {filteredGlossary.length === 0 ? (
-        <p className="text-sm text-gray-500 py-4 text-center">
+        <p className="text-sm text-text-muted py-4 text-center">
           No glossary entries match your search.
         </p>
       ) : (
         Object.entries(groupedEntries).map(([category, entries]) =>
           entries.length > 0 ? (
             <div key={category} className="space-y-2">
-              <h3 className="text-sm font-semibold text-white flex items-center gap-2">
-                <Network className="w-4 h-4 text-violet-400" />
+              <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+                <Network className="w-4 h-4 text-brand-400" />
                 {CATEGORY_LABELS[category]}
               </h3>
               <div className="space-y-1">
@@ -78,8 +78,8 @@ interface GlossaryItemProps {
 function GlossaryItem({ entry }: GlossaryItemProps): ReactElement {
   return (
     <div className="bg-white/5 rounded-lg p-3">
-      <dt className="text-sm font-medium text-white">{entry.term}</dt>
-      <dd className="text-xs text-gray-400 mt-0.5">{entry.definition}</dd>
+      <dt className="text-sm font-medium text-text-primary">{entry.term}</dt>
+      <dd className="text-xs text-text-muted mt-0.5">{entry.definition}</dd>
     </div>
   );
 }

--- a/ui/src/components/help-drawer/ShortcutsSection.tsx
+++ b/ui/src/components/help-drawer/ShortcutsSection.tsx
@@ -49,13 +49,13 @@ export function ShortcutsSection({ searchQuery }: ShortcutsSectionProps): ReactE
   return (
     <div className="space-y-6">
       {filteredShortcuts.length === 0 ? (
-        <p className="text-sm text-gray-500 py-4 text-center">No shortcuts match your search.</p>
+        <p className="text-sm text-text-muted py-4 text-center">No shortcuts match your search.</p>
       ) : (
         Object.entries(groupedShortcuts).map(([category, shortcuts]) =>
           shortcuts.length > 0 ? (
             <div key={category} className="space-y-2">
-              <h3 className="text-sm font-semibold text-white flex items-center gap-2">
-                <Command className="w-4 h-4 text-violet-400" />
+              <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+                <Command className="w-4 h-4 text-brand-400" />
                 {CATEGORY_LABELS[category]}
               </h3>
               <div className="space-y-1">
@@ -67,7 +67,7 @@ export function ShortcutsSection({ searchQuery }: ShortcutsSectionProps): ReactE
           ) : null,
         )
       )}
-      <p className="text-xs text-gray-500">
+      <p className="text-xs text-text-muted">
         Keyboard shortcuts are contextual and may vary based on the current page.
       </p>
     </div>
@@ -81,19 +81,19 @@ interface ShortcutItemProps {
 function ShortcutItem({ shortcut }: ShortcutItemProps): ReactElement {
   return (
     <div className={cn(layout.flex.between, 'py-2 px-3 bg-white/5 rounded-lg')}>
-      <span className="text-sm text-gray-300">{shortcut.description}</span>
+      <span className="text-sm text-text-secondary">{shortcut.description}</span>
       <div className={layout.inline.tight}>
         {shortcut.keys.map((key, idx) => (
           <span key={`${shortcut.description}-${key}`}>
             <kbd
               className={cn(
                 'px-2 py-0.5 text-xs font-mono rounded',
-                'bg-gray-800 border border-white/20 text-gray-300',
+                'bg-bg-elevated border border-white/20 text-text-secondary',
               )}
             >
               {key}
             </kbd>
-            {idx < shortcut.keys.length - 1 && <span className="text-gray-600 mx-0.5">+</span>}
+            {idx < shortcut.keys.length - 1 && <span className="text-text-disabled mx-0.5">+</span>}
           </span>
         ))}
       </div>

--- a/ui/src/components/pcap/PcapPacketList.tsx
+++ b/ui/src/components/pcap/PcapPacketList.tsx
@@ -35,21 +35,21 @@ const PacketRow = memo(
     <tr
       onClick={onClick}
       className={`cursor-pointer transition-colors ${
-        isSelected ? 'bg-violet-900/30' : 'hover:bg-gray-900/50'
+        isSelected ? 'bg-brand-900/30' : 'hover:bg-bg-surface/50'
       }`}
       style={rowStyle}
     >
-      <td className="px-3 py-2 text-gray-400 text-xs font-mono">{packet.number}</td>
-      <td className="px-3 py-2 text-gray-300 text-xs font-mono">{formattedTime}</td>
-      <td className="px-3 py-2 text-white text-sm font-mono">{packet.sourceIp}</td>
-      <td className="px-3 py-2 text-white text-sm font-mono">{packet.destIp}</td>
+      <td className="px-3 py-2 text-text-muted text-xs font-mono">{packet.number}</td>
+      <td className="px-3 py-2 text-text-secondary text-xs font-mono">{formattedTime}</td>
+      <td className="px-3 py-2 text-text-primary text-sm font-mono">{packet.sourceIp}</td>
+      <td className="px-3 py-2 text-text-primary text-sm font-mono">{packet.destIp}</td>
       <td className="px-3 py-2">
         <Tag colorScheme={getProtocolColor(packet.protocol)} className="text-xs">
           {packet.protocol}
         </Tag>
       </td>
-      <td className="px-3 py-2 text-gray-400 text-xs text-right">{packet.length}</td>
-      <td className="px-3 py-2 text-gray-400 text-xs truncate max-w-xs">{packet.info}</td>
+      <td className="px-3 py-2 text-text-muted text-xs text-right">{packet.length}</td>
+      <td className="px-3 py-2 text-text-muted text-xs truncate max-w-xs">{packet.info}</td>
     </tr>
   ),
 );
@@ -75,8 +75,8 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
 
     if (totalPackets === 0) {
       return (
-        <Card className="border-white/5 bg-gray-900/70 h-full">
-          <CardContent className="h-full flex items-center justify-center text-gray-400">
+        <Card className="border-white/5 bg-bg-surface/70 h-full">
+          <CardContent className="h-full flex items-center justify-center text-text-muted">
             <div className="text-center">
               <p className="text-sm">No packets to display</p>
               <SmallText>Upload a PCAP file to analyze</SmallText>
@@ -87,11 +87,11 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
     }
 
     return (
-      <Card className="border-white/5 bg-gray-900/70 h-full flex flex-col">
+      <Card className="border-white/5 bg-bg-surface/70 h-full flex flex-col">
         <CardContent className="h-full flex flex-col">
           {/* Packet count */}
           <div className="mb-3 flex items-center justify-between">
-            <SmallText className="text-gray-400">
+            <SmallText className="text-text-muted">
               Showing {packets.length} of {totalPackets} packets
             </SmallText>
           </div>
@@ -99,7 +99,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
           {/* Packet Table */}
           <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-white/5">
             {packets.length === 0 ? (
-              <div className="h-full flex items-center justify-center text-gray-400">
+              <div className="h-full flex items-center justify-center text-text-muted">
                 <div className="text-center">
                   <p className="text-sm">No packets match filter</p>
                   <SmallText>Try adjusting the filter expression</SmallText>
@@ -107,31 +107,31 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
               </div>
             ) : (
               <table className="min-w-full divide-y divide-white/5">
-                <thead className="bg-gray-900/80 sticky top-0 z-10">
+                <thead className="bg-bg-surface/80 sticky top-0 z-10">
                   <tr>
-                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
                       #
                     </th>
                     <th
-                      className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400 cursor-pointer hover:text-violet-300 select-none"
+                      className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
                       onClick={cycleTimeMode}
                       title="Click to cycle: Absolute / Relative / Delta"
                     >
                       {getTimeDisplayLabel(timeMode)}
                     </th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
                       Source
                     </th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
                       Destination
                     </th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
                       Protocol
                     </th>
-                    <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted">
                       Length
                     </th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
                       Info
                     </th>
                   </tr>

--- a/ui/src/components/pcap/PcapStats.tsx
+++ b/ui/src/components/pcap/PcapStats.tsx
@@ -48,13 +48,13 @@ const StatBlock = memo(
     value: string | number;
     helper?: string;
   }) => (
-    <div className="rounded-lg border border-white/5 bg-gray-950/50 p-4">
+    <div className="rounded-lg border border-white/5 bg-bg-base/50 p-4">
       <div className="flex items-center gap-2 mb-2">
         {icon}
-        <SmallText className="text-gray-400 uppercase tracking-wide">{label}</SmallText>
+        <SmallText className="text-text-muted uppercase tracking-wide">{label}</SmallText>
       </div>
-      <p className="text-2xl font-bold text-white">{value}</p>
-      {helper && <SmallText className="text-gray-500">{helper}</SmallText>}
+      <p className="text-2xl font-bold text-text-primary">{value}</p>
+      {helper && <SmallText className="text-text-muted">{helper}</SmallText>}
     </div>
   ),
 );
@@ -74,7 +74,7 @@ const ProtocolBreakdown: FC<{
     .slice(0, 10);
 
   if (sortedProtocols.length === 0) {
-    return <SmallText className="text-gray-400">No protocol data available</SmallText>;
+    return <SmallText className="text-text-muted">No protocol data available</SmallText>;
   }
 
   return (
@@ -89,13 +89,13 @@ const ProtocolBreakdown: FC<{
                 <Tag colorScheme={getProtocolColor(protocol)} className="text-xs">
                   {protocol}
                 </Tag>
-                <SmallText className="text-gray-400">{count.toLocaleString()}</SmallText>
+                <SmallText className="text-text-muted">{count.toLocaleString()}</SmallText>
               </div>
-              <SmallText className="text-gray-500">{percentage.toFixed(1)}%</SmallText>
+              <SmallText className="text-text-muted">{percentage.toFixed(1)}%</SmallText>
             </div>
-            <div className="h-1.5 w-full rounded-full bg-gray-800 overflow-hidden">
+            <div className="h-1.5 w-full rounded-full bg-bg-elevated overflow-hidden">
               <div
-                className="h-full rounded-full bg-violet-500 transition-all duration-500"
+                className="h-full rounded-full bg-brand-500 transition-all duration-500"
                 style={{ width: `${percentage}%` }}
               />
             </div>
@@ -120,21 +120,21 @@ const TopEndpoints: FC<{
       {/* Top Sources */}
       <div className="space-y-2">
         <div className="flex items-center gap-2 mb-3">
-          <Server className={`${iconSizes.md} text-blue-400`} />
-          <SmallText className="text-gray-400 uppercase tracking-wide font-semibold">
+          <Server className={`${iconSizes.md} text-status-info`} />
+          <SmallText className="text-text-muted uppercase tracking-wide font-semibold">
             Top Sources
           </SmallText>
         </div>
         {sources.length === 0 ? (
-          <SmallText className="text-gray-500">No source data</SmallText>
+          <SmallText className="text-text-muted">No source data</SmallText>
         ) : (
           <div className="space-y-1">
             {sources.slice(0, 5).map((item) => (
               <div
                 key={item.ip}
-                className="flex items-center justify-between rounded-lg border border-white/5 bg-gray-950/50 px-3 py-2"
+                className="flex items-center justify-between rounded-lg border border-white/5 bg-bg-base/50 px-3 py-2"
               >
-                <span className="font-mono text-sm text-white">{item.ip}</span>
+                <span className="font-mono text-sm text-text-primary">{item.ip}</span>
                 <Tag colorScheme="blue" className="text-xs">
                   {item.count.toLocaleString()}
                 </Tag>
@@ -147,21 +147,21 @@ const TopEndpoints: FC<{
       {/* Top Destinations */}
       <div className="space-y-2">
         <div className="flex items-center gap-2 mb-3">
-          <Network className={`${iconSizes.md} text-green-400`} />
-          <SmallText className="text-gray-400 uppercase tracking-wide font-semibold">
+          <Network className={`${iconSizes.md} text-status-success`} />
+          <SmallText className="text-text-muted uppercase tracking-wide font-semibold">
             Top Destinations
           </SmallText>
         </div>
         {destinations.length === 0 ? (
-          <SmallText className="text-gray-500">No destination data</SmallText>
+          <SmallText className="text-text-muted">No destination data</SmallText>
         ) : (
           <div className="space-y-1">
             {destinations.slice(0, 5).map((item) => (
               <div
                 key={item.ip}
-                className="flex items-center justify-between rounded-lg border border-white/5 bg-gray-950/50 px-3 py-2"
+                className="flex items-center justify-between rounded-lg border border-white/5 bg-bg-base/50 px-3 py-2"
               >
-                <span className="font-mono text-sm text-white">{item.ip}</span>
+                <span className="font-mono text-sm text-text-primary">{item.ip}</span>
                 <Tag colorScheme="green" className="text-xs">
                   {item.count.toLocaleString()}
                 </Tag>
@@ -188,11 +188,11 @@ TopEndpoints.displayName = 'TopEndpoints';
 export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }) => {
   if (!stats) {
     return (
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="py-12 text-center">
-          <BarChart3 className={`${iconSizes['3xl']} text-gray-600 mx-auto mb-4`} />
-          <p className="text-gray-400">No statistics available</p>
-          <SmallText className="text-gray-500">
+          <BarChart3 className={`${iconSizes['3xl']} text-text-disabled mx-auto mb-4`} />
+          <p className="text-text-muted">No statistics available</p>
+          <SmallText className="text-text-muted">
             Upload and analyze a PCAP file to see statistics
           </SmallText>
         </CardContent>
@@ -204,14 +204,14 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
     <div className="space-y-6">
       {/* File Info */}
       {filename && (
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent>
             <div className="flex items-center gap-3">
-              <FileText className={`${iconSizes.lg} text-violet-400`} />
+              <FileText className={`${iconSizes.lg} text-brand-400`} />
               <div>
-                <p className="font-medium text-white">{filename}</p>
+                <p className="font-medium text-text-primary">{filename}</p>
                 {fileSize && (
-                  <SmallText className="text-gray-400">{formatBytes(fileSize)}</SmallText>
+                  <SmallText className="text-text-muted">{formatBytes(fileSize)}</SmallText>
                 )}
               </div>
             </div>
@@ -220,32 +220,32 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       )}
 
       {/* Summary Statistics */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           <H2 className="flex items-center gap-2 mb-0">
-            <BarChart3 className={`${iconSizes.lg} text-cyan-300`} />
+            <BarChart3 className={`${iconSizes.lg} text-status-info`} />
             Summary Statistics
           </H2>
 
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <StatBlock
-              icon={<ArrowRightLeft className={`${iconSizes.md} text-violet-400`} />}
+              icon={<ArrowRightLeft className={`${iconSizes.md} text-brand-400`} />}
               label="Total Packets"
               value={stats.totalPackets.toLocaleString()}
             />
             <StatBlock
-              icon={<FileText className={`${iconSizes.md} text-blue-400`} />}
+              icon={<FileText className={`${iconSizes.md} text-status-info`} />}
               label="Total Bytes"
               value={formatBytes(stats.totalBytes)}
               helper={`${stats.totalBytes.toLocaleString()} bytes`}
             />
             <StatBlock
-              icon={<Clock className={`${iconSizes.md} text-green-400`} />}
+              icon={<Clock className={`${iconSizes.md} text-status-success`} />}
               label="Duration"
               value={formatDurationMs(stats.timeRange.durationMs)}
             />
             <StatBlock
-              icon={<Network className={`${iconSizes.md} text-yellow-400`} />}
+              icon={<Network className={`${iconSizes.md} text-status-warning`} />}
               label="Protocols"
               value={Object.keys(stats.protocols).length}
               helper="Unique protocols"
@@ -255,23 +255,23 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       </Card>
 
       {/* Time Range */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
-            <Clock className={`${iconSizes.lg} text-emerald-300`} />
+            <Clock className={`${iconSizes.lg} text-status-success`} />
             <H2>Time Range</H2>
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-lg border border-white/5 bg-gray-950/50 p-4">
-              <SmallText className="text-gray-400 uppercase tracking-wide">Start Time</SmallText>
-              <p className="text-lg font-mono text-white mt-1">
+            <div className="rounded-lg border border-white/5 bg-bg-base/50 p-4">
+              <SmallText className="text-text-muted uppercase tracking-wide">Start Time</SmallText>
+              <p className="text-lg font-mono text-text-primary mt-1">
                 {formatTimestamp(stats.timeRange.start)}
               </p>
             </div>
-            <div className="rounded-lg border border-white/5 bg-gray-950/50 p-4">
-              <SmallText className="text-gray-400 uppercase tracking-wide">End Time</SmallText>
-              <p className="text-lg font-mono text-white mt-1">
+            <div className="rounded-lg border border-white/5 bg-bg-base/50 p-4">
+              <SmallText className="text-text-muted uppercase tracking-wide">End Time</SmallText>
+              <p className="text-lg font-mono text-text-primary mt-1">
                 {formatTimestamp(stats.timeRange.end)}
               </p>
             </div>
@@ -280,10 +280,10 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       </Card>
 
       {/* Protocol Breakdown */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
-            <BarChart3 className={`${iconSizes.lg} text-violet-300`} />
+            <BarChart3 className={`${iconSizes.lg} text-brand-300`} />
             <H2>Protocol Breakdown</H2>
           </div>
 
@@ -292,10 +292,10 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       </Card>
 
       {/* Top Endpoints */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
-            <Network className={`${iconSizes.lg} text-blue-300`} />
+            <Network className={`${iconSizes.lg} text-status-info`} />
             <H2>Top Endpoints</H2>
           </div>
 

--- a/ui/src/components/pcap/PcapUploader.tsx
+++ b/ui/src/components/pcap/PcapUploader.tsx
@@ -142,7 +142,7 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
   }, [onFileSelect]);
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         {/* Drag and Drop Zone */}
         <input
@@ -162,8 +162,8 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
             relative cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-all
             ${
               isDragOver
-                ? 'border-violet-400 bg-violet-900/20'
-                : 'border-white/10 bg-gray-950/40 hover:border-white/20 hover:bg-gray-950/60'
+                ? 'border-brand-400 bg-brand-900/20'
+                : 'border-white/10 bg-bg-base/40 hover:border-white/20 hover:bg-bg-base/60'
             }
             ${isAnalyzing ? 'pointer-events-none opacity-50' : ''}
           `}
@@ -171,23 +171,23 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
         >
           <div className="flex flex-col items-center gap-3">
             <div
-              className={`rounded-full p-4 ${isDragOver ? 'bg-violet-500/20' : 'bg-gray-800/50'}`}
+              className={`rounded-full p-4 ${isDragOver ? 'bg-brand-500/20' : 'bg-bg-elevated/50'}`}
             >
               <Upload
-                className={`${iconSizes['2xl']} ${isDragOver ? 'text-violet-400' : 'text-gray-400'}`}
+                className={`${iconSizes['2xl']} ${isDragOver ? 'text-brand-400' : 'text-text-muted'}`}
               />
             </div>
 
             <div>
-              <p className="text-lg font-medium text-white">
+              <p className="text-lg font-medium text-text-primary">
                 {isDragOver ? 'Drop file to upload' : 'Drag & drop PCAP file'}
               </p>
-              <SmallText className="text-gray-400">
+              <SmallText className="text-text-muted">
                 or click to browse ({ACCEPTED_EXTENSIONS.join(', ')})
               </SmallText>
             </div>
 
-            <SmallText className="text-gray-500">
+            <SmallText className="text-text-muted">
               Maximum file size: {formatBytes(MAX_FILE_SIZE)}
             </SmallText>
           </div>
@@ -195,12 +195,12 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
 
         {/* Selected File Display */}
         {selectedFile && (
-          <div className="flex items-center justify-between rounded-lg border border-white/10 bg-gray-950/50 p-4">
+          <div className="flex items-center justify-between rounded-lg border border-white/10 bg-bg-base/50 p-4">
             <div className="flex items-center gap-3">
-              <FileUp className={`${iconSizes.lg} text-violet-400`} />
+              <FileUp className={`${iconSizes.lg} text-brand-400`} />
               <div>
-                <p className="font-medium text-white">{selectedFile.name}</p>
-                <SmallText className="text-gray-400">{formatBytes(selectedFile.size)}</SmallText>
+                <p className="font-medium text-text-primary">{selectedFile.name}</p>
+                <SmallText className="text-text-muted">{formatBytes(selectedFile.size)}</SmallText>
               </div>
               <Tag colorScheme="purple" className="text-xs">
                 Ready
@@ -223,16 +223,16 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
 
         {/* Status Messages */}
         {error && (
-          <div className="flex items-center gap-2 rounded-lg border border-red-500/30 bg-red-900/20 p-3">
-            <AlertCircle className={`${iconSizes.lg} flex-shrink-0 text-red-400`} />
-            <SmallText className="text-red-300">{error}</SmallText>
+          <div className="flex items-center gap-2 rounded-lg border border-status-error/30 bg-status-error/20 p-3">
+            <AlertCircle className={`${iconSizes.lg} flex-shrink-0 text-status-error`} />
+            <SmallText className="text-status-error">{error}</SmallText>
           </div>
         )}
 
         {success && (
-          <div className="flex items-center gap-2 rounded-lg border border-green-500/30 bg-green-900/20 p-3">
-            <CheckCircle className={`${iconSizes.lg} flex-shrink-0 text-green-400`} />
-            <SmallText className="text-green-300">{success}</SmallText>
+          <div className="flex items-center gap-2 rounded-lg border border-status-success/30 bg-status-success/20 p-3">
+            <CheckCircle className={`${iconSizes.lg} flex-shrink-0 text-status-success`} />
+            <SmallText className="text-status-success">{success}</SmallText>
           </div>
         )}
 

--- a/ui/src/components/settings/SimulationSection.tsx
+++ b/ui/src/components/settings/SimulationSection.tsx
@@ -134,17 +134,17 @@ export function SimulationSection(): ReactElement {
     <div className="space-y-4">
       {/* Section Header */}
       <div className="flex items-center gap-2">
-        <PlugZap className="w-5 h-5 text-violet-400" aria-hidden="true" />
-        <h3 className="text-sm font-semibold text-white">Simulation</h3>
+        <PlugZap className="w-5 h-5 text-brand-400" aria-hidden="true" />
+        <h3 className="text-sm font-semibold text-text-primary">Simulation</h3>
       </div>
 
       {/* Interface Selector */}
       <div className="space-y-2">
-        <label htmlFor="sim-interface" className="block text-sm text-gray-400">
+        <label htmlFor="sim-interface" className="block text-sm text-text-muted">
           Network Interface
         </label>
         <div className="relative">
-          <Network className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+          <Network className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
           <select
             id="sim-interface"
             value={simulationSettings.selectedInterface}
@@ -152,8 +152,8 @@ export function SimulationSection(): ReactElement {
             disabled={loading}
             className={cn(
               'w-full pl-10 pr-4 py-2 text-sm',
-              'bg-gray-800 border border-white/10 rounded-lg',
-              'text-white focus:outline-none focus:ring-2 focus:ring-violet-500/50',
+              'bg-bg-elevated border border-white/10 rounded-lg',
+              'text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-500/50',
               'disabled:opacity-50 disabled:cursor-not-allowed',
             )}
           >
@@ -166,14 +166,14 @@ export function SimulationSection(): ReactElement {
             ))}
           </select>
         </div>
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-text-muted">
           Only ethernet, WiFi, and loopback interfaces are shown.
         </p>
       </div>
 
       {/* Config Source Tabs */}
       <div className="space-y-3">
-        <span className="block text-sm text-gray-400">Configuration</span>
+        <span className="block text-sm text-text-muted">Configuration</span>
         <div className="flex border border-white/10 rounded-lg overflow-hidden" role="tablist">
           {CONFIG_TABS.map((tab) => (
             <button
@@ -184,8 +184,8 @@ export function SimulationSection(): ReactElement {
                 'flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium',
                 'transition-colors',
                 activeTab === tab.id
-                  ? 'bg-violet-600 text-white'
-                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white',
+                  ? 'bg-brand-600 text-text-primary'
+                  : 'bg-bg-elevated text-text-muted hover:bg-bg-elevated hover:text-text-primary',
               )}
             >
               {tab.icon}
@@ -198,7 +198,7 @@ export function SimulationSection(): ReactElement {
       {/* Tab Content */}
       <div className="min-h-[120px]">
         {loading && (
-          <div className="flex items-center justify-center py-8 text-gray-500 text-sm">
+          <div className="flex items-center justify-center py-8 text-text-muted text-sm">
             Loading...
           </div>
         )}
@@ -228,11 +228,11 @@ export function SimulationSection(): ReactElement {
 
       {/* Current Selection Display */}
       {simulationSettings.configName && (
-        <div className="p-3 bg-violet-900/20 border border-violet-500/30 rounded-lg">
-          <p className="text-xs text-gray-400">Selected configuration:</p>
-          <p className="text-sm text-white font-medium mt-1">
+        <div className="p-3 bg-brand-900/20 border border-brand-500/30 rounded-lg">
+          <p className="text-xs text-text-muted">Selected configuration:</p>
+          <p className="text-sm text-text-primary font-medium mt-1">
             {simulationSettings.configName}
-            <span className="text-gray-500 ml-2">
+            <span className="text-text-muted ml-2">
               ({simulationSettings.configSource === 'template' ? 'Template' : 'User Config'})
             </span>
           </p>
@@ -270,14 +270,14 @@ function TemplateList({ templates, selectedName, onSelect }: TemplateListProps):
         onChange={(e) => setSearch(e.target.value)}
         className={cn(
           'w-full px-3 py-2 text-sm',
-          'bg-gray-800 border border-white/10 rounded-lg',
-          'text-white placeholder:text-gray-500',
-          'focus:outline-none focus:ring-2 focus:ring-violet-500/50',
+          'bg-bg-elevated border border-white/10 rounded-lg',
+          'text-text-primary placeholder:text-text-muted',
+          'focus:outline-none focus:ring-2 focus:ring-brand-500/50',
         )}
       />
       <div className="max-h-[200px] overflow-y-auto space-y-1">
         {filteredTemplates.length === 0 && (
-          <p className="text-sm text-gray-500 py-4 text-center">
+          <p className="text-sm text-text-muted py-4 text-center">
             {search ? 'No templates match your search' : 'No templates available'}
           </p>
         )}
@@ -289,13 +289,13 @@ function TemplateList({ templates, selectedName, onSelect }: TemplateListProps):
             className={cn(
               'w-full text-left px-3 py-2 rounded-lg transition-colors',
               selectedName === template.name
-                ? 'bg-violet-600/30 border border-violet-500/50'
+                ? 'bg-brand-600/30 border border-brand-500/50'
                 : 'bg-white/5 hover:bg-white/10 border border-transparent',
             )}
           >
-            <div className="text-sm text-white font-medium">{template.name}</div>
-            <div className="text-xs text-gray-400 truncate">{template.description}</div>
-            <div className="text-xs text-gray-500 mt-1">
+            <div className="text-sm text-text-primary font-medium">{template.name}</div>
+            <div className="text-xs text-text-muted truncate">{template.description}</div>
+            <div className="text-xs text-text-muted mt-1">
               {template.deviceCount} device{template.deviceCount !== 1 ? 's' : ''}
             </div>
           </button>
@@ -315,9 +315,11 @@ function UserConfigList({ configs, selectedName, onSelect }: UserConfigListProps
   if (configs.length === 0) {
     return (
       <div className="text-center py-8">
-        <FolderOpen className="w-8 h-8 text-gray-600 mx-auto mb-2" />
-        <p className="text-sm text-gray-500">No user configs uploaded yet</p>
-        <p className="text-xs text-gray-600 mt-1">Use the Upload tab to add your own configs</p>
+        <FolderOpen className="w-8 h-8 text-text-disabled mx-auto mb-2" />
+        <p className="text-sm text-text-muted">No user configs uploaded yet</p>
+        <p className="text-xs text-text-disabled mt-1">
+          Use the Upload tab to add your own configs
+        </p>
       </div>
     );
   }
@@ -332,12 +334,12 @@ function UserConfigList({ configs, selectedName, onSelect }: UserConfigListProps
           className={cn(
             'w-full text-left px-3 py-2 rounded-lg transition-colors',
             selectedName === config.name
-              ? 'bg-violet-600/30 border border-violet-500/50'
+              ? 'bg-brand-600/30 border border-brand-500/50'
               : 'bg-white/5 hover:bg-white/10 border border-transparent',
           )}
         >
-          <div className="text-sm text-white font-medium">{config.name}</div>
-          <div className="text-xs text-gray-400">
+          <div className="text-sm text-text-primary font-medium">{config.name}</div>
+          <div className="text-xs text-text-muted">
             {config.deviceCount} device{config.deviceCount !== 1 ? 's' : ''}
           </div>
         </button>
@@ -388,7 +390,7 @@ function UploadSection(): ReactElement {
       <div
         className={cn(
           'border-2 border-dashed border-white/10 rounded-lg p-4',
-          'hover:border-violet-500/50 transition-colors',
+          'hover:border-brand-500/50 transition-colors',
         )}
       >
         <input
@@ -399,14 +401,14 @@ function UploadSection(): ReactElement {
           className="sr-only"
         />
         <label htmlFor="config-upload" className="flex flex-col items-center cursor-pointer">
-          <FileUp className="w-8 h-8 text-gray-500 mb-2" />
-          <span className="text-sm text-gray-400">
+          <FileUp className="w-8 h-8 text-text-muted mb-2" />
+          <span className="text-sm text-text-muted">
             {selectedFile ? selectedFile.name : 'Click to upload a YAML config'}
           </span>
-          <span className="text-xs text-gray-600 mt-1">.yaml or .yml files, max 10MB</span>
+          <span className="text-xs text-text-disabled mt-1">.yaml or .yml files, max 10MB</span>
         </label>
       </div>
-      <p className="text-xs text-gray-500">
+      <p className="text-xs text-text-muted">
         Upload a config file to use for this simulation session. The file will be sent when you
         start the simulation.
       </p>

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -240,7 +240,7 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
         <div className="flex-1" />
         <label
           htmlFor="config-upload"
-          className={`flex items-center gap-1.5 rounded border border-white/10 bg-gray-900/60 px-3 py-1 text-xs font-medium text-gray-200 hover:bg-white/5 ${
+          className={`flex items-center gap-1.5 rounded border border-white/10 bg-bg-surface/60 px-3 py-1 text-xs font-medium text-text-primary hover:bg-white/5 ${
             convertingDsl ? 'cursor-wait opacity-60' : 'cursor-pointer'
           }`}
           title="Pick a config from disk. YAML is used as-is; legacy Java-DSL (.cfg) is auto-converted."
@@ -260,14 +260,14 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
           <button
             type="button"
             onClick={handleClearLocal}
-            className="text-xs font-medium text-red-300 hover:text-red-200"
+            className="text-xs font-medium text-status-error hover:text-status-error"
           >
             Clear
           </button>
         )}
       </div>
       {convertError && (
-        <SmallText className="text-red-300" role="alert">
+        <SmallText className="text-status-error" role="alert">
           {convertError}
         </SmallText>
       )}
@@ -275,17 +275,17 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
       {/* Search + view toggle */}
       <div className="flex items-center gap-2">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-muted" />
           <input
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search configs…"
-            className="w-full rounded border border-white/10 bg-gray-900/60 py-2 pl-9 pr-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+            className="w-full rounded border border-white/10 bg-bg-surface/60 py-2 pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
           />
         </div>
         <fieldset
-          className="flex rounded border border-white/10 bg-gray-900/60 p-0.5"
+          className="flex rounded border border-white/10 bg-bg-surface/60 p-0.5"
           aria-label="View density"
         >
           <ViewToggle
@@ -319,11 +319,11 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
 
       {/* Java-DSL import — collapsed by default since most users won't need it */}
       <details
-        className="rounded border border-white/10 bg-gray-950/40 p-3"
+        className="rounded border border-white/10 bg-bg-base/40 p-3"
         open={showJavaDsl}
         onToggle={(e) => setShowJavaDsl(e.currentTarget.open)}
       >
-        <summary className="flex cursor-pointer items-center gap-2 text-sm text-gray-300 hover:text-white">
+        <summary className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary hover:text-text-primary">
           {showJavaDsl ? (
             <ChevronDown className={iconSizes.md} />
           ) : (

--- a/ui/src/components/simulation/ConfigPicker.types.ts
+++ b/ui/src/components/simulation/ConfigPicker.types.ts
@@ -28,13 +28,13 @@ export const TEMPLATE_TYPE_ICON: Record<Template['type'], FC<{ className?: strin
 };
 
 export const TEMPLATE_TYPE_TINT: Record<Template['type'], string> = {
-  basic: 'bg-blue-500/15 text-blue-200 border-blue-400/30',
-  router: 'bg-orange-500/15 text-orange-200 border-orange-400/30',
-  switch: 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30',
-  'access-point': 'bg-purple-500/15 text-purple-200 border-purple-400/30',
-  server: 'bg-cyan-500/15 text-cyan-200 border-cyan-400/30',
-  firewall: 'bg-red-500/15 text-red-200 border-red-400/30',
-  complete: 'bg-amber-500/15 text-amber-200 border-amber-400/30',
+  basic: 'bg-status-info/15 text-status-info border-status-info/30',
+  router: 'bg-status-warning/15 text-status-warning border-status-warning/30',
+  switch: 'bg-status-success/15 text-status-success border-status-success/30',
+  'access-point': 'bg-brand-500/15 text-brand-200 border-brand-400/30',
+  server: 'bg-status-info/15 text-status-info border-status-info/30',
+  firewall: 'bg-status-error/15 text-status-error border-status-error/30',
+  complete: 'bg-status-warning/15 text-status-warning border-status-warning/30',
   custom: 'bg-pink-500/15 text-pink-200 border-pink-400/30',
 };
 

--- a/ui/src/components/simulation/ConfigPickerControls.tsx
+++ b/ui/src/components/simulation/ConfigPickerControls.tsx
@@ -18,8 +18,8 @@ export const ViewToggle: FC<{
     title={label}
     className={`rounded px-2 py-1 transition-colors ${
       active
-        ? 'bg-violet-500/20 text-violet-100'
-        : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+        ? 'bg-brand-500/20 text-brand-100'
+        : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
     }`}
   >
     {icon}

--- a/ui/src/components/simulation/ConfigPickerList.tsx
+++ b/ui/src/components/simulation/ConfigPickerList.tsx
@@ -59,13 +59,13 @@ export const ConfigsList: FC<{
   searching,
 }) => {
   if (loading) {
-    return <SmallText className="text-gray-500">Loading networks…</SmallText>;
+    return <SmallText className="text-text-muted">Loading networks…</SmallText>;
   }
 
   const total = sections.local.length + sections.favorites.length + sections.all.length;
   if (total === 0) {
     return (
-      <SmallText className="text-gray-500">
+      <SmallText className="text-text-muted">
         Nothing matches. Try a different search or upload a local YAML with the button above.
       </SmallText>
     );
@@ -76,8 +76,10 @@ export const ConfigsList: FC<{
     return (
       <section className="space-y-2" key={label}>
         <header className="flex items-baseline gap-2">
-          <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400">{label}</h3>
-          <span className="text-xs text-gray-500">· {items.length}</span>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+            {label}
+          </h3>
+          <span className="text-xs text-text-muted">· {items.length}</span>
         </header>
         {viewMode === 'grid' ? (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
@@ -95,7 +97,7 @@ export const ConfigsList: FC<{
             ))}
           </div>
         ) : (
-          <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-white/10 bg-gray-950/40">
+          <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-white/10 bg-bg-base/40">
             {items.map((item) => (
               <ConfigRow
                 key={item.key}
@@ -139,7 +141,9 @@ const FavoriteStar: FC<{
     aria-label={favorited ? 'Remove from favorites' : 'Add to favorites'}
     title={favorited ? 'Remove from favorites' : 'Add to favorites'}
     className={`rounded p-1 transition-colors ${
-      favorited ? 'text-amber-300 hover:text-amber-200' : 'text-gray-500 hover:text-amber-300'
+      favorited
+        ? 'text-status-warning hover:text-status-warning'
+        : 'text-text-muted hover:text-status-warning'
     } ${compact ? '' : 'hover:bg-white/5'}`}
   >
     <Star
@@ -168,15 +172,15 @@ const ConfigCard: FC<SharedItemProps> = ({
     item.kind === 'builtin'
       ? (TEMPLATE_TYPE_TINT[item.template.type] ?? TEMPLATE_TYPE_TINT.custom)
       : item.kind === 'saved'
-        ? 'bg-emerald-500/15 text-emerald-200 border-emerald-400/30'
-        : 'bg-blue-500/15 text-blue-200 border-blue-400/30';
+        ? 'bg-status-success/15 text-status-success border-status-success/30'
+        : 'bg-status-info/15 text-status-info border-status-info/30';
 
   return (
     <div
       className={`flex flex-col gap-3 rounded-lg border p-3 transition-colors ${
         selected
-          ? 'border-violet-400/50 bg-violet-500/10'
-          : 'border-white/10 bg-gray-950/40 hover:border-violet-500/30'
+          ? 'border-brand-400/50 bg-brand-500/10'
+          : 'border-white/10 bg-bg-base/40 hover:border-brand-500/30'
       }`}
     >
       <div className="flex items-start justify-between gap-2">
@@ -188,8 +192,8 @@ const ConfigCard: FC<SharedItemProps> = ({
         )}
       </div>
       <div>
-        <div className="font-semibold text-white">{item.name}</div>
-        <SmallText className="mt-0.5 line-clamp-2 text-gray-400">
+        <div className="font-semibold text-text-primary">{item.name}</div>
+        <SmallText className="mt-0.5 line-clamp-2 text-text-muted">
           {item.description || 'No description'}
         </SmallText>
       </div>
@@ -208,7 +212,7 @@ const ConfigCard: FC<SharedItemProps> = ({
       </div>
       <div className="flex gap-2">
         {selected ? (
-          <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-violet-500/30 px-2 py-1.5 text-xs font-medium text-violet-50 ring-1 ring-violet-400/60">
+          <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-brand-500/30 px-2 py-1.5 text-xs font-medium text-brand-50 ring-1 ring-brand-400/60">
             <Check className={iconSizes.sm} />
             <span>Selected</span>
           </div>
@@ -216,7 +220,7 @@ const ConfigCard: FC<SharedItemProps> = ({
           <button
             type="button"
             onClick={() => onSelect(item)}
-            className="flex-1 rounded bg-violet-500/20 px-2 py-1.5 text-xs font-medium text-violet-100 ring-1 ring-violet-400/40 hover:bg-violet-500/30"
+            className="flex-1 rounded bg-brand-500/20 px-2 py-1.5 text-xs font-medium text-brand-100 ring-1 ring-brand-400/40 hover:bg-brand-500/30"
             title="Select this network — click Start Simulation below to run it"
           >
             Select
@@ -226,7 +230,7 @@ const ConfigCard: FC<SharedItemProps> = ({
           <button
             type="button"
             onClick={() => onView(item)}
-            className="rounded border border-white/10 bg-gray-900/60 px-2 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
+            className="rounded border border-white/10 bg-bg-surface/60 px-2 py-1.5 text-xs font-medium text-text-primary hover:bg-white/10"
             title="Preview YAML"
           >
             <Eye className={iconSizes.sm} />
@@ -236,7 +240,7 @@ const ConfigCard: FC<SharedItemProps> = ({
           <button
             type="button"
             onClick={onClearLocal}
-            className="rounded border border-red-400/30 bg-red-500/10 px-2 py-1.5 text-xs font-medium text-red-200 hover:bg-red-500/20"
+            className="rounded border border-status-error/30 bg-status-error/10 px-2 py-1.5 text-xs font-medium text-status-error hover:bg-status-error/20"
             title="Drop the local file"
           >
             Clear
@@ -258,7 +262,7 @@ const ConfigRow: FC<SharedItemProps> = ({
 }) => (
   <li
     className={`flex items-center gap-3 px-3 py-2 transition-colors ${
-      selected ? 'bg-violet-500/10' : 'hover:bg-white/5'
+      selected ? 'bg-brand-500/10' : 'hover:bg-white/5'
     }`}
   >
     {item.kind !== 'local' && (
@@ -271,7 +275,7 @@ const ConfigRow: FC<SharedItemProps> = ({
       title={`Select ${item.name}`}
     >
       <div className="flex items-center gap-2">
-        <span className="font-medium text-white">{item.name}</span>
+        <span className="font-medium text-text-primary">{item.name}</span>
         {item.kind !== 'local' && (
           <Tag colorScheme="purple" className="text-[10px]">
             {item.deviceCount} {item.deviceCount === 1 ? 'device' : 'devices'}
@@ -285,8 +289,8 @@ const ConfigRow: FC<SharedItemProps> = ({
       </div>
       {item.description && (
         <SmallText
-          className={`mt-0.5 line-clamp-1 text-gray-400 ${
-            item.kind === 'saved' ? 'font-mono text-[11px] text-gray-500' : ''
+          className={`mt-0.5 line-clamp-1 text-text-muted ${
+            item.kind === 'saved' ? 'font-mono text-[11px] text-text-muted' : ''
           }`}
         >
           {item.description}
@@ -297,7 +301,7 @@ const ConfigRow: FC<SharedItemProps> = ({
       <button
         type="button"
         onClick={() => onView(item)}
-        className="rounded p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
+        className="rounded p-1.5 text-text-muted hover:bg-white/10 hover:text-text-primary"
         title="Preview the template YAML"
       >
         <Eye className={iconSizes.md} />
@@ -307,7 +311,7 @@ const ConfigRow: FC<SharedItemProps> = ({
       <button
         type="button"
         onClick={onClearLocal}
-        className="text-xs font-medium text-red-300 hover:text-red-200"
+        className="text-xs font-medium text-status-error hover:text-status-error"
         title="Drop the local file"
       >
         Clear

--- a/ui/src/components/templates/JavaDslImportCard.tsx
+++ b/ui/src/components/templates/JavaDslImportCard.tsx
@@ -56,13 +56,13 @@ export const JavaDslImportCard: FC = () => {
   };
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         <H2 className="flex items-center gap-2">
-          <FileInput className={`${iconSizes.lg} text-emerald-300`} />
+          <FileInput className={`${iconSizes.lg} text-status-success`} />
           Import legacy config (Java DSL → YAML)
         </H2>
-        <P className="text-sm text-gray-400">
+        <P className="text-sm text-text-muted">
           Paste a legacy <code>.cfg</code> file (the Java-DSL <code>device foo {'{ ... }'}</code>{' '}
           format) or upload one — same as <code>niac config export</code> on the CLI. The result is
           a normalised YAML you can save as a template, drop into a Git repo, or feed straight into
@@ -70,11 +70,11 @@ export const JavaDslImportCard: FC = () => {
         </P>
 
         <div className="flex flex-wrap items-center gap-3">
-          <label className="cursor-pointer rounded bg-gray-800/60 px-3 py-1.5 text-xs font-medium text-gray-200 ring-1 ring-white/10 hover:bg-gray-800">
+          <label className="cursor-pointer rounded bg-bg-elevated/60 px-3 py-1.5 text-xs font-medium text-text-primary ring-1 ring-white/10 hover:bg-bg-elevated">
             Choose .cfg file…
             <input type="file" accept=".cfg,.conf,.txt" onChange={onPickFile} className="hidden" />
           </label>
-          <SmallText className="text-gray-500">
+          <SmallText className="text-text-muted">
             Or paste below ({content.length.toLocaleString()} chars)
           </SmallText>
         </div>
@@ -87,7 +87,7 @@ export const JavaDslImportCard: FC = () => {
           }}
           placeholder="device my-router {&#10;  type = router&#10;  ip = 192.168.1.1&#10;  ...&#10;}"
           rows={10}
-          className="w-full rounded border border-white/5 bg-gray-950/60 p-3 font-mono text-xs text-gray-100 placeholder-gray-500 focus:border-emerald-400 focus:outline-none"
+          className="w-full rounded border border-white/5 bg-bg-base/60 p-3 font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-success focus:outline-none"
           aria-label="Legacy Java DSL config content"
         />
 
@@ -101,7 +101,7 @@ export const JavaDslImportCard: FC = () => {
             {busy ? 'Converting…' : 'Convert to YAML'}
           </Button>
           {error && (
-            <SmallText className="text-red-300" role="alert">
+            <SmallText className="text-status-error" role="alert">
               {error}
             </SmallText>
           )}
@@ -110,7 +110,7 @@ export const JavaDslImportCard: FC = () => {
         {yaml && (
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <SmallText className="text-emerald-300">
+              <SmallText className="text-status-success">
                 ✓ Converted ({deviceCount} {deviceCount === 1 ? 'device' : 'devices'})
               </SmallText>
               <Button
@@ -121,7 +121,7 @@ export const JavaDslImportCard: FC = () => {
                 Download YAML
               </Button>
             </div>
-            <pre className="max-h-64 overflow-auto rounded bg-gray-950/80 p-3 font-mono text-xs text-gray-200">
+            <pre className="max-h-64 overflow-auto rounded bg-bg-base/80 p-3 font-mono text-xs text-text-primary">
               {yaml}
             </pre>
           </div>

--- a/ui/src/constants/device-types.ts
+++ b/ui/src/constants/device-types.ts
@@ -149,12 +149,12 @@ export function getDeviceLabel(type: DeviceType): string {
  * Used for icon backgrounds and text colors
  */
 const deviceColorClasses: Record<TagColorScheme, { bg: string; text: string }> = {
-  blue: { bg: 'bg-blue-500/20', text: 'text-blue-400' },
-  green: { bg: 'bg-green-500/20', text: 'text-green-400' },
-  purple: { bg: 'bg-purple-500/20', text: 'text-purple-400' },
-  yellow: { bg: 'bg-yellow-500/20', text: 'text-yellow-400' },
-  red: { bg: 'bg-red-500/20', text: 'text-red-400' },
-  gray: { bg: 'bg-gray-500/20', text: 'text-gray-400' },
+  blue: { bg: 'bg-status-info/20', text: 'text-status-info' },
+  green: { bg: 'bg-status-success/20', text: 'text-status-success' },
+  purple: { bg: 'bg-brand-500/20', text: 'text-brand-400' },
+  yellow: { bg: 'bg-status-warning/20', text: 'text-status-warning' },
+  red: { bg: 'bg-status-error/20', text: 'text-status-error' },
+  gray: { bg: 'bg-bg-muted/20', text: 'text-text-muted' },
 };
 
 /**

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -93,6 +93,16 @@
   --color-info-900: #1e3a8a;
 
   /* ========================================
+   * Status semantic aliases (mirror seed/stem naming)
+   * Map to the canonical 500-shade of each palette above so all three
+   * projects share bg-status-success / text-status-error / etc.
+   * ======================================== */
+  --color-status-success: #22c55e;
+  --color-status-warning: #f59e0b;
+  --color-status-error: #ef4444;
+  --color-status-info: #3b82f6;
+
+  /* ========================================
    * Device Type Colors (Topology)
    * ======================================== */
   --color-device-router: #3b82f6;

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -251,7 +251,7 @@ export const pages: PageConfig[] = [
           <code>--webhook-allowed-host</code>, only those hostnames are allowed. Set the allowlist
           in production rather than relying on the implicit IP filter — see{' '}
           <a
-            className="text-violet-300 underline"
+            className="text-brand-300 underline"
             href="https://github.com/krisarmstrong/niac-go/blob/main/SECURITY.md"
           >
             SECURITY.md

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -80,39 +80,41 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
   };
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         <H2 className="flex items-center gap-2">
-          <BellRing className={`${iconSizes.lg} text-orange-300`} />
+          <BellRing className={`${iconSizes.lg} text-status-warning`} />
           Alert policy
         </H2>
-        <P className="text-gray-300">
+        <P className="text-text-secondary">
           The daemon fires a webhook when total packet count crosses the threshold. Updates take
           effect immediately — no CLI restart required. Leave the threshold blank or zero to disable
           packet alerts entirely. The webhook destination is also gated by the daemon's{' '}
           <code>--webhook-allowed-host</code> allowlist when set (see{' '}
           <a
             href="https://github.com/krisarmstrong/niac-go/blob/main/SECURITY.md"
-            className="text-violet-300 underline"
+            className="text-brand-300 underline"
           >
             SECURITY.md
           </a>
           ).
         </P>
-        <SmallText className="text-gray-500">
-          Recent errors counter: <strong className="text-gray-300">{recentErrors}</strong>
+        <SmallText className="text-text-muted">
+          Recent errors counter: <strong className="text-text-secondary">{recentErrors}</strong>
         </SmallText>
-        {loading && <SmallText className="text-gray-400">Loading alert configuration…</SmallText>}
+        {loading && <SmallText className="text-text-muted">Loading alert configuration…</SmallText>}
         {error && (
-          <SmallText className="text-red-400">Unable to load alerts: {error.message}</SmallText>
+          <SmallText className="text-status-error">
+            Unable to load alerts: {error.message}
+          </SmallText>
         )}
         {data && (
           <>
             <div className="grid gap-4 md:grid-cols-2">
               <div>
-                <SmallText className="text-gray-400">Packet threshold</SmallText>
+                <SmallText className="text-text-muted">Packet threshold</SmallText>
                 <input
-                  className="mt-1 w-full rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
                   type="number"
                   min="0"
                   placeholder="100000"
@@ -126,9 +128,9 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
                 />
               </div>
               <div>
-                <SmallText className="text-gray-400">Webhook URL</SmallText>
+                <SmallText className="text-text-muted">Webhook URL</SmallText>
                 <input
-                  className="mt-1 w-full rounded-lg border border-white/10 bg-gray-950/60 p-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
                   placeholder="https://hooks.example.com/niac"
                   value={webhook}
                   title="POST'd JSON when the threshold trips. Must be http(s) and not point at a private/loopback/link-local IP. The daemon's --webhook-allowed-host flag further locks this down."
@@ -142,7 +144,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
             </div>
             {status && (
               <SmallText
-                className={status.tone === 'success' ? 'text-emerald-300' : 'text-red-400'}
+                className={status.tone === 'success' ? 'text-status-success' : 'text-status-error'}
               >
                 {status.text}
               </SmallText>

--- a/ui/src/pages/ConfigDiffPage.tsx
+++ b/ui/src/pages/ConfigDiffPage.tsx
@@ -149,15 +149,15 @@ export const ConfigDiffPage: FC = () => {
   return (
     <div className="space-y-6">
       {/* Header section */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <H2 className="flex items-center gap-2">
-                <GitCompare className={`${iconSizes.lg} text-violet-300`} />
+                <GitCompare className={`${iconSizes.lg} text-brand-300`} />
                 Compare & Merge
               </H2>
-              <P className="text-gray-400 mt-1">
+              <P className="text-text-muted mt-1">
                 Compare two YAML network configs side-by-side and merge changes between them.
               </P>
             </div>
@@ -175,8 +175,8 @@ export const ConfigDiffPage: FC = () => {
             <div
               className={`flex items-center gap-2 rounded-lg p-3 ${
                 message.type === 'success'
-                  ? 'border border-green-500/30 bg-green-500/10 text-green-300'
-                  : 'border border-red-500/30 bg-red-500/10 text-red-300'
+                  ? 'border border-status-success/30 bg-status-success/10 text-status-success'
+                  : 'border border-status-error/30 bg-status-error/10 text-status-error'
               }`}
               role="alert"
             >
@@ -201,7 +201,7 @@ export const ConfigDiffPage: FC = () => {
 
       {/* File upload section */}
       <div className="grid gap-6 lg:grid-cols-2">
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <H2 className="text-lg">Original File</H2>
@@ -223,7 +223,7 @@ export const ConfigDiffPage: FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <H2 className="text-lg">Modified File</H2>
@@ -249,10 +249,10 @@ export const ConfigDiffPage: FC = () => {
       {/* Diff viewer section */}
       {hasFiles && (
         <>
-          <Card className="border-white/5 bg-gray-900/70">
+          <Card className="border-white/5 bg-bg-surface/70">
             <CardContent className="space-y-4">
               <H2 className="flex items-center gap-2">
-                <GitCompare className={`${iconSizes.lg} text-cyan-300`} />
+                <GitCompare className={`${iconSizes.lg} text-status-info`} />
                 Side-by-Side Comparison
               </H2>
               <DiffViewer
@@ -281,15 +281,15 @@ export const ConfigDiffPage: FC = () => {
           />
 
           {/* Server-side overlay merge (CLI parity) */}
-          <Card className="border-white/5 bg-gray-900/70">
+          <Card className="border-white/5 bg-bg-surface/70">
             <CardContent className="space-y-3">
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <H2 className="mb-1 flex items-center gap-2 text-lg">
-                    <Layers className={`${iconSizes.lg} text-violet-300`} />
+                    <Layers className={`${iconSizes.lg} text-brand-300`} />
                     Server-side overlay merge
                   </H2>
-                  <P className="text-sm text-gray-400">
+                  <P className="text-sm text-text-muted">
                     Treats the right file as an overlay applied to the left base — same semantics as{' '}
                     <code>niac config merge</code>. Devices in the overlay with the same name
                     REPLACE base entries; overlay-only devices are appended; base-only devices are
@@ -336,26 +336,26 @@ export const ConfigDiffPage: FC = () => {
 
       {/* Empty state when no files */}
       {!hasFiles && (
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent className="py-12 text-center">
-            <GitCompare className={`mx-auto ${iconSizes['3xl']} text-gray-600`} />
+            <GitCompare className={`mx-auto ${iconSizes['3xl']} text-text-disabled`} />
             <H2 className="mt-4 mb-2">Ready to Compare</H2>
-            <P className="text-gray-400 max-w-md mx-auto">
+            <P className="text-text-muted max-w-md mx-auto">
               Upload two YAML configuration files above to see a side-by-side comparison with
               color-coded changes and interactive merge controls.
             </P>
             <div className="flex flex-wrap justify-center gap-4 mt-6">
               <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded bg-green-500" />
-                <SmallText className="text-gray-400">Additions</SmallText>
+                <div className="w-3 h-3 rounded bg-status-success" />
+                <SmallText className="text-text-muted">Additions</SmallText>
               </div>
               <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded bg-red-500" />
-                <SmallText className="text-gray-400">Deletions</SmallText>
+                <div className="w-3 h-3 rounded bg-status-error" />
+                <SmallText className="text-text-muted">Deletions</SmallText>
               </div>
               <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded bg-yellow-500" />
-                <SmallText className="text-gray-400">Modifications</SmallText>
+                <div className="w-3 h-3 rounded bg-status-warning" />
+                <SmallText className="text-text-muted">Modifications</SmallText>
               </div>
             </div>
           </CardContent>

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -47,17 +47,17 @@ export const DashboardPage: FC = () => {
             <div className="flex items-center gap-4">
               <div className="relative">
                 <div
-                  className={`h-3 w-3 rounded-full ${isRunning ? 'bg-emerald-500' : 'bg-gray-500'}`}
+                  className={`h-3 w-3 rounded-full ${isRunning ? 'bg-status-success' : 'bg-bg-muted'}`}
                 />
                 {isRunning && (
-                  <div className="absolute inset-0 h-3 w-3 rounded-full bg-emerald-500 animate-ping opacity-75" />
+                  <div className="absolute inset-0 h-3 w-3 rounded-full bg-status-success animate-ping opacity-75" />
                 )}
               </div>
               <div>
-                <p className="font-semibold text-white">
+                <p className="font-semibold text-text-primary">
                   {isRunning ? 'Simulation Running' : 'Simulation Stopped'}
                 </p>
-                <p className="text-sm text-gray-400">
+                <p className="text-sm text-text-muted">
                   {stats?.interface ?? 'No interface'} • {stats?.deviceCount ?? 0} devices
                 </p>
               </div>
@@ -76,28 +76,28 @@ export const DashboardPage: FC = () => {
         <Card hover={true} className="group">
           <CardContent className="space-y-1">
             <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-gray-400">Devices Online</span>
+              <span className="text-sm font-medium text-text-muted">Devices Online</span>
               <Server
-                className={`${iconSizes.lg} text-violet-400 group-hover:scale-110 transition-transform`}
+                className={`${iconSizes.lg} text-brand-400 group-hover:scale-110 transition-transform`}
               />
             </div>
-            <p className="text-3xl font-bold text-white">{stats?.deviceCount ?? '—'}</p>
-            <p className="text-xs text-gray-500">Active network devices</p>
+            <p className="text-3xl font-bold text-text-primary">{stats?.deviceCount ?? '—'}</p>
+            <p className="text-xs text-text-muted">Active network devices</p>
           </CardContent>
         </Card>
 
         <Card hover={true} className="group">
           <CardContent className="space-y-1">
             <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-gray-400">Packets RX</span>
+              <span className="text-sm font-medium text-text-muted">Packets RX</span>
               <Activity
-                className={`${iconSizes.lg} text-emerald-400 group-hover:scale-110 transition-transform`}
+                className={`${iconSizes.lg} text-status-success group-hover:scale-110 transition-transform`}
               />
             </div>
-            <p className="text-3xl font-bold text-white">
+            <p className="text-3xl font-bold text-text-primary">
               {stats ? formatNumber(stats.stack.packetsReceived) : '—'}
             </p>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-text-muted">
               {stats ? `${formatNumber(stats.stack.packetsSent)} sent` : 'Awaiting data'}
             </p>
           </CardContent>
@@ -106,15 +106,15 @@ export const DashboardPage: FC = () => {
         <Card hover={true} className="group">
           <CardContent className="space-y-1">
             <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-gray-400">DNS Queries</span>
+              <span className="text-sm font-medium text-text-muted">DNS Queries</span>
               <SatelliteDish
-                className={`${iconSizes.lg} text-amber-400 group-hover:scale-110 transition-transform`}
+                className={`${iconSizes.lg} text-status-warning group-hover:scale-110 transition-transform`}
               />
             </div>
-            <p className="text-3xl font-bold text-white">
+            <p className="text-3xl font-bold text-text-primary">
               {stats ? formatNumber(stats.stack.dnsQueries) : '—'}
             </p>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-text-muted">
               DHCP: {stats ? formatNumber(stats.stack.dhcpRequests) : '—'}
             </p>
           </CardContent>
@@ -127,56 +127,56 @@ export const DashboardPage: FC = () => {
         <Card className="lg:col-span-2">
           <CardContent className="space-y-4">
             <H2 className="flex items-center gap-2">
-              <Zap className={`${iconSizes.lg} text-violet-400`} />
+              <Zap className={`${iconSizes.lg} text-brand-400`} />
               Quick Actions
             </H2>
             <div className="grid gap-3 sm:grid-cols-2">
               <button
                 type="button"
                 onClick={() => setShowErrors(!showErrors)}
-                className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group"
+                className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group"
               >
-                <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-yellow-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                  <PlugZap className={`${iconSizes.lg} text-yellow-400`} />
+                <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-status-warning/20 flex items-center justify-center group-hover:scale-110 transition-transform">
+                  <PlugZap className={`${iconSizes.lg} text-status-warning`} />
                 </div>
                 <div>
-                  <p className="font-medium text-white">Error Injection</p>
-                  <p className="text-sm text-gray-400">Inject network errors</p>
+                  <p className="font-medium text-text-primary">Error Injection</p>
+                  <p className="text-sm text-text-muted">Inject network errors</p>
                 </div>
               </button>
 
               <AccentLink to="/debug" className="no-underline">
-                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group">
-                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-violet-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <Terminal className={`${iconSizes.lg} text-violet-400`} />
+                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group">
+                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-brand-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
+                    <Terminal className={`${iconSizes.lg} text-brand-400`} />
                   </div>
                   <div>
-                    <p className="font-medium text-white">Debug Console</p>
-                    <p className="text-sm text-gray-400">View live logs</p>
+                    <p className="font-medium text-text-primary">Debug Console</p>
+                    <p className="text-sm text-text-muted">View live logs</p>
                   </div>
                 </div>
               </AccentLink>
 
               <AccentLink to="/traffic" className="no-underline">
-                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group">
-                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-blue-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <Activity className={`${iconSizes.lg} text-blue-400`} />
+                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group">
+                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-status-info/20 flex items-center justify-center group-hover:scale-110 transition-transform">
+                    <Activity className={`${iconSizes.lg} text-status-info`} />
                   </div>
                   <div>
-                    <p className="font-medium text-white">Traffic Injection</p>
-                    <p className="text-sm text-gray-400">Replay PCAP files</p>
+                    <p className="font-medium text-text-primary">Traffic Injection</p>
+                    <p className="text-sm text-text-muted">Replay PCAP files</p>
                   </div>
                 </div>
               </AccentLink>
 
               <AccentLink to="/topology" className="no-underline">
-                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-violet-500/30 transition-all group">
-                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-emerald-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <Network className={`${iconSizes.lg} text-emerald-400`} />
+                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group">
+                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-status-success/20 flex items-center justify-center group-hover:scale-110 transition-transform">
+                    <Network className={`${iconSizes.lg} text-status-success`} />
                   </div>
                   <div>
-                    <p className="font-medium text-white">View Topology</p>
-                    <p className="text-sm text-gray-400">Network graph</p>
+                    <p className="font-medium text-text-primary">View Topology</p>
+                    <p className="text-sm text-text-muted">Network graph</p>
                   </div>
                 </div>
               </AccentLink>
@@ -199,25 +199,25 @@ export const DashboardPage: FC = () => {
               {(history ?? []).slice(0, 4).map((item) => (
                 <div
                   key={item.id}
-                  className="rounded-lg border border-white/5 bg-gray-950/50 p-3 hover:border-white/10 transition-colors"
+                  className="rounded-lg border border-white/5 bg-bg-base/50 p-3 hover:border-white/10 transition-colors"
                 >
                   <div className="flex items-center justify-between mb-1">
-                    <p className="font-mono text-xs text-violet-300">
-                      {formatTime(item.startedAt)}
-                    </p>
+                    <p className="font-mono text-xs text-brand-300">{formatTime(item.startedAt)}</p>
                     <Tag colorScheme="gray" className="text-[10px]">
                       {item.deviceCount} dev
                     </Tag>
                   </div>
-                  <p className="text-white font-medium text-sm truncate">{item.configName}</p>
-                  <div className="flex gap-3 mt-1 text-xs text-gray-500">
+                  <p className="text-text-primary font-medium text-sm truncate">
+                    {item.configName}
+                  </p>
+                  <div className="flex gap-3 mt-1 text-xs text-text-muted">
                     <span>RX {formatNumber(item.packetsReceived)}</span>
                     <span>TX {formatNumber(item.packetsSent)}</span>
                   </div>
                 </div>
               ))}
               {history?.length === 0 && (
-                <div className="text-center py-6 text-gray-500">
+                <div className="text-center py-6 text-text-muted">
                   <Activity className={`${iconSizes['2xl']} mx-auto mb-2 opacity-50`} />
                   <p className="text-sm">No run history yet</p>
                 </div>
@@ -242,26 +242,26 @@ export const DashboardPage: FC = () => {
  */
 const ErrorInjectionPanel = memo(
   ({ errorTypes, info }: { errorTypes: ErrorType[]; info: string }) => (
-    <div className="mt-4 rounded-xl border border-yellow-500/20 bg-yellow-900/10 p-4">
+    <div className="mt-4 rounded-xl border border-status-warning/20 bg-status-warning/10 p-4">
       <div className="mb-3 flex items-start gap-2">
-        <PlugZap className={`mt-0.5 ${iconSizes.lg} text-yellow-400`} />
+        <PlugZap className={`mt-0.5 ${iconSizes.lg} text-status-warning`} />
         <div>
-          <p className="font-semibold text-yellow-200">Error Injection Types</p>
-          <SmallText className="text-yellow-300/80">{info}</SmallText>
+          <p className="font-semibold text-status-warning">Error Injection Types</p>
+          <SmallText className="text-status-warning/80">{info}</SmallText>
         </div>
       </div>
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {errorTypes.map((errorType) => (
           <div
             key={errorType.type}
-            className="rounded-lg border border-white/10 bg-gray-900/50 p-3"
+            className="rounded-lg border border-white/10 bg-bg-surface/50 p-3"
           >
-            <p className="font-semibold text-white">{errorType.type}</p>
-            <SmallText className="text-gray-400">{errorType.description}</SmallText>
+            <p className="font-semibold text-text-primary">{errorType.type}</p>
+            <SmallText className="text-text-muted">{errorType.description}</SmallText>
           </div>
         ))}
       </div>
-      <div className="mt-3 rounded-lg bg-blue-900/20 p-3 text-sm text-blue-200">
+      <div className="mt-3 rounded-lg bg-status-info/20 p-3 text-sm text-status-info">
         <strong>TUI Mode:</strong> Run{' '}
         <code className="rounded bg-black/30 px-1.5 py-0.5 font-mono text-xs">
           niac interactive [interface] [config]
@@ -287,9 +287,9 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
 
   if (timeline.length === 0) {
     return (
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent>
-          <SmallText className="text-gray-400">
+          <SmallText className="text-text-muted">
             Automation updates will appear after the first run completes.
           </SmallText>
         </CardContent>
@@ -298,11 +298,11 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
   }
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex items-center justify-between">
           <H2 className="flex items-center gap-2">
-            <SatelliteDish className={`${iconSizes.lg} text-violet-300`} />
+            <SatelliteDish className={`${iconSizes.lg} text-brand-300`} />
             Automation timeline
           </H2>
           <Tag colorScheme="gray">Latest events</Tag>
@@ -311,12 +311,12 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
           {timeline.map((event) => (
             <div
               key={event.title}
-              className="flex flex-col gap-1 rounded-lg border border-white/5 bg-gray-950/50 p-4 sm:flex-row sm:items-center sm:justify-between"
+              className="flex flex-col gap-1 rounded-lg border border-white/5 bg-bg-base/50 p-4 sm:flex-row sm:items-center sm:justify-between"
             >
               <div>
-                <SmallText className="text-blue-300">{event.time}</SmallText>
-                <p className="font-semibold text-white">{event.title}</p>
-                <SmallText className="text-gray-400">{event.detail}</SmallText>
+                <SmallText className="text-status-info">{event.time}</SmallText>
+                <p className="font-semibold text-text-primary">{event.title}</p>
+                <SmallText className="text-text-muted">{event.detail}</SmallText>
               </div>
               <Button
                 variant="ghost"

--- a/ui/src/pages/DebugConsolePage.tsx
+++ b/ui/src/pages/DebugConsolePage.tsx
@@ -146,32 +146,32 @@ export const DebugConsolePage: FC = () => {
       return {
         label: 'Paused',
         color: 'yellow' as const,
-        indicator: 'bg-yellow-400',
+        indicator: 'bg-status-warning',
       };
     }
     if (connected) {
       return {
         label: 'Live',
         color: 'green' as const,
-        indicator: 'bg-green-400 animate-pulse',
+        indicator: 'bg-status-success animate-pulse',
       };
     }
     // SSE auto-reconnects, so disconnected state is brief
     return {
       label: 'Connecting...',
       color: 'yellow' as const,
-      indicator: 'bg-yellow-400 animate-pulse',
+      indicator: 'bg-status-warning animate-pulse',
     };
   }, [connected, paused]);
 
   return (
     <div className="space-y-6">
       {/* Main Console Card */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           {/* Header with Connection Status */}
           <div className="flex items-center justify-between">
-            <h2 className="text-xl font-semibold text-white">Debug Console</h2>
+            <h2 className="text-xl font-semibold text-text-primary">Debug Console</h2>
             <div className="flex items-center gap-3">
               {/* Debug Settings Toggle */}
               <Button
@@ -195,7 +195,7 @@ export const DebugConsolePage: FC = () => {
               <button
                 type="button"
                 onClick={reconnect}
-                className="flex items-center gap-2 rounded-lg border border-white/10 bg-gray-950/50 px-3 py-1.5 text-sm transition-colors hover:bg-gray-800/50"
+                className="flex items-center gap-2 rounded-lg border border-white/10 bg-bg-base/50 px-3 py-1.5 text-sm transition-colors hover:bg-bg-elevated/50"
                 title={connected ? 'Connected to log stream' : 'Click to reconnect'}
               >
                 <span className={`h-2 w-2 rounded-full ${connectionStatus.indicator}`} />
@@ -223,7 +223,7 @@ export const DebugConsolePage: FC = () => {
 
           {/* Filter Status */}
           {(levelFilter !== 'All' || protocolFilter !== 'All' || searchQuery) && (
-            <div className="flex flex-wrap items-center gap-2 text-sm text-gray-400">
+            <div className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
               <span>
                 Showing {filteredLogs.length} of {logs.length} logs
               </span>
@@ -237,7 +237,7 @@ export const DebugConsolePage: FC = () => {
                   setProtocolFilter('All');
                   setSearchQuery('');
                 }}
-                className="text-violet-400 hover:text-violet-300 underline"
+                className="text-brand-400 hover:text-brand-300 underline"
               >
                 Clear filters
               </button>
@@ -248,7 +248,7 @@ export const DebugConsolePage: FC = () => {
           <LogViewer logs={filteredLogs} searchQuery={searchQuery} autoScroll={autoScroll} />
 
           {/* Footer Info */}
-          <div className="flex items-center justify-between text-xs text-gray-500">
+          <div className="flex items-center justify-between text-xs text-text-muted">
             <span>
               Buffer: {logs.length}/{MAX_LOG_BUFFER} logs
               {logs.length >= MAX_LOG_BUFFER && ' (oldest logs will be removed)'}

--- a/ui/src/pages/DeviceListPage.tsx
+++ b/ui/src/pages/DeviceListPage.tsx
@@ -61,7 +61,7 @@ export const DeviceListPage: FC = () => {
   return (
     <div className="space-y-6">
       {/* Header section */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           <DeviceListHeader
             deviceCount={devices.length}

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -47,7 +47,7 @@ const DeviceListCard: FC = () => {
     <BaseCard<DeviceSummary[]>
       title="Config workspace"
       subtitle="Devices rendered from active YAML config"
-      icon={<Server className={`${iconSizes.lg} text-cyan-300`} />}
+      icon={<Server className={`${iconSizes.lg} text-status-info`} />}
       data={devices}
       loading={loading && !devices}
       error={error?.message}
@@ -72,7 +72,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
 
   if (devices.length === 0) {
     return (
-      <div className="rounded-xl border border-white/5 bg-gray-950/50 p-8 text-center text-gray-400">
+      <div className="rounded-xl border border-white/5 bg-bg-base/50 p-8 text-center text-text-muted">
         No devices defined in the loaded configuration.
       </div>
     );
@@ -82,7 +82,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
     return (
       <div className="overflow-x-auto rounded-xl border border-white/5">
         <table className="min-w-full divide-y divide-white/10 text-sm">
-          <thead className="bg-gray-900/60 text-xs uppercase tracking-wide text-gray-400">
+          <thead className="bg-bg-surface/60 text-xs uppercase tracking-wide text-text-muted">
             <tr>
               <th className="px-4 py-3 text-left">Device</th>
               <th className="px-4 py-3 text-left">Type</th>
@@ -90,7 +90,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
               <th className="px-4 py-3 text-left">Protocols</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-white/5 text-gray-300">
+          <tbody className="divide-y divide-white/5 text-text-secondary">
             {devices.map((device) => (
               <DeviceRow key={device.name} device={device} />
             ))}
@@ -102,7 +102,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
 
   return (
     <div className="rounded-xl border border-white/5">
-      <div className="bg-gray-900/60 px-4 py-2 text-xs text-gray-400">
+      <div className="bg-bg-surface/60 px-4 py-2 text-xs text-text-muted">
         Showing {virtualScroll.visibleItems.length} of {devices.length} devices (virtual scrolling
         enabled)
       </div>
@@ -110,7 +110,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
         <div {...virtualScroll.spacerProps}>
           <div {...virtualScroll.contentProps}>
             <table className="min-w-full divide-y divide-white/10 text-sm">
-              <thead className="bg-gray-900/60 text-xs uppercase tracking-wide text-gray-400">
+              <thead className="bg-bg-surface/60 text-xs uppercase tracking-wide text-text-muted">
                 <tr>
                   <th className="px-4 py-3 text-left">Device</th>
                   <th className="px-4 py-3 text-left">Type</th>
@@ -118,7 +118,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
                   <th className="px-4 py-3 text-left">Protocols</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-white/5 text-gray-300">
+              <tbody className="divide-y divide-white/5 text-text-secondary">
                 {virtualScroll.visibleItems.map(({ item: device }) => (
                   <DeviceRow key={device.name} device={device} />
                 ))}
@@ -138,7 +138,7 @@ DeviceTable.displayName = 'DeviceTable';
  */
 const DeviceRow = memo(({ device }: { device: DeviceSummary }) => (
   <tr>
-    <td className="px-4 py-3 font-semibold text-white">{device.name}</td>
+    <td className="px-4 py-3 font-semibold text-text-primary">{device.name}</td>
     <td className="px-4 py-3">{device.type}</td>
     <td className="px-4 py-3 font-mono text-xs">{device.ips.join(', ') || '—'}</td>
     <td className="px-4 py-3">
@@ -148,7 +148,7 @@ const DeviceRow = memo(({ device }: { device: DeviceSummary }) => (
             {proto}
           </Tag>
         ))}
-        {device.protocols.length === 0 && <SmallText className="text-gray-400">None</SmallText>}
+        {device.protocols.length === 0 && <SmallText className="text-text-muted">None</SmallText>}
       </div>
     </td>
   </tr>
@@ -235,7 +235,7 @@ const ConfigEditorCard: FC = () => {
       <BaseCard
         title="YAML editor"
         subtitle="Edit active configuration"
-        icon={<FileCog className={`${iconSizes.lg} text-emerald-300`} />}
+        icon={<FileCog className={`${iconSizes.lg} text-status-success`} />}
         data={null}
         emptyMessage="No simulation is running. Pick a network on Simulation and start it to see and edit the running YAML here."
         getStatus={() => 'success'}
@@ -249,7 +249,7 @@ const ConfigEditorCard: FC = () => {
     <BaseCard<{ content: string; path: string; modifiedAt: string; sizeBytes: number }>
       title="YAML editor"
       subtitle="Edit active configuration"
-      icon={<FileCog className={`${iconSizes.lg} text-emerald-300`} />}
+      icon={<FileCog className={`${iconSizes.lg} text-status-success`} />}
       data={data}
       loading={loading && !data}
       error={error?.message}
@@ -261,14 +261,16 @@ const ConfigEditorCard: FC = () => {
           <CardRow label="Updated" value={formatTime(cfg.modifiedAt)} />
           <CardRow label="Size" value={formatBytes(cfg.sizeBytes)} />
           <textarea
-            className="mt-3 h-72 w-full rounded-xl border border-white/10 bg-gray-950/70 p-3 font-mono text-sm text-white shadow-inner focus:border-violet-400 focus:outline-none"
+            className="mt-3 h-72 w-full rounded-xl border border-white/10 bg-bg-base/70 p-3 font-mono text-sm text-text-primary shadow-inner focus:border-brand-400 focus:outline-none"
             value={value}
             onChange={handleChange}
             spellCheck={false}
             disabled={loading || saving}
           />
           {status && (
-            <SmallText className={status.tone === 'success' ? 'text-emerald-300' : 'text-red-400'}>
+            <SmallText
+              className={status.tone === 'success' ? 'text-status-success' : 'text-status-error'}
+            >
               {status.message}
             </SmallText>
           )}
@@ -285,7 +287,7 @@ const ConfigEditorCard: FC = () => {
               Discard changes
             </Button>
           </div>
-          <SmallText className="mt-2 text-gray-400">
+          <SmallText className="mt-2 text-text-muted">
             Save runs the same validation as <code>niac validate</code>, writes the YAML to disk,
             then diff-reloads the running stack — added devices spin up, removed devices stop,
             existing devices are updated in place.
@@ -309,16 +311,16 @@ const WalkFileBrowser: FC<{
   }
   return (
     <div className="space-y-2">
-      <SmallText className="text-gray-400">Available SNMP walks</SmallText>
-      <div className="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-white/10 bg-gray-950/50 p-2 text-sm text-gray-300">
+      <SmallText className="text-text-muted">Available SNMP walks</SmallText>
+      <div className="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-white/10 bg-bg-base/50 p-2 text-sm text-text-secondary">
         {files.map((file) => (
           <div
             key={file.name}
-            className="flex items-center justify-between gap-2 rounded-lg border border-white/5 bg-gray-900/50 px-3 py-2"
+            className="flex items-center justify-between gap-2 rounded-lg border border-white/5 bg-bg-surface/50 px-3 py-2"
           >
             <div>
-              <p className="text-white">{file.name}</p>
-              <SmallText className="text-gray-500 capitalize">{file.source}</SmallText>
+              <p className="text-text-primary">{file.name}</p>
+              <SmallText className="text-text-muted capitalize">{file.source}</SmallText>
             </div>
             <Button size="sm" variant="outline" onClick={() => onCopy(file.name)}>
               Copy name

--- a/ui/src/pages/LibraryFilesPage.tsx
+++ b/ui/src/pages/LibraryFilesPage.tsx
@@ -45,16 +45,16 @@ function LibraryFilesView({ kind }: Props) {
 
   return (
     <div className="space-y-6">
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-cyan-500/20">
-                <KindIcon className="w-6 h-6 text-cyan-400" />
+              <div className="p-2 rounded-lg bg-status-info/20">
+                <KindIcon className="w-6 h-6 text-status-info" />
               </div>
               <div>
                 <H2>{title}</H2>
-                <SmallText className="text-gray-400">
+                <SmallText className="text-text-muted">
                   {entries.length} {entries.length === 1 ? 'file' : 'files'} ·{' '}
                   {humanBytes(totalBytes)}
                 </SmallText>
@@ -63,14 +63,14 @@ function LibraryFilesView({ kind }: Props) {
 
             <div className="flex items-center gap-2">
               <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500" />
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted" />
                 <input
                   type="search"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   placeholder="Search by name…"
                   aria-label="Filter library entries by name"
-                  className="w-64 rounded-md border border-white/10 bg-gray-950/40 pl-7 pr-3 py-1.5 text-xs text-gray-200 placeholder:text-gray-500 focus:border-cyan-500/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+                  className="w-64 rounded-md border border-white/10 bg-bg-base/40 pl-7 pr-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
                 />
               </div>
               <Button
@@ -87,19 +87,21 @@ function LibraryFilesView({ kind }: Props) {
         </CardContent>
       </Card>
 
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent>
           {error ? (
-            <SmallText className="text-red-400">Failed to load library: {error.message}</SmallText>
+            <SmallText className="text-status-error">
+              Failed to load library: {error.message}
+            </SmallText>
           ) : entries.length === 0 ? (
             <div className="py-10 text-center">
-              <SmallText className="text-gray-400">No {kind} installed yet.</SmallText>
-              <p className="mt-2 text-xs text-gray-500">{emptyHint}</p>
+              <SmallText className="text-text-muted">No {kind} installed yet.</SmallText>
+              <p className="mt-2 text-xs text-text-muted">{emptyHint}</p>
             </div>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
-                <thead className="text-xs text-gray-500 uppercase tracking-wide">
+                <thead className="text-xs text-text-muted uppercase tracking-wide">
                   <tr className="border-b border-white/10">
                     <th className="text-left py-2 pr-4">Name</th>
                     <th className="text-right py-2 pr-4">Size</th>
@@ -107,7 +109,7 @@ function LibraryFilesView({ kind }: Props) {
                     <th className="text-left py-2">Modified</th>
                   </tr>
                 </thead>
-                <tbody className="text-gray-200">
+                <tbody className="text-text-primary">
                   {filtered.map((entry) => (
                     <tr key={entry.name} className="border-b border-white/5 last:border-0">
                       <td className="py-2 pr-4 font-mono text-xs">{entry.name}</td>
@@ -117,14 +119,14 @@ function LibraryFilesView({ kind }: Props) {
                       <td className="py-2 pr-4">
                         <SourceBadge source={entry.source} />
                       </td>
-                      <td className="py-2 text-xs text-gray-400">
+                      <td className="py-2 text-xs text-text-muted">
                         {new Date(entry.modifiedAt).toLocaleString()}
                       </td>
                     </tr>
                   ))}
                   {search.trim() !== '' && filtered.length === 0 && (
                     <tr>
-                      <td colSpan={4} className="py-6 text-center text-xs text-gray-500">
+                      <td colSpan={4} className="py-6 text-center text-xs text-text-muted">
                         No entries match "{search}"
                       </td>
                     </tr>
@@ -141,9 +143,9 @@ function LibraryFilesView({ kind }: Props) {
 
 const SourceBadge: FC<{ source: LibraryFileEntry['source'] }> = ({ source }) => {
   const styles: Record<LibraryFileEntry['source'], string> = {
-    starter: 'border-violet-500/40 bg-violet-500/10 text-violet-200',
-    bundle: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-200',
-    user: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+    starter: 'border-brand-500/40 bg-brand-500/10 text-brand-200',
+    bundle: 'border-status-info/40 bg-status-info/10 text-status-info',
+    user: 'border-status-success/40 bg-status-success/10 text-status-success',
   };
   return (
     <span

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -61,7 +61,7 @@ const ConnectionStatus: FC<{
   if (connected) {
     return (
       <div className="flex items-center gap-2">
-        <Wifi className={`${iconSizes.md} text-green-400`} />
+        <Wifi className={`${iconSizes.md} text-status-success`} />
         <Tag colorScheme="green">Connected</Tag>
       </div>
     );
@@ -70,7 +70,7 @@ const ConnectionStatus: FC<{
   // SSE auto-reconnects, so disconnected state is brief
   return (
     <div className="flex items-center gap-2">
-      <WifiOff className={`${iconSizes.md} text-yellow-400 animate-pulse`} />
+      <WifiOff className={`${iconSizes.md} text-status-warning animate-pulse`} />
       <Tag colorScheme="yellow">Connecting...</Tag>
     </div>
   );
@@ -275,7 +275,7 @@ export const PacketInspectorPage: FC = () => {
     <div className="space-y-6">
       {/* Live / PCAP Files tab control */}
       <div
-        className="inline-flex rounded-lg border border-white/10 bg-gray-950/40 p-0.5"
+        className="inline-flex rounded-lg border border-white/10 bg-bg-base/40 p-0.5"
         role="tablist"
         aria-label="Packets view"
       >
@@ -286,8 +286,8 @@ export const PacketInspectorPage: FC = () => {
           onClick={() => setView('live')}
           className={`flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
             view === 'live'
-              ? 'bg-violet-500/20 text-violet-100'
-              : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+              ? 'bg-brand-500/20 text-brand-100'
+              : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
           }`}
         >
           <Radio className="w-3.5 h-3.5" />
@@ -300,8 +300,8 @@ export const PacketInspectorPage: FC = () => {
           onClick={() => setView('files')}
           className={`flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
             view === 'files'
-              ? 'bg-violet-500/20 text-violet-100'
-              : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+              ? 'bg-brand-500/20 text-brand-100'
+              : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
           }`}
         >
           <FileBox className="w-3.5 h-3.5" />
@@ -316,14 +316,14 @@ export const PacketInspectorPage: FC = () => {
       {view === 'live' && (
         <>
           {/* Header with controls */}
-          <Card className="border-white/5 bg-gray-900/70">
+          <Card className="border-white/5 bg-bg-surface/70">
             <CardContent>
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 {/* Title and connection status */}
                 <div className="flex items-center gap-4">
                   <H2>Packets</H2>
-                  <SmallText className="text-gray-400">
-                    on <span className="font-mono text-gray-200">{activeInterface ?? '—'}</span>
+                  <SmallText className="text-text-muted">
+                    on <span className="font-mono text-text-primary">{activeInterface ?? '—'}</span>
                   </SmallText>
                   {captureRunning && !simRunning && <Tag colorScheme="violet">Standalone</Tag>}
                   <ConnectionStatus connected={connected} />
@@ -424,13 +424,13 @@ export const PacketInspectorPage: FC = () => {
                     type="checkbox"
                     checked={autoScroll}
                     onChange={(e) => setAutoScroll(e.target.checked)}
-                    className="rounded border-gray-600 bg-gray-800 text-violet-500 focus:ring-violet-400 focus:ring-offset-gray-900"
+                    className="rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-400 focus:ring-offset-gray-900"
                   />
-                  <SmallText className="text-gray-400">Auto-scroll</SmallText>
+                  <SmallText className="text-text-muted">Auto-scroll</SmallText>
                 </label>
 
                 {/* Packet count */}
-                <SmallText className="text-gray-400">
+                <SmallText className="text-text-muted">
                   {filteredPackets.length} / {packets.length} packets
                 </SmallText>
               </div>
@@ -438,7 +438,7 @@ export const PacketInspectorPage: FC = () => {
           </Card>
 
           {/* BPF Capture Filter */}
-          <Card className="border-white/5 bg-gray-900/70">
+          <Card className="border-white/5 bg-bg-surface/70">
             <CardContent>
               <BpfFilterBar />
             </CardContent>
@@ -448,10 +448,10 @@ export const PacketInspectorPage: FC = () => {
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
             {/* Packet List - Left sidebar */}
             <div className="lg:col-span-4 xl:col-span-3">
-              <Card className="border-white/5 bg-gray-900/70 h-[600px]">
+              <Card className="border-white/5 bg-bg-surface/70 h-[600px]">
                 <CardContent className="h-full flex flex-col">
                   <div className="flex items-center justify-between mb-3">
-                    <SmallText className="text-gray-400 uppercase tracking-wide font-semibold">
+                    <SmallText className="text-text-muted uppercase tracking-wide font-semibold">
                       Packet List
                     </SmallText>
                     {isPaused && (
@@ -476,9 +476,9 @@ export const PacketInspectorPage: FC = () => {
             {/* Right panel - Hex dump and details */}
             <div className="lg:col-span-8 xl:col-span-9 space-y-6">
               {/* Hex Dump Viewer */}
-              <Card className="border-white/5 bg-gray-900/70 h-[350px]">
+              <Card className="border-white/5 bg-bg-surface/70 h-[350px]">
                 <CardContent className="h-full flex flex-col">
-                  <SmallText className="text-gray-400 uppercase tracking-wide font-semibold mb-3">
+                  <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                     Hex Dump
                   </SmallText>
                   <div className="flex-1 min-h-0">
@@ -492,9 +492,9 @@ export const PacketInspectorPage: FC = () => {
               </Card>
 
               {/* Packet Details */}
-              <Card className="border-white/5 bg-gray-900/70 h-[220px]">
+              <Card className="border-white/5 bg-bg-surface/70 h-[220px]">
                 <CardContent className="h-full flex flex-col">
-                  <SmallText className="text-gray-400 uppercase tracking-wide font-semibold mb-3">
+                  <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                     Packet Details
                   </SmallText>
                   <div className="flex-1 min-h-0 overflow-y-auto">
@@ -580,19 +580,19 @@ const StandaloneCaptureStarter: FC<{
   }, [bpfFilter, busy, onStarted, selectedIface]);
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex items-start gap-3">
-          <Activity className={`mt-1 ${iconSizes.lg} text-violet-300`} />
+          <Activity className={`mt-1 ${iconSizes.lg} text-brand-300`} />
           <div className="flex-1">
-            <p className="font-semibold text-white">Standalone packet capture</p>
-            <SmallText className="text-gray-400">
+            <p className="font-semibold text-text-primary">Standalone packet capture</p>
+            <SmallText className="text-text-muted">
               Sniff an interface without starting a simulation. Frames stream into the viewer below
               as soon as they hit the wire. Or{' '}
               <button
                 type="button"
                 onClick={navigateToSim}
-                className="text-violet-300 underline hover:text-violet-200"
+                className="text-brand-300 underline hover:text-brand-200"
               >
                 start a simulation
               </button>{' '}
@@ -601,13 +601,13 @@ const StandaloneCaptureStarter: FC<{
           </div>
         </div>
         <div className="grid gap-3 sm:grid-cols-[1fr_2fr_auto] sm:items-end">
-          <label className="flex flex-col gap-1 text-sm text-gray-400">
+          <label className="flex flex-col gap-1 text-sm text-text-muted">
             Interface
             <select
               value={selectedIface}
               onChange={(e) => setSelectedIface(e.target.value)}
               disabled={busy || interfaces.length === 0}
-              className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
             >
               {interfaces.length === 0 ? (
                 <option value="">No interfaces detected</option>
@@ -623,7 +623,7 @@ const StandaloneCaptureStarter: FC<{
               )}
             </select>
           </label>
-          <label className="flex flex-col gap-1 text-sm text-gray-400">
+          <label className="flex flex-col gap-1 text-sm text-text-muted">
             BPF filter (optional)
             <input
               type="text"
@@ -631,7 +631,7 @@ const StandaloneCaptureStarter: FC<{
               onChange={(e) => setBpfFilter(e.target.value)}
               disabled={busy}
               placeholder="e.g. tcp port 80"
-              className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-2 font-mono text-sm text-white focus:border-violet-400 focus:outline-none"
+              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-2 font-mono text-sm text-text-primary focus:border-brand-400 focus:outline-none"
             />
           </label>
           <Button tone="violet" onClick={handleStart} disabled={!selectedIface || busy}>
@@ -639,7 +639,7 @@ const StandaloneCaptureStarter: FC<{
           </Button>
         </div>
         {error && (
-          <SmallText className="text-red-400" role="alert">
+          <SmallText className="text-status-error" role="alert">
             {error}
           </SmallText>
         )}

--- a/ui/src/pages/PcapAnalyzerPage.tsx
+++ b/ui/src/pages/PcapAnalyzerPage.tsx
@@ -226,13 +226,13 @@ export const PcapAnalyzerPage: FC = () => {
       {analysisResult && (
         <>
           {/* Controls Header */}
-          <Card className="border-white/5 bg-gray-900/70">
+          <Card className="border-white/5 bg-bg-surface/70">
             <CardContent>
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 {/* Title and file info */}
                 <div className="flex items-center gap-4">
                   <H2 className="flex items-center gap-2">
-                    <FileSearch className={`${iconSizes.lg} text-violet-400`} />
+                    <FileSearch className={`${iconSizes.lg} text-brand-400`} />
                     PCAP Analysis
                   </H2>
                   <Tag colorScheme="green">{analysisResult.packets.length} packets</Tag>
@@ -241,14 +241,14 @@ export const PcapAnalyzerPage: FC = () => {
                 {/* Control buttons */}
                 <div className="flex flex-wrap items-center gap-2">
                   {/* View Mode Toggle */}
-                  <div className="flex rounded-lg border border-white/10 bg-gray-950/50 p-1">
+                  <div className="flex rounded-lg border border-white/10 bg-bg-base/50 p-1">
                     <button
                       type="button"
                       onClick={() => setViewMode('packets')}
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'packets'
-                          ? 'bg-violet-600 text-white'
-                          : 'text-gray-400 hover:text-white'
+                          ? 'bg-brand-600 text-text-primary'
+                          : 'text-text-muted hover:text-text-primary'
                       }`}
                     >
                       Packets
@@ -258,8 +258,8 @@ export const PcapAnalyzerPage: FC = () => {
                       onClick={() => setViewMode('stats')}
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'stats'
-                          ? 'bg-violet-600 text-white'
-                          : 'text-gray-400 hover:text-white'
+                          ? 'bg-brand-600 text-text-primary'
+                          : 'text-text-muted hover:text-text-primary'
                       }`}
                     >
                       Statistics
@@ -269,8 +269,8 @@ export const PcapAnalyzerPage: FC = () => {
                       onClick={() => setViewMode('conversations')}
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'conversations'
-                          ? 'bg-violet-600 text-white'
-                          : 'text-gray-400 hover:text-white'
+                          ? 'bg-brand-600 text-text-primary'
+                          : 'text-text-muted hover:text-text-primary'
                       }`}
                     >
                       Conversations
@@ -343,9 +343,9 @@ export const PcapAnalyzerPage: FC = () => {
                 {/* Right panel - Details */}
                 <div className="lg:col-span-5 xl:col-span-4 space-y-6">
                   {/* Hex Dump Viewer */}
-                  <Card className="border-white/5 bg-gray-900/70 h-[280px]">
+                  <Card className="border-white/5 bg-bg-surface/70 h-[280px]">
                     <CardContent className="h-full flex flex-col">
-                      <SmallText className="text-gray-400 uppercase tracking-wide font-semibold mb-3">
+                      <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                         Hex Dump
                       </SmallText>
                       <div className="flex-1 min-h-0">
@@ -359,9 +359,9 @@ export const PcapAnalyzerPage: FC = () => {
                   </Card>
 
                   {/* Packet Details */}
-                  <Card className="border-white/5 bg-gray-900/70 h-[280px]">
+                  <Card className="border-white/5 bg-bg-surface/70 h-[280px]">
                     <CardContent className="h-full flex flex-col">
-                      <SmallText className="text-gray-400 uppercase tracking-wide font-semibold mb-3">
+                      <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                         Packet Details
                       </SmallText>
                       <div className="flex-1 min-h-0 overflow-y-auto">
@@ -398,13 +398,13 @@ export const PcapAnalyzerPage: FC = () => {
 
       {/* Info Banner when no file is loaded */}
       {!(analysisResult || selectedFile) && (
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent>
             <div className="flex items-start gap-3">
-              <Info className={`${iconSizes.lg} text-blue-400 flex-shrink-0 mt-0.5`} />
+              <Info className={`${iconSizes.lg} text-status-info flex-shrink-0 mt-0.5`} />
               <div>
-                <p className="font-medium text-white">About PCAP Analyzer</p>
-                <SmallText className="text-gray-400">
+                <p className="font-medium text-text-primary">About PCAP Analyzer</p>
+                <SmallText className="text-text-muted">
                   Upload a PCAP or PCAPNG file to analyze network traffic. The analyzer will parse
                   packets and provide detailed statistics, protocol breakdown, and packet-level
                   inspection including hex dump viewing.

--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -218,16 +218,16 @@ export const RuntimeControlPage: FC = () => {
     <div className="space-y-6">
       {/* Daemon Mode Warning */}
       {!isDaemonMode && (
-        <Card className="border-yellow-500/30 bg-yellow-900/20">
+        <Card className="border-status-warning/30 bg-status-warning/20">
           <CardContent className="space-y-3">
             <div className="flex items-start gap-3">
-              <BellRing className={`mt-1 ${iconSizes.lg} text-yellow-400`} />
+              <BellRing className={`mt-1 ${iconSizes.lg} text-status-warning`} />
               <div>
-                <p className="font-semibold text-yellow-200">Daemon Mode Not Detected</p>
-                <SmallText className="text-yellow-300/90">
+                <p className="font-semibold text-status-warning">Daemon Mode Not Detected</p>
+                <SmallText className="text-status-warning/90">
                   To use simulation controls, start NIAC in daemon mode:
                 </SmallText>
-                <code className="mt-2 block rounded bg-black/40 p-3 font-mono text-sm text-yellow-100">
+                <code className="mt-2 block rounded bg-black/40 p-3 font-mono text-sm text-status-warning">
                   niac daemon --listen :8080 --token yourtoken
                 </code>
               </div>
@@ -238,24 +238,24 @@ export const RuntimeControlPage: FC = () => {
 
       {/* Start Simulation Card */}
       {isDaemonMode && !simStatus?.running && (
-        <Card className="border-white/5 bg-gradient-to-br from-violet-900/30 to-gray-900/70">
+        <Card className="border-white/5 bg-gradient-to-br from-brand-900/30 to-bg-surface/70">
           <CardContent className="space-y-4">
             {/* Single-row action bar: interface + start. The interface
                 dropdown takes the natural width of its content; Start sits
                 immediately next to it so the action is obvious. */}
             <div className="flex flex-wrap items-end gap-3">
               <div className="flex items-center gap-3">
-                <PlugZap className={`${iconSizes.xl} text-violet-400`} />
+                <PlugZap className={`${iconSizes.xl} text-brand-400`} />
                 <H2>Start Simulation</H2>
               </div>
               <div className="ml-auto flex flex-wrap items-end gap-3">
                 <div className="min-w-[14rem]">
-                  <label htmlFor="rc-interface" className="block text-xs text-gray-400">
+                  <label htmlFor="rc-interface" className="block text-xs text-text-muted">
                     Network interface
                   </label>
                   <div className="relative">
                     <Network
-                      className={`absolute left-3 top-1/2 -translate-y-1/2 ${iconSizes.md} text-gray-500`}
+                      className={`absolute left-3 top-1/2 -translate-y-1/2 ${iconSizes.md} text-text-muted`}
                     />
                     <select
                       id="rc-interface"
@@ -263,7 +263,7 @@ export const RuntimeControlPage: FC = () => {
                       onChange={handleInterfaceChange}
                       disabled={interfacesLoading || interfaces.length === 0}
                       title="Pick the host interface the daemon should bind to. Loopback (lo0/lo) is safest for local testing."
-                      className="w-full rounded border border-white/10 bg-gray-800 py-2 pl-10 pr-3 text-sm text-white focus:border-violet-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                      className="w-full rounded border border-white/10 bg-bg-elevated py-2 pl-10 pr-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {interfacesLoading && <option value="">Loading…</option>}
                       {!interfacesLoading && interfaces.length === 0 && (
@@ -290,7 +290,7 @@ export const RuntimeControlPage: FC = () => {
                   // Pulse the button when everything's picked so it's the obvious next click.
                   className={
                     hasValidConfig && !starting
-                      ? 'animate-pulse shadow-lg shadow-violet-500/30'
+                      ? 'animate-pulse shadow-lg shadow-brand-500/30'
                       : undefined
                   }
                   title={
@@ -307,16 +307,16 @@ export const RuntimeControlPage: FC = () => {
             </div>
 
             {/* Picked-config status pill */}
-            <div className="flex items-center justify-between rounded border border-white/5 bg-gray-900/40 px-3 py-2 text-xs">
-              <span className="text-gray-400">Configuration:</span>
+            <div className="flex items-center justify-between rounded border border-white/5 bg-bg-surface/40 px-3 py-2 text-xs">
+              <span className="text-text-muted">Configuration:</span>
               {simulationSettings.configName || quickUploadFile ? (
-                <SmallText className="text-emerald-300">
+                <SmallText className="text-status-success">
                   {quickUploadFile
                     ? `${quickUploadFile.name} (upload)`
                     : `${simulationSettings.configName} (${simulationSettings.configSource === 'template' ? 'template' : 'config'})`}
                 </SmallText>
               ) : (
-                <SmallText className="italic text-gray-500">
+                <SmallText className="italic text-text-muted">
                   Pick one below — Start unlocks once you do
                 </SmallText>
               )}
@@ -344,7 +344,7 @@ export const RuntimeControlPage: FC = () => {
 
             {message && (
               <SmallText
-                className={message.tone === 'success' ? 'text-emerald-300' : 'text-red-400'}
+                className={message.tone === 'success' ? 'text-status-success' : 'text-status-error'}
                 role="alert"
                 aria-live="polite"
               >

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -547,16 +547,16 @@ export const TopologyPage: FC = () => {
   return (
     <div className="space-y-6">
       {/* Header Card */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-cyan-500/20">
-                <Network className="w-6 h-6 text-cyan-400" />
+              <div className="p-2 rounded-lg bg-status-info/20">
+                <Network className="w-6 h-6 text-status-info" />
               </div>
               <div>
                 <H2>Network Topology</H2>
-                <SmallText className="text-gray-400">
+                <SmallText className="text-text-muted">
                   {devices?.length || 0} {devices?.length === 1 ? 'device' : 'devices'} |{' '}
                   {topology?.links?.length || 0}{' '}
                   {topology?.links?.length === 1 ? 'connection' : 'connections'}
@@ -566,7 +566,7 @@ export const TopologyPage: FC = () => {
 
             <div className="flex flex-wrap items-center gap-2">
               <div
-                className="inline-flex rounded-lg border border-white/10 bg-gray-950/40 p-0.5"
+                className="inline-flex rounded-lg border border-white/10 bg-bg-base/40 p-0.5"
                 role="tablist"
                 aria-label="Topology view"
               >
@@ -577,8 +577,8 @@ export const TopologyPage: FC = () => {
                   onClick={() => setView('graph')}
                   className={`flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
                     view === 'graph'
-                      ? 'bg-cyan-500/20 text-cyan-100'
-                      : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+                      ? 'bg-status-info/20 text-status-info'
+                      : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
                   }`}
                 >
                   <Network className="w-3.5 h-3.5" />
@@ -591,8 +591,8 @@ export const TopologyPage: FC = () => {
                   onClick={() => setView('neighbors')}
                   className={`flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
                     view === 'neighbors'
-                      ? 'bg-cyan-500/20 text-cyan-100'
-                      : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+                      ? 'bg-status-info/20 text-status-info'
+                      : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
                   }`}
                 >
                   <Radar className="w-3.5 h-3.5" />
@@ -649,7 +649,7 @@ export const TopologyPage: FC = () => {
                       the existing Graph/Neighbors view picker above,
                       which uses tablist; we use aria-pressed instead so
                       either pattern (radio or toggle) reads cleanly. */}
-                  <div className="inline-flex rounded-lg border border-white/10 bg-gray-950/40 p-0.5">
+                  <div className="inline-flex rounded-lg border border-white/10 bg-bg-base/40 p-0.5">
                     {LAYOUT_MODES.map((entry) => {
                       const active = layoutMode === entry.mode;
                       return (
@@ -662,8 +662,8 @@ export const TopologyPage: FC = () => {
                           onClick={() => handleLayoutModeChange(entry.mode)}
                           className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
                             active
-                              ? 'bg-cyan-500/20 text-cyan-100'
-                              : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+                              ? 'bg-status-info/20 text-status-info'
+                              : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
                           }`}
                         >
                           {entry.label}
@@ -688,11 +688,11 @@ export const TopologyPage: FC = () => {
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search devices by name…"
                 aria-label="Filter devices by name"
-                className="w-full sm:w-64 rounded-md border border-white/10 bg-gray-950/40 px-3 py-1.5 text-xs text-gray-200 placeholder:text-gray-500 focus:border-cyan-500/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+                className="w-full sm:w-64 rounded-md border border-white/10 bg-bg-base/40 px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
               />
               {availableTypes.length > 0 && (
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <SmallText className="text-gray-500">Types:</SmallText>
+                  <SmallText className="text-text-muted">Types:</SmallText>
                   {availableTypes.map((type) => {
                     const active = activeTypes.has(type);
                     return (
@@ -703,8 +703,8 @@ export const TopologyPage: FC = () => {
                         aria-pressed={active}
                         className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium capitalize transition-colors ${
                           active
-                            ? 'border-cyan-500/40 bg-cyan-500/20 text-cyan-100'
-                            : 'border-white/10 bg-gray-950/40 text-gray-400 hover:bg-white/5 hover:text-gray-200'
+                            ? 'border-status-info/40 bg-status-info/20 text-status-info'
+                            : 'border-white/10 bg-bg-base/40 text-text-muted hover:bg-white/5 hover:text-text-primary'
                         }`}
                       >
                         {type}
@@ -715,7 +715,7 @@ export const TopologyPage: FC = () => {
                     <button
                       type="button"
                       onClick={() => setActiveTypes(new Set())}
-                      className="rounded-full px-2 py-0.5 text-[11px] font-medium text-gray-400 hover:text-gray-200 underline-offset-2 hover:underline"
+                      className="rounded-full px-2 py-0.5 text-[11px] font-medium text-text-muted hover:text-text-primary underline-offset-2 hover:underline"
                     >
                       Clear
                     </button>
@@ -732,21 +732,21 @@ export const TopologyPage: FC = () => {
           ≈ 240 px on this layout). Gives much more room for the graph
           on standard 1080p+ displays. */}
       {view === 'graph' && (
-        <Card className="border-white/5 bg-gray-900/70 overflow-hidden">
+        <Card className="border-white/5 bg-bg-surface/70 overflow-hidden">
           <div className="h-[calc(100vh-260px)] min-h-[520px] relative">
             {loading ? (
               <div className="absolute inset-0 flex items-center justify-center">
                 <div className="flex flex-col items-center gap-3">
                   <RefreshCw className="w-8 h-8 text-brand-400 animate-spin" />
-                  <SmallText className="text-gray-400">Loading topology...</SmallText>
+                  <SmallText className="text-text-muted">Loading topology...</SmallText>
                 </div>
               </div>
             ) : nodes.length === 0 ? (
               <div className="absolute inset-0 flex items-center justify-center">
                 <div className="text-center">
-                  <Network className="w-16 h-16 text-gray-600 mx-auto mb-4" />
-                  <p className="text-gray-400 mb-2">No topology data available</p>
-                  <SmallText className="text-gray-500">
+                  <Network className="w-16 h-16 text-text-disabled mx-auto mb-4" />
+                  <p className="text-text-muted mb-2">No topology data available</p>
+                  <SmallText className="text-text-muted">
                     Configure devices with trunk ports or port-channels to visualize connections
                   </SmallText>
                 </div>
@@ -757,12 +757,12 @@ export const TopologyPage: FC = () => {
                   // z-50 wins over ReactFlow's internal Panel chrome and
                   // pointer-events-none lets pan/zoom drag through the
                   // banner so it doesn't trap clicks on the canvas below.
-                  <div className="pointer-events-none absolute top-0 left-0 right-0 z-50 bg-yellow-900/60 border-b border-yellow-500/40 px-4 py-2 text-center backdrop-blur-sm">
-                    <SmallText className="text-yellow-200">
+                  <div className="pointer-events-none absolute top-0 left-0 right-0 z-50 bg-status-warning/60 border-b border-status-warning/40 px-4 py-2 text-center backdrop-blur-sm">
+                    <SmallText className="text-status-warning">
                       Devices loaded, but the running config has no declared topology links. Add{' '}
-                      <code className="text-yellow-100">trunk_ports:</code> or{' '}
-                      <code className="text-yellow-100">port_channels:</code> entries to your YAML
-                      to visualise connections. Live LLDP/CDP/EDP/FDP neighbours are on the{' '}
+                      <code className="text-status-warning">trunk_ports:</code> or{' '}
+                      <code className="text-status-warning">port_channels:</code> entries to your
+                      YAML to visualise connections. Live LLDP/CDP/EDP/FDP neighbours are on the{' '}
                       <strong>Neighbors</strong> page.
                     </SmallText>
                   </div>

--- a/ui/src/pages/TrafficInjectionPage.tsx
+++ b/ui/src/pages/TrafficInjectionPage.tsx
@@ -22,7 +22,7 @@ export const TrafficInjectionPage: FC = () => {
       <div className="space-y-4">
         <div>
           <H2>Error Injection</H2>
-          <P className="text-gray-400">
+          <P className="text-text-muted">
             Inject network errors on device interfaces for testing and simulation scenarios.
           </P>
         </div>
@@ -33,7 +33,7 @@ export const TrafficInjectionPage: FC = () => {
       <div className="space-y-4">
         <div>
           <H2>PCAP Replay</H2>
-          <P className="text-gray-400">
+          <P className="text-text-muted">
             Replay captured packet traffic with loop and timing controls for testing.
           </P>
         </div>
@@ -41,28 +41,30 @@ export const TrafficInjectionPage: FC = () => {
       </div>
 
       {/* Recent runs — previously lived on the standalone /analysis page */}
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-3">
           <div className="flex items-center justify-between">
             <H2 className="flex items-center gap-2 text-lg">
-              <History className={`${iconSizes.lg} text-gray-400`} />
+              <History className={`${iconSizes.lg} text-text-muted`} />
               Recent runs
             </H2>
             <Tag colorScheme="gray">History</Tag>
           </div>
-          <SmallText className="text-gray-400">Past simulation runs the daemon recorded.</SmallText>
-          <div className="space-y-2 text-sm text-gray-300">
+          <SmallText className="text-text-muted">
+            Past simulation runs the daemon recorded.
+          </SmallText>
+          <div className="space-y-2 text-sm text-text-secondary">
             {(history ?? []).slice(0, 5).map((item) => (
-              <div key={item.id} className="rounded-lg border border-white/5 bg-gray-950/50 p-3">
-                <p className="text-white font-semibold">{item.configName}</p>
-                <SmallText className="text-gray-400">
+              <div key={item.id} className="rounded-lg border border-white/5 bg-bg-base/50 p-3">
+                <p className="text-text-primary font-semibold">{item.configName}</p>
+                <SmallText className="text-text-muted">
                   {formatTime(item.startedAt)} · duration {formatDuration(item.duration)} · RX{' '}
                   {formatNumber(item.packetsReceived)} · TX {formatNumber(item.packetsSent)}
                 </SmallText>
               </div>
             ))}
             {(!history || history.length === 0) && (
-              <SmallText className="text-gray-500 italic">No captured runs yet.</SmallText>
+              <SmallText className="text-text-muted italic">No captured runs yet.</SmallText>
             )}
           </div>
         </CardContent>

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -6,8 +6,8 @@ import { Card, CardContent } from '../ui/Card';
 type Severity = 'error' | 'warning' | 'info';
 
 const SEVERITY_BADGE: Record<Severity, string> = {
-  error: 'bg-red-500/20 text-red-200 ring-red-400/40',
-  warning: 'bg-amber-500/20 text-amber-200 ring-amber-400/40',
+  error: 'bg-status-error/20 text-status-error ring-status-error/40',
+  warning: 'bg-status-warning/20 text-status-warning ring-status-warning/40',
   info: 'bg-sky-500/20 text-sky-200 ring-sky-400/40',
 };
 
@@ -92,11 +92,11 @@ export const WalkValidatorPage: FC = () => {
 
   return (
     <div className="space-y-6">
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-4">
           <header>
-            <h1 className="text-2xl font-semibold text-white">SNMP Walks</h1>
-            <p className="text-sm text-gray-400">
+            <h1 className="text-2xl font-semibold text-text-primary">SNMP Walks</h1>
+            <p className="text-sm text-text-muted">
               Same engine as <code>niac analyze-walk</code>. Validate detects malformed lines,
               missing OIDs, and unquoted strings; fix auto-rewrites the file in place.
             </p>
@@ -104,13 +104,13 @@ export const WalkValidatorPage: FC = () => {
 
           <div className="grid gap-4 md:grid-cols-2">
             <label className="block text-sm">
-              <span className="text-gray-300">From walks/ directory</span>
+              <span className="text-text-secondary">From walks/ directory</span>
               <select
                 value={selectedFile}
                 onChange={(e) => setSelectedFile(e.target.value)}
                 disabled={filesLoading || files.length === 0}
                 title="Hydrated from /api/v1/files?kind=walks (the sandboxed walks directory). Use the absolute-path field to validate a walk outside this directory."
-                className="mt-1 w-full rounded border border-white/5 bg-gray-950/60 px-3 py-2 text-sm text-gray-100 focus:border-cyan-400 focus:outline-none disabled:opacity-50"
+                className="mt-1 w-full rounded border border-white/5 bg-bg-base/60 px-3 py-2 text-sm text-text-primary focus:border-status-info focus:outline-none disabled:opacity-50"
               >
                 {filesLoading && <option>Loading…</option>}
                 {!filesLoading && files.length === 0 && <option>No walks found</option>}
@@ -120,18 +120,20 @@ export const WalkValidatorPage: FC = () => {
                   </option>
                 ))}
               </select>
-              {filesError && <span className="mt-1 block text-xs text-red-300">{filesError}</span>}
+              {filesError && (
+                <span className="mt-1 block text-xs text-status-error">{filesError}</span>
+              )}
             </label>
 
             <label className="block text-sm">
-              <span className="text-gray-300">Or paste an absolute path</span>
+              <span className="text-text-secondary">Or paste an absolute path</span>
               <input
                 type="text"
                 value={customPath}
                 onChange={(e) => setCustomPath(e.target.value)}
                 placeholder="/srv/niac/walks/cisco-c9300.walk"
                 title="Absolute path to a walk file. Takes precedence over the dropdown selection. The path is bounded server-side; ../ traversal is rejected."
-                className="mt-1 w-full rounded border border-white/5 bg-gray-950/60 px-3 py-2 font-mono text-xs text-gray-100 placeholder-gray-500 focus:border-cyan-400 focus:outline-none"
+                className="mt-1 w-full rounded border border-white/5 bg-bg-base/60 px-3 py-2 font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
               />
             </label>
           </div>
@@ -142,7 +144,7 @@ export const WalkValidatorPage: FC = () => {
               onClick={() => void run('validating')}
               disabled={busy !== 'idle' || !targetPath}
               title="Read-only validation: parses the walk and returns per-line issues. Doesn't modify the file."
-              className="rounded bg-cyan-500/20 px-3 py-1.5 text-sm font-medium text-cyan-100 ring-1 ring-cyan-400/40 hover:bg-cyan-500/30 disabled:opacity-50"
+              className="rounded bg-status-info/20 px-3 py-1.5 text-sm font-medium text-status-info ring-1 ring-cyan-400/40 hover:bg-status-info/30 disabled:opacity-50"
             >
               {busy === 'validating' ? 'Validating…' : 'Validate'}
             </button>
@@ -150,13 +152,13 @@ export const WalkValidatorPage: FC = () => {
               type="button"
               onClick={() => void run('fixing')}
               disabled={busy !== 'idle' || !targetPath}
-              className="rounded bg-amber-500/20 px-3 py-1.5 text-sm font-medium text-amber-100 ring-1 ring-amber-400/40 hover:bg-amber-500/30 disabled:opacity-50"
+              className="rounded bg-status-warning/20 px-3 py-1.5 text-sm font-medium text-status-warning ring-1 ring-status-warning/40 hover:bg-status-warning/30 disabled:opacity-50"
               title="Validate and rewrite the file in place. A .bak is created next to the original."
             >
               {busy === 'fixing' ? 'Fixing…' : 'Auto-fix'}
             </button>
             {error && (
-              <span className="text-sm text-red-300" role="alert">
+              <span className="text-sm text-status-error" role="alert">
                 {error}
               </span>
             )}
@@ -165,18 +167,20 @@ export const WalkValidatorPage: FC = () => {
       </Card>
 
       {response?.result && (
-        <Card className="border-white/5 bg-gray-900/70">
+        <Card className="border-white/5 bg-bg-surface/70">
           <CardContent className="space-y-4">
             <header className="flex flex-wrap items-baseline gap-4">
-              <h2 className="text-lg font-semibold text-white">{response.message ?? 'Result'}</h2>
-              <span className="text-sm text-gray-400">
+              <h2 className="text-lg font-semibold text-text-primary">
+                {response.message ?? 'Result'}
+              </h2>
+              <span className="text-sm text-text-muted">
                 {response.result.totalLines} lines, {response.result.validLines} valid
               </span>
               <span
                 className={`rounded px-2 py-0.5 text-xs font-medium ring-1 ${
                   response.result.valid
-                    ? 'bg-emerald-500/20 text-emerald-200 ring-emerald-400/40'
-                    : 'bg-red-500/20 text-red-200 ring-red-400/40'
+                    ? 'bg-status-success/20 text-status-success ring-status-success/40'
+                    : 'bg-status-error/20 text-status-error ring-status-error/40'
                 }`}
               >
                 {response.result.valid ? 'VALID' : 'INVALID'}
@@ -190,17 +194,17 @@ export const WalkValidatorPage: FC = () => {
                 </span>
               ))}
               {typeof response.result.fixedCount === 'number' && (
-                <span className="rounded bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-200 ring-1 ring-emerald-400/40">
+                <span className="rounded bg-status-success/20 px-2 py-0.5 text-xs font-medium text-status-success ring-1 ring-status-success/40">
                   fixed: {response.result.fixedCount}
                 </span>
               )}
             </header>
 
             {issues.length === 0 ? (
-              <p className="text-sm text-gray-400">No issues reported.</p>
+              <p className="text-sm text-text-muted">No issues reported.</p>
             ) : (
               <table className="w-full text-sm">
-                <thead className="bg-gray-950/40 text-left text-xs uppercase tracking-wider text-gray-400">
+                <thead className="bg-bg-base/40 text-left text-xs uppercase tracking-wider text-text-muted">
                   <tr>
                     <th className="px-3 py-2 w-16">Line</th>
                     <th className="px-3 py-2 w-24">Severity</th>
@@ -210,8 +214,11 @@ export const WalkValidatorPage: FC = () => {
                 </thead>
                 <tbody className="divide-y divide-white/5">
                   {issues.slice(0, 200).map((issue, idx) => (
-                    <tr key={`${issue.line}-${idx}`} className="text-gray-200 hover:bg-gray-950/40">
-                      <td className="px-3 py-2 font-mono text-xs text-gray-400">{issue.line}</td>
+                    <tr
+                      key={`${issue.line}-${idx}`}
+                      className="text-text-primary hover:bg-bg-base/40"
+                    >
+                      <td className="px-3 py-2 font-mono text-xs text-text-muted">{issue.line}</td>
                       <td className="px-3 py-2">
                         <span
                           className={`rounded px-2 py-0.5 text-[10px] font-medium ring-1 ${SEVERITY_BADGE[issue.severity as Severity] ?? ''}`}
@@ -220,7 +227,7 @@ export const WalkValidatorPage: FC = () => {
                         </span>
                       </td>
                       <td className="px-3 py-2">{issue.message}</td>
-                      <td className="px-3 py-2 truncate font-mono text-xs text-gray-500">
+                      <td className="px-3 py-2 truncate font-mono text-xs text-text-muted">
                         {issue.original}
                       </td>
                     </tr>
@@ -229,7 +236,7 @@ export const WalkValidatorPage: FC = () => {
               </table>
             )}
             {issues.length > 200 && (
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-text-muted">
                 Showing first 200 of {issues.length} issues — auto-fix to clear them all.
               </p>
             )}

--- a/ui/src/pages/config-diff/FileUploadZone.tsx
+++ b/ui/src/pages/config-diff/FileUploadZone.tsx
@@ -106,15 +106,15 @@ export const FileUploadZone: FC<FileUploadZoneProps> = ({
 
   if (file) {
     return (
-      <div className="rounded-xl border border-green-500/30 bg-green-500/10 p-4">
+      <div className="rounded-xl border border-status-success/30 bg-status-success/10 p-4">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-green-500/20 p-2">
-              <FileCode className={`${iconSizes.lg} text-green-300`} />
+            <div className="rounded-lg bg-status-success/20 p-2">
+              <FileCode className={`${iconSizes.lg} text-status-success`} />
             </div>
             <div>
-              <p className="font-semibold text-white">{file.name}</p>
-              <SmallText className="text-green-300">
+              <p className="font-semibold text-text-primary">{file.name}</p>
+              <SmallText className="text-status-success">
                 {formatBytes(file.size)} | {file.content.split('\n').length} lines
               </SmallText>
             </div>
@@ -123,7 +123,7 @@ export const FileUploadZone: FC<FileUploadZoneProps> = ({
             type="button"
             onClick={onClear}
             disabled={disabled}
-            className="rounded-lg p-1.5 text-gray-400 hover:bg-white/10 hover:text-white transition-colors disabled:opacity-50"
+            className="rounded-lg p-1.5 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors disabled:opacity-50"
             aria-label={`Remove ${file.name}`}
           >
             <X className={iconSizes.md} />
@@ -138,8 +138,8 @@ export const FileUploadZone: FC<FileUploadZoneProps> = ({
       <label
         className={`block rounded-xl border-2 border-dashed p-6 text-center transition-colors cursor-pointer ${
           dragOver
-            ? 'border-violet-400 bg-violet-500/10'
-            : 'border-white/20 hover:border-violet-400/50 hover:bg-gray-950/50'
+            ? 'border-brand-400 bg-brand-500/10'
+            : 'border-white/20 hover:border-brand-400/50 hover:bg-bg-base/50'
         } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
@@ -152,12 +152,14 @@ export const FileUploadZone: FC<FileUploadZoneProps> = ({
           disabled={disabled}
           className="hidden"
         />
-        <Upload className={`mx-auto ${iconSizes['2xl']} text-gray-400 mb-2`} />
-        <p className="text-gray-300 font-medium">{label}</p>
-        <SmallText className="text-gray-500">Drag & drop or click to select a YAML file</SmallText>
+        <Upload className={`mx-auto ${iconSizes['2xl']} text-text-muted mb-2`} />
+        <p className="text-text-secondary font-medium">{label}</p>
+        <SmallText className="text-text-muted">
+          Drag & drop or click to select a YAML file
+        </SmallText>
       </label>
       {error && (
-        <div className="flex items-center gap-2 text-red-400 text-sm">
+        <div className="flex items-center gap-2 text-status-error text-sm">
           <AlertCircle className={iconSizes.md} />
           {error}
         </div>

--- a/ui/src/pages/runtime/AdvancedSection.tsx
+++ b/ui/src/pages/runtime/AdvancedSection.tsx
@@ -11,14 +11,14 @@ export const AdvancedSection: FC = () => {
   const [open, setOpen] = useState(false);
   return (
     <details
-      className="rounded border border-white/10 bg-gray-950/40"
+      className="rounded border border-white/10 bg-bg-base/40"
       open={open}
       onToggle={(e) => setOpen(e.currentTarget.open)}
     >
-      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-gray-300 hover:text-white">
-        <span className="text-gray-500">{open ? '▾' : '▸'}</span>
+      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-text-secondary hover:text-text-primary">
+        <span className="text-text-muted">{open ? '▾' : '▸'}</span>
         <span>Advanced</span>
-        <SmallText className="text-gray-500">(global protocol debug level)</SmallText>
+        <SmallText className="text-text-muted">(global protocol debug level)</SmallText>
       </summary>
       <div className="border-t border-white/10 p-3">
         <GlobalDebugLevelCard />

--- a/ui/src/pages/runtime/GlobalDebugLevelCard.tsx
+++ b/ui/src/pages/runtime/GlobalDebugLevelCard.tsx
@@ -46,13 +46,13 @@ export const GlobalDebugLevelCard: FC = () => {
   };
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-3">
         <H2 className="flex items-center gap-2 text-lg">
-          <Activity className={`${iconSizes.lg} text-violet-300`} />
+          <Activity className={`${iconSizes.lg} text-brand-300`} />
           Debug level
         </H2>
-        <SmallText className="text-gray-400">
+        <SmallText className="text-text-muted">
           Sets every protocol to the same level. Use Protocol Debug for per-protocol tuning.
         </SmallText>
         <div className="flex flex-wrap items-center gap-3">
@@ -60,7 +60,7 @@ export const GlobalDebugLevelCard: FC = () => {
             value={current}
             onChange={(e) => setPending(e.target.value as DebugLevel)}
             disabled={busy || !data}
-            className="rounded border border-white/10 bg-gray-950/60 px-3 py-1.5 text-sm text-gray-100 focus:border-violet-400 focus:outline-none disabled:opacity-50"
+            className="rounded border border-white/10 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-400 focus:outline-none disabled:opacity-50"
             aria-label="Global debug level"
             title="Applies to every protocol in the running stack. OFF silences everything; TRACE is the loudest."
           >
@@ -79,7 +79,7 @@ export const GlobalDebugLevelCard: FC = () => {
             {busy ? 'Applying…' : 'Apply'}
           </Button>
           {error && (
-            <SmallText className="text-red-300" role="alert">
+            <SmallText className="text-status-error" role="alert">
               {error}
             </SmallText>
           )}

--- a/ui/src/pages/runtime/RunningSimulationCard.tsx
+++ b/ui/src/pages/runtime/RunningSimulationCard.tsx
@@ -54,11 +54,11 @@ export const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
   };
 
   return (
-    <Card className="border-green-500/30 bg-gradient-to-br from-green-900/30 to-gray-900/70">
+    <Card className="border-status-success/30 bg-gradient-to-br from-green-900/30 to-bg-surface/70">
       <CardContent className="space-y-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="h-3 w-3 animate-pulse rounded-full bg-green-400" />
+            <div className="h-3 w-3 animate-pulse rounded-full bg-status-success" />
             <H2>Simulation Running</H2>
           </div>
           <Tag colorScheme="green">ACTIVE</Tag>
@@ -93,7 +93,9 @@ export const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
         </div>
 
         {message && (
-          <SmallText className={message.tone === 'success' ? 'text-emerald-300' : 'text-red-400'}>
+          <SmallText
+            className={message.tone === 'success' ? 'text-status-success' : 'text-status-error'}
+          >
             {message.text}
           </SmallText>
         )}

--- a/ui/src/pages/runtime/SelectedNetworkPreview.tsx
+++ b/ui/src/pages/runtime/SelectedNetworkPreview.tsx
@@ -146,26 +146,26 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
   const displayName = uploadFile?.name ?? name;
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-3">
         <div className="flex items-baseline justify-between gap-3">
           <H2 className="flex items-center gap-2 text-lg">
-            <Eye className={`${iconSizes.lg} text-violet-300`} />
+            <Eye className={`${iconSizes.lg} text-brand-300`} />
             Selected: {displayName}
           </H2>
-          <SmallText className="text-gray-500">Preview only — Start to launch</SmallText>
+          <SmallText className="text-text-muted">Preview only — Start to launch</SmallText>
         </div>
 
-        {loading && <SmallText className="text-gray-400">Loading preview…</SmallText>}
+        {loading && <SmallText className="text-text-muted">Loading preview…</SmallText>}
 
         {error && (
-          <SmallText className="text-red-300" role="alert">
+          <SmallText className="text-status-error" role="alert">
             Couldn't load preview: {error}
           </SmallText>
         )}
 
         {!loading && !error && devices.length === 0 && yamlText !== null && (
-          <SmallText className="text-gray-500 italic">
+          <SmallText className="text-text-muted italic">
             Picked config has no devices — nothing will run.
           </SmallText>
         )}
@@ -177,17 +177,17 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
               return (
                 <li
                   key={d.name}
-                  className="rounded-lg border border-white/10 bg-gray-950/40 px-3 py-2"
+                  className="rounded-lg border border-white/10 bg-bg-base/40 px-3 py-2"
                 >
                   <div className="flex items-center gap-2">
-                    <Icon className={`${iconSizes.sm} text-gray-400`} />
-                    <span className="font-medium text-white">{d.name}</span>
+                    <Icon className={`${iconSizes.sm} text-text-muted`} />
+                    <span className="font-medium text-text-primary">{d.name}</span>
                     <Tag colorScheme="gray" className="text-[10px] capitalize">
                       {d.type}
                     </Tag>
                   </div>
                   {(d.mac || d.ips.length > 0) && (
-                    <div className="mt-1 font-mono text-[11px] text-gray-500">
+                    <div className="mt-1 font-mono text-[11px] text-text-muted">
                       {d.mac && <span>{d.mac}</span>}
                       {d.mac && d.ips.length > 0 && <span> · </span>}
                       {d.ips.length > 0 && <span>{d.ips.join(', ')}</span>}
@@ -209,7 +209,7 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
         )}
 
         {devices.length > 0 && (
-          <SmallText className="text-gray-500">
+          <SmallText className="text-text-muted">
             {devices.length} {devices.length === 1 ? 'device' : 'devices'} will launch when Start is
             clicked.
           </SmallText>

--- a/ui/src/pages/templates/TemplateStates.tsx
+++ b/ui/src/pages/templates/TemplateStates.tsx
@@ -15,11 +15,11 @@ export const TemplatesLoadingState: FC<LoadingStateProps> = ({ show }) => {
   }
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="flex items-center justify-center py-12">
-        <div className="flex items-center gap-3 text-gray-400">
+        <div className="flex items-center gap-3 text-text-muted">
           <div
-            className={`${iconSizes.lg} animate-spin rounded-full border-2 border-violet-500 border-t-transparent`}
+            className={`${iconSizes.lg} animate-spin rounded-full border-2 border-brand-500 border-t-transparent`}
           />
           <span>Loading templates...</span>
         </div>
@@ -39,13 +39,13 @@ export const TemplatesErrorState: FC<ErrorStateProps> = ({ error, onRetry }) => 
   }
 
   return (
-    <Card className="border-red-500/30 bg-red-900/20">
+    <Card className="border-status-error/30 bg-status-error/20">
       <CardContent className="space-y-3">
         <div className="flex items-start gap-3">
-          <AlertCircle className={`mt-1 ${iconSizes.lg} text-red-400`} />
+          <AlertCircle className={`mt-1 ${iconSizes.lg} text-status-error`} />
           <div>
-            <p className="font-semibold text-red-200">Failed to Load Templates</p>
-            <SmallText className="text-red-300/90">{error.message}</SmallText>
+            <p className="font-semibold text-status-error">Failed to Load Templates</p>
+            <SmallText className="text-status-error/90">{error.message}</SmallText>
             <Button variant="outline" size="sm" className="mt-3" onClick={onRetry}>
               Retry
             </Button>
@@ -67,11 +67,11 @@ export const TemplatesEmptyState: FC<EmptyStateProps> = ({ show, onUploadClick }
   }
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="py-12 text-center">
-        <FileCode className={`mx-auto ${iconSizes['3xl']} text-gray-600`} />
+        <FileCode className={`mx-auto ${iconSizes['3xl']} text-text-disabled`} />
         <H2 className="mt-4 mb-2">No Templates Available</H2>
-        <P className="text-gray-400">Upload your first configuration template to get started.</P>
+        <P className="text-text-muted">Upload your first configuration template to get started.</P>
         <Button
           tone="violet"
           className="mt-4"
@@ -101,11 +101,11 @@ export const TemplatesNoResultsState: FC<NoResultsStateProps> = ({
   }
 
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="py-12 text-center">
-        <Search className={`mx-auto ${iconSizes['3xl']} text-gray-600`} />
+        <Search className={`mx-auto ${iconSizes['3xl']} text-text-disabled`} />
         <H2 className="mt-4 mb-2">No Matching Templates</H2>
-        <P className="text-gray-400">
+        <P className="text-text-muted">
           No templates match your search &quot;{searchQuery}&quot;. Try a different search term.
         </P>
         <Button variant="outline" className="mt-4" onClick={onClearSearch}>

--- a/ui/src/pages/templates/TemplatesHeader.tsx
+++ b/ui/src/pages/templates/TemplatesHeader.tsx
@@ -22,15 +22,15 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
   onDismissMessage,
 }) => {
   return (
-    <Card className="border-white/5 bg-gray-900/70">
+    <Card className="border-white/5 bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
             <H2 className="flex items-center gap-2">
-              <FileCode className={`${iconSizes.lg} text-violet-300`} />
+              <FileCode className={`${iconSizes.lg} text-brand-300`} />
               Configuration Templates
             </H2>
-            <P className="text-gray-400 mt-1">
+            <P className="text-text-muted mt-1">
               Browse and use pre-configured network templates to quickly start simulations.
             </P>
           </div>
@@ -46,20 +46,20 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
         {/* Search bar */}
         <div className="relative">
           <Search
-            className={`absolute left-3 top-1/2 ${iconSizes.lg} -translate-y-1/2 text-gray-400`}
+            className={`absolute left-3 top-1/2 ${iconSizes.lg} -translate-y-1/2 text-text-muted`}
           />
           <input
             type="text"
             placeholder="Search templates by name, description, or type..."
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
-            className="w-full rounded-lg border border-white/10 bg-gray-950/60 py-3 pl-10 pr-10 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+            className="w-full rounded-lg border border-white/10 bg-bg-base/60 py-3 pl-10 pr-10 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
           />
           {searchQuery && (
             <button
               type="button"
               onClick={() => onSearchChange('')}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary"
               aria-label="Clear search"
             >
               <X className={iconSizes.md} />
@@ -72,8 +72,8 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
           <div
             className={`flex items-center gap-2 rounded-lg p-3 ${
               message.type === 'success'
-                ? 'border border-green-500/30 bg-green-500/10 text-green-300'
-                : 'border border-red-500/30 bg-red-500/10 text-red-300'
+                ? 'border border-status-success/30 bg-status-success/10 text-status-success'
+                : 'border border-status-error/30 bg-status-error/10 text-status-error'
             }`}
             role="alert"
           >

--- a/ui/src/pages/templates/UploadTemplateModal.tsx
+++ b/ui/src/pages/templates/UploadTemplateModal.tsx
@@ -92,7 +92,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
         aria-label="Close upload modal"
       />
       <div
-        className="relative mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl"
+        className="relative mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
         aria-labelledby="upload-modal-title"
@@ -100,20 +100,20 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
         {/* Modal Header */}
         <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-violet-500/20 p-2">
-              <Upload className={`${iconSizes.lg} text-violet-300`} />
+            <div className="rounded-lg bg-brand-500/20 p-2">
+              <Upload className={`${iconSizes.lg} text-brand-300`} />
             </div>
             <div>
-              <h2 id="upload-modal-title" className="text-lg font-semibold text-white">
+              <h2 id="upload-modal-title" className="text-lg font-semibold text-text-primary">
                 Upload Template
               </h2>
-              <SmallText className="text-gray-400">Add a new configuration template</SmallText>
+              <SmallText className="text-text-muted">Add a new configuration template</SmallText>
             </div>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
+            className="rounded-lg p-2 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors"
             aria-label="Close modal"
           >
             <X className={iconSizes.lg} />
@@ -126,7 +126,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
           <div>
             <label
               htmlFor="template-upload"
-              className="mb-2 block text-sm font-medium text-gray-300"
+              className="mb-2 block text-sm font-medium text-text-secondary"
             >
               Upload YAML File
             </label>
@@ -135,16 +135,21 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               type="file"
               accept=".yaml,.yml"
               onChange={(e) => handleFileChange(e.target.files?.[0] || null)}
-              className="w-full cursor-pointer rounded-lg border border-dashed border-white/20 bg-gray-950/40 p-3 text-sm text-white file:mr-3 file:rounded-md file:border-0 file:bg-violet-600 file:px-3 file:py-1 file:text-sm file:font-medium"
+              className="w-full cursor-pointer rounded-lg border border-dashed border-white/20 bg-bg-base/40 p-3 text-sm text-text-primary file:mr-3 file:rounded-md file:border-0 file:bg-brand-600 file:px-3 file:py-1 file:text-sm file:font-medium"
             />
             {uploadFile && (
-              <SmallText className="mt-1 text-green-400">Selected: {uploadFile.name}</SmallText>
+              <SmallText className="mt-1 text-status-success">
+                Selected: {uploadFile.name}
+              </SmallText>
             )}
           </div>
 
           {/* Name input */}
           <div>
-            <label htmlFor="template-name" className="mb-2 block text-sm font-medium text-gray-300">
+            <label
+              htmlFor="template-name"
+              className="mb-2 block text-sm font-medium text-text-secondary"
+            >
               Template Name *
             </label>
             <input
@@ -153,7 +158,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g., Basic Network"
-              className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
             />
           </div>
 
@@ -161,7 +166,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
           <div>
             <label
               htmlFor="template-description"
-              className="mb-2 block text-sm font-medium text-gray-300"
+              className="mb-2 block text-sm font-medium text-text-secondary"
             >
               Description
             </label>
@@ -171,20 +176,23 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Brief description of this template..."
               rows={2}
-              className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none resize-none"
+              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none resize-none"
             />
           </div>
 
           {/* Type selector */}
           <div>
-            <label htmlFor="template-type" className="mb-2 block text-sm font-medium text-gray-300">
+            <label
+              htmlFor="template-type"
+              className="mb-2 block text-sm font-medium text-text-secondary"
+            >
               Template Type
             </label>
             <select
               id="template-type"
               value={type}
               onChange={(e) => setType(e.target.value as Template['type'])}
-              className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white focus:border-violet-400 focus:outline-none"
+              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
             >
               <option value="basic">Basic Network</option>
               <option value="router">Router</option>
@@ -200,7 +208,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
           <div>
             <label
               htmlFor="template-content"
-              className="mb-2 block text-sm font-medium text-gray-300"
+              className="mb-2 block text-sm font-medium text-text-secondary"
             >
               YAML Content *
             </label>
@@ -210,14 +218,14 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               onChange={(e) => setContent(e.target.value)}
               placeholder="Paste your YAML configuration here..."
               rows={10}
-              className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 font-mono text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none resize-none"
+              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 font-mono text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none resize-none"
               spellCheck={false}
             />
           </div>
         </div>
 
         {/* Modal Footer */}
-        <div className="flex justify-end gap-3 border-t border-white/10 px-6 py-4 bg-gray-950/50">
+        <div className="flex justify-end gap-3 border-t border-white/10 px-6 py-4 bg-bg-base/50">
           <Button variant="outline" onClick={onClose} disabled={uploading}>
             Cancel
           </Button>

--- a/ui/src/pages/topology/ActionsMenu.tsx
+++ b/ui/src/pages/topology/ActionsMenu.tsx
@@ -61,25 +61,25 @@ export const ActionsMenu: FC<{
       {open && (
         <div
           role="menu"
-          className="absolute right-0 mt-1 min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur z-50"
+          className="absolute right-0 mt-1 min-w-[180px] rounded-md border border-white/10 bg-bg-base/95 py-1 text-xs text-text-primary shadow-xl backdrop-blur z-50"
         >
           <button
             type="button"
             role="menuitem"
             onClick={handle(onExportPNG)}
-            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-white"
+            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-text-primary"
           >
             <span>Export as PNG</span>
-            <span className="text-[10px] text-gray-500">image</span>
+            <span className="text-[10px] text-text-muted">image</span>
           </button>
           <button
             type="button"
             role="menuitem"
             onClick={handle(onExportJSON)}
-            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-white"
+            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-text-primary"
           >
             <span>Export topology JSON</span>
-            <span className="text-[10px] text-gray-500">data</span>
+            <span className="text-[10px] text-text-muted">data</span>
           </button>
         </div>
       )}

--- a/ui/src/pages/topology/ContextMenu.tsx
+++ b/ui/src/pages/topology/ContextMenu.tsx
@@ -101,7 +101,7 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
       // [9999] because the topology page sits inside a stacking
       // context (the Card chrome creates one) and z-50 lost to
       // ReactFlow's own overlay elements in earlier versions.
-      className="fixed z-[9999] min-w-[180px] rounded-md border border-white/10 bg-gray-950/95 py-1 text-xs text-gray-200 shadow-xl backdrop-blur"
+      className="fixed z-[9999] min-w-[180px] rounded-md border border-white/10 bg-bg-base/95 py-1 text-xs text-text-primary shadow-xl backdrop-blur"
       style={{ left: clampedX, top: clampedY }}
       // Stop right-click on the menu itself from re-opening the pane
       // menu through ReactFlow's onPaneContextMenu.
@@ -118,14 +118,14 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
             onClick={(e) => handleItemClick(e, item)}
             className={`flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors ${
               item.disabled
-                ? 'text-gray-600 cursor-not-allowed'
+                ? 'text-text-disabled cursor-not-allowed'
                 : item.destructive
-                  ? 'text-red-300 hover:bg-red-500/15 hover:text-red-200'
-                  : 'hover:bg-white/5 hover:text-white'
+                  ? 'text-status-error hover:bg-status-error/15 hover:text-status-error'
+                  : 'hover:bg-white/5 hover:text-text-primary'
             }`}
           >
             <span>{item.label}</span>
-            {item.hint && <span className="text-[10px] text-gray-500">{item.hint}</span>}
+            {item.hint && <span className="text-[10px] text-text-muted">{item.hint}</span>}
           </button>
         </div>
       ))}

--- a/ui/src/pages/topology/DeviceDetailsPanel.tsx
+++ b/ui/src/pages/topology/DeviceDetailsPanel.tsx
@@ -34,7 +34,7 @@ export const DeviceDetailsPanel: FC<DeviceDetailsPanelProps> = ({ device, onClos
   const color = deviceColors[deviceType] || deviceColors.unknown;
 
   return (
-    <div className="absolute top-4 right-4 w-80 bg-gray-800/95 backdrop-blur-sm border border-white/10 rounded-xl p-4 shadow-2xl z-50">
+    <div className="absolute top-4 right-4 w-80 bg-bg-elevated/95 backdrop-blur-sm border border-white/10 rounded-xl p-4 shadow-2xl z-50">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <div
@@ -46,21 +46,25 @@ export const DeviceDetailsPanel: FC<DeviceDetailsPanelProps> = ({ device, onClos
             <Icon className="w-6 h-6" />
           </div>
           <div>
-            <h3 className="font-semibold text-white">{device.name}</h3>
-            <p className="text-sm text-gray-400 capitalize">{device.type}</p>
+            <h3 className="font-semibold text-text-primary">{device.name}</h3>
+            <p className="text-sm text-text-muted capitalize">{device.type}</p>
           </div>
         </div>
-        <button type="button" onClick={onClose} className="text-gray-400 hover:text-white text-xl">
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-text-muted hover:text-text-primary text-xl"
+        >
           &times;
         </button>
       </div>
 
       {device.ips && device.ips.length > 0 && (
         <div className="mb-3">
-          <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">IP Addresses</div>
+          <div className="text-xs text-text-muted uppercase tracking-wide mb-1">IP Addresses</div>
           <div className="space-y-1">
             {device.ips.map((ip) => (
-              <code key={ip} className="block text-sm text-blue-300 font-mono">
+              <code key={ip} className="block text-sm text-status-info font-mono">
                 {ip}
               </code>
             ))}
@@ -70,7 +74,7 @@ export const DeviceDetailsPanel: FC<DeviceDetailsPanelProps> = ({ device, onClos
 
       {device.protocols && device.protocols.length > 0 && (
         <div className="mb-4">
-          <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">Protocols</div>
+          <div className="text-xs text-text-muted uppercase tracking-wide mb-1">Protocols</div>
           <div className="flex flex-wrap gap-1">
             {device.protocols.map((proto) => (
               <Tag key={proto} colorScheme="purple" className="text-xs">

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -25,9 +25,9 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
   const color = deviceColors[deviceType] || deviceColors.unknown;
 
   const statusColor = {
-    online: 'bg-green-500',
-    offline: 'bg-gray-500',
-    warning: 'bg-yellow-500',
+    online: 'bg-status-success',
+    offline: 'bg-bg-muted',
+    warning: 'bg-status-warning',
   }[data.status || 'online'];
 
   return (
@@ -59,17 +59,17 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
       <Handle
         type="target"
         position={Position.Left}
-        className="!w-2 !h-2 !bg-violet-400 !border-0"
+        className="!w-2 !h-2 !bg-brand-400 !border-0"
       />
       <Handle
         type="source"
         position={Position.Right}
-        className="!w-2 !h-2 !bg-violet-400 !border-0"
+        className="!w-2 !h-2 !bg-brand-400 !border-0"
       />
 
       {/* Status indicator */}
       <div
-        className={`absolute -top-1 -right-1 w-3 h-3 rounded-full ${statusColor} border-2 border-gray-900`}
+        className={`absolute -top-1 -right-1 w-3 h-3 rounded-full ${statusColor} border-2 border-border-muted`}
       />
 
       {/* Icon and name */}
@@ -83,17 +83,19 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
           <Icon className="w-5 h-5" />
         </div>
         <div className="min-w-0 flex-1">
-          <div className="font-semibold text-white text-sm truncate">{data.label}</div>
-          <div className="text-xs text-gray-400 capitalize">{data.type}</div>
+          <div className="font-semibold text-text-primary text-sm truncate">{data.label}</div>
+          <div className="text-xs text-text-muted capitalize">{data.type}</div>
         </div>
       </div>
 
       {/* IPs */}
       {data.ips && data.ips.length > 0 && (
         <div className="mt-2 pt-2 border-t border-white/10">
-          <div className="text-xs font-mono text-gray-400 truncate">
+          <div className="text-xs font-mono text-text-muted truncate">
             {data.ips[0]}
-            {data.ips.length > 1 && <span className="text-gray-500"> +{data.ips.length - 1}</span>}
+            {data.ips.length > 1 && (
+              <span className="text-text-muted"> +{data.ips.length - 1}</span>
+            )}
           </div>
         </div>
       )}
@@ -104,13 +106,13 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
           {data.protocols.slice(0, 3).map((proto) => (
             <span
               key={proto}
-              className="px-1.5 py-0.5 text-[10px] rounded-md bg-white/10 text-gray-300"
+              className="px-1.5 py-0.5 text-[10px] rounded-md bg-white/10 text-text-secondary"
             >
               {proto}
             </span>
           ))}
           {data.protocols.length > 3 && (
-            <span className="px-1.5 py-0.5 text-[10px] rounded-md bg-white/5 text-gray-500">
+            <span className="px-1.5 py-0.5 text-[10px] rounded-md bg-white/5 text-text-muted">
               +{data.protocols.length - 3}
             </span>
           )}

--- a/ui/src/pages/topology/NeighborsView.tsx
+++ b/ui/src/pages/topology/NeighborsView.tsx
@@ -127,7 +127,7 @@ export const NeighborsView: FC = () => {
 
   return (
     <div className="space-y-4">
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="space-y-3">
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex items-center gap-2">
@@ -146,12 +146,12 @@ export const NeighborsView: FC = () => {
                     }
                     className={`rounded px-3 py-1 text-xs font-medium ${
                       active
-                        ? 'bg-cyan-500/20 text-cyan-200 ring-1 ring-cyan-400/40'
-                        : 'bg-gray-800/60 text-gray-300 hover:bg-gray-800'
+                        ? 'bg-status-info/20 text-status-info ring-1 ring-cyan-400/40'
+                        : 'bg-bg-elevated/60 text-text-secondary hover:bg-bg-elevated'
                     }`}
                   >
                     {p === 'all' ? 'All' : p}
-                    <span className="ml-1.5 text-[10px] text-gray-500">{count}</span>
+                    <span className="ml-1.5 text-[10px] text-text-muted">{count}</span>
                   </button>
                 );
               })}
@@ -162,26 +162,26 @@ export const NeighborsView: FC = () => {
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Filter by device or chassis ID…"
               title="Substring match on local device, remote device, chassis ID, or remote port (case-insensitive)."
-              className="ml-auto w-64 rounded border border-white/5 bg-gray-950/60 px-3 py-1.5 text-sm text-gray-100 placeholder-gray-500 focus:border-cyan-400 focus:outline-none"
+              className="ml-auto w-64 rounded border border-white/5 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
               aria-label="Filter neighbors"
             />
-            <span className="text-xs text-gray-500">
+            <span className="text-xs text-text-muted">
               Polling every {NEIGHBOR_POLL_MS / 1000}s · {neighbors?.length ?? 0} entries
             </span>
           </div>
         </CardContent>
       </Card>
 
-      <Card className="border-white/5 bg-gray-900/70">
+      <Card className="border-white/5 bg-bg-surface/70">
         <CardContent className="p-0">
-          {loading && !neighbors && <div className="p-6 text-sm text-gray-400">Loading…</div>}
+          {loading && !neighbors && <div className="p-6 text-sm text-text-muted">Loading…</div>}
           {error && (
-            <div className="p-6 text-sm text-red-300" role="alert">
+            <div className="p-6 text-sm text-status-error" role="alert">
               Failed to load neighbors: {error.message}
             </div>
           )}
           {neighbors && filtered.length === 0 && (
-            <div className="p-6 text-sm text-gray-500">
+            <div className="p-6 text-sm text-text-muted">
               {neighbors.length === 0
                 ? 'No neighbors discovered yet. Start a simulation that has CDP/LLDP/EDP/FDP enabled to populate this table.'
                 : 'No neighbors match the current filters.'}
@@ -189,7 +189,7 @@ export const NeighborsView: FC = () => {
           )}
           {filtered.length > 0 && (
             <table className="w-full text-sm">
-              <thead className="bg-gray-950/40 text-left text-xs uppercase tracking-wider text-gray-400">
+              <thead className="bg-bg-base/40 text-left text-xs uppercase tracking-wider text-text-muted">
                 <tr>
                   <th className="px-4 py-2">Protocol</th>
                   <th className="px-4 py-2">Local Device</th>
@@ -205,22 +205,22 @@ export const NeighborsView: FC = () => {
                 {filtered.map((n) => (
                   <tr
                     key={`${n.localDevice}-${n.remoteDevice}-${n.remotePort}`}
-                    className="text-gray-200 hover:bg-gray-950/40"
+                    className="text-text-primary hover:bg-bg-base/40"
                   >
-                    <td className="px-4 py-2 font-mono text-xs text-cyan-300">
+                    <td className="px-4 py-2 font-mono text-xs text-status-info">
                       {n.protocols.join(', ')}
                     </td>
                     <td className="px-4 py-2">{n.localDevice}</td>
                     <td className="px-4 py-2">{n.remoteDevice}</td>
-                    <td className="px-4 py-2 text-gray-400">{n.remotePort || '—'}</td>
-                    <td className="px-4 py-2 font-mono text-xs text-gray-400">
+                    <td className="px-4 py-2 text-text-muted">{n.remotePort || '—'}</td>
+                    <td className="px-4 py-2 font-mono text-xs text-text-muted">
                       {n.remoteChassisId || '—'}
                     </td>
-                    <td className="px-4 py-2 font-mono text-xs text-gray-400">
+                    <td className="px-4 py-2 font-mono text-xs text-text-muted">
                       {n.managementAddress || '—'}
                     </td>
-                    <td className="px-4 py-2 text-gray-400">{formatTtl(n.ttl)}</td>
-                    <td className="px-4 py-2 text-gray-400">{formatRelative(n.lastSeen)}</td>
+                    <td className="px-4 py-2 text-text-muted">{formatTtl(n.ttl)}</td>
+                    <td className="px-4 py-2 text-text-muted">{formatRelative(n.lastSeen)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/ui/src/pages/topology/TopologyHeader.tsx
+++ b/ui/src/pages/topology/TopologyHeader.tsx
@@ -37,12 +37,12 @@ export const TopologyHeader: FC<TopologyHeaderProps> = ({
   onAutoLayout,
 }) => {
   return (
-    <div className="flex items-center justify-between p-4 border-b border-white/10 bg-gray-900/80 backdrop-blur-sm">
+    <div className="flex items-center justify-between p-4 border-b border-white/10 bg-bg-surface/80 backdrop-blur-sm">
       <div className="flex items-center gap-4">
-        <h1 className="text-xl font-semibold text-white">{title}</h1>
-        <div className="flex items-center gap-3 text-sm text-gray-400">
+        <h1 className="text-xl font-semibold text-text-primary">{title}</h1>
+        <div className="flex items-center gap-3 text-sm text-text-muted">
           <span>{deviceCount} devices</span>
-          <span className="text-gray-600">|</span>
+          <span className="text-text-disabled">|</span>
           <span>{linkCount} links</span>
         </div>
       </div>

--- a/ui/src/pages/topology/TopologyLegend.tsx
+++ b/ui/src/pages/topology/TopologyLegend.tsx
@@ -27,7 +27,7 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
       <button
         type="button"
         onClick={onToggle}
-        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-800/90 border border-white/10 text-sm text-gray-300 hover:bg-gray-700/90 transition-colors"
+        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-bg-elevated/90 border border-white/10 text-sm text-text-secondary hover:bg-bg-elevated/90 transition-colors"
       >
         <Eye className="w-4 h-4" />
         Show Legend
@@ -36,10 +36,14 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
   }
 
   return (
-    <div className="bg-gray-800/95 backdrop-blur-sm border border-white/10 rounded-xl p-4 min-w-[200px]">
+    <div className="bg-bg-elevated/95 backdrop-blur-sm border border-white/10 rounded-xl p-4 min-w-[200px]">
       <div className="flex items-center justify-between mb-3">
-        <span className="text-sm font-semibold text-white">Legend</span>
-        <button type="button" onClick={onToggle} className="text-gray-400 hover:text-white">
+        <span className="text-sm font-semibold text-text-primary">Legend</span>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="text-text-muted hover:text-text-primary"
+        >
           <EyeOff className="w-4 h-4" />
         </button>
       </div>
@@ -47,7 +51,7 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
       <div className="space-y-4">
         {/* Device Types */}
         <div>
-          <div className="text-xs text-gray-400 uppercase tracking-wide mb-2">Device Types</div>
+          <div className="text-xs text-text-muted uppercase tracking-wide mb-2">Device Types</div>
           <div className="space-y-1.5">
             {[
               { type: 'router', label: 'Router' },
@@ -64,7 +68,7 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
                   <div className="w-4 h-4 flex items-center justify-center">
                     <Icon className="w-4 h-4 text-current" />
                   </div>
-                  <span className="text-xs text-gray-300">{label}</span>
+                  <span className="text-xs text-text-secondary">{label}</span>
                   <div
                     className="w-2 h-2 rounded-full ml-auto"
                     style={{ backgroundColor: color }}
@@ -77,7 +81,7 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
 
         {/* Link Speeds */}
         <div>
-          <div className="text-xs text-gray-400 uppercase tracking-wide mb-2">Link Speeds</div>
+          <div className="text-xs text-text-muted uppercase tracking-wide mb-2">Link Speeds</div>
           <div className="space-y-1.5">
             {[
               { label: '100M', color: 'var(--color-link-100m)' },
@@ -87,7 +91,7 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
             ].map(({ label, color }) => (
               <div key={label} className="flex items-center gap-2">
                 <div className="w-6 h-0.5 rounded" style={{ backgroundColor: color }} />
-                <span className="text-xs text-gray-300">{label}</span>
+                <span className="text-xs text-text-secondary">{label}</span>
               </div>
             ))}
           </div>

--- a/ui/src/pages/topology/TrunkEdge.tsx
+++ b/ui/src/pages/topology/TrunkEdge.tsx
@@ -126,7 +126,7 @@ export const TrunkEdge: FC<EdgeProps> = ({
 
 const labelBoxStyle =
   'absolute pointer-events-none px-1.5 py-0.5 rounded text-[10px] font-medium ' +
-  'border border-white/10 bg-gray-950/90 text-gray-200 shadow-sm whitespace-nowrap';
+  'border border-white/10 bg-bg-base/90 text-text-primary shadow-sm whitespace-nowrap';
 
 const EndLabel: FC<{ x: number; y: number; text: string; opacity: number }> = ({
   x,
@@ -149,7 +149,7 @@ const MiddleLabel: FC<{ x: number; y: number; text: string; opacity: number }> =
   opacity,
 }) => (
   <div
-    className={`${labelBoxStyle} text-violet-200`}
+    className={`${labelBoxStyle} text-brand-200`}
     style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)`, opacity }}
   >
     {text}
@@ -186,14 +186,14 @@ const EdgeTooltip: FC<{ x: number; y: number; data: LinkEdgeData }> = ({ x, y, d
 
   return (
     <div
-      className="absolute pointer-events-none rounded-lg border border-white/10 bg-gray-950/95 px-3 py-2 text-xs text-gray-200 shadow-lg z-50"
+      className="absolute pointer-events-none rounded-lg border border-white/10 bg-bg-base/95 px-3 py-2 text-xs text-text-primary shadow-lg z-50"
       style={{ transform: `translate(-50%, calc(-100% - 12px)) translate(${x}px, ${y}px)` }}
     >
       <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
         {rows.map(([k, v]) => (
           <div key={k} className="contents">
-            <span className="text-gray-500">{k}</span>
-            <span className="font-medium text-white">{v}</span>
+            <span className="text-text-muted">{k}</span>
+            <span className="font-medium text-text-primary">{v}</span>
           </div>
         ))}
       </div>

--- a/ui/src/styles/themeComponents.ts
+++ b/ui/src/styles/themeComponents.ts
@@ -1,28 +1,29 @@
 // Copyright (c) 2025 Mustard Seed Networks. All rights reserved.
 
 /**
- * =============================================================================
- * COMPONENT VARIANTS
- * =============================================================================
+ * themeComponents.ts — reusable component styling tokens.
+ * Re-exported through theme.ts.
  *
- * Reusable component styling tokens for buttons, inputs, cards, modals, etc.
+ * All values reference semantic theme tokens declared in src/index.css via
+ * Tailwind v4 @theme directive (brand-*, status-*, text-*, bg-*, border-*).
+ * No raw Tailwind palette colors — change the @theme block to retheme;
+ * do not hardcode here.
  */
 
-/**
- * Button variants - consistent button styling
- */
 export const button = {
-  base: 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-violet-500/50 disabled:opacity-50 disabled:cursor-not-allowed',
+  base: 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-500/50 disabled:opacity-50 disabled:cursor-not-allowed',
 
   variant: {
     primary:
-      'bg-gradient-to-r from-violet-600 to-violet-500 text-white shadow-lg shadow-violet-500/30 hover:from-violet-500 hover:to-violet-400 active:scale-[0.98]',
-    secondary: 'bg-white/10 text-white hover:bg-white/15 border border-white/10',
-    ghost: 'text-gray-400 hover:text-white hover:bg-white/10',
-    outline: 'border border-white/20 text-gray-300 hover:bg-white/5 hover:border-violet-500/50',
-    danger: 'bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30',
+      'bg-gradient-to-r from-brand-600 to-brand-500 text-text-primary shadow-lg shadow-brand-500/30 hover:from-brand-500 hover:to-brand-400 active:scale-[0.98]',
+    secondary: 'bg-bg-elevated text-text-primary hover:bg-bg-overlay border border-border-default',
+    ghost: 'text-text-muted hover:text-text-primary hover:bg-bg-elevated',
+    outline:
+      'border border-border-muted text-text-secondary hover:bg-bg-elevated hover:border-brand-500/50',
+    danger:
+      'bg-status-error/20 text-status-error border border-status-error/30 hover:bg-status-error/30',
     success:
-      'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/30',
+      'bg-status-success/20 text-status-success border border-status-success/30 hover:bg-status-success/30',
   },
 
   size: {
@@ -33,16 +34,13 @@ export const button = {
   },
 } as const;
 
-/**
- * Input variants - consistent form input styling
- */
 export const input = {
-  base: 'w-full rounded-lg bg-gray-900/50 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500/50 disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-500',
+  base: 'w-full rounded-lg bg-bg-surface text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500/50 disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-text-disabled',
 
   state: {
-    default: 'border border-white/10',
-    error: 'border border-red-500/50',
-    success: 'border border-emerald-500/50',
+    default: 'border border-border-default',
+    error: 'border border-status-error/50',
+    success: 'border border-status-success/50',
   },
 
   size: {
@@ -52,19 +50,16 @@ export const input = {
   },
 } as const;
 
-/**
- * Card variants - glass morphism cards
- */
 export const card = {
   base: 'rounded-xl backdrop-blur-xl',
 
   variant: {
-    default: 'bg-gradient-to-br from-gray-800/50 to-gray-900/50 border border-white/10',
+    default: 'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default',
     elevated:
-      'bg-gradient-to-br from-gray-800/70 to-gray-900/70 border border-white/10 shadow-xl shadow-black/20',
+      'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default shadow-xl shadow-black/20',
     interactive:
-      'bg-gradient-to-br from-gray-800/50 to-gray-900/50 border border-white/10 hover:border-violet-500/30 cursor-pointer transition-colors',
-    glass: 'bg-white/5 backdrop-blur-2xl border border-white/10 shadow-2xl',
+      'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default hover:border-brand-500/30 cursor-pointer transition-colors',
+    glass: 'bg-bg-elevated/40 backdrop-blur-2xl border border-border-default shadow-2xl',
   },
 
   padding: {
@@ -75,21 +70,18 @@ export const card = {
   },
 } as const;
 
-/**
- * Badge variants - status badges and tags
- */
 export const badge = {
   base: 'inline-flex items-center gap-1 rounded-full text-xs font-medium',
 
   variant: {
-    default: 'bg-white/10 text-gray-300',
-    success: 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30',
-    warning: 'bg-amber-500/20 text-amber-400 border border-amber-500/30',
-    error: 'bg-red-500/20 text-red-400 border border-red-500/30',
-    info: 'bg-blue-500/20 text-blue-400 border border-blue-500/30',
-    primary: 'bg-violet-500/20 text-violet-400 border border-violet-500/30',
-    new: 'bg-emerald-500/20 text-emerald-300',
-    beta: 'bg-amber-500/20 text-amber-300',
+    default: 'bg-bg-elevated text-text-secondary',
+    success: 'bg-status-success/20 text-status-success border border-status-success/30',
+    warning: 'bg-status-warning/20 text-status-warning border border-status-warning/30',
+    error: 'bg-status-error/20 text-status-error border border-status-error/30',
+    info: 'bg-status-info/20 text-status-info border border-status-info/30',
+    primary: 'bg-brand-500/20 text-brand-400 border border-brand-500/30',
+    new: 'bg-status-success/20 text-status-success',
+    beta: 'bg-status-warning/20 text-status-warning',
   },
 
   size: {
@@ -99,28 +91,22 @@ export const badge = {
   },
 } as const;
 
-/**
- * Alert/Banner variants
- */
 export const alert = {
   base: 'px-4 py-3 rounded-lg border',
 
   variant: {
-    error: 'bg-red-500/10 border-red-500/20 text-red-400',
-    warning: 'bg-amber-500/10 border-amber-500/20 text-amber-400',
-    success: 'bg-emerald-500/10 border-emerald-500/20 text-emerald-400',
-    info: 'bg-blue-500/10 border-blue-500/20 text-blue-400',
+    error: 'bg-status-error/10 border-status-error/20 text-status-error',
+    warning: 'bg-status-warning/10 border-status-warning/20 text-status-warning',
+    success: 'bg-status-success/10 border-status-success/20 text-status-success',
+    info: 'bg-status-info/10 border-status-info/20 text-status-info',
   },
 } as const;
 
-/**
- * Modal/Dialog variants
- */
 export const modal = {
   overlay: 'fixed inset-0 z-50 flex items-center justify-center p-4',
   backdrop: 'absolute inset-0 bg-black/60 backdrop-blur-sm',
   content:
-    'relative bg-gray-900 border border-white/10 rounded-xl shadow-2xl max-h-[85vh] overflow-y-auto',
+    'relative bg-bg-surface border border-border-default rounded-xl shadow-2xl max-h-[85vh] overflow-y-auto',
 
   size: {
     sm: 'max-w-md w-full',
@@ -131,14 +117,11 @@ export const modal = {
   },
 } as const;
 
-/**
- * Drawer variants - side panels
- */
 export const drawer = {
   overlay: 'fixed inset-0 z-50',
   backdrop: 'absolute inset-0 bg-black/50 backdrop-blur-sm',
   content:
-    'absolute right-0 top-0 h-full bg-gray-900 border-l border-white/10 shadow-2xl overflow-y-auto',
+    'absolute right-0 top-0 h-full bg-bg-surface border-l border-border-default shadow-2xl overflow-y-auto',
 
   size: {
     sm: 'w-80',
@@ -148,30 +131,24 @@ export const drawer = {
   },
 } as const;
 
-/**
- * Status indicator variants - for connection status, health, etc.
- */
 export const status = {
   dot: 'inline-block w-2 h-2 rounded-full',
 
   color: {
-    success: 'bg-emerald-500',
-    warning: 'bg-amber-500',
-    error: 'bg-red-500',
-    info: 'bg-blue-500',
-    inactive: 'bg-gray-500',
-    online: 'bg-emerald-500',
-    offline: 'bg-gray-500',
-    pending: 'bg-blue-500',
+    success: 'bg-status-success',
+    warning: 'bg-status-warning',
+    error: 'bg-status-error',
+    info: 'bg-status-info',
+    inactive: 'bg-text-disabled',
+    online: 'bg-status-success',
+    offline: 'bg-text-disabled',
+    pending: 'bg-status-info',
   },
 
   withLabel: 'inline-flex items-center gap-2',
   pulse: 'animate-pulse',
 } as const;
 
-/**
- * Icon sizing utilities
- */
 export const icon = {
   size: {
     xs: 'w-3 h-3',

--- a/ui/src/styles/themeDeviceColors.ts
+++ b/ui/src/styles/themeDeviceColors.ts
@@ -1,95 +1,89 @@
 // Copyright (c) 2025 Mustard Seed Networks. All rights reserved.
 
 /**
- * =============================================================================
- * DEVICE COLORS - NIAC specific
- * =============================================================================
+ * themeDeviceColors.ts — niac-specific accent colors for topology.
+ * Re-exported through theme.ts.
  *
- * Device type colors - accent colors for network device visualization.
- * Protocol colors - for packet/protocol identification.
- * Link speed colors - for topology visualization.
+ * All classes reference niac's semantic device/proto/link tokens declared
+ * in src/index.css via @theme:
+ *   --color-device-* → utilities text-device-router, bg-device-router, ...
+ *   --color-proto-*  → utilities text-proto-arp, bg-proto-arp, ...
+ *   --color-link-*   → utilities text-link-1g, text-link-trunk, ...
+ *
+ * To re-theme: change values in index.css; do not hardcode here.
  */
 
-/**
- * Device type colors - accent colors for network device visualization
- */
 export const deviceColor = {
   router: {
-    icon: 'text-blue-500',
-    badge: 'bg-blue-500/20 text-blue-400 border border-blue-500/30',
-    border: 'border-blue-500/30',
-    bg: 'bg-blue-500',
+    icon: 'text-device-router',
+    badge: 'bg-device-router/20 text-device-router border border-device-router/30',
+    border: 'border-device-router/30',
+    bg: 'bg-device-router',
   },
   switch: {
-    icon: 'text-emerald-500',
-    badge: 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30',
-    border: 'border-emerald-500/30',
-    bg: 'bg-emerald-500',
+    icon: 'text-device-switch',
+    badge: 'bg-device-switch/20 text-device-switch border border-device-switch/30',
+    border: 'border-device-switch/30',
+    bg: 'bg-device-switch',
   },
   firewall: {
-    icon: 'text-red-500',
-    badge: 'bg-red-500/20 text-red-400 border border-red-500/30',
-    border: 'border-red-500/30',
-    bg: 'bg-red-500',
+    icon: 'text-device-firewall',
+    badge: 'bg-device-firewall/20 text-device-firewall border border-device-firewall/30',
+    border: 'border-device-firewall/30',
+    bg: 'bg-device-firewall',
   },
   server: {
-    icon: 'text-orange-500',
-    badge: 'bg-orange-500/20 text-orange-400 border border-orange-500/30',
-    border: 'border-orange-500/30',
-    bg: 'bg-orange-500',
+    icon: 'text-device-server',
+    badge: 'bg-device-server/20 text-device-server border border-device-server/30',
+    border: 'border-device-server/30',
+    bg: 'bg-device-server',
   },
   workstation: {
-    icon: 'text-gray-400',
-    badge: 'bg-gray-500/20 text-gray-400 border border-gray-500/30',
-    border: 'border-gray-500/30',
-    bg: 'bg-gray-500',
+    icon: 'text-device-workstation',
+    badge: 'bg-device-workstation/20 text-device-workstation border border-device-workstation/30',
+    border: 'border-device-workstation/30',
+    bg: 'bg-device-workstation',
   },
   ap: {
-    icon: 'text-purple-500',
-    badge: 'bg-purple-500/20 text-purple-400 border border-purple-500/30',
-    border: 'border-purple-500/30',
-    bg: 'bg-purple-500',
+    icon: 'text-device-ap',
+    badge: 'bg-device-ap/20 text-device-ap border border-device-ap/30',
+    border: 'border-device-ap/30',
+    bg: 'bg-device-ap',
   },
   iot: {
-    icon: 'text-teal-500',
-    badge: 'bg-teal-500/20 text-teal-400 border border-teal-500/30',
-    border: 'border-teal-500/30',
-    bg: 'bg-teal-500',
+    icon: 'text-device-iot',
+    badge: 'bg-device-iot/20 text-device-iot border border-device-iot/30',
+    border: 'border-device-iot/30',
+    bg: 'bg-device-iot',
   },
   unknown: {
-    icon: 'text-gray-500',
-    badge: 'bg-gray-500/20 text-gray-400 border border-gray-500/30',
-    border: 'border-gray-500/30',
-    bg: 'bg-gray-500',
+    icon: 'text-device-unknown',
+    badge: 'bg-device-unknown/20 text-device-unknown border border-device-unknown/30',
+    border: 'border-device-unknown/30',
+    bg: 'bg-device-unknown',
   },
 } as const;
 
-/**
- * Protocol colors - for packet/protocol identification
- */
 export const protocolColor = {
-  arp: { icon: 'text-emerald-500', badge: 'bg-emerald-500/20 text-emerald-400' },
-  icmp: { icon: 'text-blue-500', badge: 'bg-blue-500/20 text-blue-400' },
-  dns: { icon: 'text-purple-500', badge: 'bg-purple-500/20 text-purple-400' },
-  dhcp: { icon: 'text-orange-500', badge: 'bg-orange-500/20 text-orange-400' },
-  snmp: { icon: 'text-teal-500', badge: 'bg-teal-500/20 text-teal-400' },
-  lldp: { icon: 'text-pink-500', badge: 'bg-pink-500/20 text-pink-400' },
-  cdp: { icon: 'text-yellow-500', badge: 'bg-yellow-500/20 text-yellow-400' },
-  http: { icon: 'text-indigo-500', badge: 'bg-indigo-500/20 text-indigo-400' },
-  tcp: { icon: 'text-cyan-500', badge: 'bg-cyan-500/20 text-cyan-400' },
-  udp: { icon: 'text-violet-500', badge: 'bg-violet-500/20 text-violet-400' },
+  arp: { icon: 'text-proto-arp', badge: 'bg-proto-arp/20 text-proto-arp' },
+  icmp: { icon: 'text-proto-icmp', badge: 'bg-proto-icmp/20 text-proto-icmp' },
+  dns: { icon: 'text-proto-dns', badge: 'bg-proto-dns/20 text-proto-dns' },
+  dhcp: { icon: 'text-proto-dhcp', badge: 'bg-proto-dhcp/20 text-proto-dhcp' },
+  snmp: { icon: 'text-proto-snmp', badge: 'bg-proto-snmp/20 text-proto-snmp' },
+  lldp: { icon: 'text-proto-lldp', badge: 'bg-proto-lldp/20 text-proto-lldp' },
+  cdp: { icon: 'text-proto-cdp', badge: 'bg-proto-cdp/20 text-proto-cdp' },
+  http: { icon: 'text-proto-http', badge: 'bg-proto-http/20 text-proto-http' },
+  tcp: { icon: 'text-proto-tcp', badge: 'bg-proto-tcp/20 text-proto-tcp' },
+  udp: { icon: 'text-proto-udp', badge: 'bg-proto-udp/20 text-proto-udp' },
 } as const;
 
-/**
- * Link speed colors - for topology visualization
- */
 export const linkSpeedColor = {
-  '10m': 'text-gray-400',
-  '100m': 'text-emerald-500',
-  '1g': 'text-blue-500',
-  '10g': 'text-purple-500',
-  '25g': 'text-orange-500',
-  '40g': 'text-pink-500',
-  '100g': 'text-yellow-500',
-  trunk: 'text-cyan-500',
+  '10m': 'text-link-10m',
+  '100m': 'text-link-100m',
+  '1g': 'text-link-1g',
+  '10g': 'text-link-10g',
+  '25g': 'text-link-25g',
+  '40g': 'text-link-40g',
+  '100g': 'text-link-100g',
+  trunk: 'text-link-trunk',
 } as const;

--- a/ui/src/styles/themeLayout.ts
+++ b/ui/src/styles/themeLayout.ts
@@ -58,10 +58,10 @@ export const radius = {
  * Border utilities
  */
 export const border = {
-  default: 'border border-white/10',
-  subtle: 'border border-white/5',
-  muted: 'border border-white/20',
-  focus: 'border border-violet-500/50',
-  error: 'border border-red-500/50',
-  divider: 'border-t border-white/10',
+  default: 'border border-border-default',
+  subtle: 'border border-border-subtle',
+  muted: 'border border-border-muted',
+  focus: 'border border-brand-500/50',
+  error: 'border border-status-error/50',
+  divider: 'border-t border-border-default',
 } as const;

--- a/ui/src/styles/themeTypography.ts
+++ b/ui/src/styles/themeTypography.ts
@@ -10,21 +10,21 @@
 
 export const typography = {
   heading: {
-    h1: 'text-2xl font-bold text-white',
-    h2: 'text-xl font-semibold text-white',
-    h3: 'text-lg font-semibold text-white',
-    h4: 'text-base font-medium text-white',
+    h1: 'text-2xl font-bold text-text-primary',
+    h2: 'text-xl font-semibold text-text-primary',
+    h3: 'text-lg font-semibold text-text-primary',
+    h4: 'text-base font-medium text-text-primary',
   },
 
   body: {
-    large: 'text-base text-gray-200',
-    default: 'text-sm text-gray-300',
-    small: 'text-xs text-gray-400',
-    muted: 'text-sm text-gray-500',
+    large: 'text-base text-text-primary',
+    default: 'text-sm text-text-secondary',
+    small: 'text-xs text-text-muted',
+    muted: 'text-sm text-text-muted',
   },
 
-  label: 'text-sm font-medium text-gray-300',
-  caption: 'text-xs text-gray-500',
+  label: 'text-sm font-medium text-text-secondary',
+  caption: 'text-xs text-text-muted',
   code: 'font-mono text-sm',
 
   size: {

--- a/ui/src/ui/Alert.tsx
+++ b/ui/src/ui/Alert.tsx
@@ -21,23 +21,23 @@ const statusConfig: Record<
 > = {
   success: {
     icon: CheckCircle,
-    containerClass: 'border-green-500/30 bg-green-500/10 text-green-300',
-    iconClass: 'text-green-400',
+    containerClass: 'border-status-success/30 bg-status-success/10 text-status-success',
+    iconClass: 'text-status-success',
   },
   error: {
     icon: AlertCircle,
-    containerClass: 'border-red-500/30 bg-red-500/10 text-red-300',
-    iconClass: 'text-red-400',
+    containerClass: 'border-status-error/30 bg-status-error/10 text-status-error',
+    iconClass: 'text-status-error',
   },
   warning: {
     icon: AlertTriangle,
-    containerClass: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-300',
-    iconClass: 'text-yellow-400',
+    containerClass: 'border-status-warning/30 bg-status-warning/10 text-status-warning',
+    iconClass: 'text-status-warning',
   },
   info: {
     icon: Info,
-    containerClass: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
-    iconClass: 'text-blue-400',
+    containerClass: 'border-status-info/30 bg-status-info/10 text-status-info',
+    iconClass: 'text-status-info',
   },
 };
 

--- a/ui/src/ui/BaseCard.tsx
+++ b/ui/src/ui/BaseCard.tsx
@@ -140,7 +140,7 @@ export function BaseCard<T>({
         enableLiveRegion={true}
       >
         <CardValue value="Error" size="md" status="error" />
-        <p className="text-sm text-red-400/80 mt-1">{error}</p>
+        <p className="text-sm text-status-error/80 mt-1">{error}</p>
       </StatusCard>
     );
   }
@@ -252,7 +252,7 @@ export const SimpleBaseCard: FC<SimpleBaseCardProps> = ({
         enableLiveRegion={true}
       >
         <CardValue value="Error" size="md" status="error" />
-        <p className="text-sm text-red-400/80 mt-1">{error}</p>
+        <p className="text-sm text-status-error/80 mt-1">{error}</p>
       </StatusCard>
     );
   }

--- a/ui/src/ui/Breadcrumbs.tsx
+++ b/ui/src/ui/Breadcrumbs.tsx
@@ -44,23 +44,23 @@ export const Breadcrumbs: FC = () => {
   }
 
   return (
-    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-gray-400 mb-4">
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-text-muted mb-4">
       <Link
         to="/"
-        className="flex items-center gap-1 hover:text-white transition-colors"
+        className="flex items-center gap-1 hover:text-text-primary transition-colors"
         aria-label="Home"
       >
         <Home className={iconSizes.sm} />
       </Link>
       {items.map((item, index) => (
         <span key={item.path} className="flex items-center gap-1">
-          <ChevronRight className={`${iconSizes.xs} text-gray-600`} />
+          <ChevronRight className={`${iconSizes.xs} text-text-disabled`} />
           {index === items.length - 1 ? (
-            <span className="text-white font-medium capitalize" aria-current="page">
+            <span className="text-text-primary font-medium capitalize" aria-current="page">
               {item.label}
             </span>
           ) : (
-            <Link to={item.path} className="hover:text-white transition-colors capitalize">
+            <Link to={item.path} className="hover:text-text-primary transition-colors capitalize">
               {item.label}
             </Link>
           )}

--- a/ui/src/ui/Button.tsx
+++ b/ui/src/ui/Button.tsx
@@ -31,35 +31,36 @@ const sizeStyles: Record<ButtonSize, string> = {
 const variantStyles: Record<ButtonVariant, Record<ButtonTone, string>> = {
   solid: {
     violet:
-      'bg-gradient-to-r from-violet-600 to-violet-500 hover:from-violet-500 hover:to-violet-400 text-white shadow-lg shadow-violet-500/25 focus:ring-violet-500',
-    red: 'bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-white shadow-lg shadow-red-500/25 focus:ring-red-500',
+      'bg-gradient-to-r from-brand-600 to-brand-500 hover:from-brand-500 hover:to-brand-400 text-text-primary shadow-lg shadow-brand-500/25 focus:ring-brand-500',
+    red: 'bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-text-primary shadow-lg shadow-red-500/25 focus:ring-status-error',
     green:
-      'bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 text-white shadow-lg shadow-emerald-500/25 focus:ring-emerald-500',
-    blue: 'bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 text-white shadow-lg shadow-blue-500/25 focus:ring-blue-500',
-    gray: 'bg-gradient-to-r from-gray-600 to-gray-500 hover:from-gray-500 hover:to-gray-400 text-white shadow-lg shadow-gray-500/25 focus:ring-gray-500',
+      'bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 text-text-primary shadow-lg shadow-emerald-500/25 focus:ring-status-success',
+    blue: 'bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 text-text-primary shadow-lg shadow-blue-500/25 focus:ring-status-info',
+    gray: 'bg-gradient-to-r from-gray-600 to-gray-500 hover:from-gray-500 hover:to-gray-400 text-text-primary shadow-lg shadow-gray-500/25 focus:ring-border-muted',
   },
   outline: {
     violet:
-      'border border-violet-400/30 text-violet-300 hover:bg-violet-400/10 hover:border-violet-400/50 focus:ring-violet-500',
-    red: 'border border-red-400/30 text-red-300 hover:bg-red-400/10 hover:border-red-400/50 focus:ring-red-500',
+      'border border-brand-400/30 text-brand-300 hover:bg-brand-400/10 hover:border-brand-400/50 focus:ring-brand-500',
+    red: 'border border-status-error/30 text-status-error hover:bg-status-error/10 hover:border-status-error/50 focus:ring-status-error',
     green:
-      'border border-emerald-400/30 text-emerald-300 hover:bg-emerald-400/10 hover:border-emerald-400/50 focus:ring-emerald-500',
-    blue: 'border border-blue-400/30 text-blue-300 hover:bg-blue-400/10 hover:border-blue-400/50 focus:ring-blue-500',
-    gray: 'border border-white/20 text-gray-300 hover:bg-white/10 hover:border-white/30 focus:ring-gray-500',
+      'border border-status-success/30 text-status-success hover:bg-status-success/10 hover:border-status-success/50 focus:ring-status-success',
+    blue: 'border border-status-info/30 text-status-info hover:bg-status-info/10 hover:border-status-info/50 focus:ring-status-info',
+    gray: 'border border-white/20 text-text-secondary hover:bg-white/10 hover:border-white/30 focus:ring-border-muted',
   },
   ghost: {
-    violet: 'text-violet-300 hover:bg-violet-400/10 hover:text-violet-200 focus:ring-violet-500',
-    red: 'text-red-300 hover:bg-red-400/10 hover:text-red-200 focus:ring-red-500',
-    green: 'text-emerald-300 hover:bg-emerald-400/10 hover:text-emerald-200 focus:ring-emerald-500',
-    blue: 'text-blue-300 hover:bg-blue-400/10 hover:text-blue-200 focus:ring-blue-500',
-    gray: 'text-gray-400 hover:bg-white/10 hover:text-white focus:ring-gray-500',
+    violet: 'text-brand-300 hover:bg-brand-400/10 hover:text-brand-200 focus:ring-brand-500',
+    red: 'text-status-error hover:bg-status-error/10 hover:text-status-error focus:ring-status-error',
+    green:
+      'text-status-success hover:bg-status-success/10 hover:text-status-success focus:ring-status-success',
+    blue: 'text-status-info hover:bg-status-info/10 hover:text-status-info focus:ring-status-info',
+    gray: 'text-text-muted hover:bg-white/10 hover:text-text-primary focus:ring-border-muted',
   },
   secondary: {
-    violet: 'bg-white/10 hover:bg-white/15 text-white focus:ring-violet-500',
-    red: 'bg-white/10 hover:bg-white/15 text-white focus:ring-red-500',
-    green: 'bg-white/10 hover:bg-white/15 text-white focus:ring-emerald-500',
-    blue: 'bg-white/10 hover:bg-white/15 text-white focus:ring-blue-500',
-    gray: 'bg-white/10 hover:bg-white/15 text-white focus:ring-gray-500',
+    violet: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-brand-500',
+    red: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-status-error',
+    green: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-status-success',
+    blue: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-status-info',
+    gray: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-border-muted',
   },
 };
 
@@ -142,17 +143,17 @@ export const IconButton: FC<IconButtonProps> = ({
   };
 
   const toneStyles: Record<ButtonTone, string> = {
-    violet: 'text-violet-400 hover:text-violet-300',
-    red: 'text-red-400 hover:text-red-300',
-    green: 'text-emerald-400 hover:text-emerald-300',
-    blue: 'text-blue-400 hover:text-blue-300',
-    gray: 'text-gray-400 hover:text-white',
+    violet: 'text-brand-400 hover:text-brand-300',
+    red: 'text-status-error hover:text-status-error',
+    green: 'text-status-success hover:text-status-success',
+    blue: 'text-status-info hover:text-status-info',
+    gray: 'text-text-muted hover:text-text-primary',
   };
 
   return (
     <button
       type="button"
-      className={`inline-flex items-center justify-center transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-violet-500/50 disabled:opacity-50 disabled:cursor-not-allowed ${iconSizeStyles[size]} ${variantBase[variant]} ${toneStyles[tone]} ${className}`}
+      className={`inline-flex items-center justify-center transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-500/50 disabled:opacity-50 disabled:cursor-not-allowed ${iconSizeStyles[size]} ${variantBase[variant]} ${toneStyles[tone]} ${className}`}
       {...props}
     >
       {icon}

--- a/ui/src/ui/Card.tsx
+++ b/ui/src/ui/Card.tsx
@@ -41,9 +41,9 @@ type CardVariant = 'default' | 'elevated' | 'outlined' | 'ghost';
 
 const variantStyles: Record<CardVariant, string> = {
   default:
-    'backdrop-blur-xl bg-gradient-to-br from-gray-900/90 to-gray-900/70 border border-white/10 shadow-xl shadow-black/20',
+    'backdrop-blur-xl bg-gradient-to-br from-bg-surface/90 to-bg-surface/70 border border-white/10 shadow-xl shadow-black/20',
   elevated:
-    'backdrop-blur-xl bg-gradient-to-br from-gray-800/90 to-gray-900/80 border border-white/15 shadow-2xl shadow-black/30',
+    'backdrop-blur-xl bg-gradient-to-br from-bg-elevated/90 to-bg-surface/80 border border-white/15 shadow-2xl shadow-black/30',
   outlined: 'bg-transparent border border-white/20',
   ghost: 'bg-white/5 border border-transparent',
 };
@@ -179,15 +179,15 @@ export const StatusCard: FC<StatusCardProps> = ({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           {icon && (
-            <span className="text-gray-400 shrink-0 w-5 h-5" aria-hidden="true">
+            <span className="text-text-muted shrink-0 w-5 h-5" aria-hidden="true">
               {icon}
             </span>
           )}
           <div className="flex flex-col">
-            <h3 className="text-base font-semibold text-white" id={titleId}>
+            <h3 className="text-base font-semibold text-text-primary" id={titleId}>
               {title}
             </h3>
-            {subtitle && <p className="text-xs text-gray-400 leading-tight">{subtitle}</p>}
+            {subtitle && <p className="text-xs text-text-muted leading-tight">{subtitle}</p>}
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -281,24 +281,24 @@ export const CardValue: FC<CardValueProps> = ({
 }) => {
   const statusColor = status
     ? {
-        success: 'text-emerald-400',
-        warning: 'text-amber-400',
-        error: 'text-red-400',
-        info: 'text-cyan-400',
-        unknown: 'text-gray-400',
-        loading: 'text-cyan-400',
+        success: 'text-status-success',
+        warning: 'text-status-warning',
+        error: 'text-status-error',
+        info: 'text-status-info',
+        unknown: 'text-text-muted',
+        loading: 'text-status-info',
       }[status]
-    : 'text-white';
+    : 'text-text-primary';
 
   return (
     <div>
-      {label && <p className="text-xs text-gray-400 mb-1">{label}</p>}
+      {label && <p className="text-xs text-text-muted mb-1">{label}</p>}
       <p
         className={`${valueSizeClasses[size]} ${statusColor} ${mono ? 'font-mono tabular-nums' : ''}`}
         data-testid="card-value"
       >
         <span>{value}</span>
-        {unit && <span className="text-sm font-normal text-gray-500 ml-1">{unit}</span>}
+        {unit && <span className="text-sm font-normal text-text-muted ml-1">{unit}</span>}
       </p>
     </div>
   );
@@ -321,18 +321,18 @@ interface CardRowProps {
 export const CardRow: FC<CardRowProps> = ({ label, value, status, mono = false }) => {
   const statusColor = status
     ? {
-        success: 'text-emerald-400',
-        warning: 'text-amber-400',
-        error: 'text-red-400',
-        info: 'text-cyan-400',
-        unknown: 'text-gray-400',
-        loading: 'text-cyan-400',
+        success: 'text-status-success',
+        warning: 'text-status-warning',
+        error: 'text-status-error',
+        info: 'text-status-info',
+        unknown: 'text-text-muted',
+        loading: 'text-status-info',
       }[status]
-    : 'text-white';
+    : 'text-text-primary';
 
   return (
     <div className="flex justify-between items-center py-1">
-      <span className="text-sm text-gray-400 shrink-0">{label}</span>
+      <span className="text-sm text-text-muted shrink-0">{label}</span>
       <span
         className={`text-sm font-medium ${statusColor} ${mono ? 'font-mono tabular-nums' : ''} truncate text-right`}
         title={String(value)}
@@ -369,10 +369,10 @@ interface StatCardProps {
 export const StatCard: FC<StatCardProps> = ({ label, value, icon, trend, className = '' }) => {
   const trendColor = trend
     ? trend.value > 0
-      ? 'text-emerald-400'
+      ? 'text-status-success'
       : trend.value < 0
-        ? 'text-red-400'
-        : 'text-gray-400'
+        ? 'text-status-error'
+        : 'text-text-muted'
     : '';
 
   const trendIcon = trend ? (trend.value > 0 ? '↑' : trend.value < 0 ? '↓' : '→') : '';
@@ -381,15 +381,15 @@ export const StatCard: FC<StatCardProps> = ({ label, value, icon, trend, classNa
     <Card className={className} hover={true}>
       <CardContent className="space-y-2">
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-gray-400">{label}</span>
+          <span className="text-sm font-medium text-text-muted">{label}</span>
           {icon && <span className="text-brand-400">{icon}</span>}
         </div>
         <div className="flex items-end justify-between gap-2">
-          <span className="text-3xl font-bold text-white">{value}</span>
+          <span className="text-3xl font-bold text-text-primary">{value}</span>
           {trend && (
             <span className={`text-sm font-medium ${trendColor}`}>
               {trendIcon} {Math.abs(trend.value)}%
-              {trend.label && <span className="text-gray-500 ml-1">{trend.label}</span>}
+              {trend.label && <span className="text-text-muted ml-1">{trend.label}</span>}
             </span>
           )}
         </div>

--- a/ui/src/ui/ConfirmModal.tsx
+++ b/ui/src/ui/ConfirmModal.tsx
@@ -34,18 +34,18 @@ export const ConfirmModal: FC<ConfirmModalProps> = ({
           <AlertTriangle
             className={`${iconSizes.xl} ${
               confirmTone === 'red'
-                ? 'text-red-400'
+                ? 'text-status-error'
                 : confirmTone === 'blue'
-                  ? 'text-blue-400'
+                  ? 'text-status-info'
                   : confirmTone === 'green'
-                    ? 'text-green-400'
-                    : 'text-violet-400'
+                    ? 'text-status-success'
+                    : 'text-brand-400'
             }`}
           />
         )}
-        <h2 className="text-lg font-semibold text-white">{title}</h2>
+        <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
       </div>
-      <div className="text-gray-300">{message}</div>
+      <div className="text-text-secondary">{message}</div>
       <div className="flex justify-end gap-3 pt-2">
         <Button variant="outline" onClick={onCancel}>
           {cancelLabel}

--- a/ui/src/ui/ConnectionStatus.tsx
+++ b/ui/src/ui/ConnectionStatus.tsx
@@ -3,9 +3,9 @@ import { type FC, useCallback, useEffect, useRef, useState } from 'react';
 type Status = 'connected' | 'disconnected' | 'checking';
 
 const STATUS_STYLES: Record<Status, string> = {
-  connected: 'bg-green-400',
-  disconnected: 'bg-red-400',
-  checking: 'bg-yellow-400 animate-pulse',
+  connected: 'bg-status-success',
+  disconnected: 'bg-status-error',
+  checking: 'bg-status-warning animate-pulse',
 };
 
 const STATUS_LABELS: Record<Status, string> = {
@@ -46,7 +46,7 @@ export const ConnectionStatus: FC = () => {
   return (
     <div className="flex items-center gap-2" title={STATUS_LABELS[status]}>
       <span className={`h-2 w-2 rounded-full ${STATUS_STYLES[status]}`} />
-      <span className="text-xs text-gray-500">
+      <span className="text-xs text-text-muted">
         {status === 'connected' ? 'Online' : status === 'disconnected' ? 'Offline' : '...'}
       </span>
     </div>

--- a/ui/src/ui/Input.tsx
+++ b/ui/src/ui/Input.tsx
@@ -2,8 +2,8 @@ import type { FC, InputHTMLAttributes, ReactNode, Ref, TextareaHTMLAttributes } 
 
 // Base input styles
 const inputBaseStyles =
-  'w-full rounded-lg border bg-gray-950/60 text-white placeholder:text-gray-500 transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed';
-const inputFocusStyles = 'focus:border-violet-500 focus:ring-2 focus:ring-violet-500/20';
+  'w-full rounded-lg border bg-bg-base/60 text-text-primary placeholder:text-text-muted transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed';
+const inputFocusStyles = 'focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20';
 const inputBorderStyles = 'border-white/10 hover:border-white/20';
 
 // React 19: ref as regular prop instead of forwardRef
@@ -35,20 +35,20 @@ export const Input: FC<InputProps> = ({
   return (
     <div className={containerClassName}>
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-gray-300 mb-2">
+        <label htmlFor={inputId} className="block text-sm font-medium text-text-secondary mb-2">
           {label}
         </label>
       )}
       <div className="relative">
         {leftIcon && (
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">{leftIcon}</div>
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted">{leftIcon}</div>
         )}
         <input
           ref={ref}
           id={inputId}
           className={`
             ${inputBaseStyles}
-            ${hasError ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20' : `${inputBorderStyles} ${inputFocusStyles}`}
+            ${hasError ? 'border-status-error focus:border-status-error focus:ring-status-error/20' : `${inputBorderStyles} ${inputFocusStyles}`}
             ${leftIcon ? 'pl-10' : 'px-4'}
             ${rightIcon ? 'pr-10' : 'px-4'}
             py-2.5
@@ -57,11 +57,13 @@ export const Input: FC<InputProps> = ({
           {...props}
         />
         {rightIcon && (
-          <div className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400">{rightIcon}</div>
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted">
+            {rightIcon}
+          </div>
         )}
       </div>
       {(error || hint) && (
-        <p className={`mt-1.5 text-sm ${hasError ? 'text-red-400' : 'text-gray-500'}`}>
+        <p className={`mt-1.5 text-sm ${hasError ? 'text-status-error' : 'text-text-muted'}`}>
           {error || hint}
         </p>
       )}
@@ -94,7 +96,7 @@ export const Textarea: FC<TextareaProps> = ({
   return (
     <div className={containerClassName}>
       {label && (
-        <label htmlFor={textareaId} className="block text-sm font-medium text-gray-300 mb-2">
+        <label htmlFor={textareaId} className="block text-sm font-medium text-text-secondary mb-2">
           {label}
         </label>
       )}
@@ -103,14 +105,14 @@ export const Textarea: FC<TextareaProps> = ({
         id={textareaId}
         className={`
           ${inputBaseStyles}
-          ${hasError ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20' : `${inputBorderStyles} ${inputFocusStyles}`}
+          ${hasError ? 'border-status-error focus:border-status-error focus:ring-status-error/20' : `${inputBorderStyles} ${inputFocusStyles}`}
           px-4 py-2.5 min-h-[100px] resize-y
           ${className}
         `}
         {...props}
       />
       {(error || hint) && (
-        <p className={`mt-1.5 text-sm ${hasError ? 'text-red-400' : 'text-gray-500'}`}>
+        <p className={`mt-1.5 text-sm ${hasError ? 'text-status-error' : 'text-text-muted'}`}>
           {error || hint}
         </p>
       )}
@@ -155,7 +157,7 @@ export const Select: FC<SelectProps> = ({
   return (
     <div className={containerClassName}>
       {label && (
-        <label htmlFor={selectId} className="block text-sm font-medium text-gray-300 mb-2">
+        <label htmlFor={selectId} className="block text-sm font-medium text-text-secondary mb-2">
           {label}
         </label>
       )}
@@ -164,7 +166,7 @@ export const Select: FC<SelectProps> = ({
         id={selectId}
         className={`
           ${inputBaseStyles}
-          ${hasError ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20' : `${inputBorderStyles} ${inputFocusStyles}`}
+          ${hasError ? 'border-status-error focus:border-status-error focus:ring-status-error/20' : `${inputBorderStyles} ${inputFocusStyles}`}
           px-4 py-2.5 appearance-none cursor-pointer
           bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%239ca3af%22%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22M19%209l-7%207-7-7%22%2F%3E%3C%2Fsvg%3E')]
           bg-[length:1.25rem] bg-[right_0.75rem_center] bg-no-repeat pr-10
@@ -185,7 +187,7 @@ export const Select: FC<SelectProps> = ({
         ))}
       </select>
       {(error || hint) && (
-        <p className={`mt-1.5 text-sm ${hasError ? 'text-red-400' : 'text-gray-500'}`}>
+        <p className={`mt-1.5 text-sm ${hasError ? 'text-status-error' : 'text-text-muted'}`}>
           {error || hint}
         </p>
       )}
@@ -219,18 +221,21 @@ export const Checkbox: FC<CheckboxProps> = ({
         type="checkbox"
         id={checkboxId}
         className={`
-          mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-800 text-violet-500
-          focus:ring-2 focus:ring-violet-500/50 focus:ring-offset-0
+          mt-0.5 h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500
+          focus:ring-2 focus:ring-brand-500/50 focus:ring-offset-0
           transition-colors cursor-pointer
           ${className}
         `}
         {...props}
       />
       <div>
-        <label htmlFor={checkboxId} className="text-sm font-medium text-gray-200 cursor-pointer">
+        <label
+          htmlFor={checkboxId}
+          className="text-sm font-medium text-text-primary cursor-pointer"
+        >
           {label}
         </label>
-        {description && <p className="text-sm text-gray-500 mt-0.5">{description}</p>}
+        {description && <p className="text-sm text-text-muted mt-0.5">{description}</p>}
       </div>
     </div>
   );
@@ -259,10 +264,10 @@ export const Toggle: FC<ToggleProps> = ({
   return (
     <div className={`flex items-center justify-between gap-4 ${containerClassName}`}>
       <div>
-        <label htmlFor={toggleId} className="text-sm font-medium text-gray-200 cursor-pointer">
+        <label htmlFor={toggleId} className="text-sm font-medium text-text-primary cursor-pointer">
           {label}
         </label>
-        {description && <p className="text-sm text-gray-500 mt-0.5">{description}</p>}
+        {description && <p className="text-sm text-text-muted mt-0.5">{description}</p>}
       </div>
       <button
         type="button"
@@ -276,8 +281,8 @@ export const Toggle: FC<ToggleProps> = ({
         }}
         className={`
           relative inline-flex h-6 w-11 items-center rounded-full transition-colors
-          focus:outline-none focus:ring-2 focus:ring-violet-500/50 focus:ring-offset-2 focus:ring-offset-gray-900
-          ${checked ? 'bg-violet-600' : 'bg-gray-700'}
+          focus:outline-none focus:ring-2 focus:ring-brand-500/50 focus:ring-offset-2 focus:ring-offset-gray-900
+          ${checked ? 'bg-brand-600' : 'bg-bg-elevated'}
           ${className}
         `}
       >
@@ -338,13 +343,13 @@ export const SearchInput: FC<SearchInputProps> = ({
   return (
     <div className={containerClassName}>
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-gray-300 mb-2">
+        <label htmlFor={inputId} className="block text-sm font-medium text-text-secondary mb-2">
           {label}
         </label>
       )}
       <div className="relative">
         {/* Search icon */}
-        <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
+        <div className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="h-4 w-4"
@@ -385,7 +390,7 @@ export const SearchInput: FC<SearchInputProps> = ({
             type="button"
             onClick={handleClear}
             aria-label="Clear search"
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500/50 rounded"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500/50 rounded"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -431,8 +436,8 @@ export const FormSection: FC<FormSectionProps> = ({
 }) => (
   <div className={`space-y-4 ${className}`}>
     <div>
-      <h3 className="text-lg font-semibold text-white">{title}</h3>
-      {description && <p className="text-sm text-gray-400 mt-1">{description}</p>}
+      <h3 className="text-lg font-semibold text-text-primary">{title}</h3>
+      {description && <p className="text-sm text-text-muted mt-1">{description}</p>}
     </div>
     <div className="space-y-4">{children}</div>
   </div>

--- a/ui/src/ui/InputModal.tsx
+++ b/ui/src/ui/InputModal.tsx
@@ -57,8 +57,8 @@ export const InputModal: FC<InputModalProps> = ({
     <Modal isOpen={isOpen} onClose={onCancel} size="sm" showCloseButton={false}>
       <div className="space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-white">{title}</h2>
-          <p className="text-gray-300 mt-1">{message}</p>
+          <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
+          <p className="text-text-secondary mt-1">{message}</p>
         </div>
         <input
           ref={inputRef}
@@ -67,7 +67,7 @@ export const InputModal: FC<InputModalProps> = ({
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full rounded-lg border border-white/10 bg-gray-950/60 p-3 text-sm text-white placeholder-gray-500 focus:border-violet-400 focus:outline-none"
+          className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
         />
         <div className="flex justify-end gap-3 pt-2">
           <Button variant="outline" onClick={onCancel}>

--- a/ui/src/ui/Layout.tsx
+++ b/ui/src/ui/Layout.tsx
@@ -31,7 +31,7 @@ interface PageShellProps {
 
 export const PageShell: FC<PageShellProps> = ({ children, className = '' }) => (
   <div
-    className={`min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 ${className}`}
+    className={`min-h-screen bg-gradient-to-br from-bg-base via-bg-surface to-gray-950 ${className}`}
   >
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6">{children}</div>
   </div>
@@ -122,8 +122,8 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
         }}
         className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 whitespace-nowrap ${
           isActive
-            ? 'bg-gradient-to-r from-violet-600/30 to-violet-500/20 text-white border-l-2 border-violet-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
-            : 'text-gray-400 hover:text-white hover:bg-white/5'
+            ? 'bg-gradient-to-r from-brand-600/30 to-brand-500/20 text-text-primary border-l-2 border-brand-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
+            : 'text-text-muted hover:text-text-primary hover:bg-white/5'
         } ${isGrouped ? 'w-full justify-start' : ''}`}
       >
         {iconElement}
@@ -132,10 +132,10 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
           <span
             className={`ml-1 px-1.5 py-0.5 text-xs rounded font-medium ${
               item.badge === 'New'
-                ? 'bg-emerald-500/20 text-emerald-300'
+                ? 'bg-status-success/20 text-status-success'
                 : item.badge === 'Beta'
-                  ? 'bg-amber-500/20 text-amber-300'
-                  : 'bg-violet-500/20 text-violet-300'
+                  ? 'bg-status-warning/20 text-status-warning'
+                  : 'bg-brand-500/20 text-brand-300'
             }`}
           >
             {item.badge}
@@ -158,7 +158,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
         <button
           type="button"
           onClick={() => scroll('left')}
-          className="flex-shrink-0 p-1.5 rounded-lg bg-gray-800/80 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
+          className="flex-shrink-0 p-1.5 rounded-lg bg-bg-elevated/80 text-text-muted hover:text-text-primary hover:bg-bg-elevated transition-colors"
           aria-label="Scroll left"
         >
           <ChevronLeft className={iconSizes.md} />
@@ -180,7 +180,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
                   <button
                     type="button"
                     onClick={() => setOpenGroup(openGroup === group.label ? null : group.label)}
-                    className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-400 hover:text-white transition-colors"
+                    className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-text-muted hover:text-text-primary transition-colors"
                   >
                     <span>{group.label}</span>
                     <ChevronDown
@@ -188,7 +188,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
                     />
                   </button>
                   {openGroup === group.label && (
-                    <div className="absolute top-full left-0 mt-1 py-1 min-w-[180px] rounded-lg bg-gray-900/95 backdrop-blur-xl border border-white/10 shadow-xl z-50 animate-slide-down">
+                    <div className="absolute top-full left-0 mt-1 py-1 min-w-[180px] rounded-lg bg-bg-surface/95 backdrop-blur-xl border border-white/10 shadow-xl z-50 animate-slide-down">
                       {group.items.map((item) => (
                         <div key={item.path} className="px-1">
                           {renderNavItem(item, true)}
@@ -208,7 +208,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
         <button
           type="button"
           onClick={() => scroll('right')}
-          className="flex-shrink-0 p-1.5 rounded-lg bg-gray-800/80 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
+          className="flex-shrink-0 p-1.5 rounded-lg bg-bg-elevated/80 text-text-muted hover:text-text-primary hover:bg-bg-elevated transition-colors"
           aria-label="Scroll right"
         >
           <ChevronRight className={iconSizes.md} />
@@ -217,7 +217,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
 
       {/* Version badge */}
       {version && (
-        <div className="flex-shrink-0 ml-2 px-2 py-1 text-xs font-mono text-gray-500 bg-gray-800/50 rounded">
+        <div className="flex-shrink-0 ml-2 px-2 py-1 text-xs font-mono text-text-muted bg-bg-elevated/50 rounded">
           {version}
         </div>
       )}
@@ -261,10 +261,10 @@ export const PageHeader: FC<PageHeaderProps> = ({
       {breadcrumbs && breadcrumbs.length > 0 && <Breadcrumb items={breadcrumbs} className="mb-3" />}
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="flex items-center gap-3">
-          {icon && createElement(icon, { className: 'h-8 w-8 text-violet-400' })}
+          {icon && createElement(icon, { className: 'h-8 w-8 text-brand-400' })}
           <div>
-            <h1 className="text-2xl font-bold text-white font-display">{title}</h1>
-            {description && <p className="text-sm text-gray-400 mt-1 max-w-2xl">{description}</p>}
+            <h1 className="text-2xl font-bold text-text-primary font-display">{title}</h1>
+            {description && <p className="text-sm text-text-muted mt-1 max-w-2xl">{description}</p>}
           </div>
         </div>
         <div className="flex items-center gap-3">
@@ -275,7 +275,7 @@ export const PageHeader: FC<PageHeaderProps> = ({
               onClick={() => setHelpOpen(true)}
               aria-label={`Open help for ${title}`}
               title={`What is ${title}?`}
-              className="rounded-full p-1.5 text-gray-400 hover:bg-white/10 hover:text-white"
+              className="rounded-full p-1.5 text-text-muted hover:bg-white/10 hover:text-text-primary"
             >
               <HelpCircle className={iconSizes.lg} />
             </button>
@@ -325,19 +325,19 @@ const HelpPanel: FC<{ title: string; children: ReactNode; onClose: () => void }>
         className="absolute inset-0 cursor-default"
         onClick={onClose}
       />
-      <aside className="relative h-full w-full max-w-md overflow-y-auto bg-gray-900 p-6 shadow-2xl">
+      <aside className="relative h-full w-full max-w-md overflow-y-auto bg-bg-surface p-6 shadow-2xl">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-white">{title}</h2>
+          <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
           <button
             type="button"
             onClick={onClose}
             aria-label="Close help"
-            className="rounded p-1 text-gray-400 hover:bg-white/10 hover:text-white"
+            className="rounded p-1 text-text-muted hover:bg-white/10 hover:text-text-primary"
           >
             <X className="h-5 w-5" />
           </button>
         </div>
-        <div className="prose prose-invert prose-sm max-w-none text-gray-200">{children}</div>
+        <div className="prose prose-invert prose-sm max-w-none text-text-primary">{children}</div>
       </aside>
     </div>
   );
@@ -353,11 +353,11 @@ interface StatusIndicatorProps {
 }
 
 const statusColors = {
-  online: 'bg-emerald-500',
-  offline: 'bg-gray-500',
-  warning: 'bg-amber-500',
-  error: 'bg-red-500',
-  pending: 'bg-blue-500',
+  online: 'bg-status-success',
+  offline: 'bg-bg-muted',
+  warning: 'bg-status-warning',
+  error: 'bg-status-error',
+  pending: 'bg-status-info',
 };
 
 const statusLabels = {
@@ -393,7 +393,7 @@ export const StatusIndicator: FC<StatusIndicatorProps> = ({
         )}
       </span>
       {(label || label === undefined) && (
-        <span className="text-sm text-gray-300">{label ?? statusLabels[status]}</span>
+        <span className="text-sm text-text-secondary">{label ?? statusLabels[status]}</span>
       )}
     </div>
   );
@@ -414,13 +414,16 @@ export const Breadcrumb: FC<BreadcrumbProps> = ({ items, className = '' }) => (
   <nav className={`flex items-center gap-1 text-sm ${className}`} aria-label="Breadcrumb">
     {items.map((item, index) => (
       <div key={item.label} className="flex items-center gap-1">
-        {index > 0 && <ChevronRight className={`${iconSizes.md} text-gray-600`} />}
+        {index > 0 && <ChevronRight className={`${iconSizes.md} text-text-disabled`} />}
         {item.href ? (
-          <Link to={item.href} className="text-gray-400 hover:text-white transition-colors">
+          <Link
+            to={item.href}
+            className="text-text-muted hover:text-text-primary transition-colors"
+          >
             {item.label}
           </Link>
         ) : (
-          <span className="text-gray-300 font-medium">{item.label}</span>
+          <span className="text-text-secondary font-medium">{item.label}</span>
         )}
       </div>
     ))}

--- a/ui/src/ui/Modal.tsx
+++ b/ui/src/ui/Modal.tsx
@@ -77,7 +77,7 @@ export const Modal: FC<ModalProps> = ({
       )}
       <div
         ref={containerRef}
-        className={`mx-4 w-full ${sizeClasses[size]} rounded-2xl border border-white/10 bg-gray-900/95 shadow-2xl ${className}`}
+        className={`mx-4 w-full ${sizeClasses[size]} rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl ${className}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'modal-title' : undefined}
@@ -86,7 +86,7 @@ export const Modal: FC<ModalProps> = ({
         {(title || showCloseButton) && (
           <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
             {title && (
-              <h2 id="modal-title" className="text-lg font-semibold text-white">
+              <h2 id="modal-title" className="text-lg font-semibold text-text-primary">
                 {title}
               </h2>
             )}
@@ -94,7 +94,7 @@ export const Modal: FC<ModalProps> = ({
               <button
                 type="button"
                 onClick={onClose}
-                className="ml-auto p-1 text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-white/10"
+                className="ml-auto p-1 text-text-muted hover:text-text-primary transition-colors rounded-lg hover:bg-white/10"
                 aria-label="Close modal"
               >
                 <X className={iconSizes.lg} />

--- a/ui/src/ui/PageLoader.tsx
+++ b/ui/src/ui/PageLoader.tsx
@@ -8,8 +8,8 @@ import type { FC } from 'react';
 export const PageLoader: FC = () => (
   <div className="flex items-center justify-center min-h-[400px]">
     <div className="flex flex-col items-center gap-3">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-violet-500 border-t-transparent" />
-      <p className="text-sm text-gray-400">Loading...</p>
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-brand-500 border-t-transparent" />
+      <p className="text-sm text-text-muted">Loading...</p>
     </div>
   </div>
 );

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -66,14 +66,14 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           transition-all duration-200
           ${
             active
-              ? 'bg-gradient-to-r from-violet-600/30 to-violet-500/20 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
-              : 'text-gray-400 hover:text-white hover:bg-white/5'
+              ? 'bg-gradient-to-r from-brand-600/30 to-brand-500/20 text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
+              : 'text-text-muted hover:text-text-primary hover:bg-white/5'
           }
         `}
         title={collapsed ? item.label : undefined}
       >
         {createElement(item.icon, {
-          className: `${iconSizes.lg} flex-shrink-0 ${active ? 'text-violet-400' : 'text-gray-500 group-hover:text-gray-300'}`,
+          className: `${iconSizes.lg} flex-shrink-0 ${active ? 'text-brand-400' : 'text-text-muted group-hover:text-text-secondary'}`,
         })}
         {!collapsed && (
           <>
@@ -82,10 +82,10 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
               <span
                 className={`px-1.5 py-0.5 text-xs rounded font-medium ${
                   item.badge === 'New'
-                    ? 'bg-emerald-500/20 text-emerald-300'
+                    ? 'bg-status-success/20 text-status-success'
                     : item.badge === 'Beta'
-                      ? 'bg-amber-500/20 text-amber-300'
-                      : 'bg-violet-500/20 text-violet-300'
+                      ? 'bg-status-warning/20 text-status-warning'
+                      : 'bg-brand-500/20 text-brand-300'
                 }`}
               >
                 {item.badge}
@@ -94,7 +94,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           </>
         )}
         {collapsed && item.badge && (
-          <span className="absolute left-12 px-1.5 py-0.5 text-xs rounded font-medium bg-violet-500/20 text-violet-300">
+          <span className="absolute left-12 px-1.5 py-0.5 text-xs rounded font-medium bg-brand-500/20 text-brand-300">
             {item.badge}
           </span>
         )}
@@ -110,20 +110,22 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
       >
         <div className={`flex items-center gap-2 ${collapsed ? 'justify-center' : ''}`}>
           <div className="relative flex-shrink-0">
-            <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-violet-500 to-violet-700 flex items-center justify-center shadow-lg shadow-violet-500/30">
-              <Network className={`${iconSizes.lg} text-white`} />
+            <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center shadow-lg shadow-brand-500/30">
+              <Network className={`${iconSizes.lg} text-text-primary`} />
             </div>
-            <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-emerald-500 border-2 border-gray-900" />
+            <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-status-success border-2 border-border-muted" />
           </div>
           {!collapsed && (
-            <span className="font-display font-bold text-lg text-white tracking-tight">NIAC</span>
+            <span className="font-display font-bold text-lg text-text-primary tracking-tight">
+              NIAC
+            </span>
           )}
         </div>
         {!collapsed && (
           <button
             type="button"
             onClick={() => setCollapsed(true)}
-            className="p-1.5 rounded-lg text-gray-500 hover:text-white hover:bg-white/10 transition-colors lg:flex hidden"
+            className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors lg:flex hidden"
             aria-label="Collapse sidebar"
           >
             <ChevronLeft className={iconSizes.md} />
@@ -136,7 +138,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
         {groups.map((group) => (
           <div key={group.label}>
             {!collapsed && (
-              <h3 className="px-3 mb-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+              <h3 className="px-3 mb-2 text-xs font-semibold text-text-muted uppercase tracking-wider">
                 {group.label}
               </h3>
             )}
@@ -156,7 +158,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
             className={`
               ${collapsed ? 'w-full' : 'flex-1'}
               flex items-center ${collapsed ? 'justify-center' : 'gap-2'} px-3 py-2 rounded-lg
-              text-gray-400 hover:text-white hover:bg-white/10 transition-colors
+              text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors
               text-sm font-medium
             `}
             title={collapsed ? 'Help' : undefined}
@@ -171,7 +173,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
             className={`
               ${collapsed ? 'w-full' : 'flex-1'}
               flex items-center ${collapsed ? 'justify-center' : 'gap-2'} px-3 py-2 rounded-lg
-              text-gray-400 hover:text-white hover:bg-white/10 transition-colors
+              text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors
               text-sm font-medium
             `}
             title={collapsed ? 'Settings' : undefined}
@@ -188,17 +190,17 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
         {/* Version Info */}
         {version && (
           <div
-            className={`text-xs font-mono text-gray-500 ${collapsed ? '' : 'flex items-center justify-between'}`}
+            className={`text-xs font-mono text-text-muted ${collapsed ? '' : 'flex items-center justify-between'}`}
           >
             {!collapsed && <span>Version</span>}
-            <span className={collapsed ? '' : 'text-gray-400'}>{version}</span>
+            <span className={collapsed ? '' : 'text-text-muted'}>{version}</span>
           </div>
         )}
         {collapsed && (
           <button
             type="button"
             onClick={() => setCollapsed(false)}
-            className="mt-2 p-1.5 rounded-lg text-gray-500 hover:text-white hover:bg-white/10 transition-colors"
+            className="mt-2 p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors"
             aria-label="Expand sidebar"
           >
             <ChevronRight className={iconSizes.md} />
@@ -209,27 +211,27 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950">
+    <div className="min-h-screen bg-gradient-to-br from-bg-base via-bg-surface to-gray-950">
       {/* Skip to main content link for accessibility */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-violet-600 focus:text-white focus:outline-none"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-brand-600 focus:text-text-primary focus:outline-none"
       >
         Skip to main content
       </a>
 
       {/* Mobile header */}
-      <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3 bg-gray-900/95 backdrop-blur-xl border-b border-white/10">
+      <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3 bg-bg-surface/95 backdrop-blur-xl border-b border-white/10">
         <div className="flex items-center gap-2">
-          <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-violet-500 to-violet-700 flex items-center justify-center">
-            <Network className={`${iconSizes.md} text-white`} />
+          <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center">
+            <Network className={`${iconSizes.md} text-text-primary`} />
           </div>
-          <span className="font-display font-bold text-white">NIAC</span>
+          <span className="font-display font-bold text-text-primary">NIAC</span>
         </div>
         <button
           type="button"
           onClick={() => setMobileOpen(!mobileOpen)}
-          className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+          className="p-2 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors"
           aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
         >
           {mobileOpen ? <X className={iconSizes.lg} /> : <Menu className={iconSizes.lg} />}
@@ -249,7 +251,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
       {/* Mobile sidebar */}
       <aside
         className={`
-          lg:hidden fixed top-0 left-0 z-50 h-full w-72 bg-gray-900/95 backdrop-blur-xl border-r border-white/10
+          lg:hidden fixed top-0 left-0 z-50 h-full w-72 bg-bg-surface/95 backdrop-blur-xl border-r border-white/10
           transform transition-transform duration-300 ease-in-out
           ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}
         `}
@@ -261,7 +263,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
       <aside
         className={`
           hidden lg:flex fixed top-0 left-0 z-40 h-full flex-col
-          bg-gray-900/80 backdrop-blur-xl border-r border-white/10
+          bg-bg-surface/80 backdrop-blur-xl border-r border-white/10
           transition-all duration-300 ease-in-out
           ${collapsed ? 'w-16' : 'w-64'}
         `}

--- a/ui/src/ui/Skeleton.tsx
+++ b/ui/src/ui/Skeleton.tsx
@@ -89,7 +89,7 @@ export const StatCardSkeleton: FC<{ className?: string }> = ({ className = '' })
 
 // Skeleton for device cards (card view)
 export const DeviceCardSkeleton: FC<{ className?: string }> = ({ className = '' }) => (
-  <div className={`p-4 space-y-3 rounded-xl border border-white/5 bg-gray-900/70 ${className}`}>
+  <div className={`p-4 space-y-3 rounded-xl border border-white/5 bg-bg-surface/70 ${className}`}>
     {/* Header with checkbox and icon */}
     <div className="flex items-start justify-between">
       <div className="flex items-center gap-3">

--- a/ui/src/ui/StatusConfig.tsx
+++ b/ui/src/ui/StatusConfig.tsx
@@ -33,8 +33,8 @@ export const statusConfig: Record<Status, StatusConfigItem> = {
         />
       </svg>
     ),
-    color: 'text-emerald-400',
-    bgColor: 'bg-emerald-500/15',
+    color: 'text-status-success',
+    bgColor: 'bg-status-success/15',
     label: 'Status: success',
   },
   warning: {
@@ -47,8 +47,8 @@ export const statusConfig: Record<Status, StatusConfigItem> = {
         />
       </svg>
     ),
-    color: 'text-amber-400',
-    bgColor: 'bg-amber-500/15',
+    color: 'text-status-warning',
+    bgColor: 'bg-status-warning/15',
     label: 'Status: warning',
   },
   error: {
@@ -61,8 +61,8 @@ export const statusConfig: Record<Status, StatusConfigItem> = {
         />
       </svg>
     ),
-    color: 'text-red-400',
-    bgColor: 'bg-red-500/15',
+    color: 'text-status-error',
+    bgColor: 'bg-status-error/15',
     label: 'Status: error',
   },
   info: {
@@ -75,8 +75,8 @@ export const statusConfig: Record<Status, StatusConfigItem> = {
         />
       </svg>
     ),
-    color: 'text-cyan-400',
-    bgColor: 'bg-cyan-500/15',
+    color: 'text-status-info',
+    bgColor: 'bg-status-info/15',
     label: 'Status: info',
   },
   unknown: {
@@ -89,8 +89,8 @@ export const statusConfig: Record<Status, StatusConfigItem> = {
         />
       </svg>
     ),
-    color: 'text-gray-400',
-    bgColor: 'bg-gray-500/15',
+    color: 'text-text-muted',
+    bgColor: 'bg-bg-muted/15',
     label: 'Status: unknown',
   },
   loading: {
@@ -112,8 +112,8 @@ export const statusConfig: Record<Status, StatusConfigItem> = {
         <path className="opacity-75" fill="currentColor" d="M18 10a8 8 0 00-8-8v4a4 4 0 014 4h4z" />
       </svg>
     ),
-    color: 'text-cyan-400',
-    bgColor: 'bg-cyan-500/15',
+    color: 'text-status-info',
+    bgColor: 'bg-status-info/15',
     label: 'Status: loading',
   },
 };

--- a/ui/src/ui/Tag.tsx
+++ b/ui/src/ui/Tag.tsx
@@ -9,14 +9,14 @@ interface TagProps {
 }
 
 const colorStyles: Record<TagColorScheme, string> = {
-  gray: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
-  red: 'bg-red-500/20 text-red-300 border-red-500/30',
-  green: 'bg-green-500/20 text-green-300 border-green-500/30',
-  blue: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
-  yellow: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30',
-  purple: 'bg-purple-500/20 text-purple-300 border-purple-500/30',
-  violet: 'bg-violet-500/20 text-violet-300 border-violet-500/30',
-  cyan: 'bg-cyan-500/20 text-cyan-300 border-cyan-500/30',
+  gray: 'bg-bg-muted/20 text-text-secondary border-border-muted/30',
+  red: 'bg-status-error/20 text-status-error border-status-error/30',
+  green: 'bg-status-success/20 text-status-success border-status-success/30',
+  blue: 'bg-status-info/20 text-status-info border-status-info/30',
+  yellow: 'bg-status-warning/20 text-status-warning border-status-warning/30',
+  purple: 'bg-brand-500/20 text-brand-300 border-brand-500/30',
+  violet: 'bg-brand-500/20 text-brand-300 border-brand-500/30',
+  cyan: 'bg-status-info/20 text-status-info border-status-info/30',
 };
 
 export const Tag: FC<TagProps> = ({ children, colorScheme = 'gray', className = '' }) => (

--- a/ui/src/ui/ToastContainer.tsx
+++ b/ui/src/ui/ToastContainer.tsx
@@ -13,10 +13,10 @@ const TOAST_ICONS: Record<Notification['type'], FC<{ className?: string }>> = {
 };
 
 const TOAST_STYLES: Record<Notification['type'], string> = {
-  success: 'border-green-500/30 bg-green-900/90 text-green-100',
-  error: 'border-red-500/30 bg-red-900/90 text-red-100',
-  warning: 'border-amber-500/30 bg-amber-900/90 text-amber-100',
-  info: 'border-blue-500/30 bg-blue-900/90 text-blue-100',
+  success: 'border-status-success/30 bg-status-success/90 text-status-success',
+  error: 'border-status-error/30 bg-status-error/90 text-status-error',
+  warning: 'border-status-warning/30 bg-status-warning/90 text-status-warning',
+  info: 'border-status-info/30 bg-status-info/90 text-status-info',
 };
 
 const Toast: FC<{ notification: Notification }> = ({ notification }) => {

--- a/ui/src/ui/Tooltip.tsx
+++ b/ui/src/ui/Tooltip.tsx
@@ -55,7 +55,7 @@ export const Tooltip: FC<TooltipProps> = ({ text, side = 'top', children, classN
       <span
         id={id}
         role="tooltip"
-        className={`pointer-events-none absolute z-50 max-w-xs whitespace-normal rounded-md bg-gray-950/95 px-2 py-1 text-xs text-gray-100 ring-1 ring-white/10 transition-opacity duration-100 ${sideClass[side]} ${open ? 'opacity-100' : 'opacity-0'}`}
+        className={`pointer-events-none absolute z-50 max-w-xs whitespace-normal rounded-md bg-bg-base/95 px-2 py-1 text-xs text-text-primary ring-1 ring-white/10 transition-opacity duration-100 ${sideClass[side]} ${open ? 'opacity-100' : 'opacity-0'}`}
       >
         {text}
       </span>

--- a/ui/src/ui/Typography.tsx
+++ b/ui/src/ui/Typography.tsx
@@ -8,24 +8,24 @@ import { Link } from 'react-router-dom';
  * Visual scale (top to bottom, sized for our dark-theme baseline):
  *
  *   H1  — page header (set by Layout's <PageHeader>, rarely used in body)
- *         text-2xl / font-bold / text-white
+ *         text-2xl / font-bold / text-text-primary
  *   H2  — section header inside a card
- *         text-xl  / font-semibold / text-white
+ *         text-xl  / font-semibold / text-text-primary
  *   H3  — sub-section header
- *         text-lg  / font-semibold / text-white
+ *         text-lg  / font-semibold / text-text-primary
  *   H4  — small label / pill header (often with an icon)
- *         text-sm  / font-semibold / text-white
+ *         text-sm  / font-semibold / text-text-primary
  *
- *   P         — body copy:                 text-gray-300 leading-relaxed
- *   SmallText — secondary inline text:     text-sm  text-gray-400
- *   Caption   — labels / captions / units: text-xs  text-gray-400
+ *   P         — body copy:                 text-text-secondary leading-relaxed
+ *   SmallText — secondary inline text:     text-sm  text-text-muted
+ *   Caption   — labels / captions / units: text-xs  text-text-muted
  *
  * Contrast — all foreground colors above hit WCAG AA against our
- * --color-bg-base / --color-bg-elevated surfaces. Avoid text-gray-500
+ * --color-bg-base / --color-bg-elevated surfaces. Avoid text-text-muted
  * for sustained body copy; reserve it for placeholders, disabled
  * states, and timestamps where lower contrast is intentional.
  *
- * Accent colors: brand violet (text-violet-300/400) is the only
+ * Accent colors: brand violet (text-brand-300/400) is the only
  * "highlight" colour; status colours (red/amber/emerald) come from the
  * Tailwind palette directly. If you find yourself reaching for
  * text-purple/pink/sky for chrome, route it through this file first.
@@ -37,43 +37,43 @@ interface TypographyProps extends HTMLAttributes<HTMLElement> {
 }
 
 export const H1: FC<TypographyProps> = ({ children, className = '', ...props }) => (
-  <h1 className={`text-2xl font-bold text-white ${className}`} {...props}>
+  <h1 className={`text-2xl font-bold text-text-primary ${className}`} {...props}>
     {children}
   </h1>
 );
 
 export const H2: FC<TypographyProps> = ({ children, className = '', ...props }) => (
-  <h2 className={`text-xl font-semibold text-white ${className}`} {...props}>
+  <h2 className={`text-xl font-semibold text-text-primary ${className}`} {...props}>
     {children}
   </h2>
 );
 
 export const H3: FC<TypographyProps> = ({ children, className = '', ...props }) => (
-  <h3 className={`text-lg font-semibold text-white ${className}`} {...props}>
+  <h3 className={`text-lg font-semibold text-text-primary ${className}`} {...props}>
     {children}
   </h3>
 );
 
 export const H4: FC<TypographyProps> = ({ children, className = '', ...props }) => (
-  <h4 className={`text-sm font-semibold text-white ${className}`} {...props}>
+  <h4 className={`text-sm font-semibold text-text-primary ${className}`} {...props}>
     {children}
   </h4>
 );
 
 export const P: FC<TypographyProps> = ({ children, className = '', ...props }) => (
-  <p className={`text-gray-300 leading-relaxed ${className}`} {...props}>
+  <p className={`text-text-secondary leading-relaxed ${className}`} {...props}>
     {children}
   </p>
 );
 
 export const SmallText: FC<TypographyProps> = ({ children, className = '', ...props }) => (
-  <span className={`text-sm text-gray-400 ${className}`} {...props}>
+  <span className={`text-sm text-text-muted ${className}`} {...props}>
     {children}
   </span>
 );
 
 export const Caption: FC<TypographyProps> = ({ children, className = '', ...props }) => (
-  <span className={`text-xs text-gray-400 ${className}`} {...props}>
+  <span className={`text-xs text-text-muted ${className}`} {...props}>
     {children}
   </span>
 );
@@ -92,7 +92,7 @@ export const AccentLink: FC<AccentLinkProps> = ({
   onClick,
   ...props
 }) => {
-  const linkClass = `text-violet-300 hover:text-violet-200 underline underline-offset-2 transition-colors ${className}`;
+  const linkClass = `text-brand-300 hover:text-brand-200 underline underline-offset-2 transition-colors ${className}`;
 
   if (to) {
     return (


### PR DESCRIPTION
## Summary

Eliminates ~1,700 raw Tailwind palette references (text-gray-*, bg-violet-*, text-red-*, bg-emerald-*, etc.) across niac's UI by replacing them with semantic theme tokens declared in `src/index.css` via the `@theme` directive. **97.7% reduction (1741 → 40).**

### Why
Niac's `@theme` defines rich semantic tokens (`--color-brand-*`, `--color-text-*`, `--color-bg-*`, `--color-status-*`, `--color-device-*`, `--color-proto-*`, `--color-link-*`) but most components were bypassing them with raw Tailwind palette colors. That meant retheming via `@theme` would have had no visible effect — the components were hardcoded.

Now all major patterns flow through the theme. Changing a `--color-*` value in `index.css` propagates everywhere.

### Cross-project alignment
Adds `--color-status-{success,warning,error,info}` semantic aliases to niac's `@theme` so all three projects (seed, stem, niac) share the same `bg-status-success` / `text-status-error` class naming. Previously niac used `bg-emerald-500/20` while seed/stem used `bg-status-success/20`.

### Mappings applied
- `text-gray-*` → `text-text-{primary,secondary,muted,disabled}`
- `bg-gray-*` → `bg-bg-{base,surface,elevated,muted}`
- `border-gray-*` / `border-white/N` → `border-border-{default,subtle,muted}`
- `text-violet-*`, `bg-violet-*` → `text-brand-*`, `bg-brand-*`
- `text-red-*` / `bg-red-*` → `text-status-error` / `bg-status-error`
- `text-emerald-*` / `text-green-*` → `text-status-success`
- `text-amber-*` / `text-yellow-*` → `text-status-warning`
- `text-blue-*` / `text-cyan-*` → `text-status-info`
- `text-orange-*` → `text-status-warning`
- `text-purple-*` → `text-brand-*`
- Raw colors in `themeDeviceColors.ts` → `text-device-router`, `text-proto-arp`, `text-link-1g`, etc.

### Theme files rewritten to consume their own tokens
- `themeComponents.ts` (button/input/card/badge/alert/modal/drawer/status)
- `themeDeviceColors.ts` (deviceColor/protocolColor/linkSpeedColor)
- `themeLayout.ts` (border tokens)
- `themeTypography.ts` (heading/body/label/caption — all white/gray → text-*)

### Remaining work
40 stubborn refs survive — gradient endpoints (`from-X-N to-Y-M`), shadow tints, focus rings — that need per-site context review. Can be addressed in follow-up.

## Test plan
- [ ] CI green
- [ ] Visual smoke on dashboard, topology, settings, drawers
- [ ] Confirm dark theme still consistent across pages