### PR TITLE
feat(ui): harmonize color theme — MSN Green brand, dark default + light toggle

### DIFF
--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -20,12 +20,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     />
-    <script type="module" crossorigin src="/assets/index-SHnGKA7b.js"></script>
+    <script type="module" crossorigin src="/assets/index-DIcqtrrD.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-eeLRIeX4.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-xyflow-BgvehhUW.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-DWCVT6q4.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-ui-Eojmkgt-.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-codemirror-C6W6iGZP.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-CeEOyKCx.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BkwskAAY.css">
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/BpfFilterBar.tsx
+++ b/ui/src/components/BpfFilterBar.tsx
@@ -132,7 +132,7 @@ export const BpfFilterBar: FC = memo(() => {
               ? 'border-status-error/60 focus:ring-status-error/40'
               : isActive
                 ? 'border-status-success/40 focus:ring-green-500/40'
-                : 'border-white/10 focus:ring-brand-500/40'
+                : 'border-surface-border focus:ring-brand-primary/40'
           }`}
           disabled={isLoading}
         />
@@ -185,7 +185,7 @@ export const BpfFilterBar: FC = memo(() => {
             key={preset.filter}
             type="button"
             onClick={() => handlePreset(preset.filter)}
-            className="px-2 py-0.5 text-xs rounded bg-bg-elevated/60 text-text-muted hover:text-text-primary hover:bg-bg-elevated/60 border border-white/5 transition-colors"
+            className="px-2 py-0.5 text-xs rounded bg-bg-elevated/60 text-text-muted hover:text-text-primary hover:bg-bg-elevated/60 border border-surface-border transition-colors"
           >
             {preset.label}
           </button>

--- a/ui/src/components/ColoringRulesPanel.tsx
+++ b/ui/src/components/ColoringRulesPanel.tsx
@@ -29,18 +29,18 @@ const RuleRow: FC<{
   const filterError = rule.filter ? validate(rule.filter) : null;
 
   return (
-    <div className="flex items-center gap-2 py-2 px-2 rounded-lg bg-bg-base/40 border border-white/5">
+    <div className="flex items-center gap-2 py-2 px-2 rounded-lg bg-bg-base/40 border border-surface-border">
       {/* Enable toggle */}
       <input
         type="checkbox"
         checked={rule.enabled}
         onChange={(e) => onChange({ ...rule, enabled: e.target.checked })}
-        className="rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-400 focus:ring-offset-gray-900 flex-shrink-0"
+        className="rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-accent focus:ring-offset-gray-900 flex-shrink-0"
       />
 
       {/* Color preview */}
       <div
-        className="w-6 h-6 rounded border border-white/10 flex-shrink-0"
+        className="w-6 h-6 rounded border border-surface-border flex-shrink-0"
         style={{ backgroundColor: rule.background, color: rule.foreground }}
       >
         <span className="text-xs font-bold flex items-center justify-center h-full">A</span>
@@ -51,7 +51,7 @@ const RuleRow: FC<{
         type="text"
         value={rule.name}
         onChange={(e) => onChange({ ...rule, name: e.target.value })}
-        className="w-24 bg-transparent border-b border-white/10 text-sm text-text-primary focus:outline-none focus:border-brand-400 px-1"
+        className="w-24 bg-transparent border-b border-surface-border text-sm text-text-primary focus:outline-none focus:border-brand-accent px-1"
         placeholder="Name"
       />
 
@@ -63,7 +63,7 @@ const RuleRow: FC<{
         className={`flex-1 bg-transparent border-b text-sm font-mono text-text-primary focus:outline-none px-1 ${
           filterError
             ? 'border-status-error/60 focus:border-status-error'
-            : 'border-white/10 focus:border-brand-400'
+            : 'border-surface-border focus:border-brand-accent'
         }`}
         placeholder="Filter expression"
       />
@@ -187,9 +187,9 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-        <div className="w-full max-w-3xl mx-4 bg-bg-surface border border-white/10 rounded-xl shadow-2xl max-h-[80vh] flex flex-col">
+        <div className="w-full max-w-3xl mx-4 bg-bg-surface border border-surface-border rounded-xl shadow-2xl max-h-[80vh] flex flex-col">
           {/* Header */}
-          <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-surface-border">
             <h3 className="text-lg font-semibold text-text-primary">Coloring Rules</h3>
             <button
               type="button"
@@ -227,7 +227,7 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-between px-5 py-4 border-t border-white/10">
+          <div className="flex items-center justify-between px-5 py-4 border-t border-surface-border">
             <div className="flex items-center gap-2">
               <Button
                 variant="ghost"

--- a/ui/src/components/ConversationList.tsx
+++ b/ui/src/components/ConversationList.tsx
@@ -78,7 +78,7 @@ export const ConversationList: FC<ConversationListProps> = memo(
 
     if (conversations.length === 0) {
       return (
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent>
             <div className="text-center py-8 text-text-muted">
               <p className="text-sm">No TCP/UDP conversations found</p>
@@ -90,7 +90,7 @@ export const ConversationList: FC<ConversationListProps> = memo(
     }
 
     return (
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent>
           <div className="mb-3 flex items-center justify-between">
             <SmallText className="text-text-muted">
@@ -99,7 +99,7 @@ export const ConversationList: FC<ConversationListProps> = memo(
             <SmallText className="text-text-muted">Click a row to filter packets</SmallText>
           </div>
 
-          <div className="overflow-auto rounded-lg border border-white/5 max-h-[500px]">
+          <div className="overflow-auto rounded-lg border border-surface-border max-h-[500px]">
             <table className="min-w-full divide-y divide-white/5">
               <thead className="bg-bg-surface/80 sticky top-0 z-10">
                 <tr>
@@ -110,25 +110,25 @@ export const ConversationList: FC<ConversationListProps> = memo(
                     Endpoint B
                   </th>
                   <th
-                    className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
+                    className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-accent select-none"
                     onClick={() => handleSort('protocol')}
                   >
                     Protocol{sortIndicator('protocol')}
                   </th>
                   <th
-                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
+                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-accent select-none"
                     onClick={() => handleSort('packets')}
                   >
                     Packets{sortIndicator('packets')}
                   </th>
                   <th
-                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
+                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-accent select-none"
                     onClick={() => handleSort('bytes')}
                   >
                     Bytes{sortIndicator('bytes')}
                   </th>
                   <th
-                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
+                    className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-accent select-none"
                     onClick={() => handleSort('duration')}
                   >
                     Duration{sortIndicator('duration')}

--- a/ui/src/components/FilterBar.tsx
+++ b/ui/src/components/FilterBar.tsx
@@ -27,7 +27,7 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
   const isValid = !validationError;
 
   const borderColor = !value.trim()
-    ? 'border-white/10'
+    ? 'border-surface-border'
     : isValid
       ? 'border-status-success/60'
       : 'border-status-error/60';
@@ -122,7 +122,7 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
 
           {/* Autocomplete dropdown */}
           {suggestions.length > 0 && isFocused && (
-            <div className="absolute top-full left-0 mt-1 w-full bg-bg-surface border border-white/10 rounded-lg shadow-lg z-30 max-h-48 overflow-y-auto">
+            <div className="absolute top-full left-0 mt-1 w-full bg-bg-surface border border-surface-border rounded-lg shadow-lg z-30 max-h-48 overflow-y-auto">
               {suggestions.map((suggestion, idx) => (
                 <button
                   key={suggestion.text}
@@ -137,7 +137,7 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
                     applySuggestion(suggestion);
                   }}
                 >
-                  <span className="font-mono text-brand-300">{suggestion.text}</span>
+                  <span className="font-mono text-brand-accent">{suggestion.text}</span>
                   <span className="ml-2 text-text-muted text-xs">{suggestion.description}</span>
                 </button>
               ))}
@@ -152,7 +152,7 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
               key={protocol}
               type="button"
               onClick={() => handleQuickInsert(protocol)}
-              className="px-2 py-1 text-xs rounded border border-white/10 text-text-muted hover:text-text-primary hover:border-white/20 bg-bg-surface/50 transition-colors uppercase"
+              className="px-2 py-1 text-xs rounded border border-surface-border text-text-muted hover:text-text-primary hover:border-surface-border bg-bg-surface/50 transition-colors uppercase"
             >
               {protocol}
             </button>

--- a/ui/src/components/HelpDrawer.tsx
+++ b/ui/src/components/HelpDrawer.tsx
@@ -92,17 +92,17 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
           className={cn(drawer.content, drawer.size.lg, 'animate-slide-in-right')}
         >
           {/* Header */}
-          <div className="sticky top-0 bg-bg-surface border-b border-white/10 z-10">
+          <div className="sticky top-0 bg-bg-surface border-b border-surface-border z-10">
             <div className="px-4 py-3 flex items-center justify-between">
               <div className={layout.inline.default}>
-                <HelpCircle className="w-5 h-5 text-brand-400" aria-hidden="true" />
+                <HelpCircle className="w-5 h-5 text-brand-accent" aria-hidden="true" />
                 <h2 className="text-lg font-semibold text-text-primary">Help</h2>
               </div>
               <button
                 type="button"
                 onClick={onClose}
                 className={cn(
-                  'p-2 hover:bg-white/10 rounded-lg transition-colors',
+                  'p-2 hover:bg-surface-hover rounded-lg transition-colors',
                   'text-text-muted hover:text-text-primary',
                 )}
                 aria-label="Close help"
@@ -121,16 +121,16 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className={cn(
-                    'w-full pl-10 pr-4 py-2 bg-white/5 border border-white/10 rounded-lg',
+                    'w-full pl-10 pr-4 py-2 bg-surface-hover border border-surface-border rounded-lg',
                     'text-sm text-text-primary placeholder:text-text-muted',
-                    'focus:outline-none focus:ring-2 focus:ring-brand-500/50',
+                    'focus:outline-none focus:ring-2 focus:ring-brand-primary/50',
                   )}
                 />
               </div>
             </div>
 
             {/* Tab Navigation */}
-            <div className="border-b border-white/10 px-2">
+            <div className="border-b border-surface-border px-2">
               <nav className="flex gap-1 -mb-px">
                 {TABS.map((tab) => (
                   <button
@@ -143,8 +143,8 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
                       'flex items-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors',
                       'border-b-2 -mb-[2px]',
                       activeTab === tab.id
-                        ? 'border-brand-500 text-text-primary'
-                        : 'border-transparent text-text-muted hover:text-text-primary hover:border-white/20',
+                        ? 'border-brand-primary text-text-primary'
+                        : 'border-transparent text-text-muted hover:text-text-primary hover:border-surface-border',
                     )}
                   >
                     {tab.icon}

--- a/ui/src/components/HexDumpViewer.tsx
+++ b/ui/src/components/HexDumpViewer.tsx
@@ -126,7 +126,7 @@ const HexRow = memo(
     return (
       <div className="flex font-mono text-xs leading-5">
         {/* Offset column */}
-        <span className="text-brand-400 w-20 flex-shrink-0">{formatOffset(offset)}:</span>
+        <span className="text-brand-accent w-20 flex-shrink-0">{formatOffset(offset)}:</span>
 
         {/* Hex column */}
         <span className="flex-1 min-w-0">
@@ -198,7 +198,7 @@ export const HexDumpViewer: FC<HexDumpViewerProps> = memo(
     return (
       <div className="h-full flex flex-col">
         {/* Header with legend */}
-        <div className="flex items-center justify-between mb-2 pb-2 border-b border-white/10">
+        <div className="flex items-center justify-between mb-2 pb-2 border-b border-surface-border">
           <div className="flex items-center gap-4 text-xs">
             <span className="text-text-muted">{totalBytes} bytes</span>
             <div className="flex items-center gap-2">
@@ -219,7 +219,7 @@ export const HexDumpViewer: FC<HexDumpViewerProps> = memo(
         </div>
 
         {/* Hex dump content */}
-        <div className="flex-1 overflow-y-auto rounded-lg bg-bg-base/70 p-3 border border-white/5">
+        <div className="flex-1 overflow-y-auto rounded-lg bg-bg-base/70 p-3 border border-surface-border">
           <div className="space-y-0.5">
             {rows.map((row) => (
               <HexRow

--- a/ui/src/components/LogFilters.tsx
+++ b/ui/src/components/LogFilters.tsx
@@ -85,7 +85,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
               id="level-filter"
               value={levelFilter}
               onChange={handleLevelChange}
-              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+              className="rounded-lg border border-surface-border bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
               aria-label="Filter by log level"
             >
               {LOG_LEVELS.map((level) => (
@@ -105,7 +105,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
               id="protocol-filter"
               value={protocolFilter}
               onChange={handleProtocolChange}
-              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+              className="rounded-lg border border-surface-border bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
               aria-label="Filter by protocol"
             >
               {PROTOCOLS.map((protocol) => (
@@ -129,7 +129,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
                 value={searchQuery}
                 onChange={handleSearchChange}
                 placeholder="Filter logs..."
-                className="w-full rounded-lg border border-white/10 bg-bg-base/60 py-1.5 pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-1.5 pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                 aria-label="Search logs"
               />
             </div>
@@ -145,7 +145,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
                 type="checkbox"
                 checked={autoScroll}
                 onChange={handleAutoScrollChange}
-                className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500 focus:ring-offset-gray-900"
+                className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary focus:ring-offset-gray-900"
               />
               <span className="text-sm text-text-secondary">Auto-scroll</span>
             </label>

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -39,9 +39,9 @@ const LEVEL_COLORS: Record<
     accent: 'bg-status-warning',
   },
   info: {
-    bg: 'bg-white/5',
+    bg: 'bg-surface-hover',
     text: 'text-text-primary',
-    border: 'border-white/10',
+    border: 'border-surface-border',
     accent: 'bg-status-info',
   },
   debug: {
@@ -188,7 +188,7 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
     <div className={`border-b ${colors.border} transition-colors`}>
       {/* Main log row */}
       <div
-        className={`flex items-start gap-2 px-3 py-2 font-mono text-sm ${colors.bg} hover:bg-white/5 transition-colors`}
+        className={`flex items-start gap-2 px-3 py-2 font-mono text-sm ${colors.bg} hover:bg-surface-hover transition-colors`}
       >
         <button
           type="button"
@@ -225,7 +225,7 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
           </span>
 
           {/* Protocol Badge */}
-          <span className="shrink-0 rounded border border-brand-500/30 bg-brand-500/20 px-1.5 py-0.5 text-xs font-semibold text-brand-400">
+          <span className="shrink-0 rounded border border-brand-primary/30 bg-brand-primary/20 px-1.5 py-0.5 text-xs font-semibold text-brand-accent">
             {log.protocol}
           </span>
 
@@ -244,7 +244,7 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
         <button
           type="button"
           onClick={handleCopy}
-          className="shrink-0 p-1 rounded hover:bg-white/10 text-text-muted hover:text-text-secondary transition-colors"
+          className="shrink-0 p-1 rounded hover:bg-surface-hover text-text-muted hover:text-text-secondary transition-colors"
           title="Copy log entry"
           aria-label="Copy log entry"
         >
@@ -277,8 +277,8 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
             </div>
 
             {/* Details JSON */}
-            <div className="rounded-lg border border-white/10 bg-bg-base/70 overflow-hidden">
-              <div className="flex items-center justify-between px-3 py-1.5 bg-bg-surface/50 border-b border-white/10">
+            <div className="rounded-lg border border-surface-border bg-bg-base/70 overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-1.5 bg-bg-surface/50 border-b border-surface-border">
                 <span className="text-xs font-medium text-text-muted">Details</span>
                 <button
                   type="button"
@@ -288,7 +288,7 @@ const LogEntryRow: FC<{ log: LogEntry; searchQuery: string }> = memo(({ log, sea
                       await navigator.clipboard.writeText(formatDetails(log.details));
                     }
                   }}
-                  className="p-1 rounded hover:bg-white/10 text-text-muted hover:text-text-secondary transition-colors"
+                  className="p-1 rounded hover:bg-surface-hover text-text-muted hover:text-text-secondary transition-colors"
                   title="Copy details JSON"
                   aria-label="Copy details JSON"
                 >
@@ -342,7 +342,7 @@ export const LogViewer: FC<LogViewerProps> = memo(({ logs, searchQuery, autoScro
     return (
       <div
         ref={containerRef}
-        className="flex h-96 items-center justify-center rounded-lg border border-white/10 bg-bg-base/50"
+        className="flex h-96 items-center justify-center rounded-lg border border-surface-border bg-bg-base/50"
       >
         <div className="text-center space-y-3">
           <div
@@ -387,7 +387,7 @@ export const LogViewer: FC<LogViewerProps> = memo(({ logs, searchQuery, autoScro
       {/* Log Container */}
       <div
         ref={containerRef}
-        className="h-[500px] overflow-y-auto rounded-lg border border-white/10 bg-bg-base/70 scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-gray-700"
+        className="h-[500px] overflow-y-auto rounded-lg border border-surface-border bg-bg-base/70 scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-gray-700"
         role="log"
         aria-label="Debug console log output"
         aria-live="polite"

--- a/ui/src/components/PacketDetails.tsx
+++ b/ui/src/components/PacketDetails.tsx
@@ -29,7 +29,7 @@ const DetailRow = memo(
     }
 
     return (
-      <div className="flex items-start gap-2 py-1.5 border-b border-white/5 last:border-0">
+      <div className="flex items-start gap-2 py-1.5 border-b border-surface-border last:border-0">
         <SmallText className="text-text-muted w-24 flex-shrink-0">{label}</SmallText>
         <span className={`text-sm text-text-primary ${mono ? 'font-mono' : ''}`}>{value}</span>
       </div>
@@ -50,7 +50,7 @@ const HeadersSection = memo(({ headers }: { headers: Record<string, unknown> | u
   return (
     <div className="mt-4">
       <h4 className="text-sm font-semibold text-text-secondary mb-2">Protocol Headers</h4>
-      <div className="rounded-lg bg-bg-base/50 p-3 border border-white/5">
+      <div className="rounded-lg bg-bg-base/50 p-3 border border-surface-border">
         {Object.entries(headers).map(([key, value]) => (
           <DetailRow
             key={key}
@@ -98,7 +98,7 @@ export const PacketDetails: FC<PacketDetailsProps> = memo(({ packet, onFieldSele
 
       {/* Summary */}
       {packet.summary && (
-        <div className="mt-3 pt-2 border-t border-white/5">
+        <div className="mt-3 pt-2 border-t border-surface-border">
           <SmallText className="text-text-muted uppercase text-xs tracking-wide">Summary</SmallText>
           <p className="text-sm text-text-secondary py-1">{packet.summary}</p>
         </div>

--- a/ui/src/components/PacketList.tsx
+++ b/ui/src/components/PacketList.tsx
@@ -52,8 +52,8 @@ const PacketRow = memo(
       onClick={onClick}
       className={`w-full text-left p-2 rounded-lg border transition-colors ${
         isSelected
-          ? 'border-brand-500/50 bg-brand-900/30'
-          : 'border-white/5 bg-bg-base/50 hover:bg-bg-surface/50 hover:border-white/10'
+          ? 'border-brand-primary/50 bg-brand-primary/30'
+          : 'border-surface-border bg-bg-base/50 hover:bg-bg-surface/50 hover:border-surface-border'
       }`}
       style={rowStyle}
     >
@@ -103,7 +103,7 @@ export const PacketList: FC<PacketListProps> = memo(
         <button
           type="button"
           onClick={cycleTimeMode}
-          className="text-xs text-text-muted hover:text-brand-300 mb-1 text-left select-none"
+          className="text-xs text-text-muted hover:text-brand-accent mb-1 text-left select-none"
           title="Click to cycle: Absolute / Relative / Delta"
         >
           Mode: {getTimeDisplayLabel(timeMode)}

--- a/ui/src/components/ProtocolTreeLayer.tsx
+++ b/ui/src/components/ProtocolTreeLayer.tsx
@@ -33,18 +33,18 @@ export const ProtocolTreeLayer: FC<ProtocolTreeLayerProps> = memo(({ layer, onFi
       <button
         type="button"
         onClick={toggleExpanded}
-        className="flex items-center gap-1 w-full text-left py-0.5 hover:bg-white/5 rounded px-1 -ml-1"
+        className="flex items-center gap-1 w-full text-left py-0.5 hover:bg-surface-hover rounded px-1 -ml-1"
       >
         {isExpanded ? (
           <ChevronDown className={`${iconSizes.sm} text-text-muted flex-shrink-0`} />
         ) : (
           <ChevronRight className={`${iconSizes.sm} text-text-muted flex-shrink-0`} />
         )}
-        <span className="text-brand-300 font-medium">{layer.name}</span>
+        <span className="text-brand-accent font-medium">{layer.name}</span>
       </button>
 
       {isExpanded && (
-        <div className="ml-5 border-l border-white/5 pl-2">
+        <div className="ml-5 border-l border-surface-border pl-2">
           {layer.fields.map((field) => {
             const hasRange = field.byteStart !== undefined && field.byteEnd !== undefined;
             return (

--- a/ui/src/components/SettingsDrawer.tsx
+++ b/ui/src/components/SettingsDrawer.tsx
@@ -19,10 +19,12 @@ import {
   ChevronRight,
   Info,
   Monitor,
+  Moon,
   Network,
   Palette,
   PlugZap,
   Settings,
+  Sun,
   X,
 } from 'lucide-react';
 import type { ReactElement, ReactNode } from 'react';
@@ -31,6 +33,7 @@ import { fetchInterfaces } from '../api/client';
 import type { NetworkInterface } from '../api/types';
 import { iconSizes } from '../constants/sizes';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { type Theme, useTheme } from '../hooks/useTheme';
 import { badge, cn, drawer, layout, spacing } from '../styles/theme';
 import { SimulationSection } from './settings/SimulationSection';
 
@@ -92,16 +95,16 @@ export function SettingsDrawer({
           className={cn(drawer.content, drawer.size.lg, 'animate-slide-in-right')}
         >
           {/* Header */}
-          <div className="sticky top-0 bg-bg-surface border-b border-white/10 px-4 py-3 flex items-center justify-between z-10">
+          <div className="sticky top-0 bg-bg-surface border-b border-surface-border px-4 py-3 flex items-center justify-between z-10">
             <div className={layout.inline.default}>
-              <Settings className="w-5 h-5 text-brand-400" aria-hidden="true" />
+              <Settings className="w-5 h-5 text-brand-accent" aria-hidden="true" />
               <h2 className="text-lg font-semibold text-text-primary">Settings</h2>
             </div>
             <button
               type="button"
               onClick={onClose}
               className={cn(
-                'p-2 hover:bg-white/10 rounded-lg transition-colors',
+                'p-2 hover:bg-surface-hover rounded-lg transition-colors',
                 'text-text-muted hover:text-text-primary',
               )}
               aria-label="Close settings"
@@ -111,7 +114,7 @@ export function SettingsDrawer({
           </div>
 
           {/* Tab Navigation */}
-          <div className="border-b border-white/10 px-2">
+          <div className="border-b border-surface-border px-2">
             <nav className="flex gap-1 -mb-px">
               {TABS.map((tab) => (
                 <button
@@ -124,8 +127,8 @@ export function SettingsDrawer({
                     'flex items-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors',
                     'border-b-2 -mb-[2px]',
                     activeTab === tab.id
-                      ? 'border-brand-500 text-text-primary'
-                      : 'border-transparent text-text-muted hover:text-text-primary hover:border-white/20',
+                      ? 'border-brand-primary text-text-primary'
+                      : 'border-transparent text-text-muted hover:text-text-primary hover:border-surface-border',
                   )}
                 >
                   {tab.icon}
@@ -176,7 +179,7 @@ interface SettingRowProps {
 }
 
 const SettingRow = ({ label, description, children }: SettingRowProps): ReactElement => (
-  <div className="flex items-center justify-between gap-4 py-2 px-3 bg-white/5 rounded-lg">
+  <div className="flex items-center justify-between gap-4 py-2 px-3 bg-surface-hover rounded-lg">
     <div className="flex-1 min-w-0">
       <div className="text-sm text-text-primary">{label}</div>
       {description && <div className="text-xs text-text-muted truncate">{description}</div>}
@@ -190,52 +193,84 @@ const SettingRow = ({ label, description, children }: SettingRowProps): ReactEle
 // =============================================================================
 
 function AppearanceSection(): ReactElement {
-  // Theme state would be managed by a global context in the future
-  const [theme, setTheme] = useState<'dark' | 'light' | 'system'>('dark');
+  const { theme, setTheme, isDark, toggleTheme } = useTheme();
+
+  const options: Array<{ id: Theme; label: string; icon: ReactNode }> = [
+    { id: 'dark', label: 'Dark', icon: <Moon className="w-4 h-4" aria-hidden="true" /> },
+    { id: 'light', label: 'Light', icon: <Sun className="w-4 h-4" aria-hidden="true" /> },
+    {
+      id: 'system',
+      label: 'System',
+      icon: <Monitor className="w-4 h-4" aria-hidden="true" />,
+    },
+  ];
 
   return (
     <Section title="Theme" description="Customize the appearance of NIAC">
       <div className="grid grid-cols-3 gap-2">
-        {(['dark', 'light', 'system'] as const).map((option) => (
-          <button
-            key={option}
-            type="button"
-            onClick={() => setTheme(option)}
-            className={cn(
-              'flex flex-col items-center gap-2 p-3 rounded-lg border transition-all',
-              theme === option
-                ? 'border-brand-500 bg-brand-500/10'
-                : 'border-white/10 hover:border-white/20 hover:bg-white/5',
-            )}
-          >
-            <div
+        {options.map((option) => {
+          const selected = theme === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => setTheme(option.id)}
               className={cn(
-                'w-8 h-8 rounded-lg flex items-center justify-center',
-                option === 'dark' && 'bg-bg-elevated',
-                option === 'light' && 'bg-bg-muted',
-                option === 'system' && 'bg-gradient-to-br from-gray-200 to-bg-elevated',
+                'flex flex-col items-center gap-2 p-3 rounded-lg border transition-all',
+                selected
+                  ? 'border-brand-primary bg-brand-primary/10'
+                  : 'border-surface-border hover:border-brand-primary/40 hover:bg-surface-hover',
               )}
             >
-              <Monitor
+              <div
                 className={cn(
-                  'w-4 h-4',
-                  option === 'light' ? 'text-text-disabled' : 'text-text-primary',
+                  'w-8 h-8 rounded-lg flex items-center justify-center',
+                  selected
+                    ? 'bg-brand-primary/15 text-brand-primary'
+                    : 'bg-surface-hover text-text-secondary',
                 )}
-              />
-            </div>
-            <span
-              className={cn(
-                'text-xs font-medium capitalize',
-                theme === option ? 'text-text-primary' : 'text-text-muted',
-              )}
-            >
-              {option}
-            </span>
-          </button>
-        ))}
+              >
+                {option.icon}
+              </div>
+              <span
+                className={cn(
+                  'text-xs font-medium',
+                  selected ? 'text-text-primary' : 'text-text-muted',
+                )}
+              >
+                {option.label}
+              </span>
+            </button>
+          );
+        })}
       </div>
+      <button
+        type="button"
+        onClick={toggleTheme}
+        title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+        className={cn(
+          'mt-3 w-full flex items-center justify-between gap-2 p-2.5 rounded-lg border transition-colors',
+          'border-surface-border bg-surface-hover hover:bg-surface-base text-text-primary',
+        )}
+      >
+        <span className="text-sm">Quick toggle</span>
+        <span className="flex items-center gap-1.5 text-xs text-text-muted">
+          {isDark ? (
+            <>
+              <Sun className="w-4 h-4" aria-hidden="true" />
+              Light
+            </>
+          ) : (
+            <>
+              <Moon className="w-4 h-4" aria-hidden="true" />
+              Dark
+            </>
+          )}
+        </span>
+      </button>
       <p className="text-xs text-text-muted mt-2">
-        Light mode coming soon. Currently only dark mode is available.
+        Dark mode is the default. Your preference is saved across sessions.
       </p>
     </Section>
   );
@@ -301,7 +336,7 @@ function NetworkSection(): ReactElement {
 
       <Section title="Connection Settings" description="Configure backend connection">
         <SettingRow label="Backend URL" description="NIAC backend server address">
-          <code className="text-xs text-brand-400 bg-brand-500/10 px-2 py-1 rounded">
+          <code className="text-xs text-brand-accent bg-brand-primary/10 px-2 py-1 rounded">
             localhost:8080
           </code>
         </SettingRow>
@@ -322,7 +357,7 @@ interface InterfaceItemProps {
 
 function InterfaceItem({ name, type, status, ip }: InterfaceItemProps): ReactElement {
   return (
-    <div className="flex items-center justify-between py-2 px-3 bg-white/5 rounded-lg">
+    <div className="flex items-center justify-between py-2 px-3 bg-surface-hover rounded-lg">
       <div className={layout.inline.default}>
         <Network
           className={cn('w-4 h-4', status === 'active' ? 'text-status-success' : 'text-text-muted')}
@@ -359,8 +394,8 @@ function DebugSection(): ReactElement {
             value={logLevel}
             onChange={(e) => setLogLevel(e.target.value as typeof logLevel)}
             className={cn(
-              'bg-bg-elevated border border-white/10 rounded-lg px-3 py-1.5 text-sm text-text-primary',
-              'focus:outline-none focus:ring-2 focus:ring-brand-500/50',
+              'bg-bg-elevated border border-surface-border rounded-lg px-3 py-1.5 text-sm text-text-primary',
+              'focus:outline-none focus:ring-2 focus:ring-brand-primary/50',
             )}
           >
             <option value="error">Error</option>
@@ -376,8 +411,8 @@ function DebugSection(): ReactElement {
           type="button"
           className={cn(
             layout.flex.between,
-            'w-full py-2 px-3 bg-white/5 rounded-lg',
-            'hover:bg-white/10 transition-colors text-left',
+            'w-full py-2 px-3 bg-surface-hover rounded-lg',
+            'hover:bg-surface-hover transition-colors text-left',
           )}
         >
           <div>
@@ -391,8 +426,8 @@ function DebugSection(): ReactElement {
           type="button"
           className={cn(
             layout.flex.between,
-            'w-full py-2 px-3 bg-white/5 rounded-lg',
-            'hover:bg-white/10 transition-colors text-left',
+            'w-full py-2 px-3 bg-surface-hover rounded-lg',
+            'hover:bg-surface-hover transition-colors text-left',
           )}
         >
           <div>
@@ -418,9 +453,9 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
   return (
     <>
       <Section title="Application">
-        <div className="bg-white/5 rounded-lg p-4 space-y-3">
+        <div className="bg-surface-hover rounded-lg p-4 space-y-3">
           <div className="flex items-center gap-3">
-            <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center shadow-lg shadow-brand-500/30">
+            <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-brand-primary to-brand-primary flex items-center justify-center shadow-lg shadow-brand-primary/30">
               <Network className={`${iconSizes.xl} text-text-primary`} />
             </div>
             <div>
@@ -428,7 +463,7 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
               <p className="text-sm text-text-muted">Network Injection & Analysis Console</p>
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-2 pt-2 border-t border-white/10">
+          <div className="grid grid-cols-2 gap-2 pt-2 border-t border-surface-border">
             <InfoItem label="Version" value={version} />
             <InfoItem label="Build" value="Production" />
             <InfoItem label="React" value="19.2" />
@@ -455,8 +490,8 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
             rel="noopener noreferrer"
             className={cn(
               layout.flex.between,
-              'w-full py-2 px-3 bg-white/5 rounded-lg',
-              'hover:bg-white/10 transition-colors',
+              'w-full py-2 px-3 bg-surface-hover rounded-lg',
+              'hover:bg-surface-hover transition-colors',
             )}
           >
             <span className="text-sm text-text-primary">GitHub</span>
@@ -468,8 +503,8 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
             rel="noopener noreferrer"
             className={cn(
               layout.flex.between,
-              'w-full py-2 px-3 bg-white/5 rounded-lg',
-              'hover:bg-white/10 transition-colors',
+              'w-full py-2 px-3 bg-surface-hover rounded-lg',
+              'hover:bg-surface-hover transition-colors',
             )}
           >
             <span className="text-sm text-text-primary">Website</span>

--- a/ui/src/components/StreamView.tsx
+++ b/ui/src/components/StreamView.tsx
@@ -91,9 +91,9 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-full max-w-4xl mx-4 bg-bg-surface border border-white/10 rounded-xl shadow-2xl max-h-[85vh] flex flex-col">
+      <div className="w-full max-w-4xl mx-4 bg-bg-surface border border-surface-border rounded-xl shadow-2xl max-h-[85vh] flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-surface-border">
           <div>
             <h3 className="text-lg font-semibold text-text-primary">Follow Stream</h3>
             <SmallText className="text-text-muted">
@@ -104,13 +104,13 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
           </div>
           <div className="flex items-center gap-3">
             {/* Display mode toggle */}
-            <div className="flex rounded-lg border border-white/10 bg-bg-base/50 p-1">
+            <div className="flex rounded-lg border border-surface-border bg-bg-base/50 p-1">
               <button
                 type="button"
                 onClick={() => setDisplayMode('ascii')}
                 className={`px-3 py-1 text-xs rounded-md transition-colors ${
                   displayMode === 'ascii'
-                    ? 'bg-brand-600 text-text-primary'
+                    ? 'bg-brand-primary text-text-primary'
                     : 'text-text-muted hover:text-text-primary'
                 }`}
               >
@@ -121,7 +121,7 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
                 onClick={() => setDisplayMode('hex')}
                 className={`px-3 py-1 text-xs rounded-md transition-colors ${
                   displayMode === 'hex'
-                    ? 'bg-brand-600 text-text-primary'
+                    ? 'bg-brand-primary text-text-primary'
                     : 'text-text-muted hover:text-text-primary'
                 }`}
               >
@@ -164,7 +164,7 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end px-5 py-3 border-t border-white/10">
+        <div className="flex items-center justify-end px-5 py-3 border-t border-surface-border">
           <Button variant="ghost" size="sm" onClick={onClose}>
             Close
           </Button>

--- a/ui/src/components/TemplateCard.tsx
+++ b/ui/src/components/TemplateCard.tsx
@@ -28,7 +28,7 @@ const typeColors: Record<Template['type'], string> = {
   basic: 'bg-status-info/20 text-status-info border-status-info/30',
   router: 'bg-status-warning/20 text-status-warning border-status-warning/30',
   switch: 'bg-status-success/20 text-status-success border-status-success/30',
-  'access-point': 'bg-brand-500/20 text-brand-300 border-brand-500/30',
+  'access-point': 'bg-brand-primary/20 text-brand-accent border-brand-primary/30',
   server: 'bg-status-info/20 text-status-info border-status-info/30',
   firewall: 'bg-status-error/20 text-status-error border-status-error/30',
   complete: 'bg-status-warning/20 text-status-warning border-status-warning/30',
@@ -40,7 +40,7 @@ export const TemplateCard: FC<TemplateCardProps> = memo(({ template, onView, onU
   const colorClass = typeColors[template.type] || typeColors.custom;
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70 hover:border-brand-500/30 transition-colors">
+    <Card className="border-surface-border bg-bg-surface/70 hover:border-brand-primary/30 transition-colors">
       <CardContent className="space-y-4">
         {/* Header with icon and type */}
         <div className="flex items-start justify-between">

--- a/ui/src/components/TemplatePreviewModal.tsx
+++ b/ui/src/components/TemplatePreviewModal.tsx
@@ -108,16 +108,16 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         aria-label="Close modal"
       />
       <div
-        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
+        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
       >
         {/* Modal Header */}
-        <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+        <div className="flex items-center justify-between border-b border-surface-border px-6 py-4">
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-brand-500/20 p-2">
-              <FileCode className={`${iconSizes.lg} text-brand-300`} />
+            <div className="rounded-lg bg-brand-primary/20 p-2">
+              <FileCode className={`${iconSizes.lg} text-brand-accent`} />
             </div>
             <div>
               <h2 id="modal-title" className="text-lg font-semibold text-text-primary">
@@ -131,7 +131,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors"
+            className="rounded-lg p-2 text-text-muted hover:bg-surface-hover hover:text-text-primary transition-colors"
             aria-label="Close modal"
           >
             <X className={iconSizes.lg} />
@@ -139,7 +139,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         </div>
 
         {/* Template metadata */}
-        <div className="flex flex-wrap items-center gap-3 border-b border-white/10 px-6 py-3 bg-bg-base/50">
+        <div className="flex flex-wrap items-center gap-3 border-b border-surface-border px-6 py-3 bg-bg-base/50">
           <Tag colorScheme="purple">
             {template.deviceCount} {template.deviceCount === 1 ? 'device' : 'devices'}
           </Tag>
@@ -163,7 +163,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
           {loading && (
             <div className="flex items-center justify-center py-12">
               <div className="flex items-center gap-3 text-text-muted">
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-brand-primary border-t-transparent" />
                 <span>Loading template content...</span>
               </div>
             </div>
@@ -189,7 +189,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
         </div>
 
         {/* Modal Footer */}
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-white/10 px-6 py-4 bg-bg-base/50">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-surface-border px-6 py-4 bg-bg-base/50">
           <div className="flex gap-2">
             <Button
               variant="ghost"

--- a/ui/src/components/config/DiffViewer.tsx
+++ b/ui/src/components/config/DiffViewer.tsx
@@ -142,7 +142,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
       <ColumnHeaders leftLabel={leftLabel} rightLabel={rightLabel} />
 
       {/* Diff content */}
-      <div className="rounded-lg border border-white/10 bg-bg-base/50 overflow-hidden max-h-[500px] overflow-y-auto">
+      <div className="rounded-lg border border-surface-border bg-bg-base/50 overflow-hidden max-h-[500px] overflow-y-auto">
         {diffBlocks.map((block) => (
           <DiffBlockComponent
             key={block.id}

--- a/ui/src/components/config/MergeControls.tsx
+++ b/ui/src/components/config/MergeControls.tsx
@@ -109,12 +109,12 @@ export const MergeControls: FC<MergeControlsProps> = ({
   }, [onReset]);
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         {/* Header */}
         <div className="flex items-center justify-between">
           <H2 className="flex items-center gap-2">
-            <FileCheck className={`${iconSizes.lg} text-brand-300`} />
+            <FileCheck className={`${iconSizes.lg} text-brand-accent`} />
             Merge Controls
           </H2>
           {stats.totalChanges > 0 && (
@@ -146,7 +146,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
             </div>
             <div className="h-2 rounded-full bg-bg-elevated overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-brand-500 to-brand-400 transition-all duration-300"
+                className="h-full bg-gradient-to-r from-brand-primary to-brand-accent transition-all duration-300"
                 style={{ width: `${stats.progress}%` }}
               />
             </div>
@@ -207,7 +207,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
         </div>
 
         {/* Main actions */}
-        <div className="flex flex-wrap gap-3 pt-2 border-t border-white/10">
+        <div className="flex flex-wrap gap-3 pt-2 border-t border-surface-border">
           <Button
             tone="violet"
             disabled={disabled || stats.totalChanges === 0}
@@ -327,16 +327,16 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
         aria-label="Close modal"
       />
       <div
-        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl flex flex-col"
+        className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl flex flex-col"
         role="dialog"
         aria-modal="true"
         aria-labelledby="preview-modal-title"
       >
         {/* Modal Header */}
-        <div className="flex items-center justify-between border-b border-white/10 px-6 py-4 flex-shrink-0">
+        <div className="flex items-center justify-between border-b border-surface-border px-6 py-4 flex-shrink-0">
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-brand-500/20 p-2">
-              <FileCheck className={`${iconSizes.lg} text-brand-300`} />
+            <div className="rounded-lg bg-brand-primary/20 p-2">
+              <FileCheck className={`${iconSizes.lg} text-brand-accent`} />
             </div>
             <div>
               <h2 id="preview-modal-title" className="text-lg font-semibold text-text-primary">
@@ -348,7 +348,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors"
+            className="rounded-lg p-2 text-text-muted hover:bg-surface-hover hover:text-text-primary transition-colors"
             aria-label="Close modal"
           >
             <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -376,7 +376,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
         </div>
 
         {/* Modal Footer */}
-        <div className="flex justify-end gap-3 border-t border-white/10 px-6 py-4 bg-bg-base/50 flex-shrink-0">
+        <div className="flex justify-end gap-3 border-t border-surface-border px-6 py-4 bg-bg-base/50 flex-shrink-0">
           <Button variant="outline" onClick={onClose}>
             Close
           </Button>

--- a/ui/src/components/config/YamlEditor.tsx
+++ b/ui/src/components/config/YamlEditor.tsx
@@ -258,7 +258,7 @@ export const YamlEditor: FC<YamlEditorProps> = ({
   return (
     <section
       ref={containerRef}
-      className={`rounded-xl border border-white/10 bg-bg-base/70 overflow-hidden ${className}`}
+      className={`rounded-xl border border-surface-border bg-bg-base/70 overflow-hidden ${className}`}
       style={containerStyle}
       aria-label="YAML editor"
     />

--- a/ui/src/components/config/diff-viewer/DiffBlock.tsx
+++ b/ui/src/components/config/diff-viewer/DiffBlock.tsx
@@ -36,7 +36,7 @@ const MergeControls: FC<{
   decision?: MergeDecision;
   onDecision: (choice: MergeDecision['choice']) => void;
 }> = ({ decision, onDecision }) => (
-  <div className="flex items-center justify-center gap-2 py-2 px-4 bg-bg-surface/80 border-b border-white/10">
+  <div className="flex items-center justify-center gap-2 py-2 px-4 bg-bg-surface/80 border-b border-surface-border">
     <SmallText className="text-text-muted mr-2">Accept:</SmallText>
     <Button
       size="sm"
@@ -86,7 +86,7 @@ export const DiffBlockComponent: FC<DiffBlockComponentProps> = memo(
 
     return (
       <div
-        className={`${isChanged ? 'border border-white/10 rounded-lg overflow-hidden mb-2' : ''}`}
+        className={`${isChanged ? 'border border-surface-border rounded-lg overflow-hidden mb-2' : ''}`}
       >
         {/* Merge controls for changed blocks */}
         {isChanged && showMergeControls && (

--- a/ui/src/components/config/diff-viewer/DiffLine.tsx
+++ b/ui/src/components/config/diff-viewer/DiffLine.tsx
@@ -16,7 +16,7 @@ export const DiffLineComponent: FC<DiffLineComponentProps> = memo(({ line, side 
 
   return (
     <div className={`flex ${styles.bg} border-l-2 ${styles.border}`}>
-      <span className="w-12 flex-shrink-0 px-2 py-0.5 text-right text-xs text-text-muted select-none border-r border-white/5">
+      <span className="w-12 flex-shrink-0 px-2 py-0.5 text-right text-xs text-text-muted select-none border-r border-surface-border">
         {lineNum ?? ''}
       </span>
       <span className="px-1 py-0.5 text-xs text-text-muted select-none w-4">

--- a/ui/src/components/debug/ProtocolDebugLevels.tsx
+++ b/ui/src/components/debug/ProtocolDebugLevels.tsx
@@ -27,7 +27,7 @@ const LEVEL_COLORS: Record<DebugLevelKey, string> = {
   warn: 'bg-status-warning',
   info: 'bg-status-info',
   debug: 'bg-status-success',
-  trace: 'bg-brand-600',
+  trace: 'bg-brand-primary',
 };
 
 // Category colors for visual grouping
@@ -36,7 +36,7 @@ const CATEGORY_COLORS: Record<ProtocolCategory, string> = {
   switching: 'border-status-success/30',
   routing: 'border-status-info/30',
   redundancy: 'border-status-warning/30',
-  multicast: 'border-brand-500/30',
+  multicast: 'border-brand-primary/30',
   monitoring: 'border-pink-500/30',
 };
 
@@ -45,7 +45,7 @@ const CATEGORY_HEADER_COLORS: Record<ProtocolCategory, string> = {
   switching: 'text-status-success',
   routing: 'text-status-info',
   redundancy: 'text-status-warning',
-  multicast: 'text-brand-400',
+  multicast: 'text-brand-accent',
   monitoring: 'text-pink-400',
 };
 
@@ -71,7 +71,7 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
   );
 
   return (
-    <div className="rounded-lg border border-white/10 bg-bg-base/50 p-4">
+    <div className="rounded-lg border border-surface-border bg-bg-base/50 p-4">
       <div className="flex items-center justify-between mb-3">
         <span className="font-semibold text-text-primary">{config.protocol}</span>
         <Tag
@@ -121,7 +121,7 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
             [&::-webkit-slider-thumb]:bg-white
             [&::-webkit-slider-thumb]:shadow-md
             [&::-webkit-slider-thumb]:border-2
-            [&::-webkit-slider-thumb]:border-brand-400
+            [&::-webkit-slider-thumb]:border-brand-accent
             [&::-webkit-slider-thumb]:transition-transform
             [&::-webkit-slider-thumb]:hover:scale-110
             [&::-moz-range-thumb]:h-5
@@ -130,7 +130,7 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
             [&::-moz-range-thumb]:bg-white
             [&::-moz-range-thumb]:shadow-md
             [&::-moz-range-thumb]:border-2
-            [&::-moz-range-thumb]:border-brand-400"
+            [&::-moz-range-thumb]:border-brand-accent"
           aria-label={`${config.protocol} debug level`}
           aria-valuetext={config.level}
         />
@@ -231,7 +231,7 @@ export const ProtocolDebugLevels: FC = () => {
 
   if (loading) {
     return (
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="py-12 text-center">
           <RefreshCw className={`mx-auto ${iconSizes['2xl']} animate-spin text-text-muted`} />
           <SmallText className="mt-3 text-text-muted">Loading protocol debug settings...</SmallText>
@@ -241,12 +241,12 @@ export const ProtocolDebugLevels: FC = () => {
   }
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-6">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Settings2 className={`${iconSizes.xl} text-brand-400`} />
+            <Settings2 className={`${iconSizes.xl} text-brand-accent`} />
             <H2>Protocol Debug Levels</H2>
           </div>
 
@@ -332,7 +332,7 @@ export const ProtocolDebugLevels: FC = () => {
         </div>
 
         {/* Legend */}
-        <div className="rounded-lg border border-white/10 bg-bg-base/50 p-4">
+        <div className="rounded-lg border border-surface-border bg-bg-base/50 p-4">
           <SmallText className="font-semibold uppercase tracking-wide text-text-muted mb-3">
             Level Guide
           </SmallText>

--- a/ui/src/components/device-editor/DHCPSection.tsx
+++ b/ui/src/components/device-editor/DHCPSection.tsx
@@ -109,7 +109,7 @@ export const DhcpSection: FC<ProtocolSectionProps> = ({
           {/* Static Leases */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-              <Database className={`${iconSizes.md} text-brand-400`} />
+              <Database className={`${iconSizes.md} text-brand-accent`} />
               Static Leases
             </h4>
             {(device.dhcp.clientLeases || []).map((lease: DHCPLease, index: number) => (

--- a/ui/src/components/device-editor/DNSSection.tsx
+++ b/ui/src/components/device-editor/DNSSection.tsx
@@ -42,7 +42,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
           {/* Forward Records (A records) */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-              <Globe className={`${iconSizes.md} text-brand-400`} />
+              <Globe className={`${iconSizes.md} text-brand-accent`} />
               Forward Records (A Records)
             </h4>
             {(device.dns.forwardRecords || []).map((record: DNSRecord, index: number) => (
@@ -73,7 +73,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
                   }}
                   placeholder="IP Address"
-                  className="w-40 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
+                  className="w-40 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
                 />
                 <input
                   type="number"
@@ -87,7 +87,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
                   }}
                   placeholder="TTL"
-                  className="w-24 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                  className="w-24 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                 />
                 <Button
                   variant="ghost"
@@ -123,7 +123,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
           {/* Reverse Records (PTR records) */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-              <Globe className={`${iconSizes.md} text-brand-400`} />
+              <Globe className={`${iconSizes.md} text-brand-accent`} />
               Reverse Records (PTR Records)
             </h4>
             {(device.dns.reverseRecords || []).map((record: DNSRecord, index: number) => (
@@ -140,7 +140,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), reverseRecords: records });
                   }}
                   placeholder="IP Address"
-                  className="w-40 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
+                  className="w-40 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
                 />
                 <input
                   type="text"

--- a/ui/src/components/device-editor/DeleteConfirmModal.tsx
+++ b/ui/src/components/device-editor/DeleteConfirmModal.tsx
@@ -25,7 +25,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
         aria-label="Close delete confirmation"
       />
       <div
-        className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
+        className="mx-4 w-full max-w-md rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
       >

--- a/ui/src/components/device-editor/DeviceEditorHeader.tsx
+++ b/ui/src/components/device-editor/DeviceEditorHeader.tsx
@@ -46,19 +46,19 @@ export const DeviceEditorHeader: FC<DeviceEditorHeaderProps> = ({
   const DeviceIcon = deviceTypeIcons[deviceType as DeviceType] ?? deviceTypeIcons.unknown;
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={onNavigateBack}
-              className="p-2 text-text-muted hover:text-text-primary hover:bg-white/10 rounded-lg transition-colors"
+              className="p-2 text-text-muted hover:text-text-primary hover:bg-surface-hover rounded-lg transition-colors"
               title="Back to device list"
             >
               <ArrowLeft className={iconSizes.lg} />
             </button>
-            <DeviceIcon className={`${iconSizes.xl} text-brand-300`} />
+            <DeviceIcon className={`${iconSizes.xl} text-brand-accent`} />
             <div>
               <H2>{isNewDevice ? 'New Device' : device.hostname || 'Edit Device'}</H2>
               <SmallText className="text-text-muted">

--- a/ui/src/components/device-editor/DeviceEditorStatusView.tsx
+++ b/ui/src/components/device-editor/DeviceEditorStatusView.tsx
@@ -22,10 +22,10 @@ export const DeviceEditorStatusView: FC<DeviceEditorStatusViewProps> = ({
   if (!isNewDevice && loading) {
     return (
       <div className="space-y-6">
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent className="flex items-center justify-center py-12">
             <div className="flex items-center gap-3 text-text-muted">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-brand-primary border-t-transparent" />
               <span>Loading device...</span>
             </div>
           </CardContent>

--- a/ui/src/components/device-editor/FTPSection.tsx
+++ b/ui/src/components/device-editor/FTPSection.tsx
@@ -75,7 +75,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                   }
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.ftp.allowAnonymous ? 'translate-x-4' : ''}`}
                   />
@@ -90,7 +90,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
           {/* FTP Users */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-              <Folder className={`${iconSizes.md} text-brand-400`} />
+              <Folder className={`${iconSizes.md} text-brand-accent`} />
               FTP Users
             </h4>
             {(device.ftp.users || []).map((user: FTPUser, index: number) => (
@@ -110,7 +110,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Username"
-                  className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                 />
                 <input
                   type="text"
@@ -124,7 +124,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Password"
-                  className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                 />
                 <input
                   type="text"
@@ -135,7 +135,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Home Directory"
-                  className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
+                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
                 />
                 <Button
                   variant="ghost"

--- a/ui/src/components/device-editor/HTTPSection.tsx
+++ b/ui/src/components/device-editor/HTTPSection.tsx
@@ -51,13 +51,13 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
           {/* Endpoints */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-              <FileText className={`${iconSizes.md} text-brand-400`} />
+              <FileText className={`${iconSizes.md} text-brand-accent`} />
               Endpoints
             </h4>
             {(device.http.endpoints || []).map((endpoint: HTTPEndpoint, index: number) => (
               <div
                 key={`${endpoint.method || 'GET'}-${endpoint.path || endpoint.statusCode || 'endpoint'}`}
-                className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3"
+                className="rounded-lg border border-surface-border bg-bg-base/40 p-4 space-y-3"
               >
                 <div className="flex gap-2 items-center">
                   <select
@@ -70,7 +70,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       };
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
-                    className="w-24 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+                    className="w-24 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
                   >
                     <option value="GET">GET</option>
                     <option value="POST">POST</option>
@@ -89,7 +89,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="/api/status"
-                    className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono"
+                    className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
                   />
                   <input
                     type="number"
@@ -103,7 +103,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Status"
-                    className="w-20 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                    className="w-20 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                   />
                   <Button
                     variant="ghost"
@@ -132,7 +132,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Content-Type (e.g., application/json)"
-                    className="w-64 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                    className="w-64 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                   />
                   <input
                     type="text"
@@ -146,7 +146,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Response body"
-                    className="flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                    className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                   />
                 </div>
               </div>

--- a/ui/src/components/device-editor/NetBIOSSection.tsx
+++ b/ui/src/components/device-editor/NetBIOSSection.tsx
@@ -105,7 +105,7 @@ export const NetBiosSection: FC<ProtocolSectionProps> = ({
           {/* Services */}
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-              <Network className={`${iconSizes.md} text-brand-400`} />
+              <Network className={`${iconSizes.md} text-brand-accent`} />
               NetBIOS Services
             </h4>
             <div className="flex flex-wrap gap-4">
@@ -128,7 +128,7 @@ export const NetBiosSection: FC<ProtocolSectionProps> = ({
                         });
                       }
                     }}
-                    className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500"
+                    className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary"
                   />
                   <span className="text-sm text-text-secondary capitalize">{service}</span>
                 </label>
@@ -145,7 +145,7 @@ export const NetBiosSection: FC<ProtocolSectionProps> = ({
                     msbrowse: e.target.checked,
                   })
                 }
-                className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500"
+                className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary"
               />
               <span className="text-sm text-text-secondary">Master Browser (MSBROWSE)</span>
             </label>

--- a/ui/src/components/device-editor/TrafficSection.tsx
+++ b/ui/src/components/device-editor/TrafficSection.tsx
@@ -48,10 +48,10 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
       {device.traffic?.enabled && (
         <div className="space-y-6">
           {/* ARP Announcements */}
-          <div className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3">
+          <div className="rounded-lg border border-surface-border bg-bg-base/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-                <Radio className={`${iconSizes.md} text-brand-400`} />
+                <Radio className={`${iconSizes.md} text-brand-accent`} />
                 ARP Announcements
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -70,7 +70,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                   }}
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.arpAnnouncements?.enabled ? 'translate-x-4' : ''}`}
                   />
@@ -93,17 +93,17 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                     });
                   }}
                   min={1}
-                  className="w-32 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                  className="w-32 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                 />
               </FormField>
             )}
           </div>
 
           {/* Periodic Pings */}
-          <div className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3">
+          <div className="rounded-lg border border-surface-border bg-bg-base/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-                <Radio className={`${iconSizes.md} text-brand-400`} />
+                <Radio className={`${iconSizes.md} text-brand-accent`} />
                 Periodic Pings
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -122,7 +122,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                   }}
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.periodicPings?.enabled ? 'translate-x-4' : ''}`}
                   />
@@ -147,7 +147,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                       });
                     }}
                     min={1}
-                    className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                    className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                   />
                 </FormField>
                 <FormField label="Payload Size (bytes)" helpText="Size of ICMP payload">
@@ -167,7 +167,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                     }}
                     min={0}
                     max={65507}
-                    className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                    className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                   />
                 </FormField>
               </div>
@@ -175,10 +175,10 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
           </div>
 
           {/* Random Traffic */}
-          <div className="rounded-lg border border-white/5 bg-bg-base/40 p-4 space-y-3">
+          <div className="rounded-lg border border-surface-border bg-bg-base/40 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="text-sm font-medium text-text-primary flex items-center gap-2">
-                <Radio className={`${iconSizes.md} text-brand-400`} />
+                <Radio className={`${iconSizes.md} text-brand-accent`} />
                 Random Traffic
               </h4>
               <label className="relative inline-flex items-center cursor-pointer">
@@ -197,7 +197,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                   }}
                   className="sr-only peer"
                 />
-                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
+                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.randomTraffic?.enabled ? 'translate-x-4' : ''}`}
                   />
@@ -224,7 +224,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                         });
                       }}
                       min={1}
-                      className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                      className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                     />
                   </FormField>
                   <FormField label="Packet Count" helpText="Packets per burst">
@@ -245,7 +245,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                       }}
                       min={1}
                       max={100}
-                      className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+                      className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
                     />
                   </FormField>
                 </div>
@@ -284,7 +284,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                               });
                             }
                           }}
-                          className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500"
+                          className="w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary"
                         />
                         <span className="text-sm text-text-secondary">
                           {pattern === 'broadcast_arp'

--- a/ui/src/components/device-editor/YamlPreviewSection.tsx
+++ b/ui/src/components/device-editor/YamlPreviewSection.tsx
@@ -10,7 +10,7 @@ export interface YamlPreviewSectionProps {
 
 export const YamlPreviewSection: FC<YamlPreviewSectionProps> = ({ yamlContent }) => {
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent>
         <H2 className="mb-3 flex items-center gap-2 text-base">
           <span>YAML Preview</span>

--- a/ui/src/components/device-editor/types.ts
+++ b/ui/src/components/device-editor/types.ts
@@ -27,16 +27,16 @@ export interface SNMPSectionProps extends ProtocolSectionProps {
  * Common input class names for device editor forms
  */
 export const inputClassName =
-  'w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none';
+  'w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none';
 
 export const monoInputClassName =
-  'w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono';
+  'w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono';
 
 export const selectClassName =
-  'w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none';
+  'w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-accent focus:outline-none';
 
 export const checkboxClassName =
-  'w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-600 focus:ring-brand-500';
+  'w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary';
 
 export const smallInputClassName =
-  'flex-1 rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none font-mono';
+  'flex-1 rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono';

--- a/ui/src/components/device-list/CloneDeviceModal.tsx
+++ b/ui/src/components/device-list/CloneDeviceModal.tsx
@@ -28,7 +28,7 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
         aria-label="Close clone device modal"
       />
       <div
-        className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
+        className="mx-4 w-full max-w-md rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
       >
@@ -52,7 +52,7 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
               type="text"
               value={newHostname}
               onChange={(e) => setNewHostname(e.target.value)}
-              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
             />
           </div>
           <div className="flex justify-end gap-3 pt-2">

--- a/ui/src/components/device-list/ConfirmDeleteModal.tsx
+++ b/ui/src/components/device-list/ConfirmDeleteModal.tsx
@@ -21,7 +21,7 @@ export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
       aria-label="Close delete confirmation"
     />
     <div
-      className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
+      className="mx-4 w-full max-w-md rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl"
       role="dialog"
       aria-modal="true"
     >

--- a/ui/src/components/device-list/DeviceBulkActions.tsx
+++ b/ui/src/components/device-list/DeviceBulkActions.tsx
@@ -18,8 +18,8 @@ export const DeviceBulkActions: FC<DeviceBulkActionsProps> = ({
   }
 
   return (
-    <div className="flex items-center gap-4 p-3 rounded-lg bg-brand-500/10 border border-brand-500/30">
-      <span className="text-sm text-brand-200">
+    <div className="flex items-center gap-4 p-3 rounded-lg bg-brand-primary/10 border border-brand-primary/30">
+      <span className="text-sm text-brand-accent">
         {selectedCount} device
         {selectedCount !== 1 ? 's' : ''} selected
       </span>

--- a/ui/src/components/device-list/DeviceCardView.tsx
+++ b/ui/src/components/device-list/DeviceCardView.tsx
@@ -35,9 +35,9 @@ export const DeviceCardView: FC = () => {
         return (
           <div key={device.hostname} className="rounded-2xl">
             <Card
-              className={`group border-white/5 bg-bg-surface/70 hover:border-brand-500/30 transition-all h-full ${
+              className={`group border-surface-border bg-bg-surface/70 hover:border-brand-primary/30 transition-all h-full ${
                 selectedDevices.has(device.hostname)
-                  ? 'ring-2 ring-brand-500/50 border-brand-500/30'
+                  ? 'ring-2 ring-brand-primary/50 border-brand-primary/30'
                   : ''
               }`}
             >
@@ -49,7 +49,7 @@ export const DeviceCardView: FC = () => {
                       type="checkbox"
                       checked={selectedDevices.has(device.hostname)}
                       onChange={() => onSelectDevice(device.hostname)}
-                      className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500 cursor-pointer"
+                      className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary cursor-pointer"
                     />
                     <div className={`p-2 rounded-lg ${colorClasses.bg}`}>
                       <DeviceIcon className={`${iconSizes.lg} ${colorClasses.text}`} />
@@ -63,12 +63,12 @@ export const DeviceCardView: FC = () => {
                 <button
                   type="button"
                   onClick={() => onEdit(device.hostname)}
-                  className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+                  className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2 focus:ring-offset-gray-900"
                   aria-label={`Edit device ${device.hostname}`}
                 >
                   {/* Device name and IP */}
                   <div>
-                    <h3 className="font-semibold text-text-primary group-hover:text-brand-300 transition-colors truncate">
+                    <h3 className="font-semibold text-text-primary group-hover:text-brand-accent transition-colors truncate">
                       {device.hostname}
                     </h3>
                     <div className="flex items-center gap-1 mt-1">
@@ -105,11 +105,11 @@ export const DeviceCardView: FC = () => {
                 </button>
 
                 {/* Actions */}
-                <div className="flex justify-end gap-1 pt-2 border-t border-white/5">
+                <div className="flex justify-end gap-1 pt-2 border-t border-surface-border">
                   <button
                     type="button"
                     onClick={() => onEdit(device.hostname)}
-                    className="p-2 text-text-muted hover:text-brand-300 hover:bg-white/10 rounded-lg transition-colors"
+                    className="p-2 text-text-muted hover:text-brand-accent hover:bg-surface-hover rounded-lg transition-colors"
                     title={`Open the device editor for ${device.hostname} to modify protocols, interfaces, and credentials`}
                     aria-label={`Edit device ${device.hostname}`}
                   >
@@ -118,7 +118,7 @@ export const DeviceCardView: FC = () => {
                   <button
                     type="button"
                     onClick={() => onClone(device.hostname)}
-                    className="p-2 text-text-muted hover:text-status-info hover:bg-white/10 rounded-lg transition-colors"
+                    className="p-2 text-text-muted hover:text-status-info hover:bg-surface-hover rounded-lg transition-colors"
                     title={`Create a copy of ${device.hostname} with a new hostname; all protocols and interfaces are duplicated`}
                     aria-label={`Clone device ${device.hostname}`}
                   >
@@ -127,7 +127,7 @@ export const DeviceCardView: FC = () => {
                   <button
                     type="button"
                     onClick={() => onDelete(device.hostname)}
-                    className="p-2 text-text-muted hover:text-status-error hover:bg-white/10 rounded-lg transition-colors"
+                    className="p-2 text-text-muted hover:text-status-error hover:bg-surface-hover rounded-lg transition-colors"
                     title={`Permanently remove ${device.hostname} from the library; cannot be undone`}
                     aria-label={`Delete device ${device.hostname}`}
                   >

--- a/ui/src/components/device-list/DeviceListHeader.tsx
+++ b/ui/src/components/device-list/DeviceListHeader.tsx
@@ -41,13 +41,13 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
     <div className="flex flex-wrap items-center justify-between gap-4">
       <div>
         <H2 className="flex items-center gap-2">
-          <Server className={`${iconSizes.lg} text-brand-300`} />
+          <Server className={`${iconSizes.lg} text-brand-accent`} />
           Device Configuration
         </H2>
         <P className="text-text-muted mt-1">
           Manage network device configurations for simulation.
           {deviceCount > 0 && (
-            <output className="ml-2 text-brand-300">{deviceCount} devices</output>
+            <output className="ml-2 text-brand-accent">{deviceCount} devices</output>
           )}
         </P>
       </div>
@@ -84,14 +84,14 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
             Data
           </Button>
           {exportMenuOpen && (
-            <div className="absolute right-0 z-10 mt-1 w-44 rounded-lg border border-white/10 bg-bg-surface shadow-lg">
+            <div className="absolute right-0 z-10 mt-1 w-44 rounded-lg border border-surface-border bg-bg-surface shadow-lg">
               <button
                 type="button"
                 onClick={() => {
                   exportDevicesAsJSON(filteredDevices);
                   setExportMenuOpen(false);
                 }}
-                className="block w-full px-3 py-2 text-left text-sm text-text-primary hover:bg-white/5"
+                className="block w-full px-3 py-2 text-left text-sm text-text-primary hover:bg-surface-hover"
               >
                 JSON (data only)
               </button>
@@ -101,7 +101,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
                   exportDevicesAsCSV(filteredDevices);
                   setExportMenuOpen(false);
                 }}
-                className="block w-full px-3 py-2 text-left text-sm text-text-primary hover:bg-white/5"
+                className="block w-full px-3 py-2 text-left text-sm text-text-primary hover:bg-surface-hover"
               >
                 CSV (data only)
               </button>

--- a/ui/src/components/device-list/DeviceListStates.tsx
+++ b/ui/src/components/device-list/DeviceListStates.tsx
@@ -14,10 +14,10 @@ interface LoadingStateProps {
 export const DeviceListLoadingState: FC<LoadingStateProps> = ({ viewMode }) => {
   if (viewMode === 'table') {
     return (
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="p-0">
           {/* Table header skeleton */}
-          <div className="flex items-center gap-4 border-b border-white/10 px-4 py-3 bg-bg-base/40">
+          <div className="flex items-center gap-4 border-b border-surface-border px-4 py-3 bg-bg-base/40">
             <div className="h-4 w-4 rounded bg-bg-elevated/50" />
             <div className="flex-1 grid grid-cols-12 gap-4 text-sm font-medium text-text-muted">
               <div className="col-span-3">Hostname</div>
@@ -64,7 +64,7 @@ export const DeviceListEmptyState: FC = () => {
   const navigate = useNavigate();
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="py-12 text-center">
         <Server className="mx-auto h-12 w-12 text-text-disabled" />
         <H2 className="mt-4 mb-2">No Devices Configured</H2>
@@ -90,7 +90,7 @@ interface NoResultsStateProps {
 
 export const DeviceListNoResultsState: FC<NoResultsStateProps> = ({ onClearFilters }) => {
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="py-12 text-center">
         <Search className="mx-auto h-12 w-12 text-text-disabled" />
         <H2 className="mt-4 mb-2">No Matching Devices</H2>

--- a/ui/src/components/device-list/DeviceSearchFilters.tsx
+++ b/ui/src/components/device-list/DeviceSearchFilters.tsx
@@ -38,7 +38,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
           placeholder="Search by hostname, MAC, or IP..."
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
-          className="w-full rounded-lg border border-white/10 bg-bg-base/60 py-2.5 pl-10 pr-10 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+          className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-2.5 pl-10 pr-10 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
         />
         {searchQuery && (
           <button
@@ -58,7 +58,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
         <select
           value={typeFilter}
           onChange={(e) => onTypeFilterChange(e.target.value as DeviceType | 'all')}
-          className="rounded-lg border border-white/10 bg-bg-base/60 py-2 px-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+          className="rounded-lg border border-surface-border bg-bg-base/60 py-2 px-3 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
         >
           <option value="all">All Types</option>
           {deviceTypes.map((type) => (
@@ -73,7 +73,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
       <select
         value={protocolFilter}
         onChange={(e) => onProtocolFilterChange(e.target.value)}
-        className="rounded-lg border border-white/10 bg-bg-base/60 py-2 px-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+        className="rounded-lg border border-surface-border bg-bg-base/60 py-2 px-3 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
       >
         <option value="all">All Protocols</option>
         {protocols.map((proto) => (
@@ -84,14 +84,14 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
       </select>
 
       {/* View toggle */}
-      <div className="flex items-center gap-1 p-1 rounded-lg bg-bg-base/60 border border-white/10">
+      <div className="flex items-center gap-1 p-1 rounded-lg bg-bg-base/60 border border-surface-border">
         <button
           type="button"
           onClick={() => onViewModeChange('table')}
           className={`p-2 rounded-md transition-colors ${
             viewMode === 'table'
-              ? 'bg-brand-600 text-text-primary'
-              : 'text-text-muted hover:text-text-primary hover:bg-white/10'
+              ? 'bg-brand-primary text-text-primary'
+              : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
           }`}
           title="Table view"
           aria-label="Table view"
@@ -103,8 +103,8 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
           onClick={() => onViewModeChange('cards')}
           className={`p-2 rounded-md transition-colors ${
             viewMode === 'cards'
-              ? 'bg-brand-600 text-text-primary'
-              : 'text-text-muted hover:text-text-primary hover:bg-white/10'
+              ? 'bg-brand-primary text-text-primary'
+              : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
           }`}
           title="Card view"
           aria-label="Card view"

--- a/ui/src/components/device-list/DeviceTableView.tsx
+++ b/ui/src/components/device-list/DeviceTableView.tsx
@@ -18,16 +18,16 @@ export const DeviceTableView: FC = () => {
     getDeviceProtocols,
   } = useDeviceList();
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="p-0">
         {/* Table header */}
         <div>
-          <div className="flex items-center gap-4 border-b border-white/10 px-4 py-3 bg-bg-base/40">
+          <div className="flex items-center gap-4 border-b border-surface-border px-4 py-3 bg-bg-base/40">
             <input
               type="checkbox"
               checked={selectedDevices.size === devices.length && devices.length > 0}
               onChange={onSelectAll}
-              className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500"
+              className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary"
               aria-label="Select all devices"
             />
             <div className="flex-1 grid grid-cols-12 gap-4 text-sm font-medium text-text-muted">
@@ -55,15 +55,15 @@ export const DeviceTableView: FC = () => {
             return (
               <div
                 key={device.hostname}
-                className={`flex items-center gap-4 px-4 py-3 hover:bg-white/5 transition-colors ${
-                  selectedDevices.has(device.hostname) ? 'bg-brand-500/10' : ''
+                className={`flex items-center gap-4 px-4 py-3 hover:bg-surface-hover transition-colors ${
+                  selectedDevices.has(device.hostname) ? 'bg-brand-primary/10' : ''
                 }`}
               >
                 <input
                   type="checkbox"
                   checked={selectedDevices.has(device.hostname)}
                   onChange={() => onSelectDevice(device.hostname)}
-                  className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-500"
+                  className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary"
                   aria-label={`Select ${device.hostname}`}
                 />
                 <div className="flex-1 grid grid-cols-12 gap-4 items-center">
@@ -73,7 +73,7 @@ export const DeviceTableView: FC = () => {
                     <button
                       type="button"
                       onClick={() => onEdit(device.hostname)}
-                      className="text-text-primary hover:text-brand-300 font-medium truncate"
+                      className="text-text-primary hover:text-brand-accent font-medium truncate"
                       title={`Open ${device.hostname} in the device editor`}
                     >
                       {device.hostname}
@@ -120,7 +120,7 @@ export const DeviceTableView: FC = () => {
                     <button
                       type="button"
                       onClick={() => onEdit(device.hostname)}
-                      className="p-2 text-text-muted hover:text-brand-300 hover:bg-white/5 rounded-lg transition-colors"
+                      className="p-2 text-text-muted hover:text-brand-accent hover:bg-surface-hover rounded-lg transition-colors"
                       title={`Open the device editor for ${device.hostname} to modify protocols, interfaces, and credentials`}
                       aria-label={`Edit device ${device.hostname}`}
                     >
@@ -129,7 +129,7 @@ export const DeviceTableView: FC = () => {
                     <button
                       type="button"
                       onClick={() => onClone(device.hostname)}
-                      className="p-2 text-text-muted hover:text-status-info hover:bg-white/5 rounded-lg transition-colors"
+                      className="p-2 text-text-muted hover:text-status-info hover:bg-surface-hover rounded-lg transition-colors"
                       title={`Create a copy of ${device.hostname} with a new hostname; all protocols and interfaces are duplicated`}
                       aria-label={`Clone device ${device.hostname}`}
                     >
@@ -138,7 +138,7 @@ export const DeviceTableView: FC = () => {
                     <button
                       type="button"
                       onClick={() => onDelete(device.hostname)}
-                      className="p-2 text-text-muted hover:text-status-error hover:bg-white/5 rounded-lg transition-colors"
+                      className="p-2 text-text-muted hover:text-status-error hover:bg-surface-hover rounded-lg transition-colors"
                       title={`Permanently remove ${device.hostname} from the library; cannot be undone`}
                       aria-label={`Delete device ${device.hostname}`}
                     >

--- a/ui/src/components/form/CollapsibleSection.tsx
+++ b/ui/src/components/form/CollapsibleSection.tsx
@@ -23,15 +23,15 @@ export const CollapsibleSection: FC<CollapsibleSectionProps> = ({
   enabled,
   onEnableChange,
 }) => (
-  <Card className="border-white/5 bg-bg-surface/70 overflow-hidden">
-    <div className="flex items-center justify-between px-6 py-4 hover:bg-white/5 transition-colors">
+  <Card className="border-surface-border bg-bg-surface/70 overflow-hidden">
+    <div className="flex items-center justify-between px-6 py-4 hover:bg-surface-hover transition-colors">
       <div className="flex items-center gap-3">
         <button
           type="button"
           onClick={onToggle}
           aria-expanded={isExpanded}
           aria-label={`${title} section, ${isExpanded ? 'expanded' : 'collapsed'}`}
-          className="flex items-center gap-3 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500 rounded-lg px-1 -ml-1"
+          className="flex items-center gap-3 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-primary rounded-lg px-1 -ml-1"
         >
           {isExpanded ? (
             <ChevronDown className={`${iconSizes.md} text-text-muted`} />
@@ -54,7 +54,7 @@ export const CollapsibleSection: FC<CollapsibleSectionProps> = ({
                 onChange={(e) => onEnableChange(e.target.checked)}
                 className="sr-only peer"
               />
-              <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-600 peer-focus:ring-2 peer-focus:ring-brand-500 transition-colors">
+              <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                 <div
                   className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${enabled ? 'translate-x-4' : ''}`}
                 />

--- a/ui/src/components/help-drawer/FAQSection.tsx
+++ b/ui/src/components/help-drawer/FAQSection.tsx
@@ -53,13 +53,13 @@ function FAQItem({ entry }: FAQItemProps): ReactElement {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="bg-white/5 rounded-lg overflow-hidden">
+    <div className="bg-surface-hover rounded-lg overflow-hidden">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className={cn(
           'w-full text-left px-3 py-2.5 flex items-start gap-2',
-          'hover:bg-white/5 transition-colors',
+          'hover:bg-surface-hover transition-colors',
         )}
         aria-expanded={open}
       >
@@ -71,14 +71,14 @@ function FAQItem({ entry }: FAQItemProps): ReactElement {
         <h4 className="text-sm font-medium text-text-primary flex-1 min-w-0">{entry.question}</h4>
       </button>
       {open && (
-        <div className="px-3 pb-3 pl-9 space-y-2 border-t border-white/5">
+        <div className="px-3 pb-3 pl-9 space-y-2 border-t border-surface-border">
           <p className="text-xs text-text-muted leading-relaxed pt-2">{entry.answer}</p>
           {entry.tags.length > 0 && (
             <div className="flex flex-wrap gap-1">
               {entry.tags.map((tag) => (
                 <code
                   key={tag}
-                  className="text-xs text-text-muted bg-white/5 rounded px-1.5 py-0.5"
+                  className="text-xs text-text-muted bg-surface-hover rounded px-1.5 py-0.5"
                 >
                   {tag}
                 </code>

--- a/ui/src/components/help-drawer/GlossarySection.tsx
+++ b/ui/src/components/help-drawer/GlossarySection.tsx
@@ -62,7 +62,7 @@ export function GlossarySection({ searchQuery }: GlossarySectionProps): ReactEle
           entries.length > 0 ? (
             <div key={category} className="space-y-2">
               <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
-                <Network className="w-4 h-4 text-brand-400" />
+                <Network className="w-4 h-4 text-brand-accent" />
                 {CATEGORY_LABELS[category]}
               </h3>
               <div className="space-y-1">
@@ -84,7 +84,7 @@ interface GlossaryItemProps {
 
 function GlossaryItem({ entry }: GlossaryItemProps): ReactElement {
   return (
-    <div className="bg-white/5 rounded-lg p-3">
+    <div className="bg-surface-hover rounded-lg p-3">
       <dt className="text-sm font-medium text-text-primary">{entry.term}</dt>
       <dd className="text-xs text-text-muted mt-0.5">{entry.definition}</dd>
     </div>

--- a/ui/src/components/help-drawer/HelpItemCard.tsx
+++ b/ui/src/components/help-drawer/HelpItemCard.tsx
@@ -23,13 +23,13 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
   const [open, setOpen] = useState(defaultOpen);
 
   return (
-    <div className="bg-white/5 rounded-lg overflow-hidden">
+    <div className="bg-surface-hover rounded-lg overflow-hidden">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className={cn(
           'w-full text-left px-3 py-2.5 flex items-start gap-2',
-          'hover:bg-white/5 transition-colors',
+          'hover:bg-surface-hover transition-colors',
         )}
         aria-expanded={open}
       >
@@ -48,7 +48,7 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
       </button>
 
       {open && (
-        <div className="px-3 pb-3 pt-1 space-y-3 border-t border-white/5">
+        <div className="px-3 pb-3 pt-1 space-y-3 border-t border-surface-border">
           <section>
             <h5 className="text-xs font-semibold text-text-secondary mb-1">Technical</h5>
             <p className="text-xs text-text-muted leading-relaxed">{item.techDesc}</p>
@@ -78,14 +78,14 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
               <h5 className="text-xs font-semibold text-text-secondary mb-1">Parameters / flags</h5>
               <div className="space-y-1">
                 {item.parameters.map((p) => (
-                  <div key={p.name} className="bg-white/5 rounded p-2">
+                  <div key={p.name} className="bg-surface-hover rounded p-2">
                     <div className={layout.flex.between}>
                       <span className="text-xs font-medium text-text-primary">{p.name}</span>
                       <code className="text-xs text-text-muted">{p.flag}</code>
                     </div>
                     <p className="text-xs text-text-muted mt-0.5">{p.laymanDesc}</p>
                     {p.example && (
-                      <code className="block mt-1 text-xs text-brand-300 break-all">
+                      <code className="block mt-1 text-xs text-brand-accent break-all">
                         {p.example}
                       </code>
                     )}
@@ -100,14 +100,14 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
               <h5 className="text-xs font-semibold text-text-secondary mb-1">YAML fields</h5>
               <div className="space-y-1">
                 {item.configFields.map((f) => (
-                  <div key={f.path} className="bg-white/5 rounded p-2">
+                  <div key={f.path} className="bg-surface-hover rounded p-2">
                     <div className={layout.flex.between}>
                       <code className="text-xs text-text-primary">{f.path}</code>
                       <span className="text-xs text-text-muted">{f.type}</span>
                     </div>
                     <p className="text-xs text-text-muted mt-0.5">{f.description}</p>
                     {f.example && (
-                      <pre className="mt-1 text-xs text-brand-300 whitespace-pre-wrap break-all">
+                      <pre className="mt-1 text-xs text-brand-accent whitespace-pre-wrap break-all">
                         {f.example}
                       </pre>
                     )}
@@ -122,7 +122,7 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
               <h5 className="text-xs font-semibold text-text-secondary mb-1">Metrics</h5>
               <div className="space-y-1">
                 {item.metrics.map((m) => (
-                  <div key={m.name} className="bg-white/5 rounded p-2">
+                  <div key={m.name} className="bg-surface-hover rounded p-2">
                     <div className={layout.flex.between}>
                       <code className="text-xs text-text-primary">{m.name}</code>
                       <span className="text-xs text-text-muted">{m.unit}</span>
@@ -144,13 +144,13 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
               <h5 className="text-xs font-semibold text-text-secondary mb-1">Examples</h5>
               <div className="space-y-2">
                 {item.examples.map((ex) => (
-                  <div key={ex.command} className="bg-white/5 rounded p-2">
+                  <div key={ex.command} className="bg-surface-hover rounded p-2">
                     <p className="text-xs text-text-muted mb-1">{ex.desc}</p>
-                    <pre className="text-xs text-brand-300 whitespace-pre-wrap break-all">
+                    <pre className="text-xs text-brand-accent whitespace-pre-wrap break-all">
                       {ex.command}
                     </pre>
                     {ex.output && (
-                      <pre className="mt-1 text-xs text-text-muted whitespace-pre-wrap break-all border-l-2 border-white/10 pl-2">
+                      <pre className="mt-1 text-xs text-text-muted whitespace-pre-wrap break-all border-l-2 border-surface-border pl-2">
                         {ex.output}
                       </pre>
                     )}
@@ -178,7 +178,7 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
                 {item.seeAlso.map((ref) => (
                   <code
                     key={ref}
-                    className="text-xs text-text-muted bg-white/5 rounded px-1.5 py-0.5"
+                    className="text-xs text-text-muted bg-surface-hover rounded px-1.5 py-0.5"
                   >
                     {ref}
                   </code>

--- a/ui/src/components/help-drawer/OverviewSection.tsx
+++ b/ui/src/components/help-drawer/OverviewSection.tsx
@@ -58,7 +58,7 @@ export function OverviewSection({ searchQuery }: OverviewSectionProps): ReactEle
         ) : (
           <div className="space-y-2">
             {filteredCategories.map((cat) => (
-              <div key={cat.id} className="bg-white/5 rounded-lg p-3">
+              <div key={cat.id} className="bg-surface-hover rounded-lg p-3">
                 <div className={layout.flex.between}>
                   <h4 className="text-sm font-medium text-text-primary">{cat.name}</h4>
                   <code className="text-xs text-text-muted">{cat.items.length} items</code>
@@ -92,7 +92,7 @@ interface FeatureCardProps {
 
 function FeatureCard({ feature }: FeatureCardProps): ReactElement {
   return (
-    <div className="bg-white/5 rounded-lg p-3 hover:bg-white/10 transition-colors">
+    <div className="bg-surface-hover rounded-lg p-3 hover:bg-surface-hover transition-colors">
       <div className={layout.flex.between}>
         <div className={layout.inline.default}>
           <h4 className="text-sm font-medium text-text-primary">{feature.title}</h4>

--- a/ui/src/components/help-drawer/ShortcutsSection.tsx
+++ b/ui/src/components/help-drawer/ShortcutsSection.tsx
@@ -60,7 +60,7 @@ export function ShortcutsSection({ searchQuery }: ShortcutsSectionProps): ReactE
           shortcuts.length > 0 ? (
             <div key={category} className="space-y-2">
               <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
-                <Command className="w-4 h-4 text-brand-400" />
+                <Command className="w-4 h-4 text-brand-accent" />
                 {CATEGORY_LABELS[category]}
               </h3>
               <div className="space-y-1">
@@ -85,7 +85,7 @@ interface ShortcutItemProps {
 
 function ShortcutItem({ shortcut }: ShortcutItemProps): ReactElement {
   return (
-    <div className={cn(layout.flex.between, 'py-2 px-3 bg-white/5 rounded-lg')}>
+    <div className={cn(layout.flex.between, 'py-2 px-3 bg-surface-hover rounded-lg')}>
       <span className="text-sm text-text-secondary">{shortcut.description}</span>
       <div className={layout.inline.tight}>
         {shortcut.keys.map((key, idx) => (
@@ -93,7 +93,7 @@ function ShortcutItem({ shortcut }: ShortcutItemProps): ReactElement {
             <kbd
               className={cn(
                 'px-2 py-0.5 text-xs font-mono rounded',
-                'bg-bg-elevated border border-white/20 text-text-secondary',
+                'bg-bg-elevated border border-surface-border text-text-secondary',
               )}
             >
               {key}

--- a/ui/src/components/pcap/PcapPacketList.tsx
+++ b/ui/src/components/pcap/PcapPacketList.tsx
@@ -35,7 +35,7 @@ const PacketRow = memo(
     <tr
       onClick={onClick}
       className={`cursor-pointer transition-colors ${
-        isSelected ? 'bg-brand-900/30' : 'hover:bg-bg-surface/50'
+        isSelected ? 'bg-brand-primary/30' : 'hover:bg-bg-surface/50'
       }`}
       style={rowStyle}
     >
@@ -75,7 +75,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
 
     if (totalPackets === 0) {
       return (
-        <Card className="border-white/5 bg-bg-surface/70 h-full">
+        <Card className="border-surface-border bg-bg-surface/70 h-full">
           <CardContent className="h-full flex items-center justify-center text-text-muted">
             <div className="text-center">
               <p className="text-sm">No packets to display</p>
@@ -87,7 +87,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
     }
 
     return (
-      <Card className="border-white/5 bg-bg-surface/70 h-full flex flex-col">
+      <Card className="border-surface-border bg-bg-surface/70 h-full flex flex-col">
         <CardContent className="h-full flex flex-col">
           {/* Packet count */}
           <div className="mb-3 flex items-center justify-between">
@@ -97,7 +97,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
           </div>
 
           {/* Packet Table */}
-          <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-white/5">
+          <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-surface-border">
             {packets.length === 0 ? (
               <div className="h-full flex items-center justify-center text-text-muted">
                 <div className="text-center">
@@ -113,7 +113,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
                       #
                     </th>
                     <th
-                      className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-300 select-none"
+                      className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-text-muted cursor-pointer hover:text-brand-accent select-none"
                       onClick={cycleTimeMode}
                       title="Click to cycle: Absolute / Relative / Delta"
                     >

--- a/ui/src/components/pcap/PcapStats.tsx
+++ b/ui/src/components/pcap/PcapStats.tsx
@@ -48,7 +48,7 @@ const StatBlock = memo(
     value: string | number;
     helper?: string;
   }) => (
-    <div className="rounded-lg border border-white/5 bg-bg-base/50 p-4">
+    <div className="rounded-lg border border-surface-border bg-bg-base/50 p-4">
       <div className="flex items-center gap-2 mb-2">
         {icon}
         <SmallText className="text-text-muted uppercase tracking-wide">{label}</SmallText>
@@ -95,7 +95,7 @@ const ProtocolBreakdown: FC<{
             </div>
             <div className="h-1.5 w-full rounded-full bg-bg-elevated overflow-hidden">
               <div
-                className="h-full rounded-full bg-brand-500 transition-all duration-500"
+                className="h-full rounded-full bg-brand-primary transition-all duration-500"
                 style={{ width: `${percentage}%` }}
               />
             </div>
@@ -132,7 +132,7 @@ const TopEndpoints: FC<{
             {sources.slice(0, 5).map((item) => (
               <div
                 key={item.ip}
-                className="flex items-center justify-between rounded-lg border border-white/5 bg-bg-base/50 px-3 py-2"
+                className="flex items-center justify-between rounded-lg border border-surface-border bg-bg-base/50 px-3 py-2"
               >
                 <span className="font-mono text-sm text-text-primary">{item.ip}</span>
                 <Tag colorScheme="blue" className="text-xs">
@@ -159,7 +159,7 @@ const TopEndpoints: FC<{
             {destinations.slice(0, 5).map((item) => (
               <div
                 key={item.ip}
-                className="flex items-center justify-between rounded-lg border border-white/5 bg-bg-base/50 px-3 py-2"
+                className="flex items-center justify-between rounded-lg border border-surface-border bg-bg-base/50 px-3 py-2"
               >
                 <span className="font-mono text-sm text-text-primary">{item.ip}</span>
                 <Tag colorScheme="green" className="text-xs">
@@ -188,7 +188,7 @@ TopEndpoints.displayName = 'TopEndpoints';
 export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }) => {
   if (!stats) {
     return (
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="py-12 text-center">
           <BarChart3 className={`${iconSizes['3xl']} text-text-disabled mx-auto mb-4`} />
           <p className="text-text-muted">No statistics available</p>
@@ -204,10 +204,10 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
     <div className="space-y-6">
       {/* File Info */}
       {filename && (
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent>
             <div className="flex items-center gap-3">
-              <FileText className={`${iconSizes.lg} text-brand-400`} />
+              <FileText className={`${iconSizes.lg} text-brand-accent`} />
               <div>
                 <p className="font-medium text-text-primary">{filename}</p>
                 {fileSize && (
@@ -220,7 +220,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       )}
 
       {/* Summary Statistics */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           <H2 className="flex items-center gap-2 mb-0">
             <BarChart3 className={`${iconSizes.lg} text-status-info`} />
@@ -229,7 +229,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
 
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <StatBlock
-              icon={<ArrowRightLeft className={`${iconSizes.md} text-brand-400`} />}
+              icon={<ArrowRightLeft className={`${iconSizes.md} text-brand-accent`} />}
               label="Total Packets"
               value={stats.totalPackets.toLocaleString()}
             />
@@ -255,7 +255,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       </Card>
 
       {/* Time Range */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
             <Clock className={`${iconSizes.lg} text-status-success`} />
@@ -263,13 +263,13 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-lg border border-white/5 bg-bg-base/50 p-4">
+            <div className="rounded-lg border border-surface-border bg-bg-base/50 p-4">
               <SmallText className="text-text-muted uppercase tracking-wide">Start Time</SmallText>
               <p className="text-lg font-mono text-text-primary mt-1">
                 {formatTimestamp(stats.timeRange.start)}
               </p>
             </div>
-            <div className="rounded-lg border border-white/5 bg-bg-base/50 p-4">
+            <div className="rounded-lg border border-surface-border bg-bg-base/50 p-4">
               <SmallText className="text-text-muted uppercase tracking-wide">End Time</SmallText>
               <p className="text-lg font-mono text-text-primary mt-1">
                 {formatTimestamp(stats.timeRange.end)}
@@ -280,10 +280,10 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       </Card>
 
       {/* Protocol Breakdown */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
-            <BarChart3 className={`${iconSizes.lg} text-brand-300`} />
+            <BarChart3 className={`${iconSizes.lg} text-brand-accent`} />
             <H2>Protocol Breakdown</H2>
           </div>
 
@@ -292,7 +292,7 @@ export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }
       </Card>
 
       {/* Top Endpoints */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex items-center gap-2">
             <Network className={`${iconSizes.lg} text-status-info`} />

--- a/ui/src/components/pcap/PcapUploader.tsx
+++ b/ui/src/components/pcap/PcapUploader.tsx
@@ -142,7 +142,7 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
   }, [onFileSelect]);
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         {/* Drag and Drop Zone */}
         <input
@@ -162,8 +162,8 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
             relative cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-all
             ${
               isDragOver
-                ? 'border-brand-400 bg-brand-900/20'
-                : 'border-white/10 bg-bg-base/40 hover:border-white/20 hover:bg-bg-base/60'
+                ? 'border-brand-accent bg-brand-primary/20'
+                : 'border-surface-border bg-bg-base/40 hover:border-surface-border hover:bg-bg-base/60'
             }
             ${isAnalyzing ? 'pointer-events-none opacity-50' : ''}
           `}
@@ -171,10 +171,10 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
         >
           <div className="flex flex-col items-center gap-3">
             <div
-              className={`rounded-full p-4 ${isDragOver ? 'bg-brand-500/20' : 'bg-bg-elevated/50'}`}
+              className={`rounded-full p-4 ${isDragOver ? 'bg-brand-primary/20' : 'bg-bg-elevated/50'}`}
             >
               <Upload
-                className={`${iconSizes['2xl']} ${isDragOver ? 'text-brand-400' : 'text-text-muted'}`}
+                className={`${iconSizes['2xl']} ${isDragOver ? 'text-brand-accent' : 'text-text-muted'}`}
               />
             </div>
 
@@ -195,9 +195,9 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
 
         {/* Selected File Display */}
         {selectedFile && (
-          <div className="flex items-center justify-between rounded-lg border border-white/10 bg-bg-base/50 p-4">
+          <div className="flex items-center justify-between rounded-lg border border-surface-border bg-bg-base/50 p-4">
             <div className="flex items-center gap-3">
-              <FileUp className={`${iconSizes.lg} text-brand-400`} />
+              <FileUp className={`${iconSizes.lg} text-brand-accent`} />
               <div>
                 <p className="font-medium text-text-primary">{selectedFile.name}</p>
                 <SmallText className="text-text-muted">{formatBytes(selectedFile.size)}</SmallText>
@@ -245,7 +245,7 @@ export const PcapUploader: FC<PcapUploaderProps> = ({
           disabled={!selectedFile || isAnalyzing}
           leftIcon={
             isAnalyzing ? (
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-surface-border border-t-white" />
             ) : (
               <FileUp className={iconSizes.lg} />
             )

--- a/ui/src/components/settings/SimulationSection.tsx
+++ b/ui/src/components/settings/SimulationSection.tsx
@@ -134,7 +134,7 @@ export function SimulationSection(): ReactElement {
     <div className="space-y-4">
       {/* Section Header */}
       <div className="flex items-center gap-2">
-        <PlugZap className="w-5 h-5 text-brand-400" aria-hidden="true" />
+        <PlugZap className="w-5 h-5 text-brand-accent" aria-hidden="true" />
         <h3 className="text-sm font-semibold text-text-primary">Simulation</h3>
       </div>
 
@@ -152,8 +152,8 @@ export function SimulationSection(): ReactElement {
             disabled={loading}
             className={cn(
               'w-full pl-10 pr-4 py-2 text-sm',
-              'bg-bg-elevated border border-white/10 rounded-lg',
-              'text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-500/50',
+              'bg-bg-elevated border border-surface-border rounded-lg',
+              'text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/50',
               'disabled:opacity-50 disabled:cursor-not-allowed',
             )}
           >
@@ -174,7 +174,10 @@ export function SimulationSection(): ReactElement {
       {/* Config Source Tabs */}
       <div className="space-y-3">
         <span className="block text-sm text-text-muted">Configuration</span>
-        <div className="flex border border-white/10 rounded-lg overflow-hidden" role="tablist">
+        <div
+          className="flex border border-surface-border rounded-lg overflow-hidden"
+          role="tablist"
+        >
           {CONFIG_TABS.map((tab) => (
             <button
               key={tab.id}
@@ -184,7 +187,7 @@ export function SimulationSection(): ReactElement {
                 'flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium',
                 'transition-colors',
                 activeTab === tab.id
-                  ? 'bg-brand-600 text-text-primary'
+                  ? 'bg-brand-primary text-text-primary'
                   : 'bg-bg-elevated text-text-muted hover:bg-bg-elevated hover:text-text-primary',
               )}
             >
@@ -228,7 +231,7 @@ export function SimulationSection(): ReactElement {
 
       {/* Current Selection Display */}
       {simulationSettings.configName && (
-        <div className="p-3 bg-brand-900/20 border border-brand-500/30 rounded-lg">
+        <div className="p-3 bg-brand-primary/20 border border-brand-primary/30 rounded-lg">
           <p className="text-xs text-text-muted">Selected configuration:</p>
           <p className="text-sm text-text-primary font-medium mt-1">
             {simulationSettings.configName}
@@ -270,9 +273,9 @@ function TemplateList({ templates, selectedName, onSelect }: TemplateListProps):
         onChange={(e) => setSearch(e.target.value)}
         className={cn(
           'w-full px-3 py-2 text-sm',
-          'bg-bg-elevated border border-white/10 rounded-lg',
+          'bg-bg-elevated border border-surface-border rounded-lg',
           'text-text-primary placeholder:text-text-muted',
-          'focus:outline-none focus:ring-2 focus:ring-brand-500/50',
+          'focus:outline-none focus:ring-2 focus:ring-brand-primary/50',
         )}
       />
       <div className="max-h-[200px] overflow-y-auto space-y-1">
@@ -289,8 +292,8 @@ function TemplateList({ templates, selectedName, onSelect }: TemplateListProps):
             className={cn(
               'w-full text-left px-3 py-2 rounded-lg transition-colors',
               selectedName === template.name
-                ? 'bg-brand-600/30 border border-brand-500/50'
-                : 'bg-white/5 hover:bg-white/10 border border-transparent',
+                ? 'bg-brand-primary/30 border border-brand-primary/50'
+                : 'bg-surface-hover hover:bg-surface-hover border border-transparent',
             )}
           >
             <div className="text-sm text-text-primary font-medium">{template.name}</div>
@@ -334,8 +337,8 @@ function UserConfigList({ configs, selectedName, onSelect }: UserConfigListProps
           className={cn(
             'w-full text-left px-3 py-2 rounded-lg transition-colors',
             selectedName === config.name
-              ? 'bg-brand-600/30 border border-brand-500/50'
-              : 'bg-white/5 hover:bg-white/10 border border-transparent',
+              ? 'bg-brand-primary/30 border border-brand-primary/50'
+              : 'bg-surface-hover hover:bg-surface-hover border border-transparent',
           )}
         >
           <div className="text-sm text-text-primary font-medium">{config.name}</div>
@@ -389,8 +392,8 @@ function UploadSection(): ReactElement {
     <div className="space-y-3">
       <div
         className={cn(
-          'border-2 border-dashed border-white/10 rounded-lg p-4',
-          'hover:border-brand-500/50 transition-colors',
+          'border-2 border-dashed border-surface-border rounded-lg p-4',
+          'hover:border-brand-primary/50 transition-colors',
         )}
       >
         <input

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -240,7 +240,7 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
         <div className="flex-1" />
         <label
           htmlFor="config-upload"
-          className={`flex items-center gap-1.5 rounded border border-white/10 bg-bg-surface/60 px-3 py-1 text-xs font-medium text-text-primary hover:bg-white/5 ${
+          className={`flex items-center gap-1.5 rounded border border-surface-border bg-bg-surface/60 px-3 py-1 text-xs font-medium text-text-primary hover:bg-surface-hover ${
             convertingDsl ? 'cursor-wait opacity-60' : 'cursor-pointer'
           }`}
           title="Pick a config from disk. YAML is used as-is; legacy Java-DSL (.cfg) is auto-converted."
@@ -281,11 +281,11 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search configs…"
-            className="w-full rounded border border-white/10 bg-bg-surface/60 py-2 pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+            className="w-full rounded border border-surface-border bg-bg-surface/60 py-2 pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
           />
         </div>
         <fieldset
-          className="flex rounded border border-white/10 bg-bg-surface/60 p-0.5"
+          className="flex rounded border border-surface-border bg-bg-surface/60 p-0.5"
           aria-label="View density"
         >
           <ViewToggle
@@ -319,7 +319,7 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
 
       {/* Java-DSL import — collapsed by default since most users won't need it */}
       <details
-        className="rounded border border-white/10 bg-bg-base/40 p-3"
+        className="rounded border border-surface-border bg-bg-base/40 p-3"
         open={showJavaDsl}
         onToggle={(e) => setShowJavaDsl(e.currentTarget.open)}
       >

--- a/ui/src/components/simulation/ConfigPicker.types.ts
+++ b/ui/src/components/simulation/ConfigPicker.types.ts
@@ -31,7 +31,7 @@ export const TEMPLATE_TYPE_TINT: Record<Template['type'], string> = {
   basic: 'bg-status-info/15 text-status-info border-status-info/30',
   router: 'bg-status-warning/15 text-status-warning border-status-warning/30',
   switch: 'bg-status-success/15 text-status-success border-status-success/30',
-  'access-point': 'bg-brand-500/15 text-brand-200 border-brand-400/30',
+  'access-point': 'bg-brand-primary/15 text-brand-accent border-brand-accent/30',
   server: 'bg-status-info/15 text-status-info border-status-info/30',
   firewall: 'bg-status-error/15 text-status-error border-status-error/30',
   complete: 'bg-status-warning/15 text-status-warning border-status-warning/30',

--- a/ui/src/components/simulation/ConfigPickerControls.tsx
+++ b/ui/src/components/simulation/ConfigPickerControls.tsx
@@ -18,8 +18,8 @@ export const ViewToggle: FC<{
     title={label}
     className={`rounded px-2 py-1 transition-colors ${
       active
-        ? 'bg-brand-500/20 text-brand-100'
-        : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
+        ? 'bg-brand-primary/20 text-brand-accent'
+        : 'text-text-muted hover:bg-surface-hover hover:text-text-primary'
     }`}
   >
     {icon}

--- a/ui/src/components/simulation/ConfigPickerList.tsx
+++ b/ui/src/components/simulation/ConfigPickerList.tsx
@@ -97,7 +97,7 @@ export const ConfigsList: FC<{
             ))}
           </div>
         ) : (
-          <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-white/10 bg-bg-base/40">
+          <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-surface-border bg-bg-base/40">
             {items.map((item) => (
               <ConfigRow
                 key={item.key}
@@ -144,7 +144,7 @@ const FavoriteStar: FC<{
       favorited
         ? 'text-status-warning hover:text-status-warning'
         : 'text-text-muted hover:text-status-warning'
-    } ${compact ? '' : 'hover:bg-white/5'}`}
+    } ${compact ? '' : 'hover:bg-surface-hover'}`}
   >
     <Star
       className={compact ? iconSizes.sm : iconSizes.md}
@@ -179,8 +179,8 @@ const ConfigCard: FC<SharedItemProps> = ({
     <div
       className={`flex flex-col gap-3 rounded-lg border p-3 transition-colors ${
         selected
-          ? 'border-brand-400/50 bg-brand-500/10'
-          : 'border-white/10 bg-bg-base/40 hover:border-brand-500/30'
+          ? 'border-brand-accent/50 bg-brand-primary/10'
+          : 'border-surface-border bg-bg-base/40 hover:border-brand-primary/30'
       }`}
     >
       <div className="flex items-start justify-between gap-2">
@@ -212,7 +212,7 @@ const ConfigCard: FC<SharedItemProps> = ({
       </div>
       <div className="flex gap-2">
         {selected ? (
-          <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-brand-500/30 px-2 py-1.5 text-xs font-medium text-brand-50 ring-1 ring-brand-400/60">
+          <div className="flex flex-1 items-center justify-center gap-1.5 rounded bg-brand-primary/30 px-2 py-1.5 text-xs font-medium text-brand-accent ring-1 ring-brand-accent/60">
             <Check className={iconSizes.sm} />
             <span>Selected</span>
           </div>
@@ -220,7 +220,7 @@ const ConfigCard: FC<SharedItemProps> = ({
           <button
             type="button"
             onClick={() => onSelect(item)}
-            className="flex-1 rounded bg-brand-500/20 px-2 py-1.5 text-xs font-medium text-brand-100 ring-1 ring-brand-400/40 hover:bg-brand-500/30"
+            className="flex-1 rounded bg-brand-primary/20 px-2 py-1.5 text-xs font-medium text-brand-accent ring-1 ring-brand-accent/40 hover:bg-brand-primary/30"
             title="Select this network — click Start Simulation below to run it"
           >
             Select
@@ -230,7 +230,7 @@ const ConfigCard: FC<SharedItemProps> = ({
           <button
             type="button"
             onClick={() => onView(item)}
-            className="rounded border border-white/10 bg-bg-surface/60 px-2 py-1.5 text-xs font-medium text-text-primary hover:bg-white/10"
+            className="rounded border border-surface-border bg-bg-surface/60 px-2 py-1.5 text-xs font-medium text-text-primary hover:bg-surface-hover"
             title="Preview YAML"
           >
             <Eye className={iconSizes.sm} />
@@ -262,7 +262,7 @@ const ConfigRow: FC<SharedItemProps> = ({
 }) => (
   <li
     className={`flex items-center gap-3 px-3 py-2 transition-colors ${
-      selected ? 'bg-brand-500/10' : 'hover:bg-white/5'
+      selected ? 'bg-brand-primary/10' : 'hover:bg-surface-hover'
     }`}
   >
     {item.kind !== 'local' && (
@@ -301,7 +301,7 @@ const ConfigRow: FC<SharedItemProps> = ({
       <button
         type="button"
         onClick={() => onView(item)}
-        className="rounded p-1.5 text-text-muted hover:bg-white/10 hover:text-text-primary"
+        className="rounded p-1.5 text-text-muted hover:bg-surface-hover hover:text-text-primary"
         title="Preview the template YAML"
       >
         <Eye className={iconSizes.md} />

--- a/ui/src/components/templates/JavaDslImportCard.tsx
+++ b/ui/src/components/templates/JavaDslImportCard.tsx
@@ -56,7 +56,7 @@ export const JavaDslImportCard: FC = () => {
   };
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         <H2 className="flex items-center gap-2">
           <FileInput className={`${iconSizes.lg} text-status-success`} />
@@ -87,7 +87,7 @@ export const JavaDslImportCard: FC = () => {
           }}
           placeholder="device my-router {&#10;  type = router&#10;  ip = 192.168.1.1&#10;  ...&#10;}"
           rows={10}
-          className="w-full rounded border border-white/5 bg-bg-base/60 p-3 font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-success focus:outline-none"
+          className="w-full rounded border border-surface-border bg-bg-base/60 p-3 font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-success focus:outline-none"
           aria-label="Legacy Java DSL config content"
         />
 

--- a/ui/src/constants/device-types.ts
+++ b/ui/src/constants/device-types.ts
@@ -151,7 +151,7 @@ export function getDeviceLabel(type: DeviceType): string {
 const deviceColorClasses: Record<TagColorScheme, { bg: string; text: string }> = {
   blue: { bg: 'bg-status-info/20', text: 'text-status-info' },
   green: { bg: 'bg-status-success/20', text: 'text-status-success' },
-  purple: { bg: 'bg-brand-500/20', text: 'text-brand-400' },
+  purple: { bg: 'bg-brand-primary/20', text: 'text-brand-accent' },
   yellow: { bg: 'bg-status-warning/20', text: 'text-status-warning' },
   red: { bg: 'bg-status-error/20', text: 'text-status-error' },
   gray: { bg: 'bg-bg-muted/20', text: 'text-text-muted' },

--- a/ui/src/hooks/useTheme.ts
+++ b/ui/src/hooks/useTheme.ts
@@ -1,0 +1,159 @@
+/**
+ * Theme Management Hook
+ *
+ * Manages application theme with support for light, dark, and system modes.
+ *
+ * Features:
+ * - Light and dark theme modes
+ * - Automatic system theme detection via prefers-color-scheme
+ * - Persistent theme storage in localStorage (key: 'niac-theme')
+ * - Automatic system theme change detection while in 'system' mode
+ * - Theme toggling functionality
+ *
+ * The theme is applied by adding/removing the 'dark' class on the document
+ * root element. Tailwind CSS / our index.css uses that class to switch
+ * between :root (light) and .dark (dark) custom properties.
+ *
+ * Default value when no stored preference exists is 'dark' — this matches
+ * the seed/stem behaviour and is the intended out-of-the-box appearance.
+ *
+ * Usage:
+ * ```typescript
+ * const { theme, isDark, toggleTheme, setTheme } = useTheme();
+ *
+ * <button onClick={toggleTheme}>Toggle Theme</button>
+ * <button onClick={() => setTheme('system')}>Use System Theme</button>
+ * ```
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+/** Theme mode options */
+export type Theme = 'light' | 'dark' | 'system';
+
+/** localStorage key for theme persistence */
+const STORAGE_KEY = 'niac-theme';
+
+/**
+ * Detects the system's preferred color scheme.
+ *
+ * @returns 'dark' if system prefers dark mode, 'light' otherwise.
+ *          Defaults to 'dark' if detection is unavailable.
+ */
+function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'dark';
+}
+
+/**
+ * Applies the theme to the document root element.
+ * Resolves 'system' theme to actual light/dark preference.
+ *
+ * @param theme - Theme to apply ('light', 'dark', or 'system')
+ */
+function applyTheme(theme: Theme): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const root: HTMLElement = document.documentElement;
+  const effectiveTheme: 'light' | 'dark' = theme === 'system' ? getSystemTheme() : theme;
+
+  if (effectiveTheme === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+}
+
+/**
+ * Read the stored theme from localStorage. Defaults to 'dark' when no
+ * preference is stored, ensuring dark mode is the out-of-the-box default.
+ */
+function readStoredTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored;
+    }
+  } catch {
+    // localStorage may be unavailable (e.g. private browsing)
+  }
+  return 'dark';
+}
+
+/**
+ * Custom hook for managing application theme.
+ *
+ * Handles theme persistence, system theme detection, and automatic updates
+ * when system theme changes.
+ *
+ * @returns Theme state and control functions
+ */
+export function useTheme(): {
+  theme: Theme;
+  effectiveTheme: 'light' | 'dark';
+  setTheme: (newTheme: Theme) => void;
+  toggleTheme: () => void;
+  isDark: boolean;
+} {
+  const [theme, setThemeState] = useState<Theme>(readStoredTheme);
+
+  const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>(() =>
+    theme === 'system' ? getSystemTheme() : theme,
+  );
+
+  const setTheme = useCallback((newTheme: Theme): void => {
+    setThemeState(newTheme);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, newTheme);
+    } catch {
+      // Ignore storage failures (private browsing, quota, etc.)
+    }
+    applyTheme(newTheme);
+    setEffectiveTheme(newTheme === 'system' ? getSystemTheme() : newTheme);
+  }, []);
+
+  const toggleTheme = useCallback((): void => {
+    const newTheme: Theme = effectiveTheme === 'dark' ? 'light' : 'dark';
+    setTheme(newTheme);
+  }, [effectiveTheme, setTheme]);
+
+  // Apply theme on mount and listen for system theme changes
+  useEffect(() => {
+    applyTheme(theme);
+
+    if (theme === 'system') {
+      const mediaQuery: MediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+      const handler = (e: MediaQueryListEvent): void => {
+        setEffectiveTheme(e.matches ? 'dark' : 'light');
+        applyTheme('system');
+      };
+      mediaQuery.addEventListener('change', handler);
+      return (): void => mediaQuery.removeEventListener('change', handler);
+    }
+    return undefined;
+  }, [theme]);
+
+  return {
+    theme,
+    effectiveTheme,
+    setTheme,
+    toggleTheme,
+    isDark: effectiveTheme === 'dark',
+  };
+}
+
+/**
+ * Apply the initial theme synchronously, before React mounts. This avoids
+ * a brief flash of light mode at boot when the user has stored 'dark'.
+ *
+ * Call from main.tsx before `createRoot(...).render(...)`.
+ */
+export function initThemeFromStorage(): void {
+  applyTheme(readStoredTheme());
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3,10 +3,15 @@
 @source "../**/*.{js,ts,jsx,tsx}";
 
 /*
- * NIAC Theme System
+ * NIAC Theme System — harmonized with seed/stem
  * Tailwind v4 CSS-first configuration via @theme directive.
- * All design tokens declared here become available as utility classes
- * (e.g. --color-brand-500 → bg-brand-500, text-brand-500).
+ *
+ * Brand palette: Mustard Seed Networks - Seed Green primary.
+ * Light theme is the CSS default in :root; dark theme overrides apply
+ * when the .dark class is on <html> (managed by useTheme hook).
+ *
+ * Default app boot is dark — useTheme returns 'dark' unless a different
+ * value is stored in localStorage.
  */
 
 @theme {
@@ -19,91 +24,108 @@
   --font-mono: "JetBrains Mono", "Fira Code", monospace;
 
   /* ========================================
-   * Brand Colors
-   * Primary violet with high-contrast variants
+   * Brand Colors — Mustard Seed Networks
+   * Semantic tokens (no numeric ramp). Light/dark values live in
+   * :root and .dark blocks below.
    * ======================================== */
-  --color-brand-50: #f5f3ff;
-  --color-brand-100: #ede9fe;
-  --color-brand-200: #ddd6fe;
-  --color-brand-300: #c4b5fd;
-  --color-brand-400: #a78bfa;
-  --color-brand-500: #8b5cf6;
-  --color-brand-600: #7c3aed;
-  --color-brand-700: #6d28d9;
-  --color-brand-800: #5b21b6;
-  --color-brand-900: #4c1d95;
-  --color-brand-950: #2e1065;
+  --color-brand-primary: var(--color-brand-primary);
+  --color-brand-accent: var(--color-brand-accent);
+  --color-brand-gold: var(--color-brand-gold);
+
+  /* Legacy brand ramp aliases — all map to canonical semantic tokens.
+   * Components should migrate to brand-primary / brand-accent / brand-gold.
+   * Listed so existing `text-brand-400` / `bg-brand-500` / etc.
+   * utilities keep compiling until migration is complete. */
+  --color-brand-50: var(--color-brand-accent);
+  --color-brand-100: var(--color-brand-accent);
+  --color-brand-200: var(--color-brand-accent);
+  --color-brand-300: var(--color-brand-accent);
+  --color-brand-400: var(--color-brand-accent);
+  --color-brand-500: var(--color-brand-primary);
+  --color-brand-600: var(--color-brand-primary);
+  --color-brand-700: var(--color-brand-primary);
+  --color-brand-800: var(--color-brand-primary);
+  --color-brand-900: var(--color-brand-primary);
+  --color-brand-950: var(--color-brand-primary);
 
   /* ========================================
-   * Surface Colors (Dark Theme)
+   * Surface Colors — semantic elevation tokens
+   * (light/dark values in :root / .dark blocks)
    * ======================================== */
-  --color-bg-base: #030712;
-  --color-bg-surface: #0f1117;
-  --color-bg-elevated: #1a1d25;
-  --color-bg-overlay: #242731;
-  --color-bg-muted: #2d3139;
+  --color-surface-base: var(--color-surface-base);
+  --color-surface-raised: var(--color-surface-raised);
+  --color-surface-border: var(--color-surface-border);
+  --color-surface-hover: var(--color-surface-hover);
+  --color-surface-sunken: var(--color-surface-sunken);
+
+  /* Legacy bg-* aliases — kept so existing utilities still compile.
+   * Components should migrate to bg-surface-* over time. */
+  --color-bg-base: var(--color-surface-base);
+  --color-bg-surface: var(--color-surface-raised);
+  --color-bg-elevated: var(--color-surface-raised);
+  --color-bg-overlay: var(--color-surface-hover);
+  --color-bg-muted: var(--color-surface-hover);
 
   /* ========================================
    * Text Colors (WCAG AA contrast)
    * ======================================== */
-  --color-text-primary: #f8fafc;
-  --color-text-secondary: #cbd5e1;
-  --color-text-muted: #94a3b8;
-  --color-text-disabled: #64748b;
-  --color-text-inverse: #0f172a;
+  --color-text-primary: var(--color-text-primary);
+  --color-text-secondary: var(--color-text-secondary);
+  --color-text-muted: var(--color-text-muted);
+  --color-text-disabled: var(--color-text-disabled);
+  --color-text-inverse: var(--color-text-inverse);
 
   /* ========================================
    * Border Colors
+   * Legacy aliases kept; new code should use border-surface-border.
    * ======================================== */
-  --color-border-default: rgba(255, 255, 255, 0.08);
-  --color-border-subtle: rgba(255, 255, 255, 0.05);
-  --color-border-muted: rgba(255, 255, 255, 0.12);
-  --color-border-focus: rgba(139, 92, 246, 0.6);
-  --color-border-error: rgba(239, 68, 68, 0.5);
+  --color-border-default: var(--color-surface-border);
+  --color-border-subtle: var(--color-surface-border);
+  --color-border-muted: var(--color-surface-border);
+  --color-border-focus: var(--color-brand-primary);
+  --color-border-error: var(--color-status-error);
 
   /* ========================================
-   * Status Colors
+   * Status Colors — canonical hex values shared across seed/stem/niac.
+   * INDUSTRY STANDARD (do not change). Identical in light and dark.
    * ======================================== */
+  --color-status-success: var(--color-status-success);
+  --color-status-warning: var(--color-status-warning);
+  --color-status-error: var(--color-status-error);
+  --color-status-info: var(--color-status-info);
+
+  /* Legacy ramped status utilities — mapped to canonical hex so
+   * `text-success-400`, `bg-error-500`, etc. continue to render. */
   --color-success-50: #f0fdf4;
   --color-success-100: #dcfce7;
-  --color-success-400: #4ade80;
-  --color-success-500: #22c55e;
-  --color-success-600: #16a34a;
+  --color-success-400: var(--color-status-success);
+  --color-success-500: var(--color-status-success);
+  --color-success-600: var(--color-status-success);
   --color-success-900: #14532d;
 
   --color-warning-50: #fffbeb;
   --color-warning-100: #fef3c7;
-  --color-warning-400: #fbbf24;
-  --color-warning-500: #f59e0b;
-  --color-warning-600: #d97706;
+  --color-warning-400: var(--color-status-warning);
+  --color-warning-500: var(--color-status-warning);
+  --color-warning-600: var(--color-status-warning);
   --color-warning-900: #78350f;
 
   --color-error-50: #fef2f2;
   --color-error-100: #fee2e2;
-  --color-error-400: #f87171;
-  --color-error-500: #ef4444;
-  --color-error-600: #dc2626;
+  --color-error-400: var(--color-status-error);
+  --color-error-500: var(--color-status-error);
+  --color-error-600: var(--color-status-error);
   --color-error-900: #7f1d1d;
 
   --color-info-50: #eff6ff;
   --color-info-100: #dbeafe;
-  --color-info-400: #60a5fa;
-  --color-info-500: #3b82f6;
-  --color-info-600: #2563eb;
+  --color-info-400: var(--color-status-info);
+  --color-info-500: var(--color-status-info);
+  --color-info-600: var(--color-status-info);
   --color-info-900: #1e3a8a;
 
   /* ========================================
-   * Status semantic aliases (mirror seed/stem naming)
-   * Map to the canonical 500-shade of each palette above so all three
-   * projects share bg-status-success / text-status-error / etc.
-   * ======================================== */
-  --color-status-success: #22c55e;
-  --color-status-warning: #f59e0b;
-  --color-status-error: #ef4444;
-  --color-status-info: #3b82f6;
-
-  /* ========================================
-   * Device Type Colors (Topology)
+   * Device Type Colors (Topology) — NIAC-specific, theme-neutral
    * ======================================== */
   --color-device-router: #3b82f6;
   --color-device-switch: #22c55e;
@@ -179,7 +201,7 @@
   --color-chart-10: #6366f1;
 
   /* ========================================
-   * Neutral Scale (Gray)
+   * Neutral Scale (Gray) — unchanged
    * ======================================== */
   --color-neutral-50: #f8fafc;
   --color-neutral-100: #f1f5f9;
@@ -202,16 +224,75 @@
   --animate-slide-in-right: slideInRight 0.3s ease-out;
 }
 
+/* ==========================================================================
+   LIGHT THEME (CSS default) — Mustard Seed Networks
+   ========================================================================== */
 :root {
+  /* Brand */
+  --color-brand-primary: #2d7a3e; /* Seed Green */
+  --color-brand-accent: #4caf50;
+  --color-brand-gold: #d4a017;
+
+  /* Surfaces */
+  --color-surface-base: #f8fafc;
+  --color-surface-raised: #ffffff;
+  --color-surface-border: #e2e8f0;
+  --color-surface-hover: #f1f5f9;
+  --color-surface-sunken: #e2e8f0;
+
+  /* Text */
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #475569;
+  --color-text-muted: #64748b;
+  --color-text-disabled: #94a3b8;
+  --color-text-inverse: #ffffff;
+
+  /* Status — INDUSTRY STANDARD */
+  --color-status-success: #28a745;
+  --color-status-warning: #ffc107;
+  --color-status-error: #dc3545;
+  --color-status-info: #17a2b8;
+
   color: var(--color-text-primary);
-  background-color: var(--color-bg-base);
+  background-color: var(--color-surface-base);
+}
+
+/* ==========================================================================
+   DARK THEME — applied when html.dark by useTheme hook
+   Default boot is dark (see useTheme hook).
+   ========================================================================== */
+.dark {
+  /* Brand — lighter shades for contrast on dark surfaces */
+  --color-brand-primary: #81c784;
+  --color-brand-accent: #a5d6a7;
+  --color-brand-gold: #fbbf24;
+
+  /* Surfaces — neutral grays (NOT blue-tinted slate) */
+  --color-surface-base: #1a1a1a;
+  --color-surface-raised: #333333;
+  --color-surface-border: #666666;
+  --color-surface-hover: #404040;
+  --color-surface-sunken: #0a0a0a;
+
+  /* Text */
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: #cbd5e1;
+  --color-text-muted: #94a3b8;
+  --color-text-disabled: #64748b;
+  --color-text-inverse: #0f172a;
+
+  /* Status — INDUSTRY STANDARD (identical to light) */
+  --color-status-success: #28a745;
+  --color-status-warning: #ffc107;
+  --color-status-error: #dc3545;
+  --color-status-info: #17a2b8;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
   font-family: "Inter", system-ui, sans-serif;
-  background-color: var(--color-bg-base);
+  background-color: var(--color-surface-base);
   color: var(--color-text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -230,23 +311,23 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--color-bg-elevated);
+  background: var(--color-surface-base);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-bg-muted);
+  background: var(--color-surface-border);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-border-muted);
+  background: var(--color-text-muted);
 }
 
 /* Selection color */
 ::selection {
-  background: rgba(139, 92, 246, 0.4);
-  color: white;
+  background: color-mix(in srgb, var(--color-brand-primary) 40%, transparent);
+  color: var(--color-text-inverse);
 }
 
 /* ========================================
@@ -255,13 +336,13 @@ body {
 .focus-ring:focus {
   outline: none;
   box-shadow:
-    0 0 0 2px #111827,
-    0 0 0 4px rgba(139, 92, 246, 0.5);
+    0 0 0 2px var(--color-surface-base),
+    0 0 0 4px color-mix(in srgb, var(--color-brand-primary) 50%, transparent);
 }
 
 .focus-ring-inset:focus {
   outline: none;
-  box-shadow: inset 0 0 0 2px rgba(139, 92, 246, 0.5);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--color-brand-primary) 50%, transparent);
 }
 
 /* Text contrast utilities */
@@ -284,34 +365,42 @@ body {
 .glass-card {
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--color-surface-border);
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.2);
-  background: linear-gradient(135deg, var(--color-bg-elevated) 0%, rgba(26, 29, 37, 0.8) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-surface-raised) 0%,
+    color-mix(in srgb, var(--color-surface-raised) 80%, transparent) 100%
+  );
 }
 
 .glass-card-hover {
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--color-surface-border);
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.2);
-  background: linear-gradient(135deg, var(--color-bg-elevated) 0%, rgba(26, 29, 37, 0.8) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-surface-raised) 0%,
+    color-mix(in srgb, var(--color-surface-raised) 80%, transparent) 100%
+  );
   transition: all 300ms;
 }
 
 .glass-card-hover:hover {
   box-shadow:
     0 25px 50px -12px rgba(0, 0, 0, 0.25),
-    0 0 20px -5px rgba(139, 92, 246, 0.15);
-  border-color: var(--color-border-muted);
+    0 0 20px -5px color-mix(in srgb, var(--color-brand-primary) 15%, transparent);
+  border-color: var(--color-surface-border);
 }
 
 /* Skeleton loading animation */
 .skeleton {
   background: linear-gradient(
     to right,
-    rgba(255, 255, 255, 0.05),
-    rgba(255, 255, 255, 0.1),
-    rgba(255, 255, 255, 0.05)
+    color-mix(in srgb, var(--color-surface-border) 50%, transparent),
+    var(--color-surface-border),
+    color-mix(in srgb, var(--color-surface-border) 50%, transparent)
   );
   background-size: 200% 100%;
   animation: shimmer 2s linear infinite;
@@ -323,10 +412,10 @@ body {
   width: 100%;
   border-radius: 0.5rem;
   padding: 0.625rem 1rem;
-  color: white;
+  color: var(--color-text-primary);
   transition: all 150ms;
-  background-color: var(--color-bg-surface);
-  border: 1px solid var(--color-border-default);
+  background-color: var(--color-surface-raised);
+  border: 1px solid var(--color-surface-border);
 }
 
 .input-base::placeholder {
@@ -335,8 +424,8 @@ body {
 
 .input-base:focus {
   outline: none;
-  border-color: var(--color-brand-500);
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15);
+  border-color: var(--color-brand-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-brand-primary) 15%, transparent);
 }
 
 /* Button base - improved */
@@ -357,7 +446,7 @@ body {
 
 .btn-base:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.3);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-brand-primary) 30%, transparent);
 }
 
 .btn-primary {
@@ -368,9 +457,13 @@ body {
   border-radius: 0.5rem;
   font-weight: 500;
   transition: all 200ms;
-  color: white;
-  background: linear-gradient(135deg, var(--color-brand-600) 0%, var(--color-brand-500) 100%);
-  box-shadow: 0 4px 14px -3px rgba(139, 92, 246, 0.4);
+  color: var(--color-text-inverse);
+  background: linear-gradient(
+    135deg,
+    var(--color-brand-primary) 0%,
+    var(--color-brand-accent) 100%
+  );
+  box-shadow: 0 4px 14px -3px color-mix(in srgb, var(--color-brand-primary) 40%, transparent);
 }
 
 .btn-primary:disabled {
@@ -379,7 +472,11 @@ body {
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--color-brand-500) 0%, var(--color-brand-400) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-brand-accent) 0%,
+    var(--color-brand-primary) 100%
+  );
   transform: translateY(-1px);
 }
 
@@ -395,8 +492,8 @@ body {
   border-radius: 0.5rem;
   font-weight: 500;
   transition: all 200ms;
-  color: white;
-  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-hover);
 }
 
 .btn-secondary:disabled {
@@ -405,7 +502,8 @@ body {
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background-color: rgba(255, 255, 255, 0.15);
+  background-color: var(--color-surface-hover);
+  filter: brightness(1.1);
 }
 
 .btn-ghost {
@@ -426,7 +524,7 @@ body {
 
 .btn-ghost:hover:not(:disabled) {
   color: var(--color-text-primary);
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--color-surface-hover);
 }
 
 .btn-outline {
@@ -438,7 +536,7 @@ body {
   font-weight: 500;
   transition: all 200ms;
   color: var(--color-text-secondary);
-  border: 1px solid var(--color-border-muted);
+  border: 1px solid var(--color-surface-border);
 }
 
 .btn-outline:disabled {
@@ -447,8 +545,8 @@ body {
 }
 
 .btn-outline:hover:not(:disabled) {
-  background-color: rgba(255, 255, 255, 0.05);
-  border-color: var(--color-border-focus);
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-brand-primary);
 }
 
 /* Status indicator */
@@ -476,17 +574,17 @@ body {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  background-color: var(--color-bg-surface);
+  background-color: var(--color-surface-raised);
   color: var(--color-text-muted);
 }
 
 .table-row {
   transition: background-color 150ms;
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-surface-border);
 }
 
 .table-row:hover {
-  background-color: rgba(255, 255, 255, 0.03);
+  background-color: var(--color-surface-hover);
 }
 
 /* Page animation */
@@ -496,41 +594,41 @@ body {
 
 /* Card variants for different contexts */
 .card-surface {
-  background-color: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-default);
+  background-color: var(--color-surface-raised);
+  border: 1px solid var(--color-surface-border);
   border-radius: 0.75rem;
 }
 
 .card-elevated {
-  background-color: var(--color-bg-overlay);
-  border: 1px solid var(--color-border-muted);
+  background-color: var(--color-surface-raised);
+  border: 1px solid var(--color-surface-border);
   border-radius: 0.75rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2);
 }
 
-/* Status badges with proper contrast */
+/* Status badges with proper contrast — use canonical status hex */
 .badge-success {
-  background-color: rgba(34, 197, 94, 0.15);
-  color: var(--color-success-400);
-  border: 1px solid rgba(34, 197, 94, 0.3);
+  background-color: color-mix(in srgb, var(--color-status-success) 15%, transparent);
+  color: var(--color-status-success);
+  border: 1px solid color-mix(in srgb, var(--color-status-success) 30%, transparent);
 }
 
 .badge-warning {
-  background-color: rgba(245, 158, 11, 0.15);
-  color: var(--color-warning-400);
-  border: 1px solid rgba(245, 158, 11, 0.3);
+  background-color: color-mix(in srgb, var(--color-status-warning) 15%, transparent);
+  color: var(--color-status-warning);
+  border: 1px solid color-mix(in srgb, var(--color-status-warning) 30%, transparent);
 }
 
 .badge-error {
-  background-color: rgba(239, 68, 68, 0.15);
-  color: var(--color-error-400);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background-color: color-mix(in srgb, var(--color-status-error) 15%, transparent);
+  color: var(--color-status-error);
+  border: 1px solid color-mix(in srgb, var(--color-status-error) 30%, transparent);
 }
 
 .badge-info {
-  background-color: rgba(59, 130, 246, 0.15);
-  color: var(--color-info-400);
-  border: 1px solid rgba(59, 130, 246, 0.3);
+  background-color: color-mix(in srgb, var(--color-status-info) 15%, transparent);
+  color: var(--color-status-info);
+  border: 1px solid color-mix(in srgb, var(--color-status-info) 30%, transparent);
 }
 
 @keyframes ping {
@@ -633,28 +731,28 @@ pre,
 
 .react-flow__controls {
   box-shadow: none;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--color-surface-border);
   border-radius: 0.5rem;
   overflow: hidden;
 }
 
 .react-flow__controls-button {
-  background-color: var(--color-bg-elevated);
-  border-color: var(--color-border-subtle);
+  background-color: var(--color-surface-raised);
+  border-color: var(--color-surface-border);
   color: var(--color-text-secondary);
 }
 
 .react-flow__controls-button:hover {
-  background-color: var(--color-bg-overlay);
+  background-color: var(--color-surface-hover);
   color: var(--color-text-primary);
 }
 
 .react-flow__minimap {
-  background-color: var(--color-bg-surface);
-  border: 1px solid var(--color-border-default);
+  background-color: var(--color-surface-raised);
+  border: 1px solid var(--color-surface-border);
   border-radius: 0.5rem;
 }
 
 .react-flow__background {
-  background-color: var(--color-bg-base);
+  background-color: var(--color-surface-base);
 }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -2,7 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
+import { initThemeFromStorage } from './hooks/useTheme';
 import './index.css';
+
+// Apply persisted/default theme before first paint to avoid a flash of
+// the wrong palette. Defaults to dark when no preference is stored.
+initThemeFromStorage();
 
 const rootElement = document.getElementById('root');
 

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -251,7 +251,7 @@ export const pages: PageConfig[] = [
           <code>--webhook-allowed-host</code>, only those hostnames are allowed. Set the allowlist
           in production rather than relying on the implicit IP filter — see{' '}
           <a
-            className="text-brand-300 underline"
+            className="text-brand-accent underline"
             href="https://github.com/krisarmstrong/niac-go/blob/main/SECURITY.md"
           >
             SECURITY.md

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -80,7 +80,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
   };
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         <H2 className="flex items-center gap-2">
           <BellRing className={`${iconSizes.lg} text-status-warning`} />
@@ -93,7 +93,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
           <code>--webhook-allowed-host</code> allowlist when set (see{' '}
           <a
             href="https://github.com/krisarmstrong/niac-go/blob/main/SECURITY.md"
-            className="text-brand-300 underline"
+            className="text-brand-accent underline"
           >
             SECURITY.md
           </a>
@@ -114,7 +114,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
               <div>
                 <SmallText className="text-text-muted">Packet threshold</SmallText>
                 <input
-                  className="mt-1 w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+                  className="mt-1 w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
                   type="number"
                   min="0"
                   placeholder="100000"
@@ -130,7 +130,7 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
               <div>
                 <SmallText className="text-text-muted">Webhook URL</SmallText>
                 <input
-                  className="mt-1 w-full rounded-lg border border-white/10 bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+                  className="mt-1 w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
                   placeholder="https://hooks.example.com/niac"
                   value={webhook}
                   title="POST'd JSON when the threshold trips. Must be http(s) and not point at a private/loopback/link-local IP. The daemon's --webhook-allowed-host flag further locks this down."

--- a/ui/src/pages/ConfigDiffPage.tsx
+++ b/ui/src/pages/ConfigDiffPage.tsx
@@ -149,12 +149,12 @@ export const ConfigDiffPage: FC = () => {
   return (
     <div className="space-y-6">
       {/* Header section */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <H2 className="flex items-center gap-2">
-                <GitCompare className={`${iconSizes.lg} text-brand-300`} />
+                <GitCompare className={`${iconSizes.lg} text-brand-accent`} />
                 Compare & Merge
               </H2>
               <P className="text-text-muted mt-1">
@@ -201,7 +201,7 @@ export const ConfigDiffPage: FC = () => {
 
       {/* File upload section */}
       <div className="grid gap-6 lg:grid-cols-2">
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <H2 className="text-lg">Original File</H2>
@@ -223,7 +223,7 @@ export const ConfigDiffPage: FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <H2 className="text-lg">Modified File</H2>
@@ -249,7 +249,7 @@ export const ConfigDiffPage: FC = () => {
       {/* Diff viewer section */}
       {hasFiles && (
         <>
-          <Card className="border-white/5 bg-bg-surface/70">
+          <Card className="border-surface-border bg-bg-surface/70">
             <CardContent className="space-y-4">
               <H2 className="flex items-center gap-2">
                 <GitCompare className={`${iconSizes.lg} text-status-info`} />
@@ -281,12 +281,12 @@ export const ConfigDiffPage: FC = () => {
           />
 
           {/* Server-side overlay merge (CLI parity) */}
-          <Card className="border-white/5 bg-bg-surface/70">
+          <Card className="border-surface-border bg-bg-surface/70">
             <CardContent className="space-y-3">
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <H2 className="mb-1 flex items-center gap-2 text-lg">
-                    <Layers className={`${iconSizes.lg} text-brand-300`} />
+                    <Layers className={`${iconSizes.lg} text-brand-accent`} />
                     Server-side overlay merge
                   </H2>
                   <P className="text-sm text-text-muted">
@@ -336,7 +336,7 @@ export const ConfigDiffPage: FC = () => {
 
       {/* Empty state when no files */}
       {!hasFiles && (
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent className="py-12 text-center">
             <GitCompare className={`mx-auto ${iconSizes['3xl']} text-text-disabled`} />
             <H2 className="mt-4 mb-2">Ready to Compare</H2>

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -78,7 +78,7 @@ export const DashboardPage: FC = () => {
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium text-text-muted">Devices Online</span>
               <Server
-                className={`${iconSizes.lg} text-brand-400 group-hover:scale-110 transition-transform`}
+                className={`${iconSizes.lg} text-brand-accent group-hover:scale-110 transition-transform`}
               />
             </div>
             <p className="text-3xl font-bold text-text-primary">{stats?.deviceCount ?? '—'}</p>
@@ -127,14 +127,14 @@ export const DashboardPage: FC = () => {
         <Card className="lg:col-span-2">
           <CardContent className="space-y-4">
             <H2 className="flex items-center gap-2">
-              <Zap className={`${iconSizes.lg} text-brand-400`} />
+              <Zap className={`${iconSizes.lg} text-brand-accent`} />
               Quick Actions
             </H2>
             <div className="grid gap-3 sm:grid-cols-2">
               <button
                 type="button"
                 onClick={() => setShowErrors(!showErrors)}
-                className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group"
+                className="flex items-center gap-3 rounded-lg border border-surface-border bg-surface-hover p-4 text-left hover:bg-surface-hover hover:border-brand-primary/30 transition-all group"
               >
                 <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-status-warning/20 flex items-center justify-center group-hover:scale-110 transition-transform">
                   <PlugZap className={`${iconSizes.lg} text-status-warning`} />
@@ -146,9 +146,9 @@ export const DashboardPage: FC = () => {
               </button>
 
               <AccentLink to="/debug" className="no-underline">
-                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group">
-                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-brand-500/20 flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <Terminal className={`${iconSizes.lg} text-brand-400`} />
+                <div className="flex items-center gap-3 rounded-lg border border-surface-border bg-surface-hover p-4 text-left hover:bg-surface-hover hover:border-brand-primary/30 transition-all group">
+                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-brand-primary/20 flex items-center justify-center group-hover:scale-110 transition-transform">
+                    <Terminal className={`${iconSizes.lg} text-brand-accent`} />
                   </div>
                   <div>
                     <p className="font-medium text-text-primary">Debug Console</p>
@@ -158,7 +158,7 @@ export const DashboardPage: FC = () => {
               </AccentLink>
 
               <AccentLink to="/traffic" className="no-underline">
-                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group">
+                <div className="flex items-center gap-3 rounded-lg border border-surface-border bg-surface-hover p-4 text-left hover:bg-surface-hover hover:border-brand-primary/30 transition-all group">
                   <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-status-info/20 flex items-center justify-center group-hover:scale-110 transition-transform">
                     <Activity className={`${iconSizes.lg} text-status-info`} />
                   </div>
@@ -170,7 +170,7 @@ export const DashboardPage: FC = () => {
               </AccentLink>
 
               <AccentLink to="/topology" className="no-underline">
-                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left hover:bg-white/10 hover:border-brand-500/30 transition-all group">
+                <div className="flex items-center gap-3 rounded-lg border border-surface-border bg-surface-hover p-4 text-left hover:bg-surface-hover hover:border-brand-primary/30 transition-all group">
                   <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-status-success/20 flex items-center justify-center group-hover:scale-110 transition-transform">
                     <Network className={`${iconSizes.lg} text-status-success`} />
                   </div>
@@ -199,10 +199,12 @@ export const DashboardPage: FC = () => {
               {(history ?? []).slice(0, 4).map((item) => (
                 <div
                   key={item.id}
-                  className="rounded-lg border border-white/5 bg-bg-base/50 p-3 hover:border-white/10 transition-colors"
+                  className="rounded-lg border border-surface-border bg-bg-base/50 p-3 hover:border-surface-border transition-colors"
                 >
                   <div className="flex items-center justify-between mb-1">
-                    <p className="font-mono text-xs text-brand-300">{formatTime(item.startedAt)}</p>
+                    <p className="font-mono text-xs text-brand-accent">
+                      {formatTime(item.startedAt)}
+                    </p>
                     <Tag colorScheme="gray" className="text-[10px]">
                       {item.deviceCount} dev
                     </Tag>
@@ -254,7 +256,7 @@ const ErrorInjectionPanel = memo(
         {errorTypes.map((errorType) => (
           <div
             key={errorType.type}
-            className="rounded-lg border border-white/10 bg-bg-surface/50 p-3"
+            className="rounded-lg border border-surface-border bg-bg-surface/50 p-3"
           >
             <p className="font-semibold text-text-primary">{errorType.type}</p>
             <SmallText className="text-text-muted">{errorType.description}</SmallText>
@@ -287,7 +289,7 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
 
   if (timeline.length === 0) {
     return (
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent>
           <SmallText className="text-text-muted">
             Automation updates will appear after the first run completes.
@@ -298,11 +300,11 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
   }
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex items-center justify-between">
           <H2 className="flex items-center gap-2">
-            <SatelliteDish className={`${iconSizes.lg} text-brand-300`} />
+            <SatelliteDish className={`${iconSizes.lg} text-brand-accent`} />
             Automation timeline
           </H2>
           <Tag colorScheme="gray">Latest events</Tag>
@@ -311,7 +313,7 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
           {timeline.map((event) => (
             <div
               key={event.title}
-              className="flex flex-col gap-1 rounded-lg border border-white/5 bg-bg-base/50 p-4 sm:flex-row sm:items-center sm:justify-between"
+              className="flex flex-col gap-1 rounded-lg border border-surface-border bg-bg-base/50 p-4 sm:flex-row sm:items-center sm:justify-between"
             >
               <div>
                 <SmallText className="text-status-info">{event.time}</SmallText>

--- a/ui/src/pages/DebugConsolePage.tsx
+++ b/ui/src/pages/DebugConsolePage.tsx
@@ -167,7 +167,7 @@ export const DebugConsolePage: FC = () => {
   return (
     <div className="space-y-6">
       {/* Main Console Card */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           {/* Header with Connection Status */}
           <div className="flex items-center justify-between">
@@ -195,7 +195,7 @@ export const DebugConsolePage: FC = () => {
               <button
                 type="button"
                 onClick={reconnect}
-                className="flex items-center gap-2 rounded-lg border border-white/10 bg-bg-base/50 px-3 py-1.5 text-sm transition-colors hover:bg-bg-elevated/50"
+                className="flex items-center gap-2 rounded-lg border border-surface-border bg-bg-base/50 px-3 py-1.5 text-sm transition-colors hover:bg-bg-elevated/50"
                 title={connected ? 'Connected to log stream' : 'Click to reconnect'}
               >
                 <span className={`h-2 w-2 rounded-full ${connectionStatus.indicator}`} />
@@ -237,7 +237,7 @@ export const DebugConsolePage: FC = () => {
                   setProtocolFilter('All');
                   setSearchQuery('');
                 }}
-                className="text-brand-400 hover:text-brand-300 underline"
+                className="text-brand-accent hover:text-brand-accent underline"
               >
                 Clear filters
               </button>

--- a/ui/src/pages/DeviceListPage.tsx
+++ b/ui/src/pages/DeviceListPage.tsx
@@ -61,7 +61,7 @@ export const DeviceListPage: FC = () => {
   return (
     <div className="space-y-6">
       {/* Header section */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           <DeviceListHeader
             deviceCount={devices.length}

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -72,7 +72,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
 
   if (devices.length === 0) {
     return (
-      <div className="rounded-xl border border-white/5 bg-bg-base/50 p-8 text-center text-text-muted">
+      <div className="rounded-xl border border-surface-border bg-bg-base/50 p-8 text-center text-text-muted">
         No devices defined in the loaded configuration.
       </div>
     );
@@ -80,7 +80,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
 
   if (!useVirtualization) {
     return (
-      <div className="overflow-x-auto rounded-xl border border-white/5">
+      <div className="overflow-x-auto rounded-xl border border-surface-border">
         <table className="min-w-full divide-y divide-white/10 text-sm">
           <thead className="bg-bg-surface/60 text-xs uppercase tracking-wide text-text-muted">
             <tr>
@@ -101,7 +101,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
   }
 
   return (
-    <div className="rounded-xl border border-white/5">
+    <div className="rounded-xl border border-surface-border">
       <div className="bg-bg-surface/60 px-4 py-2 text-xs text-text-muted">
         Showing {virtualScroll.visibleItems.length} of {devices.length} devices (virtual scrolling
         enabled)
@@ -261,7 +261,7 @@ const ConfigEditorCard: FC = () => {
           <CardRow label="Updated" value={formatTime(cfg.modifiedAt)} />
           <CardRow label="Size" value={formatBytes(cfg.sizeBytes)} />
           <textarea
-            className="mt-3 h-72 w-full rounded-xl border border-white/10 bg-bg-base/70 p-3 font-mono text-sm text-text-primary shadow-inner focus:border-brand-400 focus:outline-none"
+            className="mt-3 h-72 w-full rounded-xl border border-surface-border bg-bg-base/70 p-3 font-mono text-sm text-text-primary shadow-inner focus:border-brand-accent focus:outline-none"
             value={value}
             onChange={handleChange}
             spellCheck={false}
@@ -312,11 +312,11 @@ const WalkFileBrowser: FC<{
   return (
     <div className="space-y-2">
       <SmallText className="text-text-muted">Available SNMP walks</SmallText>
-      <div className="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-white/10 bg-bg-base/50 p-2 text-sm text-text-secondary">
+      <div className="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-surface-border bg-bg-base/50 p-2 text-sm text-text-secondary">
         {files.map((file) => (
           <div
             key={file.name}
-            className="flex items-center justify-between gap-2 rounded-lg border border-white/5 bg-bg-surface/50 px-3 py-2"
+            className="flex items-center justify-between gap-2 rounded-lg border border-surface-border bg-bg-surface/50 px-3 py-2"
           >
             <div>
               <p className="text-text-primary">{file.name}</p>

--- a/ui/src/pages/LibraryFilesPage.tsx
+++ b/ui/src/pages/LibraryFilesPage.tsx
@@ -45,7 +45,7 @@ function LibraryFilesView({ kind }: Props) {
 
   return (
     <div className="space-y-6">
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div className="flex items-center gap-3">
@@ -70,7 +70,7 @@ function LibraryFilesView({ kind }: Props) {
                   onChange={(e) => setSearch(e.target.value)}
                   placeholder="Search by name…"
                   aria-label="Filter library entries by name"
-                  className="w-64 rounded-md border border-white/10 bg-bg-base/40 pl-7 pr-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+                  className="w-64 rounded-md border border-surface-border bg-bg-base/40 pl-7 pr-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
                 />
               </div>
               <Button
@@ -88,7 +88,7 @@ function LibraryFilesView({ kind }: Props) {
         </CardContent>
       </Card>
 
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent>
           {error ? (
             <SmallText className="text-status-error">
@@ -103,7 +103,7 @@ function LibraryFilesView({ kind }: Props) {
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead className="text-xs text-text-muted uppercase tracking-wide">
-                  <tr className="border-b border-white/10">
+                  <tr className="border-b border-surface-border">
                     <th className="text-left py-2 pr-4">Name</th>
                     <th className="text-right py-2 pr-4">Size</th>
                     <th className="text-left py-2 pr-4">Source</th>
@@ -112,7 +112,7 @@ function LibraryFilesView({ kind }: Props) {
                 </thead>
                 <tbody className="text-text-primary">
                   {filtered.map((entry) => (
-                    <tr key={entry.name} className="border-b border-white/5 last:border-0">
+                    <tr key={entry.name} className="border-b border-surface-border last:border-0">
                       <td className="py-2 pr-4 font-mono text-xs">{entry.name}</td>
                       <td className="py-2 pr-4 text-right tabular-nums">
                         {humanBytes(entry.sizeBytes)}
@@ -144,7 +144,7 @@ function LibraryFilesView({ kind }: Props) {
 
 const SourceBadge: FC<{ source: LibraryFileEntry['source'] }> = ({ source }) => {
   const styles: Record<LibraryFileEntry['source'], string> = {
-    starter: 'border-brand-500/40 bg-brand-500/10 text-brand-200',
+    starter: 'border-brand-primary/40 bg-brand-primary/10 text-brand-accent',
     bundle: 'border-status-info/40 bg-status-info/10 text-status-info',
     user: 'border-status-success/40 bg-status-success/10 text-status-success',
   };

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -275,7 +275,7 @@ export const PacketInspectorPage: FC = () => {
     <div className="space-y-6">
       {/* Live / PCAP Files tab control */}
       <div
-        className="inline-flex rounded-lg border border-white/10 bg-bg-base/40 p-0.5"
+        className="inline-flex rounded-lg border border-surface-border bg-bg-base/40 p-0.5"
         role="tablist"
         aria-label="Packets view"
       >
@@ -286,8 +286,8 @@ export const PacketInspectorPage: FC = () => {
           onClick={() => setView('live')}
           className={`flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
             view === 'live'
-              ? 'bg-brand-500/20 text-brand-100'
-              : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
+              ? 'bg-brand-primary/20 text-brand-accent'
+              : 'text-text-muted hover:bg-surface-hover hover:text-text-primary'
           }`}
         >
           <Radio className="w-3.5 h-3.5" />
@@ -300,8 +300,8 @@ export const PacketInspectorPage: FC = () => {
           onClick={() => setView('files')}
           className={`flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
             view === 'files'
-              ? 'bg-brand-500/20 text-brand-100'
-              : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
+              ? 'bg-brand-primary/20 text-brand-accent'
+              : 'text-text-muted hover:bg-surface-hover hover:text-text-primary'
           }`}
         >
           <FileBox className="w-3.5 h-3.5" />
@@ -316,7 +316,7 @@ export const PacketInspectorPage: FC = () => {
       {view === 'live' && (
         <>
           {/* Header with controls */}
-          <Card className="border-white/5 bg-bg-surface/70">
+          <Card className="border-surface-border bg-bg-surface/70">
             <CardContent>
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 {/* Title and connection status */}
@@ -424,7 +424,7 @@ export const PacketInspectorPage: FC = () => {
                     type="checkbox"
                     checked={autoScroll}
                     onChange={(e) => setAutoScroll(e.target.checked)}
-                    className="rounded border-border-muted bg-bg-elevated text-brand-500 focus:ring-brand-400 focus:ring-offset-gray-900"
+                    className="rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-accent focus:ring-offset-gray-900"
                   />
                   <SmallText className="text-text-muted">Auto-scroll</SmallText>
                 </label>
@@ -438,7 +438,7 @@ export const PacketInspectorPage: FC = () => {
           </Card>
 
           {/* BPF Capture Filter */}
-          <Card className="border-white/5 bg-bg-surface/70">
+          <Card className="border-surface-border bg-bg-surface/70">
             <CardContent>
               <BpfFilterBar />
             </CardContent>
@@ -448,7 +448,7 @@ export const PacketInspectorPage: FC = () => {
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
             {/* Packet List - Left sidebar */}
             <div className="lg:col-span-4 xl:col-span-3">
-              <Card className="border-white/5 bg-bg-surface/70 h-[600px]">
+              <Card className="border-surface-border bg-bg-surface/70 h-[600px]">
                 <CardContent className="h-full flex flex-col">
                   <div className="flex items-center justify-between mb-3">
                     <SmallText className="text-text-muted uppercase tracking-wide font-semibold">
@@ -476,7 +476,7 @@ export const PacketInspectorPage: FC = () => {
             {/* Right panel - Hex dump and details */}
             <div className="lg:col-span-8 xl:col-span-9 space-y-6">
               {/* Hex Dump Viewer */}
-              <Card className="border-white/5 bg-bg-surface/70 h-[350px]">
+              <Card className="border-surface-border bg-bg-surface/70 h-[350px]">
                 <CardContent className="h-full flex flex-col">
                   <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                     Hex Dump
@@ -492,7 +492,7 @@ export const PacketInspectorPage: FC = () => {
               </Card>
 
               {/* Packet Details */}
-              <Card className="border-white/5 bg-bg-surface/70 h-[220px]">
+              <Card className="border-surface-border bg-bg-surface/70 h-[220px]">
                 <CardContent className="h-full flex flex-col">
                   <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                     Packet Details
@@ -580,10 +580,10 @@ const StandaloneCaptureStarter: FC<{
   }, [bpfFilter, busy, onStarted, selectedIface]);
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex items-start gap-3">
-          <Activity className={`mt-1 ${iconSizes.lg} text-brand-300`} />
+          <Activity className={`mt-1 ${iconSizes.lg} text-brand-accent`} />
           <div className="flex-1">
             <p className="font-semibold text-text-primary">Standalone packet capture</p>
             <SmallText className="text-text-muted">
@@ -592,7 +592,7 @@ const StandaloneCaptureStarter: FC<{
               <button
                 type="button"
                 onClick={navigateToSim}
-                className="text-brand-300 underline hover:text-brand-200"
+                className="text-brand-accent underline hover:text-brand-accent"
               >
                 start a simulation
               </button>{' '}
@@ -607,7 +607,7 @@ const StandaloneCaptureStarter: FC<{
               value={selectedIface}
               onChange={(e) => setSelectedIface(e.target.value)}
               disabled={busy || interfaces.length === 0}
-              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-2 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+              className="rounded-lg border border-surface-border bg-bg-base/60 px-3 py-2 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
             >
               {interfaces.length === 0 ? (
                 <option value="">No interfaces detected</option>
@@ -631,7 +631,7 @@ const StandaloneCaptureStarter: FC<{
               onChange={(e) => setBpfFilter(e.target.value)}
               disabled={busy}
               placeholder="e.g. tcp port 80"
-              className="rounded-lg border border-white/10 bg-bg-base/60 px-3 py-2 font-mono text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+              className="rounded-lg border border-surface-border bg-bg-base/60 px-3 py-2 font-mono text-sm text-text-primary focus:border-brand-accent focus:outline-none"
             />
           </label>
           <Button tone="violet" onClick={handleStart} disabled={!selectedIface || busy}>

--- a/ui/src/pages/PcapAnalyzerPage.tsx
+++ b/ui/src/pages/PcapAnalyzerPage.tsx
@@ -226,13 +226,13 @@ export const PcapAnalyzerPage: FC = () => {
       {analysisResult && (
         <>
           {/* Controls Header */}
-          <Card className="border-white/5 bg-bg-surface/70">
+          <Card className="border-surface-border bg-bg-surface/70">
             <CardContent>
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 {/* Title and file info */}
                 <div className="flex items-center gap-4">
                   <H2 className="flex items-center gap-2">
-                    <FileSearch className={`${iconSizes.lg} text-brand-400`} />
+                    <FileSearch className={`${iconSizes.lg} text-brand-accent`} />
                     PCAP Analysis
                   </H2>
                   <Tag colorScheme="green">{analysisResult.packets.length} packets</Tag>
@@ -241,14 +241,14 @@ export const PcapAnalyzerPage: FC = () => {
                 {/* Control buttons */}
                 <div className="flex flex-wrap items-center gap-2">
                   {/* View Mode Toggle */}
-                  <div className="flex rounded-lg border border-white/10 bg-bg-base/50 p-1">
+                  <div className="flex rounded-lg border border-surface-border bg-bg-base/50 p-1">
                     <button
                       type="button"
                       onClick={() => setViewMode('packets')}
                       title="Show every decoded packet with timestamp, headers, and payload"
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'packets'
-                          ? 'bg-brand-600 text-text-primary'
+                          ? 'bg-brand-primary text-text-primary'
                           : 'text-text-muted hover:text-text-primary'
                       }`}
                     >
@@ -260,7 +260,7 @@ export const PcapAnalyzerPage: FC = () => {
                       title="Show aggregate statistics: byte/packet totals per protocol and per host"
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'stats'
-                          ? 'bg-brand-600 text-text-primary'
+                          ? 'bg-brand-primary text-text-primary'
                           : 'text-text-muted hover:text-text-primary'
                       }`}
                     >
@@ -272,7 +272,7 @@ export const PcapAnalyzerPage: FC = () => {
                       title="Group packets by 5-tuple to see TCP/UDP flows and byte totals per conversation"
                       className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
                         viewMode === 'conversations'
-                          ? 'bg-brand-600 text-text-primary'
+                          ? 'bg-brand-primary text-text-primary'
                           : 'text-text-muted hover:text-text-primary'
                       }`}
                     >
@@ -346,7 +346,7 @@ export const PcapAnalyzerPage: FC = () => {
                 {/* Right panel - Details */}
                 <div className="lg:col-span-5 xl:col-span-4 space-y-6">
                   {/* Hex Dump Viewer */}
-                  <Card className="border-white/5 bg-bg-surface/70 h-[280px]">
+                  <Card className="border-surface-border bg-bg-surface/70 h-[280px]">
                     <CardContent className="h-full flex flex-col">
                       <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                         Hex Dump
@@ -362,7 +362,7 @@ export const PcapAnalyzerPage: FC = () => {
                   </Card>
 
                   {/* Packet Details */}
-                  <Card className="border-white/5 bg-bg-surface/70 h-[280px]">
+                  <Card className="border-surface-border bg-bg-surface/70 h-[280px]">
                     <CardContent className="h-full flex flex-col">
                       <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-3">
                         Packet Details
@@ -401,7 +401,7 @@ export const PcapAnalyzerPage: FC = () => {
 
       {/* Info Banner when no file is loaded */}
       {!(analysisResult || selectedFile) && (
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent>
             <div className="flex items-start gap-3">
               <Info className={`${iconSizes.lg} text-status-info flex-shrink-0 mt-0.5`} />

--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -238,14 +238,14 @@ export const RuntimeControlPage: FC = () => {
 
       {/* Start Simulation Card */}
       {isDaemonMode && !simStatus?.running && (
-        <Card className="border-white/5 bg-gradient-to-br from-brand-900/30 to-bg-surface/70">
+        <Card className="border-surface-border bg-gradient-to-br from-brand-primary/30 to-bg-surface/70">
           <CardContent className="space-y-4">
             {/* Single-row action bar: interface + start. The interface
                 dropdown takes the natural width of its content; Start sits
                 immediately next to it so the action is obvious. */}
             <div className="flex flex-wrap items-end gap-3">
               <div className="flex items-center gap-3">
-                <PlugZap className={`${iconSizes.xl} text-brand-400`} />
+                <PlugZap className={`${iconSizes.xl} text-brand-accent`} />
                 <H2>Start Simulation</H2>
               </div>
               <div className="ml-auto flex flex-wrap items-end gap-3">
@@ -263,7 +263,7 @@ export const RuntimeControlPage: FC = () => {
                       onChange={handleInterfaceChange}
                       disabled={interfacesLoading || interfaces.length === 0}
                       title="Pick the host interface the daemon should bind to. Loopback (lo0/lo) is safest for local testing."
-                      className="w-full rounded border border-white/10 bg-bg-elevated py-2 pl-10 pr-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                      className="w-full rounded border border-surface-border bg-bg-elevated py-2 pl-10 pr-3 text-sm text-text-primary focus:border-brand-accent focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {interfacesLoading && <option value="">Loading…</option>}
                       {!interfacesLoading && interfaces.length === 0 && (
@@ -290,7 +290,7 @@ export const RuntimeControlPage: FC = () => {
                   // Pulse the button when everything's picked so it's the obvious next click.
                   className={
                     hasValidConfig && !starting
-                      ? 'animate-pulse shadow-lg shadow-brand-500/30'
+                      ? 'animate-pulse shadow-lg shadow-brand-primary/30'
                       : undefined
                   }
                   title={
@@ -307,7 +307,7 @@ export const RuntimeControlPage: FC = () => {
             </div>
 
             {/* Picked-config status pill */}
-            <div className="flex items-center justify-between rounded border border-white/5 bg-bg-surface/40 px-3 py-2 text-xs">
+            <div className="flex items-center justify-between rounded border border-surface-border bg-bg-surface/40 px-3 py-2 text-xs">
               <span className="text-text-muted">Configuration:</span>
               {simulationSettings.configName || quickUploadFile ? (
                 <SmallText className="text-status-success">

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -547,7 +547,7 @@ export const TopologyPage: FC = () => {
   return (
     <div className="space-y-6">
       {/* Header Card */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div className="flex items-center gap-3">
@@ -566,7 +566,7 @@ export const TopologyPage: FC = () => {
 
             <div className="flex flex-wrap items-center gap-2">
               <div
-                className="inline-flex rounded-lg border border-white/10 bg-bg-base/40 p-0.5"
+                className="inline-flex rounded-lg border border-surface-border bg-bg-base/40 p-0.5"
                 role="tablist"
                 aria-label="Topology view"
               >
@@ -579,7 +579,7 @@ export const TopologyPage: FC = () => {
                   className={`flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
                     view === 'graph'
                       ? 'bg-status-info/20 text-status-info'
-                      : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
+                      : 'text-text-muted hover:bg-surface-hover hover:text-text-primary'
                   }`}
                 >
                   <Network className="w-3.5 h-3.5" />
@@ -594,7 +594,7 @@ export const TopologyPage: FC = () => {
                   className={`flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
                     view === 'neighbors'
                       ? 'bg-status-info/20 text-status-info'
-                      : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
+                      : 'text-text-muted hover:bg-surface-hover hover:text-text-primary'
                   }`}
                 >
                   <Radar className="w-3.5 h-3.5" />
@@ -651,7 +651,7 @@ export const TopologyPage: FC = () => {
                       the existing Graph/Neighbors view picker above,
                       which uses tablist; we use aria-pressed instead so
                       either pattern (radio or toggle) reads cleanly. */}
-                  <div className="inline-flex rounded-lg border border-white/10 bg-bg-base/40 p-0.5">
+                  <div className="inline-flex rounded-lg border border-surface-border bg-bg-base/40 p-0.5">
                     {LAYOUT_MODES.map((entry) => {
                       const active = layoutMode === entry.mode;
                       return (
@@ -665,7 +665,7 @@ export const TopologyPage: FC = () => {
                           className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
                             active
                               ? 'bg-status-info/20 text-status-info'
-                              : 'text-text-muted hover:bg-white/5 hover:text-text-primary'
+                              : 'text-text-muted hover:bg-surface-hover hover:text-text-primary'
                           }`}
                         >
                           {entry.label}
@@ -690,7 +690,7 @@ export const TopologyPage: FC = () => {
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search devices by name…"
                 aria-label="Filter devices by name"
-                className="w-full sm:w-64 rounded-md border border-white/10 bg-bg-base/40 px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+                className="w-full sm:w-64 rounded-md border border-surface-border bg-bg-base/40 px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
               />
               {availableTypes.length > 0 && (
                 <div className="flex flex-wrap items-center gap-1.5">
@@ -711,7 +711,7 @@ export const TopologyPage: FC = () => {
                         className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium capitalize transition-colors ${
                           active
                             ? 'border-status-info/40 bg-status-info/20 text-status-info'
-                            : 'border-white/10 bg-bg-base/40 text-text-muted hover:bg-white/5 hover:text-text-primary'
+                            : 'border-surface-border bg-bg-base/40 text-text-muted hover:bg-surface-hover hover:text-text-primary'
                         }`}
                       >
                         {type}
@@ -740,12 +740,12 @@ export const TopologyPage: FC = () => {
           ≈ 240 px on this layout). Gives much more room for the graph
           on standard 1080p+ displays. */}
       {view === 'graph' && (
-        <Card className="border-white/5 bg-bg-surface/70 overflow-hidden">
+        <Card className="border-surface-border bg-bg-surface/70 overflow-hidden">
           <div className="h-[calc(100vh-260px)] min-h-[520px] relative">
             {loading ? (
               <div className="absolute inset-0 flex items-center justify-center">
                 <div className="flex flex-col items-center gap-3">
-                  <RefreshCw className="w-8 h-8 text-brand-400 animate-spin" />
+                  <RefreshCw className="w-8 h-8 text-brand-accent animate-spin" />
                   <SmallText className="text-text-muted">Loading topology...</SmallText>
                 </div>
               </div>

--- a/ui/src/pages/TrafficInjectionPage.tsx
+++ b/ui/src/pages/TrafficInjectionPage.tsx
@@ -41,7 +41,7 @@ export const TrafficInjectionPage: FC = () => {
       </div>
 
       {/* Recent runs — previously lived on the standalone /analysis page */}
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-3">
           <div className="flex items-center justify-between">
             <H2 className="flex items-center gap-2 text-lg">
@@ -55,7 +55,10 @@ export const TrafficInjectionPage: FC = () => {
           </SmallText>
           <div className="space-y-2 text-sm text-text-secondary">
             {(history ?? []).slice(0, 5).map((item) => (
-              <div key={item.id} className="rounded-lg border border-white/5 bg-bg-base/50 p-3">
+              <div
+                key={item.id}
+                className="rounded-lg border border-surface-border bg-bg-base/50 p-3"
+              >
                 <p className="text-text-primary font-semibold">{item.configName}</p>
                 <SmallText className="text-text-muted">
                   {formatTime(item.startedAt)} · duration {formatDuration(item.duration)} · RX{' '}

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -92,7 +92,7 @@ export const WalkValidatorPage: FC = () => {
 
   return (
     <div className="space-y-6">
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-4">
           <header>
             <h1 className="text-2xl font-semibold text-text-primary">SNMP Walks</h1>
@@ -110,7 +110,7 @@ export const WalkValidatorPage: FC = () => {
                 onChange={(e) => setSelectedFile(e.target.value)}
                 disabled={filesLoading || files.length === 0}
                 title="Hydrated from /api/v1/files?kind=walks (the sandboxed walks directory). Use the absolute-path field to validate a walk outside this directory."
-                className="mt-1 w-full rounded border border-white/5 bg-bg-base/60 px-3 py-2 text-sm text-text-primary focus:border-status-info focus:outline-none disabled:opacity-50"
+                className="mt-1 w-full rounded border border-surface-border bg-bg-base/60 px-3 py-2 text-sm text-text-primary focus:border-status-info focus:outline-none disabled:opacity-50"
               >
                 {filesLoading && <option>Loading…</option>}
                 {!filesLoading && files.length === 0 && <option>No walks found</option>}
@@ -133,7 +133,7 @@ export const WalkValidatorPage: FC = () => {
                 onChange={(e) => setCustomPath(e.target.value)}
                 placeholder="/srv/niac/walks/cisco-c9300.walk"
                 title="Absolute path to a walk file. Takes precedence over the dropdown selection. The path is bounded server-side; ../ traversal is rejected."
-                className="mt-1 w-full rounded border border-white/5 bg-bg-base/60 px-3 py-2 font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
+                className="mt-1 w-full rounded border border-surface-border bg-bg-base/60 px-3 py-2 font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
               />
             </label>
           </div>
@@ -167,7 +167,7 @@ export const WalkValidatorPage: FC = () => {
       </Card>
 
       {response?.result && (
-        <Card className="border-white/5 bg-bg-surface/70">
+        <Card className="border-surface-border bg-bg-surface/70">
           <CardContent className="space-y-4">
             <header className="flex flex-wrap items-baseline gap-4">
               <h2 className="text-lg font-semibold text-text-primary">

--- a/ui/src/pages/config-diff/FileUploadZone.tsx
+++ b/ui/src/pages/config-diff/FileUploadZone.tsx
@@ -123,7 +123,7 @@ export const FileUploadZone: FC<FileUploadZoneProps> = ({
             type="button"
             onClick={onClear}
             disabled={disabled}
-            className="rounded-lg p-1.5 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors disabled:opacity-50"
+            className="rounded-lg p-1.5 text-text-muted hover:bg-surface-hover hover:text-text-primary transition-colors disabled:opacity-50"
             aria-label={`Remove ${file.name}`}
           >
             <X className={iconSizes.md} />
@@ -138,8 +138,8 @@ export const FileUploadZone: FC<FileUploadZoneProps> = ({
       <label
         className={`block rounded-xl border-2 border-dashed p-6 text-center transition-colors cursor-pointer ${
           dragOver
-            ? 'border-brand-400 bg-brand-500/10'
-            : 'border-white/20 hover:border-brand-400/50 hover:bg-bg-base/50'
+            ? 'border-brand-accent bg-brand-primary/10'
+            : 'border-surface-border hover:border-brand-accent/50 hover:bg-bg-base/50'
         } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}

--- a/ui/src/pages/runtime/AdvancedSection.tsx
+++ b/ui/src/pages/runtime/AdvancedSection.tsx
@@ -11,7 +11,7 @@ export const AdvancedSection: FC = () => {
   const [open, setOpen] = useState(false);
   return (
     <details
-      className="rounded border border-white/10 bg-bg-base/40"
+      className="rounded border border-surface-border bg-bg-base/40"
       open={open}
       onToggle={(e) => setOpen(e.currentTarget.open)}
     >
@@ -20,7 +20,7 @@ export const AdvancedSection: FC = () => {
         <span>Advanced</span>
         <SmallText className="text-text-muted">(global protocol debug level)</SmallText>
       </summary>
-      <div className="border-t border-white/10 p-3">
+      <div className="border-t border-surface-border p-3">
         <GlobalDebugLevelCard />
       </div>
     </details>

--- a/ui/src/pages/runtime/GlobalDebugLevelCard.tsx
+++ b/ui/src/pages/runtime/GlobalDebugLevelCard.tsx
@@ -46,10 +46,10 @@ export const GlobalDebugLevelCard: FC = () => {
   };
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-3">
         <H2 className="flex items-center gap-2 text-lg">
-          <Activity className={`${iconSizes.lg} text-brand-300`} />
+          <Activity className={`${iconSizes.lg} text-brand-accent`} />
           Debug level
         </H2>
         <SmallText className="text-text-muted">
@@ -60,7 +60,7 @@ export const GlobalDebugLevelCard: FC = () => {
             value={current}
             onChange={(e) => setPending(e.target.value as DebugLevel)}
             disabled={busy || !data}
-            className="rounded border border-white/10 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-400 focus:outline-none disabled:opacity-50"
+            className="rounded border border-surface-border bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary focus:border-brand-accent focus:outline-none disabled:opacity-50"
             aria-label="Global debug level"
             title="Applies to every protocol in the running stack. OFF silences everything; TRACE is the loudest."
           >

--- a/ui/src/pages/runtime/SelectedNetworkPreview.tsx
+++ b/ui/src/pages/runtime/SelectedNetworkPreview.tsx
@@ -146,11 +146,11 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
   const displayName = uploadFile?.name ?? name;
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-3">
         <div className="flex items-baseline justify-between gap-3">
           <H2 className="flex items-center gap-2 text-lg">
-            <Eye className={`${iconSizes.lg} text-brand-300`} />
+            <Eye className={`${iconSizes.lg} text-brand-accent`} />
             Selected: {displayName}
           </H2>
           <SmallText className="text-text-muted">Preview only — Start to launch</SmallText>
@@ -177,7 +177,7 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
               return (
                 <li
                   key={d.name}
-                  className="rounded-lg border border-white/10 bg-bg-base/40 px-3 py-2"
+                  className="rounded-lg border border-surface-border bg-bg-base/40 px-3 py-2"
                 >
                   <div className="flex items-center gap-2">
                     <Icon className={`${iconSizes.sm} text-text-muted`} />

--- a/ui/src/pages/templates/TemplateStates.tsx
+++ b/ui/src/pages/templates/TemplateStates.tsx
@@ -15,11 +15,11 @@ export const TemplatesLoadingState: FC<LoadingStateProps> = ({ show }) => {
   }
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="flex items-center justify-center py-12">
         <div className="flex items-center gap-3 text-text-muted">
           <div
-            className={`${iconSizes.lg} animate-spin rounded-full border-2 border-brand-500 border-t-transparent`}
+            className={`${iconSizes.lg} animate-spin rounded-full border-2 border-brand-primary border-t-transparent`}
           />
           <span>Loading templates...</span>
         </div>
@@ -67,7 +67,7 @@ export const TemplatesEmptyState: FC<EmptyStateProps> = ({ show, onUploadClick }
   }
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="py-12 text-center">
         <FileCode className={`mx-auto ${iconSizes['3xl']} text-text-disabled`} />
         <H2 className="mt-4 mb-2">No Templates Available</H2>
@@ -101,7 +101,7 @@ export const TemplatesNoResultsState: FC<NoResultsStateProps> = ({
   }
 
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="py-12 text-center">
         <Search className={`mx-auto ${iconSizes['3xl']} text-text-disabled`} />
         <H2 className="mt-4 mb-2">No Matching Templates</H2>

--- a/ui/src/pages/templates/TemplatesHeader.tsx
+++ b/ui/src/pages/templates/TemplatesHeader.tsx
@@ -22,12 +22,12 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
   onDismissMessage,
 }) => {
   return (
-    <Card className="border-white/5 bg-bg-surface/70">
+    <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
             <H2 className="flex items-center gap-2">
-              <FileCode className={`${iconSizes.lg} text-brand-300`} />
+              <FileCode className={`${iconSizes.lg} text-brand-accent`} />
               Configuration Templates
             </H2>
             <P className="text-text-muted mt-1">
@@ -53,7 +53,7 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
             placeholder="Search templates by name, description, or type..."
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
-            className="w-full rounded-lg border border-white/10 bg-bg-base/60 py-3 pl-10 pr-10 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+            className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-3 pl-10 pr-10 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
           />
           {searchQuery && (
             <button

--- a/ui/src/pages/templates/UploadTemplateModal.tsx
+++ b/ui/src/pages/templates/UploadTemplateModal.tsx
@@ -92,16 +92,16 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
         aria-label="Close upload modal"
       />
       <div
-        className="relative mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl"
+        className="relative mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
         aria-labelledby="upload-modal-title"
       >
         {/* Modal Header */}
-        <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+        <div className="flex items-center justify-between border-b border-surface-border px-6 py-4">
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-brand-500/20 p-2">
-              <Upload className={`${iconSizes.lg} text-brand-300`} />
+            <div className="rounded-lg bg-brand-primary/20 p-2">
+              <Upload className={`${iconSizes.lg} text-brand-accent`} />
             </div>
             <div>
               <h2 id="upload-modal-title" className="text-lg font-semibold text-text-primary">
@@ -113,7 +113,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 text-text-muted hover:bg-white/10 hover:text-text-primary transition-colors"
+            className="rounded-lg p-2 text-text-muted hover:bg-surface-hover hover:text-text-primary transition-colors"
             aria-label="Close modal"
           >
             <X className={iconSizes.lg} />
@@ -135,7 +135,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               type="file"
               accept=".yaml,.yml"
               onChange={(e) => handleFileChange(e.target.files?.[0] || null)}
-              className="w-full cursor-pointer rounded-lg border border-dashed border-white/20 bg-bg-base/40 p-3 text-sm text-text-primary file:mr-3 file:rounded-md file:border-0 file:bg-brand-600 file:px-3 file:py-1 file:text-sm file:font-medium"
+              className="w-full cursor-pointer rounded-lg border border-dashed border-surface-border bg-bg-base/40 p-3 text-sm text-text-primary file:mr-3 file:rounded-md file:border-0 file:bg-brand-primary file:px-3 file:py-1 file:text-sm file:font-medium"
             />
             {uploadFile && (
               <SmallText className="mt-1 text-status-success">
@@ -158,7 +158,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g., Basic Network"
-              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
             />
           </div>
 
@@ -176,7 +176,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Brief description of this template..."
               rows={2}
-              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none resize-none"
+              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
             />
           </div>
 
@@ -192,7 +192,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               id="template-type"
               value={type}
               onChange={(e) => setType(e.target.value as Template['type'])}
-              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-400 focus:outline-none"
+              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
             >
               <option value="basic">Basic Network</option>
               <option value="router">Router</option>
@@ -218,14 +218,14 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
               onChange={(e) => setContent(e.target.value)}
               placeholder="Paste your YAML configuration here..."
               rows={10}
-              className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 font-mono text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none resize-none"
+              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 font-mono text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
               spellCheck={false}
             />
           </div>
         </div>
 
         {/* Modal Footer */}
-        <div className="flex justify-end gap-3 border-t border-white/10 px-6 py-4 bg-bg-base/50">
+        <div className="flex justify-end gap-3 border-t border-surface-border px-6 py-4 bg-bg-base/50">
           <Button variant="outline" onClick={onClose} disabled={uploading}>
             Cancel
           </Button>

--- a/ui/src/pages/topology/ActionsMenu.tsx
+++ b/ui/src/pages/topology/ActionsMenu.tsx
@@ -61,13 +61,13 @@ export const ActionsMenu: FC<{
       {open && (
         <div
           role="menu"
-          className="absolute right-0 mt-1 min-w-[180px] rounded-md border border-white/10 bg-bg-base/95 py-1 text-xs text-text-primary shadow-xl backdrop-blur z-50"
+          className="absolute right-0 mt-1 min-w-[180px] rounded-md border border-surface-border bg-bg-base/95 py-1 text-xs text-text-primary shadow-xl backdrop-blur z-50"
         >
           <button
             type="button"
             role="menuitem"
             onClick={handle(onExportPNG)}
-            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-text-primary"
+            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-surface-hover hover:text-text-primary"
           >
             <span>Export as PNG</span>
             <span className="text-[10px] text-text-muted">image</span>
@@ -76,7 +76,7 @@ export const ActionsMenu: FC<{
             type="button"
             role="menuitem"
             onClick={handle(onExportJSON)}
-            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-white/5 hover:text-text-primary"
+            className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-surface-hover hover:text-text-primary"
           >
             <span>Export topology JSON</span>
             <span className="text-[10px] text-text-muted">data</span>

--- a/ui/src/pages/topology/ContextMenu.tsx
+++ b/ui/src/pages/topology/ContextMenu.tsx
@@ -101,7 +101,7 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
       // [9999] because the topology page sits inside a stacking
       // context (the Card chrome creates one) and z-50 lost to
       // ReactFlow's own overlay elements in earlier versions.
-      className="fixed z-[9999] min-w-[180px] rounded-md border border-white/10 bg-bg-base/95 py-1 text-xs text-text-primary shadow-xl backdrop-blur"
+      className="fixed z-[9999] min-w-[180px] rounded-md border border-surface-border bg-bg-base/95 py-1 text-xs text-text-primary shadow-xl backdrop-blur"
       style={{ left: clampedX, top: clampedY }}
       // Stop right-click on the menu itself from re-opening the pane
       // menu through ReactFlow's onPaneContextMenu.
@@ -110,7 +110,9 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
     >
       {items.map((item, idx) => (
         <div key={item.key}>
-          {item.separatorBefore && idx > 0 && <hr className="my-1 h-px border-0 bg-white/10" />}
+          {item.separatorBefore && idx > 0 && (
+            <hr className="my-1 h-px border-0 bg-surface-hover" />
+          )}
           <button
             type="button"
             role="menuitem"
@@ -121,7 +123,7 @@ export const ContextMenu: FC<Props> = ({ x, y, items, onClose }) => {
                 ? 'text-text-disabled cursor-not-allowed'
                 : item.destructive
                   ? 'text-status-error hover:bg-status-error/15 hover:text-status-error'
-                  : 'hover:bg-white/5 hover:text-text-primary'
+                  : 'hover:bg-surface-hover hover:text-text-primary'
             }`}
           >
             <span>{item.label}</span>

--- a/ui/src/pages/topology/DeviceDetailsPanel.tsx
+++ b/ui/src/pages/topology/DeviceDetailsPanel.tsx
@@ -34,7 +34,7 @@ export const DeviceDetailsPanel: FC<DeviceDetailsPanelProps> = ({ device, onClos
   const color = deviceColors[deviceType] || deviceColors.unknown;
 
   return (
-    <div className="absolute top-4 right-4 w-80 bg-bg-elevated/95 backdrop-blur-sm border border-white/10 rounded-xl p-4 shadow-2xl z-50">
+    <div className="absolute top-4 right-4 w-80 bg-bg-elevated/95 backdrop-blur-sm border border-surface-border rounded-xl p-4 shadow-2xl z-50">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <div

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -35,7 +35,7 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
       type="button"
       className={`
         relative px-4 py-3 rounded-xl border-2 transition-all duration-200 text-left
-        ${selected ? 'ring-2 ring-brand-500 ring-offset-2 ring-offset-gray-900' : ''}
+        ${selected ? 'ring-2 ring-brand-primary ring-offset-2 ring-offset-gray-900' : ''}
         hover:shadow-lg hover:shadow-black/30
       `}
       style={{
@@ -59,12 +59,12 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
       <Handle
         type="target"
         position={Position.Left}
-        className="!w-2 !h-2 !bg-brand-400 !border-0"
+        className="!w-2 !h-2 !bg-brand-accent !border-0"
       />
       <Handle
         type="source"
         position={Position.Right}
-        className="!w-2 !h-2 !bg-brand-400 !border-0"
+        className="!w-2 !h-2 !bg-brand-accent !border-0"
       />
 
       {/* Status indicator */}
@@ -90,7 +90,7 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
 
       {/* IPs */}
       {data.ips && data.ips.length > 0 && (
-        <div className="mt-2 pt-2 border-t border-white/10">
+        <div className="mt-2 pt-2 border-t border-surface-border">
           <div className="text-xs font-mono text-text-muted truncate">
             {data.ips[0]}
             {data.ips.length > 1 && (
@@ -106,13 +106,13 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
           {data.protocols.slice(0, 3).map((proto) => (
             <span
               key={proto}
-              className="px-1.5 py-0.5 text-[10px] rounded-md bg-white/10 text-text-secondary"
+              className="px-1.5 py-0.5 text-[10px] rounded-md bg-surface-hover text-text-secondary"
             >
               {proto}
             </span>
           ))}
           {data.protocols.length > 3 && (
-            <span className="px-1.5 py-0.5 text-[10px] rounded-md bg-white/5 text-text-muted">
+            <span className="px-1.5 py-0.5 text-[10px] rounded-md bg-surface-hover text-text-muted">
               +{data.protocols.length - 3}
             </span>
           )}

--- a/ui/src/pages/topology/NeighborsView.tsx
+++ b/ui/src/pages/topology/NeighborsView.tsx
@@ -127,7 +127,7 @@ export const NeighborsView: FC = () => {
 
   return (
     <div className="space-y-4">
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="space-y-3">
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex items-center gap-2">
@@ -162,7 +162,7 @@ export const NeighborsView: FC = () => {
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Filter by device or chassis ID…"
               title="Substring match on local device, remote device, chassis ID, or remote port (case-insensitive)."
-              className="ml-auto w-64 rounded border border-white/5 bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
+              className="ml-auto w-64 rounded border border-surface-border bg-bg-base/60 px-3 py-1.5 text-sm text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
               aria-label="Filter neighbors"
             />
             <span className="text-xs text-text-muted">
@@ -172,7 +172,7 @@ export const NeighborsView: FC = () => {
         </CardContent>
       </Card>
 
-      <Card className="border-white/5 bg-bg-surface/70">
+      <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="p-0">
           {loading && !neighbors && <div className="p-6 text-sm text-text-muted">Loading…</div>}
           {error && (

--- a/ui/src/pages/topology/TopologyHeader.tsx
+++ b/ui/src/pages/topology/TopologyHeader.tsx
@@ -37,7 +37,7 @@ export const TopologyHeader: FC<TopologyHeaderProps> = ({
   onAutoLayout,
 }) => {
   return (
-    <div className="flex items-center justify-between p-4 border-b border-white/10 bg-bg-surface/80 backdrop-blur-sm">
+    <div className="flex items-center justify-between p-4 border-b border-surface-border bg-bg-surface/80 backdrop-blur-sm">
       <div className="flex items-center gap-4">
         <h1 className="text-xl font-semibold text-text-primary">{title}</h1>
         <div className="flex items-center gap-3 text-sm text-text-muted">
@@ -77,7 +77,7 @@ export const TopologyHeader: FC<TopologyHeaderProps> = ({
           </Button>
         )}
 
-        <div className="w-px h-6 bg-white/10" />
+        <div className="w-px h-6 bg-surface-hover" />
 
         {/* Layout control */}
         {onAutoLayout && (

--- a/ui/src/pages/topology/TopologyLegend.tsx
+++ b/ui/src/pages/topology/TopologyLegend.tsx
@@ -27,7 +27,7 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
       <button
         type="button"
         onClick={onToggle}
-        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-bg-elevated/90 border border-white/10 text-sm text-text-secondary hover:bg-bg-elevated/90 transition-colors"
+        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-bg-elevated/90 border border-surface-border text-sm text-text-secondary hover:bg-bg-elevated/90 transition-colors"
       >
         <Eye className="w-4 h-4" />
         Show Legend
@@ -36,7 +36,7 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
   }
 
   return (
-    <div className="bg-bg-elevated/95 backdrop-blur-sm border border-white/10 rounded-xl p-4 min-w-[200px]">
+    <div className="bg-bg-elevated/95 backdrop-blur-sm border border-surface-border rounded-xl p-4 min-w-[200px]">
       <div className="flex items-center justify-between mb-3">
         <span className="text-sm font-semibold text-text-primary">Legend</span>
         <button

--- a/ui/src/pages/topology/TrunkEdge.tsx
+++ b/ui/src/pages/topology/TrunkEdge.tsx
@@ -126,7 +126,7 @@ export const TrunkEdge: FC<EdgeProps> = ({
 
 const labelBoxStyle =
   'absolute pointer-events-none px-1.5 py-0.5 rounded text-[10px] font-medium ' +
-  'border border-white/10 bg-bg-base/90 text-text-primary shadow-sm whitespace-nowrap';
+  'border border-surface-border bg-bg-base/90 text-text-primary shadow-sm whitespace-nowrap';
 
 const EndLabel: FC<{ x: number; y: number; text: string; opacity: number }> = ({
   x,
@@ -149,7 +149,7 @@ const MiddleLabel: FC<{ x: number; y: number; text: string; opacity: number }> =
   opacity,
 }) => (
   <div
-    className={`${labelBoxStyle} text-brand-200`}
+    className={`${labelBoxStyle} text-brand-accent`}
     style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)`, opacity }}
   >
     {text}
@@ -186,7 +186,7 @@ const EdgeTooltip: FC<{ x: number; y: number; data: LinkEdgeData }> = ({ x, y, d
 
   return (
     <div
-      className="absolute pointer-events-none rounded-lg border border-white/10 bg-bg-base/95 px-3 py-2 text-xs text-text-primary shadow-lg z-50"
+      className="absolute pointer-events-none rounded-lg border border-surface-border bg-bg-base/95 px-3 py-2 text-xs text-text-primary shadow-lg z-50"
       style={{ transform: `translate(-50%, calc(-100% - 12px)) translate(${x}px, ${y}px)` }}
     >
       <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">

--- a/ui/src/styles/themeComponents.ts
+++ b/ui/src/styles/themeComponents.ts
@@ -11,15 +11,15 @@
  */
 
 export const button = {
-  base: 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-500/50 disabled:opacity-50 disabled:cursor-not-allowed',
+  base: 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-primary/50 disabled:opacity-50 disabled:cursor-not-allowed',
 
   variant: {
     primary:
-      'bg-gradient-to-r from-brand-600 to-brand-500 text-text-primary shadow-lg shadow-brand-500/30 hover:from-brand-500 hover:to-brand-400 active:scale-[0.98]',
+      'bg-gradient-to-r from-brand-primary to-brand-primary text-text-primary shadow-lg shadow-brand-primary/30 hover:from-brand-primary hover:to-brand-accent active:scale-[0.98]',
     secondary: 'bg-bg-elevated text-text-primary hover:bg-bg-overlay border border-border-default',
     ghost: 'text-text-muted hover:text-text-primary hover:bg-bg-elevated',
     outline:
-      'border border-border-muted text-text-secondary hover:bg-bg-elevated hover:border-brand-500/50',
+      'border border-border-muted text-text-secondary hover:bg-bg-elevated hover:border-brand-primary/50',
     danger:
       'bg-status-error/20 text-status-error border border-status-error/30 hover:bg-status-error/30',
     success:
@@ -35,7 +35,7 @@ export const button = {
 } as const;
 
 export const input = {
-  base: 'w-full rounded-lg bg-bg-surface text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500/50 disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-text-disabled',
+  base: 'w-full rounded-lg bg-bg-surface text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-brand-primary/50 disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-text-disabled',
 
   state: {
     default: 'border border-border-default',
@@ -58,7 +58,7 @@ export const card = {
     elevated:
       'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default shadow-xl shadow-black/20',
     interactive:
-      'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default hover:border-brand-500/30 cursor-pointer transition-colors',
+      'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default hover:border-brand-primary/30 cursor-pointer transition-colors',
     glass: 'bg-bg-elevated/40 backdrop-blur-2xl border border-border-default shadow-2xl',
   },
 
@@ -79,7 +79,7 @@ export const badge = {
     warning: 'bg-status-warning/20 text-status-warning border border-status-warning/30',
     error: 'bg-status-error/20 text-status-error border border-status-error/30',
     info: 'bg-status-info/20 text-status-info border border-status-info/30',
-    primary: 'bg-brand-500/20 text-brand-400 border border-brand-500/30',
+    primary: 'bg-brand-primary/20 text-brand-accent border border-brand-primary/30',
     new: 'bg-status-success/20 text-status-success',
     beta: 'bg-status-warning/20 text-status-warning',
   },

--- a/ui/src/styles/themeLayout.ts
+++ b/ui/src/styles/themeLayout.ts
@@ -61,7 +61,7 @@ export const border = {
   default: 'border border-border-default',
   subtle: 'border border-border-subtle',
   muted: 'border border-border-muted',
-  focus: 'border border-brand-500/50',
+  focus: 'border border-brand-primary/50',
   error: 'border border-status-error/50',
   divider: 'border-t border-border-default',
 } as const;

--- a/ui/src/ui/Button.tsx
+++ b/ui/src/ui/Button.tsx
@@ -31,7 +31,7 @@ const sizeStyles: Record<ButtonSize, string> = {
 const variantStyles: Record<ButtonVariant, Record<ButtonTone, string>> = {
   solid: {
     violet:
-      'bg-gradient-to-r from-brand-600 to-brand-500 hover:from-brand-500 hover:to-brand-400 text-text-primary shadow-lg shadow-brand-500/25 focus:ring-brand-500',
+      'bg-gradient-to-r from-brand-primary to-brand-primary hover:from-brand-primary hover:to-brand-accent text-text-primary shadow-lg shadow-brand-primary/25 focus:ring-brand-primary',
     red: 'bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-text-primary shadow-lg shadow-red-500/25 focus:ring-status-error',
     green:
       'bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 text-text-primary shadow-lg shadow-emerald-500/25 focus:ring-status-success',
@@ -40,27 +40,28 @@ const variantStyles: Record<ButtonVariant, Record<ButtonTone, string>> = {
   },
   outline: {
     violet:
-      'border border-brand-400/30 text-brand-300 hover:bg-brand-400/10 hover:border-brand-400/50 focus:ring-brand-500',
+      'border border-brand-accent/30 text-brand-accent hover:bg-brand-accent/10 hover:border-brand-accent/50 focus:ring-brand-primary',
     red: 'border border-status-error/30 text-status-error hover:bg-status-error/10 hover:border-status-error/50 focus:ring-status-error',
     green:
       'border border-status-success/30 text-status-success hover:bg-status-success/10 hover:border-status-success/50 focus:ring-status-success',
     blue: 'border border-status-info/30 text-status-info hover:bg-status-info/10 hover:border-status-info/50 focus:ring-status-info',
-    gray: 'border border-white/20 text-text-secondary hover:bg-white/10 hover:border-white/30 focus:ring-border-muted',
+    gray: 'border border-surface-border text-text-secondary hover:bg-surface-hover hover:border-surface-border focus:ring-border-muted',
   },
   ghost: {
-    violet: 'text-brand-300 hover:bg-brand-400/10 hover:text-brand-200 focus:ring-brand-500',
+    violet:
+      'text-brand-accent hover:bg-brand-accent/10 hover:text-brand-accent focus:ring-brand-primary',
     red: 'text-status-error hover:bg-status-error/10 hover:text-status-error focus:ring-status-error',
     green:
       'text-status-success hover:bg-status-success/10 hover:text-status-success focus:ring-status-success',
     blue: 'text-status-info hover:bg-status-info/10 hover:text-status-info focus:ring-status-info',
-    gray: 'text-text-muted hover:bg-white/10 hover:text-text-primary focus:ring-border-muted',
+    gray: 'text-text-muted hover:bg-surface-hover hover:text-text-primary focus:ring-border-muted',
   },
   secondary: {
-    violet: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-brand-500',
-    red: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-status-error',
-    green: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-status-success',
-    blue: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-status-info',
-    gray: 'bg-white/10 hover:bg-white/15 text-text-primary focus:ring-border-muted',
+    violet: 'bg-surface-hover hover:bg-surface-hover text-text-primary focus:ring-brand-primary',
+    red: 'bg-surface-hover hover:bg-surface-hover text-text-primary focus:ring-status-error',
+    green: 'bg-surface-hover hover:bg-surface-hover text-text-primary focus:ring-status-success',
+    blue: 'bg-surface-hover hover:bg-surface-hover text-text-primary focus:ring-status-info',
+    gray: 'bg-surface-hover hover:bg-surface-hover text-text-primary focus:ring-border-muted',
   },
 };
 
@@ -137,13 +138,13 @@ export const IconButton: FC<IconButtonProps> = ({
   };
 
   const variantBase = {
-    ghost: 'hover:bg-white/10 rounded-lg',
-    outline: 'border border-white/20 hover:bg-white/10 rounded-lg',
-    solid: 'bg-white/10 hover:bg-white/15 rounded-lg',
+    ghost: 'hover:bg-surface-hover rounded-lg',
+    outline: 'border border-surface-border hover:bg-surface-hover rounded-lg',
+    solid: 'bg-surface-hover hover:bg-surface-hover rounded-lg',
   };
 
   const toneStyles: Record<ButtonTone, string> = {
-    violet: 'text-brand-400 hover:text-brand-300',
+    violet: 'text-brand-accent hover:text-brand-accent',
     red: 'text-status-error hover:text-status-error',
     green: 'text-status-success hover:text-status-success',
     blue: 'text-status-info hover:text-status-info',
@@ -153,7 +154,7 @@ export const IconButton: FC<IconButtonProps> = ({
   return (
     <button
       type="button"
-      className={`inline-flex items-center justify-center transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-500/50 disabled:opacity-50 disabled:cursor-not-allowed ${iconSizeStyles[size]} ${variantBase[variant]} ${toneStyles[tone]} ${className}`}
+      className={`inline-flex items-center justify-center transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-primary/50 disabled:opacity-50 disabled:cursor-not-allowed ${iconSizeStyles[size]} ${variantBase[variant]} ${toneStyles[tone]} ${className}`}
       {...props}
     >
       {icon}

--- a/ui/src/ui/Card.tsx
+++ b/ui/src/ui/Card.tsx
@@ -41,15 +41,15 @@ type CardVariant = 'default' | 'elevated' | 'outlined' | 'ghost';
 
 const variantStyles: Record<CardVariant, string> = {
   default:
-    'backdrop-blur-xl bg-gradient-to-br from-bg-surface/90 to-bg-surface/70 border border-white/10 shadow-xl shadow-black/20',
+    'backdrop-blur-xl bg-gradient-to-br from-bg-surface/90 to-bg-surface/70 border border-surface-border shadow-xl shadow-black/20',
   elevated:
-    'backdrop-blur-xl bg-gradient-to-br from-bg-elevated/90 to-bg-surface/80 border border-white/15 shadow-2xl shadow-black/30',
-  outlined: 'bg-transparent border border-white/20',
-  ghost: 'bg-white/5 border border-transparent',
+    'backdrop-blur-xl bg-gradient-to-br from-bg-elevated/90 to-bg-surface/80 border border-surface-border shadow-2xl shadow-black/30',
+  outlined: 'bg-transparent border border-surface-border',
+  ghost: 'bg-surface-hover border border-transparent',
 };
 
 const hoverStyles =
-  'transition-all duration-300 hover:shadow-2xl hover:shadow-brand-500/5 hover:border-white/20 hover:-translate-y-0.5';
+  'transition-all duration-300 hover:shadow-2xl hover:shadow-brand-primary/5 hover:border-surface-border hover:-translate-y-0.5';
 
 const paddingClasses: Record<string, string> = {
   none: '',
@@ -165,8 +165,8 @@ export const StatusCard: FC<StatusCardProps> = ({
     // biome-ignore lint/a11y/noStaticElementInteractions: Interactive role is conditionally applied based on onClick presence
     <div
       className={`rounded-xl ${variantStyles[variant]} p-4 sm:p-6
-        transition-all hover:border-white/20 touch-manipulation
-        focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 outline-none
+        transition-all hover:border-surface-border touch-manipulation
+        focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 outline-none
         ${isInteractive ? 'cursor-pointer active:scale-[0.98]' : ''}
         ${className}`}
       onClick={onClick}
@@ -225,7 +225,7 @@ interface CardHeaderProps {
 
 export const CardHeader: FC<CardHeaderProps> = ({ children, className = '', actions }) => (
   <div
-    className={`flex items-center justify-between px-6 py-4 border-b border-white/10 ${className}`}
+    className={`flex items-center justify-between px-6 py-4 border-b border-surface-border ${className}`}
   >
     <div className="flex items-center gap-3">{children}</div>
     {actions && <div className="flex items-center gap-2">{actions}</div>}
@@ -238,7 +238,7 @@ interface CardFooterProps {
 }
 
 export const CardFooter: FC<CardFooterProps> = ({ children, className = '' }) => (
-  <div className={`px-6 py-4 border-t border-white/10 bg-black/20 rounded-b-xl ${className}`}>
+  <div className={`px-6 py-4 border-t border-surface-border bg-black/20 rounded-b-xl ${className}`}>
     {children}
   </div>
 );
@@ -348,7 +348,7 @@ export const CardRow: FC<CardRowProps> = ({ label, value, status, mono = false }
  * CardDivider - Horizontal divider for separating card sections.
  */
 export const CardDivider: FC<{ className?: string }> = ({ className = '' }) => (
-  <hr className={`border-white/10 my-3 ${className}`} />
+  <hr className={`border-surface-border my-3 ${className}`} />
 );
 
 // ============================================================================
@@ -382,7 +382,7 @@ export const StatCard: FC<StatCardProps> = ({ label, value, icon, trend, classNa
       <CardContent className="space-y-2">
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-text-muted">{label}</span>
-          {icon && <span className="text-brand-400">{icon}</span>}
+          {icon && <span className="text-brand-accent">{icon}</span>}
         </div>
         <div className="flex items-end justify-between gap-2">
           <span className="text-3xl font-bold text-text-primary">{value}</span>

--- a/ui/src/ui/ConfirmModal.tsx
+++ b/ui/src/ui/ConfirmModal.tsx
@@ -39,7 +39,7 @@ export const ConfirmModal: FC<ConfirmModalProps> = ({
                   ? 'text-status-info'
                   : confirmTone === 'green'
                     ? 'text-status-success'
-                    : 'text-brand-400'
+                    : 'text-brand-accent'
             }`}
           />
         )}

--- a/ui/src/ui/Input.tsx
+++ b/ui/src/ui/Input.tsx
@@ -3,8 +3,8 @@ import type { FC, InputHTMLAttributes, ReactNode, Ref, TextareaHTMLAttributes } 
 // Base input styles
 const inputBaseStyles =
   'w-full rounded-lg border bg-bg-base/60 text-text-primary placeholder:text-text-muted transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed';
-const inputFocusStyles = 'focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20';
-const inputBorderStyles = 'border-white/10 hover:border-white/20';
+const inputFocusStyles = 'focus:border-brand-primary focus:ring-2 focus:ring-brand-primary/20';
+const inputBorderStyles = 'border-surface-border hover:border-surface-border';
 
 // React 19: ref as regular prop instead of forwardRef
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -221,8 +221,8 @@ export const Checkbox: FC<CheckboxProps> = ({
         type="checkbox"
         id={checkboxId}
         className={`
-          mt-0.5 h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-500
-          focus:ring-2 focus:ring-brand-500/50 focus:ring-offset-0
+          mt-0.5 h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-primary
+          focus:ring-2 focus:ring-brand-primary/50 focus:ring-offset-0
           transition-colors cursor-pointer
           ${className}
         `}
@@ -281,8 +281,8 @@ export const Toggle: FC<ToggleProps> = ({
         }}
         className={`
           relative inline-flex h-6 w-11 items-center rounded-full transition-colors
-          focus:outline-none focus:ring-2 focus:ring-brand-500/50 focus:ring-offset-2 focus:ring-offset-gray-900
-          ${checked ? 'bg-brand-600' : 'bg-bg-elevated'}
+          focus:outline-none focus:ring-2 focus:ring-brand-primary/50 focus:ring-offset-2 focus:ring-offset-gray-900
+          ${checked ? 'bg-brand-primary' : 'bg-bg-elevated'}
           ${className}
         `}
       >
@@ -390,7 +390,7 @@ export const SearchInput: FC<SearchInputProps> = ({
             type="button"
             onClick={handleClear}
             aria-label="Clear search"
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500/50 rounded"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-brand-primary/50 rounded"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/ui/src/ui/InputModal.tsx
+++ b/ui/src/ui/InputModal.tsx
@@ -67,7 +67,7 @@ export const InputModal: FC<InputModalProps> = ({
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full rounded-lg border border-white/10 bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-400 focus:outline-none"
+          className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
         />
         <div className="flex justify-end gap-3 pt-2">
           <Button variant="outline" onClick={onCancel}>

--- a/ui/src/ui/Layout.tsx
+++ b/ui/src/ui/Layout.tsx
@@ -122,8 +122,8 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
         }}
         className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 whitespace-nowrap ${
           isActive
-            ? 'bg-gradient-to-r from-brand-600/30 to-brand-500/20 text-text-primary border-l-2 border-brand-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
-            : 'text-text-muted hover:text-text-primary hover:bg-white/5'
+            ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary border-l-2 border-brand-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
+            : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
         } ${isGrouped ? 'w-full justify-start' : ''}`}
       >
         {iconElement}
@@ -135,7 +135,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
                 ? 'bg-status-success/20 text-status-success'
                 : item.badge === 'Beta'
                   ? 'bg-status-warning/20 text-status-warning'
-                  : 'bg-brand-500/20 text-brand-300'
+                  : 'bg-brand-primary/20 text-brand-accent'
             }`}
           >
             {item.badge}
@@ -175,7 +175,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
           ? // Grouped navigation
             groups.map((group, groupIndex) => (
               <div key={group.label} className="relative flex items-center">
-                {groupIndex > 0 && <div className="h-6 w-px bg-white/10 mx-2" />}
+                {groupIndex > 0 && <div className="h-6 w-px bg-surface-hover mx-2" />}
                 <div className="relative">
                   <button
                     type="button"
@@ -188,7 +188,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
                     />
                   </button>
                   {openGroup === group.label && (
-                    <div className="absolute top-full left-0 mt-1 py-1 min-w-[180px] rounded-lg bg-bg-surface/95 backdrop-blur-xl border border-white/10 shadow-xl z-50 animate-slide-down">
+                    <div className="absolute top-full left-0 mt-1 py-1 min-w-[180px] rounded-lg bg-bg-surface/95 backdrop-blur-xl border border-surface-border shadow-xl z-50 animate-slide-down">
                       {group.items.map((item) => (
                         <div key={item.path} className="px-1">
                           {renderNavItem(item, true)}
@@ -261,7 +261,7 @@ export const PageHeader: FC<PageHeaderProps> = ({
       {breadcrumbs && breadcrumbs.length > 0 && <Breadcrumb items={breadcrumbs} className="mb-3" />}
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="flex items-center gap-3">
-          {icon && createElement(icon, { className: 'h-8 w-8 text-brand-400' })}
+          {icon && createElement(icon, { className: 'h-8 w-8 text-brand-accent' })}
           <div>
             <h1 className="text-2xl font-bold text-text-primary font-display">{title}</h1>
             {description && <p className="text-sm text-text-muted mt-1 max-w-2xl">{description}</p>}
@@ -275,7 +275,7 @@ export const PageHeader: FC<PageHeaderProps> = ({
               onClick={() => setHelpOpen(true)}
               aria-label={`Open help for ${title}`}
               title={`What is ${title}?`}
-              className="rounded-full p-1.5 text-text-muted hover:bg-white/10 hover:text-text-primary"
+              className="rounded-full p-1.5 text-text-muted hover:bg-surface-hover hover:text-text-primary"
             >
               <HelpCircle className={iconSizes.lg} />
             </button>
@@ -332,7 +332,7 @@ const HelpPanel: FC<{ title: string; children: ReactNode; onClose: () => void }>
             type="button"
             onClick={onClose}
             aria-label="Close help"
-            className="rounded p-1 text-text-muted hover:bg-white/10 hover:text-text-primary"
+            className="rounded p-1 text-text-muted hover:bg-surface-hover hover:text-text-primary"
           >
             <X className="h-5 w-5" />
           </button>

--- a/ui/src/ui/Modal.tsx
+++ b/ui/src/ui/Modal.tsx
@@ -77,14 +77,14 @@ export const Modal: FC<ModalProps> = ({
       )}
       <div
         ref={containerRef}
-        className={`mx-4 w-full ${sizeClasses[size]} rounded-2xl border border-white/10 bg-bg-surface/95 shadow-2xl ${className}`}
+        className={`mx-4 w-full ${sizeClasses[size]} rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl ${className}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'modal-title' : undefined}
         onKeyDown={handleContentKeyDown}
       >
         {(title || showCloseButton) && (
-          <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-surface-border">
             {title && (
               <h2 id="modal-title" className="text-lg font-semibold text-text-primary">
                 {title}
@@ -94,7 +94,7 @@ export const Modal: FC<ModalProps> = ({
               <button
                 type="button"
                 onClick={onClose}
-                className="ml-auto p-1 text-text-muted hover:text-text-primary transition-colors rounded-lg hover:bg-white/10"
+                className="ml-auto p-1 text-text-muted hover:text-text-primary transition-colors rounded-lg hover:bg-surface-hover"
                 aria-label="Close modal"
               >
                 <X className={iconSizes.lg} />
@@ -123,7 +123,7 @@ export const ModalFooter: FC<{ children: ReactNode; className?: string }> = ({
   children,
   className = '',
 }) => (
-  <div className={`flex justify-end gap-3 pt-4 mt-4 border-t border-white/10 ${className}`}>
+  <div className={`flex justify-end gap-3 pt-4 mt-4 border-t border-surface-border ${className}`}>
     {children}
   </div>
 );

--- a/ui/src/ui/PageLoader.tsx
+++ b/ui/src/ui/PageLoader.tsx
@@ -8,7 +8,7 @@ import type { FC } from 'react';
 export const PageLoader: FC = () => (
   <div className="flex items-center justify-center min-h-[400px]">
     <div className="flex flex-col items-center gap-3">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-brand-500 border-t-transparent" />
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-brand-primary border-t-transparent" />
       <p className="text-sm text-text-muted">Loading...</p>
     </div>
   </div>

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -66,14 +66,14 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           transition-all duration-200
           ${
             active
-              ? 'bg-gradient-to-r from-brand-600/30 to-brand-500/20 text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
-              : 'text-text-muted hover:text-text-primary hover:bg-white/5'
+              ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
+              : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
           }
         `}
         title={collapsed ? item.label : undefined}
       >
         {createElement(item.icon, {
-          className: `${iconSizes.lg} flex-shrink-0 ${active ? 'text-brand-400' : 'text-text-muted group-hover:text-text-secondary'}`,
+          className: `${iconSizes.lg} flex-shrink-0 ${active ? 'text-brand-accent' : 'text-text-muted group-hover:text-text-secondary'}`,
         })}
         {!collapsed && (
           <>
@@ -85,7 +85,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
                     ? 'bg-status-success/20 text-status-success'
                     : item.badge === 'Beta'
                       ? 'bg-status-warning/20 text-status-warning'
-                      : 'bg-brand-500/20 text-brand-300'
+                      : 'bg-brand-primary/20 text-brand-accent'
                 }`}
               >
                 {item.badge}
@@ -94,7 +94,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           </>
         )}
         {collapsed && item.badge && (
-          <span className="absolute left-12 px-1.5 py-0.5 text-xs rounded font-medium bg-brand-500/20 text-brand-300">
+          <span className="absolute left-12 px-1.5 py-0.5 text-xs rounded font-medium bg-brand-primary/20 text-brand-accent">
             {item.badge}
           </span>
         )}
@@ -106,11 +106,11 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
     <>
       {/* Logo */}
       <div
-        className={`flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-3 py-4 border-b border-white/10`}
+        className={`flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-3 py-4 border-b border-surface-border`}
       >
         <div className={`flex items-center gap-2 ${collapsed ? 'justify-center' : ''}`}>
           <div className="relative flex-shrink-0">
-            <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center shadow-lg shadow-brand-500/30">
+            <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-primary to-brand-primary flex items-center justify-center shadow-lg shadow-brand-primary/30">
               <Network className={`${iconSizes.lg} text-text-primary`} />
             </div>
             <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-status-success border-2 border-border-muted" />
@@ -125,7 +125,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           <button
             type="button"
             onClick={() => setCollapsed(true)}
-            className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors lg:flex hidden"
+            className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors lg:flex hidden"
             title="Collapse the sidebar to icons-only mode to give the main content more horizontal space"
             aria-label="Collapse sidebar"
           >
@@ -143,14 +143,14 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
                 {group.label}
               </h3>
             )}
-            {collapsed && <div className="h-px bg-white/10 mx-2 mb-2" />}
+            {collapsed && <div className="h-px bg-surface-hover mx-2 mb-2" />}
             <div className="space-y-1">{group.items.map(renderNavItem)}</div>
           </div>
         ))}
       </nav>
 
       {/* Footer */}
-      <div className={`px-3 py-4 border-t border-white/10 ${collapsed ? 'text-center' : ''}`}>
+      <div className={`px-3 py-4 border-t border-surface-border ${collapsed ? 'text-center' : ''}`}>
         {/* Action Buttons */}
         <div className={`${collapsed ? 'space-y-2' : 'flex items-center gap-2'} mb-3`}>
           <button
@@ -159,7 +159,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
             className={`
               ${collapsed ? 'w-full' : 'flex-1'}
               flex items-center ${collapsed ? 'justify-center' : 'gap-2'} px-3 py-2 rounded-lg
-              text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors
+              text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors
               text-sm font-medium
             `}
             title="Open the help dialog with keyboard shortcuts, documentation links, and supported features"
@@ -174,7 +174,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
             className={`
               ${collapsed ? 'w-full' : 'flex-1'}
               flex items-center ${collapsed ? 'justify-center' : 'gap-2'} px-3 py-2 rounded-lg
-              text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors
+              text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors
               text-sm font-medium
             `}
             title="Open the settings modal to change theme, default capture interface, and other application preferences"
@@ -201,7 +201,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           <button
             type="button"
             onClick={() => setCollapsed(false)}
-            className="mt-2 p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors"
+            className="mt-2 p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors"
             title="Expand the sidebar to show navigation labels alongside icons"
             aria-label="Expand sidebar"
           >
@@ -217,15 +217,15 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
       {/* Skip to main content link for accessibility */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-brand-600 focus:text-text-primary focus:outline-none"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-brand-primary focus:text-text-primary focus:outline-none"
       >
         Skip to main content
       </a>
 
       {/* Mobile header */}
-      <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3 bg-bg-surface/95 backdrop-blur-xl border-b border-white/10">
+      <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3 bg-bg-surface/95 backdrop-blur-xl border-b border-surface-border">
         <div className="flex items-center gap-2">
-          <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center">
+          <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-primary to-brand-primary flex items-center justify-center">
             <Network className={`${iconSizes.md} text-text-primary`} />
           </div>
           <span className="font-display font-bold text-text-primary">NIAC</span>
@@ -233,7 +233,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
         <button
           type="button"
           onClick={() => setMobileOpen(!mobileOpen)}
-          className="p-2 rounded-lg text-text-muted hover:text-text-primary hover:bg-white/10 transition-colors"
+          className="p-2 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors"
           title={
             mobileOpen
               ? 'Close the navigation drawer'
@@ -259,7 +259,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
       {/* Mobile sidebar */}
       <aside
         className={`
-          lg:hidden fixed top-0 left-0 z-50 h-full w-72 bg-bg-surface/95 backdrop-blur-xl border-r border-white/10
+          lg:hidden fixed top-0 left-0 z-50 h-full w-72 bg-bg-surface/95 backdrop-blur-xl border-r border-surface-border
           transform transition-transform duration-300 ease-in-out
           ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}
         `}
@@ -271,7 +271,7 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
       <aside
         className={`
           hidden lg:flex fixed top-0 left-0 z-40 h-full flex-col
-          bg-bg-surface/80 backdrop-blur-xl border-r border-white/10
+          bg-bg-surface/80 backdrop-blur-xl border-r border-surface-border
           transition-all duration-300 ease-in-out
           ${collapsed ? 'w-16' : 'w-64'}
         `}

--- a/ui/src/ui/Skeleton.tsx
+++ b/ui/src/ui/Skeleton.tsx
@@ -89,7 +89,9 @@ export const StatCardSkeleton: FC<{ className?: string }> = ({ className = '' })
 
 // Skeleton for device cards (card view)
 export const DeviceCardSkeleton: FC<{ className?: string }> = ({ className = '' }) => (
-  <div className={`p-4 space-y-3 rounded-xl border border-white/5 bg-bg-surface/70 ${className}`}>
+  <div
+    className={`p-4 space-y-3 rounded-xl border border-surface-border bg-bg-surface/70 ${className}`}
+  >
     {/* Header with checkbox and icon */}
     <div className="flex items-start justify-between">
       <div className="flex items-center gap-3">
@@ -112,7 +114,7 @@ export const DeviceCardSkeleton: FC<{ className?: string }> = ({ className = '' 
       <Skeleton width={40} height={20} className="rounded" />
     </div>
     {/* Actions */}
-    <div className="flex justify-end gap-1 pt-2 border-t border-white/5">
+    <div className="flex justify-end gap-1 pt-2 border-t border-surface-border">
       <Skeleton variant="rectangular" width={32} height={32} className="rounded-lg" />
       <Skeleton variant="rectangular" width={32} height={32} className="rounded-lg" />
       <Skeleton variant="rectangular" width={32} height={32} className="rounded-lg" />
@@ -122,7 +124,7 @@ export const DeviceCardSkeleton: FC<{ className?: string }> = ({ className = '' 
 
 // Skeleton for device table rows
 export const DeviceTableRowSkeleton: FC<{ className?: string }> = ({ className = '' }) => (
-  <div className={`flex items-center gap-4 px-4 py-3 border-b border-white/5 ${className}`}>
+  <div className={`flex items-center gap-4 px-4 py-3 border-b border-surface-border ${className}`}>
     <Skeleton variant="rectangular" width={16} height={16} />
     <div className="flex-1 grid grid-cols-12 gap-4 items-center">
       {/* Hostname */}

--- a/ui/src/ui/Tag.tsx
+++ b/ui/src/ui/Tag.tsx
@@ -14,8 +14,8 @@ const colorStyles: Record<TagColorScheme, string> = {
   green: 'bg-status-success/20 text-status-success border-status-success/30',
   blue: 'bg-status-info/20 text-status-info border-status-info/30',
   yellow: 'bg-status-warning/20 text-status-warning border-status-warning/30',
-  purple: 'bg-brand-500/20 text-brand-300 border-brand-500/30',
-  violet: 'bg-brand-500/20 text-brand-300 border-brand-500/30',
+  purple: 'bg-brand-primary/20 text-brand-accent border-brand-primary/30',
+  violet: 'bg-brand-primary/20 text-brand-accent border-brand-primary/30',
   cyan: 'bg-status-info/20 text-status-info border-status-info/30',
 };
 

--- a/ui/src/ui/ToastContainer.tsx
+++ b/ui/src/ui/ToastContainer.tsx
@@ -45,7 +45,7 @@ const Toast: FC<{ notification: Notification }> = ({ notification }) => {
       <button
         type="button"
         onClick={() => removeNotification(notification.id)}
-        className="flex-shrink-0 p-1 rounded hover:bg-white/10 transition-colors"
+        className="flex-shrink-0 p-1 rounded hover:bg-surface-hover transition-colors"
         aria-label="Dismiss notification"
       >
         <X className={iconSizes.md} />

--- a/ui/src/ui/Typography.tsx
+++ b/ui/src/ui/Typography.tsx
@@ -25,7 +25,7 @@ import { Link } from 'react-router-dom';
  * for sustained body copy; reserve it for placeholders, disabled
  * states, and timestamps where lower contrast is intentional.
  *
- * Accent colors: brand violet (text-brand-300/400) is the only
+ * Accent colors: brand violet (text-brand-accent/400) is the only
  * "highlight" colour; status colours (red/amber/emerald) come from the
  * Tailwind palette directly. If you find yourself reaching for
  * text-purple/pink/sky for chrome, route it through this file first.
@@ -92,7 +92,7 @@ export const AccentLink: FC<AccentLinkProps> = ({
   onClick,
   ...props
 }) => {
-  const linkClass = `text-brand-300 hover:text-brand-200 underline underline-offset-2 transition-colors ${className}`;
+  const linkClass = `text-brand-accent hover:text-brand-accent underline underline-offset-2 transition-colors ${className}`;
 
   if (to) {
     return (


### PR DESCRIPTION
## Summary

Bring niac into the Mustard Seed Networks color family. All three sibling projects (niac, stem, seed) now share the same brand identity and dark/light theme contract.

Before: niac used violet brand `#8b5cf6` + too-dark surfaces `#030712` — stood out vs seed/stem.
After: niac uses Seed Green `#2d7a3e` (light) / `#81c784` (dark) + reconciled surfaces matching seed.

## What changed

### Theme (src/index.css)
- Replace `brand-50..950` violet ramp with semantic `brand-primary` / `brand-accent` / `brand-gold` tokens
- Light theme (`:root`): `#2d7a3e` Seed Green, `#f8fafc` surfaces, `#e2e8f0` borders
- Dark theme (`.dark`): `#81c784` lighter green, `#1a1a1a/#333333/#666666` surfaces
- Status palette identical to seed/stem: `#28a745/#ffc107/#dc3545/#17a2b8`
- Light is CSS default; dark applied via `.dark` class — matches seed/stem
- Legacy `brand-50..950` and old `bg-*/border-*` aliases kept as `var()` mappings so existing Tailwind utilities still compile during component migration

### Theme hook (new: src/hooks/useTheme.ts)
- Ported from seed; storage key `'niac-theme'`, defaults to `'dark'`
- Light / Dark / System with `prefers-color-scheme` listener
- Exports `initThemeFromStorage()` for pre-paint apply (no FOUC)

### Entry-point wiring (src/main.tsx)
- `initThemeFromStorage()` runs before first React render

### Component migration (~75 files via perl batch)
- `text-brand-{50..400}` → `text-brand-accent`
- `text-brand-{500..950}` → `text-brand-primary`
- `border-white/N` overlays → `border-surface-border` semantic
- `bg-white/N` overlays → `bg-surface-hover`

### Settings drawer
- AppearanceSection: Light/Dark/System tri-radio with brand-primary highlight, plus quick-toggle button
- Tab nav `border-brand-500` → `border-brand-primary`

## Verification

- `npm run build`: clean (6.0s)
- `npx biome check src/`: 0 errors across 212 files
- `npm test`: 60/60 pass
- 0 lingering `brand-{50..950}` utility refs
- 0 lingering `white/N` overlay refs

## Follow-up not in this PR

- A sun/moon toggle button in Sidebar.tsx footer (alongside Help/Settings) — deferred because Phase A architecture work is concurrently refactoring Sidebar.tsx. Will be a tiny follow-up after Phase A lands.

## Test plan
- [ ] CI green
- [ ] Verify dark theme is the default on first load (no localStorage entry)
- [ ] Visual smoke test: brand color is green not violet across pages, surfaces are lighter than before, status badges render correctly
- [ ] Toggle to light mode in Settings → Appearance → confirm theme switches; reload → light theme persists