### PR TITLE
feat(ui): comprehensive tooltip parity for icon-only actions

### DIFF
--- a/ui/src/components/device-list/DeviceCardView.tsx
+++ b/ui/src/components/device-list/DeviceCardView.tsx
@@ -110,7 +110,8 @@ export const DeviceCardView: FC = () => {
                     type="button"
                     onClick={() => onEdit(device.hostname)}
                     className="p-2 text-text-muted hover:text-brand-300 hover:bg-white/10 rounded-lg transition-colors"
-                    title="Edit device"
+                    title={`Open the device editor for ${device.hostname} to modify protocols, interfaces, and credentials`}
+                    aria-label={`Edit device ${device.hostname}`}
                   >
                     <Edit3 className={iconSizes.md} />
                   </button>
@@ -118,7 +119,8 @@ export const DeviceCardView: FC = () => {
                     type="button"
                     onClick={() => onClone(device.hostname)}
                     className="p-2 text-text-muted hover:text-status-info hover:bg-white/10 rounded-lg transition-colors"
-                    title="Clone device"
+                    title={`Create a copy of ${device.hostname} with a new hostname; all protocols and interfaces are duplicated`}
+                    aria-label={`Clone device ${device.hostname}`}
                   >
                     <Copy className={iconSizes.md} />
                   </button>
@@ -126,7 +128,8 @@ export const DeviceCardView: FC = () => {
                     type="button"
                     onClick={() => onDelete(device.hostname)}
                     className="p-2 text-text-muted hover:text-status-error hover:bg-white/10 rounded-lg transition-colors"
-                    title="Delete device"
+                    title={`Permanently remove ${device.hostname} from the library; cannot be undone`}
+                    aria-label={`Delete device ${device.hostname}`}
                   >
                     <Trash2 className={iconSizes.md} />
                   </button>

--- a/ui/src/components/device-list/DeviceTableView.tsx
+++ b/ui/src/components/device-list/DeviceTableView.tsx
@@ -74,6 +74,7 @@ export const DeviceTableView: FC = () => {
                       type="button"
                       onClick={() => onEdit(device.hostname)}
                       className="text-text-primary hover:text-brand-300 font-medium truncate"
+                      title={`Open ${device.hostname} in the device editor`}
                     >
                       {device.hostname}
                     </button>
@@ -120,7 +121,8 @@ export const DeviceTableView: FC = () => {
                       type="button"
                       onClick={() => onEdit(device.hostname)}
                       className="p-2 text-text-muted hover:text-brand-300 hover:bg-white/5 rounded-lg transition-colors"
-                      title="Edit device"
+                      title={`Open the device editor for ${device.hostname} to modify protocols, interfaces, and credentials`}
+                      aria-label={`Edit device ${device.hostname}`}
                     >
                       <Edit3 className={iconSizes.md} />
                     </button>
@@ -128,7 +130,8 @@ export const DeviceTableView: FC = () => {
                       type="button"
                       onClick={() => onClone(device.hostname)}
                       className="p-2 text-text-muted hover:text-status-info hover:bg-white/5 rounded-lg transition-colors"
-                      title="Clone device"
+                      title={`Create a copy of ${device.hostname} with a new hostname; all protocols and interfaces are duplicated`}
+                      aria-label={`Clone device ${device.hostname}`}
                     >
                       <Copy className={iconSizes.md} />
                     </button>
@@ -136,7 +139,8 @@ export const DeviceTableView: FC = () => {
                       type="button"
                       onClick={() => onDelete(device.hostname)}
                       className="p-2 text-text-muted hover:text-status-error hover:bg-white/5 rounded-lg transition-colors"
-                      title="Delete device"
+                      title={`Permanently remove ${device.hostname} from the library; cannot be undone`}
+                      aria-label={`Delete device ${device.hostname}`}
                     >
                       <Trash2 className={iconSizes.md} />
                     </button>

--- a/ui/src/pages/LibraryFilesPage.tsx
+++ b/ui/src/pages/LibraryFilesPage.tsx
@@ -79,6 +79,7 @@ function LibraryFilesView({ kind }: Props) {
                 onClick={refetch}
                 leftIcon={<RefreshCw className="w-4 h-4" />}
                 disabled={loading}
+                title="Re-fetch the file listing from the daemon's library directory"
               >
                 Refresh
               </Button>

--- a/ui/src/pages/PcapAnalyzerPage.tsx
+++ b/ui/src/pages/PcapAnalyzerPage.tsx
@@ -245,6 +245,7 @@ export const PcapAnalyzerPage: FC = () => {
                     <button
                       type="button"
                       onClick={() => setViewMode('packets')}
+                      title="Show every decoded packet with timestamp, headers, and payload"
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'packets'
                           ? 'bg-brand-600 text-text-primary'
@@ -256,6 +257,7 @@ export const PcapAnalyzerPage: FC = () => {
                     <button
                       type="button"
                       onClick={() => setViewMode('stats')}
+                      title="Show aggregate statistics: byte/packet totals per protocol and per host"
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'stats'
                           ? 'bg-brand-600 text-text-primary'
@@ -267,6 +269,7 @@ export const PcapAnalyzerPage: FC = () => {
                     <button
                       type="button"
                       onClick={() => setViewMode('conversations')}
+                      title="Group packets by 5-tuple to see TCP/UDP flows and byte totals per conversation"
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'conversations'
                           ? 'bg-brand-600 text-text-primary'

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -575,6 +575,7 @@ export const TopologyPage: FC = () => {
                   role="tab"
                   aria-selected={view === 'graph'}
                   onClick={() => setView('graph')}
+                  title="Show devices and links as an interactive graph (drag to reposition, scroll to zoom)"
                   className={`flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
                     view === 'graph'
                       ? 'bg-status-info/20 text-status-info'
@@ -589,6 +590,7 @@ export const TopologyPage: FC = () => {
                   role="tab"
                   aria-selected={view === 'neighbors'}
                   onClick={() => setView('neighbors')}
+                  title="Show LLDP/CDP neighbor relationships as a sortable table grouped by device"
                   className={`flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
                     view === 'neighbors'
                       ? 'bg-status-info/20 text-status-info'
@@ -701,6 +703,11 @@ export const TopologyPage: FC = () => {
                         type="button"
                         onClick={() => toggleType(type)}
                         aria-pressed={active}
+                        title={
+                          active
+                            ? `Hide ${type} devices from the graph`
+                            : `Show only ${type} devices (toggles a filter chip)`
+                        }
                         className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium capitalize transition-colors ${
                           active
                             ? 'border-status-info/40 bg-status-info/20 text-status-info'
@@ -715,6 +722,7 @@ export const TopologyPage: FC = () => {
                     <button
                       type="button"
                       onClick={() => setActiveTypes(new Set())}
+                      title="Remove all device-type filters and show every device in the topology"
                       className="rounded-full px-2 py-0.5 text-[11px] font-medium text-text-muted hover:text-text-primary underline-offset-2 hover:underline"
                     >
                       Clear

--- a/ui/src/pages/topology/DeviceDetailsPanel.tsx
+++ b/ui/src/pages/topology/DeviceDetailsPanel.tsx
@@ -54,6 +54,8 @@ export const DeviceDetailsPanel: FC<DeviceDetailsPanelProps> = ({ device, onClos
           type="button"
           onClick={onClose}
           className="text-text-muted hover:text-text-primary text-xl"
+          title="Close the device details panel and return to the topology view"
+          aria-label="Close device details"
         >
           &times;
         </button>

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -126,6 +126,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
             type="button"
             onClick={() => setCollapsed(true)}
             className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors lg:flex hidden"
+            title="Collapse the sidebar to icons-only mode to give the main content more horizontal space"
             aria-label="Collapse sidebar"
           >
             <ChevronLeft className={iconSizes.md} />
@@ -161,7 +162,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
               text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors
               text-sm font-medium
             `}
-            title={collapsed ? 'Help' : undefined}
+            title="Open the help dialog with keyboard shortcuts, documentation links, and supported features"
             aria-label="Open help"
           >
             <HelpCircle className={`${iconSizes.md} flex-shrink-0`} />
@@ -176,7 +177,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
               text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors
               text-sm font-medium
             `}
-            title={collapsed ? 'Settings' : undefined}
+            title="Open the settings modal to change theme, default capture interface, and other application preferences"
             aria-label="Open settings"
           >
             <Settings className={`${iconSizes.md} flex-shrink-0`} />
@@ -201,6 +202,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
             type="button"
             onClick={() => setCollapsed(false)}
             className="mt-2 p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors"
+            title="Expand the sidebar to show navigation labels alongside icons"
             aria-label="Expand sidebar"
           >
             <ChevronRight className={iconSizes.md} />
@@ -232,6 +234,11 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           type="button"
           onClick={() => setMobileOpen(!mobileOpen)}
           className="p-2 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors"
+          title={
+            mobileOpen
+              ? 'Close the navigation drawer'
+              : 'Open the navigation drawer to switch pages'
+          }
           aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
         >
           {mobileOpen ? <X className={iconSizes.lg} /> : <Menu className={iconSizes.lg} />}
@@ -244,6 +251,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           type="button"
           className="lg:hidden fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
           onClick={() => setMobileOpen(false)}
+          title="Tap outside to close the navigation drawer"
           aria-label="Close menu"
         />
       )}


### PR DESCRIPTION
## Summary

Brings niac up to parity with seed/stem for hover-tooltip coverage by adding descriptive title + aria-label pairs on icon-only action buttons across the app.

Per the cross-repo tooltip style guide:
- Tooltips describe the action AND its side effect (not just name the icon)
- Industry-standard terms stay in English (LLDP/CDP, RFC, PTP, VLAN, etc.)
- Icon-only buttons get both `title=` and `aria-label` for browser + screen reader users
- We keep native `title=` rather than over-using the `<Tooltip>` component (plain text doesn't need the heavier primitive)

### Changes (~16 tooltips added/improved)

- **Sidebar** (`src/ui/Sidebar.tsx`): collapse/expand, mobile menu open/close, Help, Settings now show always-on descriptive tooltips (not only when sidebar is collapsed)
- **Device list** (`src/components/device-list/DeviceTableView.tsx`, `DeviceCardView.tsx`): Edit / Clone / Delete row buttons describe the action and include the device hostname
- **Topology** (`src/pages/TopologyPage.tsx`, `src/pages/topology/DeviceDetailsPanel.tsx`): Graph/Neighbors view tabs, device-type filter chips, Clear button, DeviceDetailsPanel close
- **Pcap Analyzer** (`src/pages/PcapAnalyzerPage.tsx`): Packets / Statistics / Conversations view-mode buttons
- **Library Files** (`src/pages/LibraryFilesPage.tsx`): Refresh button

## Test plan

- [x] `npm run build` succeeds
- [x] `npx biome check src/` passes with no new errors
- [ ] Manual: hover each affected button, confirm tooltip text reads naturally
- [ ] Manual: confirm screen-reader announces aria-label correctly on icon-only buttons
- [ ] Manual: confirm Sidebar tooltips show when sidebar is expanded (not just collapsed)

## Companion PRs

- stem: pushed direct to main (no branch protection) — commit 5a9ef39
- seed: spot-check only (already has 267 tooltips)