### PR TITLE
docs: README rewrite + relicense to BSL 1.1 + email standardization

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -194,7 +194,7 @@ nfpms:
     package_name: niac
     vendor: Mustard Seed Networks
     homepage: https://github.com/krisarmstrong/niac-go
-    maintainer: Kris Armstrong <kris@mustardseednetworks.com>
+    maintainer: Kris Armstrong <kris.armstrong@icloud.com>
     description: |
       NIAC - Network In A Can by Mustard Seed Networks
       .

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at kris.armstrong@netally.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at kris.armstrong@icloud.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,105 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+Business Source License 1.1
 
-Copyright (c) 2002-2015 Kevin Kayes (Original NIAC for Fluke Networks)
-Copyright (c) 2025 Kris Armstrong (Java Modernization & Go Rewrite)
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+---
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Parameters
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Licensor: Mustard Seed Networks
+Licensed Work: NIAC (Network In A Can)
+The Licensed Work is (c) 2025 Mustard Seed Networks.
+Additional Use Grant: You may make use of the Licensed Work, provided that
+you do not use the Licensed Work for a Network
+Simulation Service.
 
-SPDX-License-Identifier: GPL-3.0-or-later
+                      A "Network Simulation Service" is a commercial offering
+                      that allows third parties (other than your employees
+                      and contractors) to access the functionality of the
+                      Licensed Work by providing network device simulation,
+                      lab-as-a-service, or hosted protocol emulation
+                      capabilities.
+
+Change Date: 2029-12-01
+
+Change License: Apache License, Version 2.0
+
+---
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+---
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+---
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/README.md
+++ b/README.md
@@ -1,591 +1,174 @@
-# NIAC-Go: Network In A Can (Go Edition)
-[![Checks](https://github.com/krisarmstrong/niac-go/actions/workflows/checks.yml/badge.svg)](https://github.com/krisarmstrong/niac-go/actions/workflows/checks.yml)
+# NIAC — Network In A Can
 
+> Single-binary network device simulator for protocol testing, packet capture analysis, and topology modelling.
 
-[![CI](https://github.com/krisarmstrong/niac-go/workflows/CI/badge.svg)](https://github.com/krisarmstrong/niac-go/actions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Go](https://img.shields.io/badge/go-1.25.4%2B-blue.svg)](https://golang.org/dl/)
-[![Version](https://img.shields.io/github/v/release/krisarmstrong/niac-go)](https://github.com/krisarmstrong/niac-go/releases)
+[![CI](https://github.com/krisarmstrong/niac-go/actions/workflows/ci.yml/badge.svg)](https://github.com/krisarmstrong/niac-go/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/krisarmstrong/niac-go?logo=github)](https://github.com/krisarmstrong/niac-go/releases/latest)
+[![CodeQL](https://github.com/krisarmstrong/niac-go/actions/workflows/codeql.yml/badge.svg)](https://github.com/krisarmstrong/niac-go/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/krisarmstrong/niac-go/badge)](https://scorecard.dev/viewer/?uri=github.com/krisarmstrong/niac-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/krisarmstrong/niac-go.svg)](https://pkg.go.dev/github.com/krisarmstrong/niac-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/krisarmstrong/niac-go)](https://goreportcard.com/report/github.com/krisarmstrong/niac-go)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL%201.1-blue.svg)](LICENSE)
 
-**Production-ready network device simulator** - Complete YAML configuration system with per-protocol debug control, multi-IP support, and comprehensive protocol coverage.
-
-**Requires Go 1.23 or later** for building from source.
-
-## 🚀 Why Go?
-
-NIAC-Go is a modern rewrite of the original Java-based NIAC, leveraging Go's strengths:
-
-- **🔥 Native Performance**: No JVM overhead, instant startup
-- **⚡ Blazing Fast**: 7.7M error injections/sec (vs ~100K/sec in Java)
-- **💾 Lightweight**: 6.1MB binary vs 542KB JAR + 200MB JRE
-- **🎯 Simple Deployment**: Single binary, no dependencies
-- **🧵 Concurrency**: Goroutines make packet handling trivial
-- **🎨 Beautiful TUI**: Modern terminal UI with Bubbletea
-- **📝 Complete YAML Config**: All protocols fully configurable
-
-## Performance Comparison
-
-| Metric | Java (GraalVM) | Go | Improvement |
-|--------|---------------|-----|-------------|
-| **Startup** | ~50ms | ~5ms | **10x faster** |
-| **Memory** | ~100MB | ~15MB | **6.7x less** |
-| **Binary Size** | 16MB | 6.1MB | **2.6x smaller** |
-| **Error Injection** | ~100K/sec | 7.7M/sec | **77x faster** |
-| **Config Parsing** | ~1ms | ~1.3µs | **770x faster** |
-| **Build Time** | 4-5 min | 5 sec | **48-60x faster** |
+NIAC is a network device simulator from **Mustard Seed Networks**. It stands up
+configurable layer-2/3 endpoints — routers, switches, servers, workstations,
+APs — that respond to ARP, ICMP, DHCP, DNS, LLDP/CDP, SNMP, HTTP, and other
+protocols against real interfaces. Use it to exercise discovery tools, generate
+test traffic, validate monitoring pipelines, or reproduce field issues in
+the lab.
 
 ## Features
 
-### v1.13.0 Highlights 🎉
-
-- **🎯 Enhanced CLI/Help**: Professional CLI experience
-  - Shell completion for bash, zsh, fish, and powershell
-  - Rich help examples for all commands
-  - Unix man pages generation (`niac man`)
-  - Installation instructions for all shells
-- **🔧 Configuration Management Tools**: DevOps-ready config tools
-  - `niac config export` - Normalize and clean YAML configurations
-  - `niac config diff` - Compare configurations and detect drift
-  - `niac config merge` - Merge base and overlay configurations
-  - Environment-specific overrides support
-
-### v1.12.0 Highlights 🎉
-
-- **🎨 Interactive TUI Command**: Modern terminal interface for real-time monitoring
-  - New `niac interactive` command with Bubble Tea UI
-  - Live device status and statistics
-  - Interactive error injection (press 'i')
-  - Keyboard controls and beautiful visualization
-
-### v1.11.0 Highlights 🎉
-
-- **📦 Configuration Templates**: Quick start with pre-built templates
-  - 7 production-ready templates (minimal, router, switch, ap, server, iot, complete)
-  - `niac template list|show|use` commands
-  - Templates embedded in binary
-  - Instant deployment for common scenarios
-
-### v1.10.0 Highlights 🎉
-
-- **✅ Modern CLI Framework**: Cobra-based command structure
-  - `niac validate` command with comprehensive validation
-  - Structured error reporting (ConfigError, ConfigErrorList)
-  - JSON output for CI/CD integration (--json flag)
-  - Verbose mode for detailed insights (--verbose)
-  - Beautiful terminal formatting with context and suggestions
-- **🔍 Configuration Validator**: Production-ready validation
-  - Device validation (names, types, MAC/IP duplicates)
-  - SNMP trap validation (thresholds 0-100, receiver format)
-  - DNS record validation (domain names, IPs)
-  - Three severity levels (error, warning, info)
-  - Line/column tracking for precise error location
-
-### v1.7.0 Highlights 🎉
-
-- **✅ Comprehensive Testing Infrastructure**: Production-ready test coverage
-  - **87 new tests** added across 4 major packages
-  - Config package: **50.6% coverage** (5.2x improvement from 9.8%)
-  - Protocol package: **15.4% coverage** (2.75x improvement from 5.6%)
-  - Device simulator: **22.0% coverage** (new)
-  - SNMP traps: **6.7% coverage** (new)
-  - Full validation of v1.6.0 features (traffic patterns, SNMP traps)
-- **🔍 Configuration Validator**: Comprehensive config validation tool
-  - Three-level validation (Errors, Warnings, Info)
-  - Device-level validation (name, type, MAC, IP addresses)
-  - Protocol-specific validation (19 protocols)
-  - v1.6.0 feature validation (traffic patterns, SNMP traps)
-  - Threshold validation (CPU/memory percentages, STP priorities)
-  - Detailed error messages with field names and suggestions
-  - Integrated with `--dry-run` flag for pre-flight checks
-  - Verbose mode for detailed configuration insights
-- **⏳ Enhanced CLI/UX**: Improved user experience
-  - Progress indicators during startup (capture engine, protocol stack, devices)
-  - Feature summary on startup (SNMP agents, traps, traffic generation)
-  - Clear error reporting with emojis (✓ ❌ ⚠️)
-  - Enhanced `--dry-run` validation output
-
-### Latest Features (v1.23.0) - Topology Configuration
-
-- **🔗 Port-Channels (Link Aggregation)**: Bundle multiple physical interfaces for increased bandwidth and redundancy
-  - LACP modes: active, passive, on
-  - 2+ member interfaces with automatic validation
-  - Trunk over port-channel support
-- **🌉 Trunk Ports with VLAN Tagging**: 802.1Q trunk configuration
-  - Multiple VLANs per trunk (1-4094)
-  - Native VLAN support
-  - Remote device references for topology validation
-- **🏗️ Multi-Device Topologies**: Complete network environment simulation
-  - Spine-leaf data center topologies
-  - Enterprise campus (core-distribution-access)
-  - Branch office and wireless deployments
-  - Multi-vendor integration (Cisco, Juniper, Aruba)
-- **📖 Comprehensive Guides**: New documentation for advanced scenarios
-  - [Topology Configuration Guide](docs/TOPOLOGY_GUIDE.md) - Port-channels, trunks, VLANs
-  - [Environment Simulation Guide](docs/ENVIRONMENTS.md) - Complete network examples
-  - See `examples/topology/` and `examples/combinations/` for ready-to-use configs
-
-### Previous Features (v1.6.0)
-
-- **🚦 Configurable Traffic Patterns**: Per-device traffic control
-  - ARP announcement intervals
-  - Periodic ping intervals and payload sizes
-  - Random traffic generation (packet count, intervals, patterns)
-- **📡 SNMP Trap Generation**: SNMPv2c trap PDUs
-  - Event-based traps (coldStart, linkUp/Down, authenticationFailure)
-  - Threshold-based traps (high CPU, high memory, interface errors)
-  - Multiple trap receivers with configurable thresholds
-- **📝 Complete Protocol & YAML Work**: All protocol configuration complete
-  - 19 protocols fully configurable via YAML
-  - Per-device traffic and trap configuration
-  - Comprehensive examples for all features
-- **🎨 Enhanced Examples**: Updated complete-kitchen-sink.yaml with 9 devices showcasing all features
-
-### Previous Features (v1.5.0)
-
-- **🎨 Color-Coded Debug Output**: Protocol messages color-coded for better readability
-- **🔧 Per-Protocol Debug Control**: 19 independent debug flags (--debug-arp, --debug-lldp, etc.)
-- **🌐 Multiple IPs per Device**: Dual-stack (IPv4/IPv6) and multi-homed configurations
-- **📝 Complete YAML Configuration**: All protocols configurable via YAML
-  - Discovery Protocols: LLDP, CDP, EDP, FDP with custom values
-  - Layer 2: STP bridge priority, timers, and versions
-  - Application Services: HTTP endpoints, FTP users, NetBIOS names
-  - Network Protocols: ICMP TTL, ICMPv6 hop limits, DHCPv6 pools
-- **📚 Comprehensive Examples**: 20+ example files organized by use case
-- **🔒 RFC Compliance**: ICMPv6 NDP always uses hop limit 255 per RFC 4861
-
-### Core Features
-
-✅ **Complete Protocol Stack** (19 protocols):
-- **Layer 2**: ARP, STP, LLDP, CDP, EDP, FDP
-- **Layer 3**: IPv4, IPv6, ICMP, ICMPv6
-- **Layer 4**: TCP, UDP
-- **Application**: HTTP, FTP, DNS, DHCP (v4/v6), NetBIOS, SNMP
-
-✅ **Advanced Capabilities**:
-- Interactive error injection mode with beautiful TUI
-- Packet capture and injection (via gopacket/libpcap)
-- YAML and legacy .cfg file parsing
-- Thread-safe error state management
-- Network interface detection
-- Multiple error types (FCS, Discards, CPU, Memory, etc.)
-- Real-time statistics
-- SNMP agent with walk file support
-- Comprehensive unit tests
-- Performance benchmarks
-
-## Installation
-
-### From Source
-
-```bash
-# Clone repository
-git clone https://github.com/krisarmstrong/niac-go
-cd niac-go
-
-# Build
-go build -o niac ./cmd/niac
-
-# Install (optional)
-sudo cp niac /usr/local/bin/
-```
-
-### Requirements
-
-- **Go**: 1.24+ for building
-- **libpcap**: For packet capture
-  - macOS: `brew install libpcap` (usually pre-installed)
-  - Linux: `sudo apt-get install libpcap-dev`
-  - Windows: WinPcap or Npcap
+- **Configurable topology** — declare devices, interfaces, VLANs, and neighbours in YAML; load templates or generate interactively
+- **Multi-IP per device** — each simulated endpoint can carry multiple v4/v6 addresses
+- **Protocol coverage** — ARP, ICMPv4/v6, DHCPv4/v6, DNS, LLDP, CDP, SNMP (v1/v2c/v3, walks + traps), TCP, UDP, HTTP, iperf3
+- **Per-protocol debug levels** — turn verbose logging on/off at the protocol layer without restarting
+- **PCAP analysis** — `niac analyze-pcap` summarises captures by protocol; `niac analyze-walk` extracts topology from SNMP walks
+- **Error injection** — inject latency, loss, jitter, or protocol-specific faults on a running simulation
+- **Web UI** — daemon mode exposes a React/TypeScript control plane on port 8080
+- **Interactive TUI** — single-screen control for ad-hoc lab use
+- **Templates** — ship YAML scenarios (`niac template`) and run them anywhere
 
 ## Quick Start
 
-### Interactive Mode
-
 ```bash
-# Run with interactive error injection (Cobra subcommand)
-sudo ./niac interactive en0 examples/layer2/lldp-only.yaml
+# Install (Linux/macOS, requires Go 1.26+)
+git clone https://github.com/krisarmstrong/niac-go ~/Developer/niac/go
+cd ~/Developer/niac/go
+make build
 
-# Legacy flag is still supported
-sudo ./niac --interactive en0 examples/layer2/lldp-only.yaml
+# Generate a starter config interactively
+./niac init my-lab.yaml
 
-# Or try the complete example with all features
-sudo ./niac --interactive en0 examples/complete-kitchen-sink.yaml
+# Validate
+./niac validate my-lab.yaml
 
-# Controls:
-#   [i] - Open interactive menu
-#   [s] - Toggle detailed statistics
-#   [N]/[n] - Toggle neighbor discovery table
-#   [x] - Toggle packet hex dump viewer
-#   [c] - Clear all errors
-#   [q] - Quit
+# Run on eth0 (needs CAP_NET_RAW or sudo)
+sudo ./niac run eth0 my-lab.yaml
 
-# In menu:
-#   [↑↓] - Navigate
-#   [Enter] - Select
+# Or start the daemon + web UI
+sudo ./niac daemon
+# → open http://localhost:8080
 ```
 
-Both entrypoints launch the full simulator stack; the TUI now displays live packet statistics, the learned neighbor table (LLDP/CDP/EDP/FDP), and shares the same runtime as the standard CLI workflow.
-
-### Web UI (v2 Preview)
-
-The upcoming 2.x release introduces a React-based control plane that mirrors everything the CLI/TUI can do—statistics, neighbor insights, config management, and (soon) automation. The UI reuses the shared `@krisarmstrong/web-foundation` system that also powers `krisarmstrong-portfolio` and `wi-fi-vigilante`.
-
-```bash
-# Install once
-cd ui
-npm install
-
-# Run the development server
-npm run dev
-
-# Build production assets (served by the Go API layer)
-npm run build
-```
-
-The React app lives in `ui/` with Tailwind CSS, React Router, and the shared component library already wired up. During the v2.0 development cycle it ships alongside the existing CLI/TUI so you can pick whichever entrypoint fits the workflow.
-
-### Basic Usage
-
-```bash
-# Validate configuration
-./niac --dry-run lo0 examples/network/ipv4-only.yaml
-
-# Run simulation
-sudo ./niac en0 examples/vendors/cisco-network.yaml
-
-# Run with verbose debug
-sudo ./niac --verbose en0 examples/layer2/lldp-only.yaml
-
-# Debug specific protocol only
-sudo ./niac --debug 1 --debug-lldp 3 en0 examples/layer2/lldp-only.yaml
-```
-
-### Web UI & REST API
-
-```bash
-niac --api-listen :8080 --api-token supersecret en0 config.yaml
-```
-
-Visit `http://localhost:8080`, enter the token, and monitor packets, devices, history, and a live topology graph. The built-in YAML editor now talks to `/api/v1/config`, so edits run the same validation pipeline as `niac validate` before landing on disk. Packet replay and alert thresholds can also be managed directly from the Web UI via `/api/v1/replay` and `/api/v1/alerts`. Full API documentation lives in [`docs/REST_API.md`](docs/REST_API.md).
-
-### Reloading Configuration
-
-The 1.x runtime can apply config changes without restarting:
-
-```bash
-# Ask a running niac process to reload its config file
-kill -HUP $(pgrep -f "niac .*en0")
-```
-
-Interactive mode also exposes the shortcut `[r]` to reload the active configuration and refresh the TUI. Behind the scenes both flows call the same hot-reload path that the Web UI/API use, so CLI, TUI, and browser all stay in sync.
-
-### Metrics & Alerting
-
-```bash
-niac --api-listen :8080 \
-     --metrics-listen :9090 \
-     --alert-packets-threshold 100000 \
-     --alert-webhook https://hooks.example.com/niac \
-     en0 config.yaml
-```
-
-Prometheus metrics are exposed at `/metrics` and alerts are pushed to the optional webhook when the configured packet threshold is crossed.
-
-### Run History Storage
-
-NIAC automatically persists recent run metadata (interface, packets, errors) to a BoltDB database so the Web UI can show history. By default it is written to `~/.niac/niac.db`, but you can relocate or disable it:
-
-```bash
-# Store history alongside other simulator artifacts
-niac --storage-path /var/lib/niac/history.db en0 config.yaml
-
-# Opt out of persistence entirely (stateless containers, CI, etc.)
-niac --storage-path disabled en0 config.yaml
-```
-
-When disabled, the API simply returns an empty history list, keeping both CLI and TUI behaviour consistent.
-
-### Container & Kubernetes Deployment
-
-Use the provided `Dockerfile`, `docker-compose.yml`, and `deploy/kubernetes/niac-deployment.yaml` manifests to run NIAC inside containers:
-
-```bash
-docker compose up --build
-# or
-kubectl apply -f deploy/kubernetes/niac-deployment.yaml
-```
-
-The sample manifests run NIAC on the container's loopback interface and expose the Web UI on port 8080.
-
-### Help
-
-```bash
-./niac --help
-```
-
-Shows all 50+ command-line options including:
-- Core flags: --debug, --verbose, --quiet, --interactive, --dry-run
-- Information: --version, --list-interfaces, --list-devices
-- Output: --no-color, --log-file, --stats-interval
-- Per-protocol debug: --debug-arp, --debug-lldp, --debug-dhcpv6, etc.
-
-### Generating Modern Walk Files
-
-Need an SNMP walk for newer hardware? Use the built-in generator to create realistic synthetic walks for modern switches, firewalls, and routers:
-
-```bash
-# Discover the 18 supported vendor/model profiles
-python3 scripts/generate_modern_walk.py --list
-
-# Generate a specific device walk file
-python3 scripts/generate_modern_walk.py \
-  --vendor cisco \
-  --model c9300-48p \
-  --output examples/device_walks/generated/cisco-c9300.walk
-
-# Use a custom hostname in the generated data
-python3 scripts/generate_modern_walk.py \
-  --vendor aruba \
-  --model cx6300-48g \
-  --hostname core-sw-01 \
-  --output aruba-cx6300.walk
-```
-
-The resulting `.walk` files can be referenced from any device’s `snmp_agent.walk_file` field, right alongside the sanitized captures that ship with NiAC-Go.
-
-## Configuration
-
-### YAML Configuration (v1.5.0+)
-
-NIAC-Go uses YAML for configuration with full support for all protocol options:
-
-```yaml
-devices:
-  # Cisco router with LLDP and CDP
-  - name: cisco-router-01
-    mac: "00:1a:2b:3c:4d:01"
-    ips:
-      - "192.168.1.1"        # IPv4
-      - "2001:db8::1"        # IPv6
-
-    # Discovery protocols
-    lldp:
-      enabled: true
-      system_description: "Cisco IOS 15.4"
-      port_description: "GigabitEthernet0/0"
-
-    cdp:
-      enabled: true
-      platform: "Cisco 2921"
-      software_version: "IOS 15.4(3)M6a"
-
-    # DHCP server
-    dhcp:
-      enabled: true
-      pools:
-        - network: "192.168.1.0/24"
-          range_start: "192.168.1.100"
-          range_end: "192.168.1.200"
-          gateway: "192.168.1.1"
-          dns_servers: ["8.8.8.8"]
-
-    # ICMP configuration
-    icmp:
-      enabled: true
-      ttl: 128              # Windows-like TTL
-      rate_limit: 100
-
-  # IPv6-only device
-  - name: ipv6-server
-    mac: "00:11:22:33:44:55"
-    ips:
-      - "2001:db8::100"
-
-    dhcpv6:
-      enabled: true
-      pools:
-        - network: "2001:db8::/64"
-          range_start: "2001:db8::200"
-          range_end: "2001:db8::2ff"
-      preference: 255       # Highest priority
-```
-
-### Example Library
-
-See `examples/` directory for 20+ organized examples:
-- **Complete reference**: `complete-kitchen-sink.yaml` (all v1.6.0 features, 9 devices)
-- **Traffic patterns** (v1.6.0): `traffic-patterns.yaml` - Configurable ARP, pings, random traffic
-- **SNMP traps** (v1.6.0): `snmp-traps.yaml` - Event & threshold-based trap generation
-- **Layer 2 protocols**: `layer2/lldp-only.yaml`, `layer2/stp-bridge.yaml`
-- **DHCP servers**: `dhcp/dhcpv4-simple.yaml`, `dhcp/dhcpv4-advanced.yaml`
-- **Services**: `services/dns-server.yaml`, `services/http-server.yaml`
-- **Network configs**: `network/ipv4-only.yaml`, `network/dual-stack.yaml`
-- **Vendor examples**: `vendors/cisco-network.yaml`
-
-Full documentation: `examples/EXAMPLES-README.md`
-
-### Topology & Protocol Analysis
-
-```bash
-# Export Graphviz topology from an SNMP walk
-niac analyze-walk device.walk --graphviz topology.dot
-dot -Tpng topology.dot -o topology.png
-
-# Summarise a packet capture
-niac analyze-pcap captures/demo.pcap --output json
-```
-
-## Development
-Run the full local checks:
-
-```bash
-./check.sh
-```
-
-
-### Testing
-
-```bash
-# Run all tests
-go test ./...
-
-# Run with coverage
-go test ./... -cover
-
-# Run benchmarks
-go test ./pkg/... -bench=. -benchmem
-```
-
-### Benchmark Results (Apple M2)
-
-```
-BenchmarkSetError-8       	 7742178	  154.1 ns/op	  48 B/op	   3 allocs/op
-BenchmarkGetError-8       	 6643556	  180.0 ns/op	 144 B/op	   4 allocs/op
-BenchmarkGetAllStates-8   	10493102	  114.9 ns/op	 104 B/op	   2 allocs/op
-BenchmarkParseSimpleConfig-8  816152	 1302 ns/op	 2024 B/op	  19 allocs/op
-```
-
-### Project Structure
-
-```
-niac-go/
-├── cmd/niac/              # Main application entry point
-├── pkg/
-│   ├── capture/           # Packet capture & injection
-│   ├── config/            # Configuration parsing
-│   ├── errors/            # Error injection & state management
-│   ├── interactive/       # Interactive TUI
-│   ├── protocols/         # Network protocols (ARP, CDP, etc.)
-│   └── snmp/              # SNMP agent
-├── examples/              # Example configurations
-└── README.md
-```
-
-## Reference Guides
-
-Need deeper dives? The `docs/` directory ships with dedicated walkthroughs:
-
-- [docs/TOPOLOGY_GUIDE.md](docs/TOPOLOGY_GUIDE.md) – Port-channels, trunk ports, VLAN-aware topologies, and LLDP/CDP neighbor design.
-- [docs/ENVIRONMENTS.md](docs/ENVIRONMENTS.md) – Complete data center, enterprise campus, branch, wireless, and multi-vendor simulation scenarios.
-- [docs/PROTOCOL_GUIDE.md](docs/PROTOCOL_GUIDE.md) – How to configure LLDP, CDP, DHCP, DNS, SNMP (agents + traps), STP variants, and more.
-- [docs/API_REFERENCE.md](docs/API_REFERENCE.md) – The full YAML schema with every field, default, and validation rule.
-- [docs/REST_API.md](docs/REST_API.md) – REST endpoints, Web UI, authentication, and alerting options.
-- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) – Common validation failures, debugging tips, and performance tuning advice.
-- [docs/WALK_FILES.md](docs/WALK_FILES.md) – Vendor coverage, synthetic vs. sanitized walks, and contribution guidelines.
-
-Each guide includes paste-ready YAML snippets and command-line workflows so you can adapt the scenarios to your lab quickly.
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `niac daemon` | Run with web UI control plane (port 8080) |
+| `niac run <iface> <config>` | Run a simulation on a real interface |
+| `niac interactive <iface> <config>` | Run with a TUI dashboard |
+| `niac init [out]` | Interactive template wizard |
+| `niac generate [out]` | Interactive configuration generator |
+| `niac validate <config>` | Validate a YAML configuration |
+| `niac template` | Manage built-in scenario templates |
+| `niac status` | Query a running simulation |
+| `niac monitor` | Stream real-time stats |
+| `niac logs` | Stream simulation logs |
+| `niac dump` | Dump captured packets |
+| `niac inject <device> <error-type> <value>` | Inject errors on running devices |
+| `niac neighbors [watch]` | LLDP/CDP neighbour table |
+| `niac analyze-pcap <file>` | Summarise a PCAP by protocol |
+| `niac analyze-walk <file>` | Extract relationships from an SNMP walk |
+| `niac sanitize <in> <out>` | Anonymise SNMP walks |
+| `niac topology` | Topology management |
+| `niac service` | Windows service management |
+| `niac man` | Generate man pages |
+| `niac completion <shell>` | Shell completion scripts |
+
+Run `niac <command> --help` for flags.
 
 ## Architecture
 
-### Error Injection System
-
 ```
-┌─────────────────────────────────────────────┐
-│         Interactive TUI (Bubbletea)         │
-│  • Real-time stats                          │
-│  • Menu navigation                          │
-│  • Error control                            │
-└───────────────────┬─────────────────────────┘
-                    │
-┌───────────────────▼─────────────────────────┐
-│       StateManager (Thread-Safe)            │
-│  • ConcurrentHashMap for device states     │
-│  • Goroutine-safe operations               │
-│  • 7 error types supported                 │
-└───────────────────┬─────────────────────────┘
-                    │
-┌───────────────────▼─────────────────────────┐
-│       Packet Capture Engine (gopacket)      │
-│  • Direct libpcap integration              │
-│  • No JNI overhead                         │
-│  • Rate limiting                           │
-└─────────────────────────────────────────────┘
+ui/src/             → React/TypeScript control plane (Vite)
+                          ↓ npm run build
+internal/api/ui/    → Built assets (embedded via go:embed)
+                          ↓
+cmd/niac/           → Cobra-based CLI (subcommands above)
+internal/
+├── api/            → HTTP/WebSocket handlers
+├── protocols/      → Per-protocol simulators (arp, icmp, dhcp, snmp, …)
+├── device/         → Device model + simulator loop
+├── topology/       → Topology graph + neighbours
+├── ipc/            → daemon ↔ runner socket
+├── converter/      → YAML ↔ runtime config
+└── version/        → Build metadata (injected via ldflags)
 ```
 
-## Error Types
+The frontend builds **directly into `internal/api/ui/`** and is embedded at
+compile time — no copy step, no file syncing. One binary, no runtime
+dependencies.
 
-- **FCS Errors**: Frame Check Sequence errors
-- **Packet Discards**: Dropped packets
-- **Interface Errors**: Generic interface errors
-- **High Utilization**: Interface bandwidth saturation
-- **High CPU**: Device CPU load
-- **High Memory**: Device memory usage
-- **High Disk**: Device disk usage
+## Configuration
 
-## Why Rewrite?
+YAML topology + per-device behaviour. Generate a starter with `niac init`
+or use a template (`niac template list`). Schema is documented in
+[`docs/schemas/niac.schema.json`](docs/schemas/niac.schema.json) and
+regenerated by `make schema`.
 
-### Java (Original)
-- ✅ Mature, battle-tested (20+ years)
-- ✅ Excellent libraries
-- ❌ JVM overhead
-- ❌ Slow startup
-- ❌ Large memory footprint
-- ❌ Deployment complexity
+```yaml
+# minimal example
+devices:
+  - name: switch-1
+    type: switch
+    interfaces:
+      - name: eth0
+        ipv4: 192.168.1.10/24
+        protocols: [arp, icmp, lldp, snmp]
+```
 
-### Go (New)
-- ✅ Native binary, instant startup
-- ✅ Tiny memory footprint
-- ✅ Simple deployment
-- ✅ Excellent concurrency
-- ✅ Modern tooling
-- ✅ Fast compile times
-- ⚠️  Need to rebuild protocol handlers
+## Build
 
-## Compatibility
+| Command | Purpose |
+|---------|---------|
+| `make build` | Full build (frontend + backend) |
+| `make quick` | Backend-only (dev iteration; do **not** ship) |
+| `make test` | Go unit + integration tests |
+| `make test-e2e` | Playwright UI tests |
+| `make lint` | golangci-lint + Biome |
+| `make fmt-check` | Format check (Go + TS) |
+| `make fmt-all` | Auto-format everything |
+| `make schema` | Regenerate JSON schema from `Config` struct |
+| `make packages` | Local `.deb` + `.rpm` via GoReleaser |
+| `make pkg` | macOS `.pkg` |
+| `make deploy-all` | Deploy + validate on all target servers |
 
-NIAC-Go has achieved feature parity with NIAC-Java and surpassed it:
+Verified versions: **Go 1.26.3**, Node.js 26, golangci-lint v2.12.1.
+Cross-platform releases (linux/macOS/windows × amd64/arm64) are built by
+the `release.yml` workflow on tag push.
 
-| Feature | Java | Go | Status |
-|---------|------|-----|--------|
-| Interactive Mode | ✅ | ✅ | **Complete** |
-| Error Injection | ✅ | ✅ | **Complete** |
-| Config Parsing | ✅ | ✅ | **Complete + YAML** |
-| Packet Capture | ✅ | ✅ | **Complete** |
-| SNMP Agent | ✅ | ✅ | **Complete** |
-| Protocol Support | ✅ | ✅ | **Complete (19 protocols)** |
-| Device Simulation | ✅ | ✅ | **Complete** |
-| YAML Configuration | ❌ | ✅ | **Go Only** |
-| Per-Protocol Debug | ❌ | ✅ | **Go Only** |
-| Color Output | ❌ | ✅ | **Go Only** |
-| Multi-IP Devices | ❌ | ✅ | **Go Only** |
+## Container
 
-## Contributing
+Multi-arch images on GHCR built via native runners (no QEMU):
 
-Contributions welcome! This is a fun rewrite project to learn Go and modernize NIAC.
+```bash
+docker run --rm --network host \
+  ghcr.io/krisarmstrong/niac-go:latest daemon
+```
+
+Images carry SLSA-3 provenance and a Syft-generated SBOM.
+
+## Versioning & Releases
+
+Conventional commits drive [release-please](https://github.com/googleapis/release-please).
+`feat:` → minor bump, `fix:` → patch, `refactor:`/`chore:`/`ci:` →
+no bump (use `Release-As:` footer to force). Tags trigger `release.yml`
+which builds binaries, `.deb`, `.rpm`, `.pkg`, Windows `.zip`, and the
+container image, all signed with cosign keyless OIDC.
 
 ## License
 
-Same as original NIAC project.
+[Business Source License 1.1](LICENSE) — free for non-commercial use;
+commercial use requires a license. Converts to Apache-2.0 on the change
+date stated in the LICENSE file. Matches the licensing on seed and stem.
 
-## Credits
+For commercial licensing inquiries: `kris.armstrong@gmail.com`.
 
-- **Original NIAC**: Kevin Kayes (2002-2015)
-- **Java Modernization & Go Rewrite**: Kris Armstrong (2025)
+## Related projects
 
-## Related Projects
+NIAC is the simulator. Two sibling tools complete the Mustard Seed Networks
+testing toolkit:
 
-- [NIAC (Java)](https://github.com/krisarmstrong/network-in-a-can) - Original Java implementation
-
----
-
-**Built with ❤️ and Go** • Made for network engineers who love fast tools
+- **[seed](https://github.com/krisarmstrong/seed)** — portable network diagnostic appliance
+- **[stem](https://github.com/krisarmstrong/stem)** — RFC-compliant network performance testing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Use one of these private channels instead:
    <https://github.com/krisarmstrong/niac-go/security/advisories/new>.
    This creates a private advisory visible only to repository maintainers
    and you, with a built-in audit trail and CVE coordination workflow.
-2. **Email:** `kris.armstrong@netally.com` with subject `[NIAC SECURITY]`.
+2. **Email:** `kris.armstrong@icloud.com` with subject `[NIAC SECURITY]`.
 
 Include in your report:
 

--- a/examples/ERROR_INJECTION_HOWTO.md
+++ b/examples/ERROR_INJECTION_HOWTO.md
@@ -253,4 +253,4 @@ Back to Terminal 2 (monitoring tool):
 
 ## Author
 
-Kris Armstrong <kris.armstrong@me.com>
+Kris Armstrong <kris.armstrong@icloud.com>


### PR DESCRIPTION
## Summary

Three related cleanups bundled because they affect the project's metadata identity:

### 1. README rewrite (236 → 240 lines, replacing 591 stale lines)
The previous README referenced versions that don't exist on this project (v1.5/v1.6/v1.7/v1.10/v1.11/v1.12/v1.13/v1.23 — actual latest is v0.70.0) and Go versions that don't match go.mod (claimed 1.23/1.25.4 — actual 1.26.3). Rewritten to mirror the structure now used by seed and stem:
- Accurate badges (CI, Release, CodeQL, Scorecard, Go Reference, Go Report Card, License)
- One-line tagline + brief description
- Features list aligned to today's capabilities
- Quick Start + first-run flow
- Commands table covering all 22 current subcommands
- Architecture diagram (cmd/internal layout, frontend embed)
- Build/test/release commands table
- Container, versioning, license, related-projects sections

### 2. License: GPL-3.0 → BSL 1.1
**Context: NIAC-Go is a clean-room rewrite — no shared code with the original Java NIAC (Fluke Networks).** Confirmed by repo owner. The previous GPL-3.0 LICENSE carried forward a stale Kevin Kayes copyright notice from the original; since the Go codebase shares no code, that attribution was incorrect.

The new LICENSE aligns niac with seed and stem (both already BSL 1.1) for a consistent commercial model across the three Mustard Seed Networks projects:
- **Licensor**: Mustard Seed Networks
- **Additional Use Grant**: excludes commercial "Network Simulation Service" offerings (lab-as-a-service, hosted protocol emulation)
- **Change Date**: 2029-12-01
- **Change License**: Apache-2.0

BSL 1.1 is commercial-friendly (free for non-commercial; commercial licensing available) and auto-converts to Apache-2.0 on the change date.

### 3. Email standardization
Consolidate maintainer email to `kris.armstrong@icloud.com` across CODE_OF_CONDUCT.md, SECURITY.md, .goreleaser.yml, and examples/ — previously mixed (@me.com, @netally.com, @mustardseednetworks.com). Matches seed and stem.

## Test plan
- [ ] CI green
- [ ] Confirm BSL 1.1 is intended given clean-room rewrite status
- [ ] Confirm email choice