### PR TITLE
ci(release-please): use RELEASE_PLEASE_TOKEN PAT to enable workflow cascade

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,11 +31,12 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          # token defaults to GITHUB_TOKEN. The repo's Actions permission
-          # 'Allow GitHub Actions to create and approve pull requests' must
-          # be enabled (Settings -> Actions -> General). Without the
-          # RELEASE_PLEASE_TOKEN secret, the explicit token line caused
-          # 'Input required and not supplied: token' on every run.
+          # PAT (not GITHUB_TOKEN) so the release PR's CI runs and the
+          # tag-push event triggers release.yml. With GITHUB_TOKEN those
+          # downstream workflows are silently skipped per GitHub's
+          # anti-recursion policy. Falls back to GITHUB_TOKEN if the
+          # secret isn't set (release PR will open but no cascade).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           release-type: go
 
       - name: Release created


### PR DESCRIPTION
## Summary

Fix the long-standing issue where every release-please PR opens with 0 CI checks and every tag push doesn't trigger \`release.yml\`. Root cause: GitHub deliberately blocks workflows triggered by \`GITHUB_TOKEN\` from cascading to downstream workflows (anti-recursion safety). Switching release-please to use a PAT (\`RELEASE_PLEASE_TOKEN\` secret) sidesteps that — the token is treated as a "different actor" so cascades work normally.

Falls back to \`GITHUB_TOKEN\` if the secret isn't set so this doesn't break the workflow if the PAT expires before being renewed.

Aligns with seed which already uses this pattern.

## Prerequisite (not blocking this PR, but the PAT must exist for the cascade to work)
1. Create a fine-grained PAT at https://github.com/settings/tokens?type=beta with permissions: Contents R/W, Pull requests R/W, Actions R/W, Workflows R/W; repo access limited to seed/stem/niac-go.
2. Add as secret named \`RELEASE_PLEASE_TOKEN\` in Settings → Secrets → Actions for each of seed, stem, niac-go.

## Test plan
- [ ] CI passes
- [ ] PAT secret is set in niac-go before next release-please run
- [ ] Verify next release PR opens with CI checks running, and tag push triggers release.yml