### PR TITLE
feat(ui): Topbar with theme toggle + color sync with stem

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,12 +1,14 @@
-import { Wrench } from 'lucide-react';
-import { memo, type ReactNode, Suspense } from 'react';
+import { Moon, Sun, Wrench } from 'lucide-react';
+import { memo, type ReactElement, type ReactNode, Suspense } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { ErrorBoundary, PageErrorBoundary } from './components/ErrorBoundary';
 import { AppProvider, useAppState } from './contexts/AppContext';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { useTheme } from './hooks/useTheme';
 import { navGroups } from './navGroups';
 import { DeviceEditorPageRef, type PageConfig, pages } from './pageRegistry';
 import { Breadcrumbs } from './ui/Breadcrumbs';
+import { ConnectionStatus } from './ui/ConnectionStatus';
 import { PageHeader } from './ui/Layout';
 import { PageLoader } from './ui/PageLoader';
 import { SidebarLayout } from './ui/Sidebar';
@@ -33,13 +35,44 @@ export default function App() {
   );
 }
 
+/**
+ * TopBar renders the sticky upper-right control cluster: connection
+ * indicator + theme toggle. Mirrors stem's UI shell so cross-product
+ * navigation has consistent affordances.
+ */
+function TopBar(): ReactElement {
+  const { isDark, toggleTheme } = useTheme();
+  return (
+    <>
+      {/* Left side reserved for future breadcrumbs / page-level chrome. */}
+      <div className="flex items-center" />
+      <div className="flex items-center gap-2">
+        <ConnectionStatus />
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-hover"
+          title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+          aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {isDark ? (
+            <Sun className="h-5 w-5" aria-hidden="true" />
+          ) : (
+            <Moon className="h-5 w-5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+    </>
+  );
+}
+
 function AppShell() {
   const { data: version } = useAppState('version');
 
   useKeyboardShortcuts();
 
   return (
-    <SidebarLayout groups={navGroups} version={version?.version}>
+    <SidebarLayout groups={navGroups} version={version?.version} topBar={<TopBar />}>
       <ToastContainer />
       <Suspense fallback={<PageLoader />}>
         <Routes>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -267,17 +267,18 @@
   --color-brand-accent: #a5d6a7;
   --color-brand-gold: #fbbf24;
 
-  /* Surfaces — neutral grays (NOT blue-tinted slate) */
+  /* Surfaces — neutral grays (NOT blue-tinted slate).
+   * Values mirror stem's dark theme so cross-product UI stays harmonized. */
   --color-surface-base: #1a1a1a;
   --color-surface-raised: #333333;
   --color-surface-border: #666666;
-  --color-surface-hover: #404040;
-  --color-surface-sunken: #0a0a0a;
+  --color-surface-hover: #666666;
+  --color-surface-sunken: #000000;
 
-  /* Text */
+  /* Text — mirrors stem's dark theme values. */
   --color-text-primary: #f8fafc;
-  --color-text-secondary: #cbd5e1;
-  --color-text-muted: #94a3b8;
+  --color-text-secondary: #e5e5e5;
+  --color-text-muted: #999999;
   --color-text-disabled: #64748b;
   --color-text-inverse: #0f172a;
 

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -1,24 +1,12 @@
 import type { LucideIcon } from 'lucide-react';
-import {
-  ChevronLeft,
-  ChevronRight,
-  HelpCircle,
-  Menu,
-  Moon,
-  Network,
-  Settings,
-  Sun,
-  X,
-} from 'lucide-react';
+import { ChevronLeft, ChevronRight, HelpCircle, Menu, Network, Settings, X } from 'lucide-react';
 import { createElement, type FC, type ReactNode, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { HelpDrawer } from '../components/HelpDrawer';
 import { SettingsDrawer } from '../components/SettingsDrawer';
 import { iconSizes } from '../constants/sizes';
-import { useTheme } from '../hooks/useTheme';
 import { prefetchRoute } from '../utils/prefetch';
 import { safeGetItem, safeSetItem } from '../utils/storage';
-import { ConnectionStatus } from './ConnectionStatus';
 
 export interface SidebarNavItem {
   path: string;
@@ -36,12 +24,18 @@ interface SidebarProps {
   groups: SidebarNavGroup[];
   version?: string;
   children: ReactNode;
+  /**
+   * Optional topbar slot rendered above the routed page content. Mirrors
+   * stem's UI shell so the theme toggle and connection indicator live in
+   * the upper-right of the viewport instead of the sidebar footer.
+   */
+  topBar?: ReactNode;
 }
 
 // Store collapsed state in localStorage
 const STORAGE_KEY = 'niac-sidebar-collapsed';
 
-export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) => {
+export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children, topBar }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const [collapsed, setCollapsed] = useState(() => {
@@ -50,7 +44,6 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
   const [mobileOpen, setMobileOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
-  const { isDark, toggleTheme } = useTheme();
 
   // Save collapsed state
   useEffect(() => {
@@ -195,28 +188,10 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
             <Settings className={`${iconSizes.md} flex-shrink-0`} />
             {!collapsed && <span>Settings</span>}
           </button>
-          <button
-            type="button"
-            onClick={toggleTheme}
-            className={`
-              ${collapsed ? 'w-full' : ''}
-              flex items-center ${collapsed ? 'justify-center' : 'gap-2'} px-3 py-2 rounded-lg
-              text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors
-              text-sm font-medium
-            `}
-            title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-            aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-          >
-            {isDark ? (
-              <Sun className={`${iconSizes.md} flex-shrink-0`} aria-hidden="true" />
-            ) : (
-              <Moon className={`${iconSizes.md} flex-shrink-0`} aria-hidden="true" />
-            )}
-          </button>
         </div>
 
-        {/* Connection Status */}
-        {!collapsed && <ConnectionStatus />}
+        {/* Theme toggle and connection indicator now live in the topbar
+            (see SidebarLayout's topBar slot rendered above page content). */}
 
         {/* Version Info */}
         {version && (
@@ -318,6 +293,11 @@ export const SidebarLayout: FC<SidebarProps> = ({ groups, version, children }) =
           ${collapsed ? 'lg:pl-16' : 'lg:pl-64'}
         `}
       >
+        {topBar && (
+          <div className="sticky top-0 z-30 border-b border-surface-border bg-surface-base px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between gap-3">
+            {topBar}
+          </div>
+        )}
         <div className="p-4 sm:p-6 lg:p-8">{children}</div>
       </main>
 


### PR DESCRIPTION
Implements #71. Two commits:

1. **Color sync**: dark-mode neutrals brought into exact alignment with stem (surface-hover #404040 → #666666, surface-sunken #0a0a0a → #000000, text-secondary #cbd5e1 → #e5e5e5, text-muted #94a3b8 → #999999). Light mode unchanged.

2. **Topbar**: new sticky header above the page content with theme toggle (sun/moon) and ConnectionStatus on the right, mirroring stem's pattern. Theme toggle removed from sidebar footer. Help + Settings buttons kept in sidebar for now (followup if desired).

Build clean: `npx biome check src/` (213 files, 0 warnings), `npm run build`, `go build ./...` all pass.