### PR TITLE
fix(ci): Point Lighthouse at the real served URLs (#65)

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,11 +1,10 @@
 {
   "ci": {
     "collect": {
-      "url": ["https://localhost:8443", "https://localhost:8443/login"],
+      "url": ["http://localhost:8080/", "http://localhost:8080/devices"],
       "numberOfRuns": 3,
       "settings": {
-        "preset": "desktop",
-        "chromeFlags": "--ignore-certificate-errors"
+        "preset": "desktop"
       }
     },
     "assert": {


### PR DESCRIPTION
niac's .lighthouserc.json was hardcoded to https://localhost:8443/login — copy-pasted from seed at creation. CI actually starts niac on http://localhost:8080. The audit was hitting a non-existent endpoint silently. Fix the URLs + drop the now-unnecessary --ignore-certificate-errors flag. Followup pass needed when #78+#81 land to retarget at https://localhost:8445.