### PR TITLE
fix(ci): Exclude advisory E2E + Lighthouse from CI Complete needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,6 +768,12 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
+    # NOTE: e2e and lighthouse are deliberately excluded from this aggregator.
+    # They were dropped from required-status-checks on main because they're
+    # advisory (flaky / surface real issues that are tracked separately).
+    # Including them here would re-block merge via the dispatcher on the
+    # same flakes. They still run on every PR and surface their own status;
+    # they just don't gate merge.
     needs:
       - changes
       - backend
@@ -778,8 +784,6 @@ jobs:
       - quality
       - docs
       - build
-      - e2e
-      - lighthouse
     if: always()
     steps:
       - name: Verify upstream results


### PR DESCRIPTION
Follow-up to #615. CI Complete was treating e2e + lighthouse as blocking via the dispatcher even though branch protection had already dropped them as required. Net effect: any e2e/lighthouse flake re-blocked merge through the back door. Exclude them from the aggregator's needs so the dispatcher only reflects actually-required upstreams.