### PR TITLE
feat: Graceful port fallback when canonical port is in use (#69)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -23,6 +23,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -300,8 +301,18 @@ func (s *Server) Start() error {
 		s.registerAPIRoutes(mux)
 		s.httpServer = newSecureHTTPServer(s.cfg.Addr, mux)
 
+		// Bind before launching the serve goroutine so a fatal bind error
+		// (e.g. permission denied, or all fallback ports taken) surfaces
+		// synchronously instead of disappearing into a background log.
+		// See #69 — busy 8080 falls back to +1..+9 with a WARN.
+		apiLn, apiAddr, bindErr := bindWithFallback(context.Background(), s.logger, s.cfg.Addr)
+		if bindErr != nil {
+			return fmt.Errorf("API server bind: %w", bindErr)
+		}
+		s.httpServer.Addr = apiAddr
+
 		go func() {
-			if err := s.httpServer.ListenAndServe(); err != nil &&
+			if err := s.httpServer.Serve(apiLn); err != nil &&
 				!errors.Is(err, http.ErrServerClosed) {
 				s.logger.Error("API server stopped", "error", err)
 			}
@@ -313,8 +324,14 @@ func (s *Server) Start() error {
 		mux.HandleFunc("/metrics", s.recoverMiddleware(s.auth(s.handleMetrics)))
 		s.metricsServer = newSecureHTTPServer(s.cfg.MetricsAddr, mux)
 
+		metricsLn, metricsAddr, bindErr := bindWithFallback(context.Background(), s.logger, s.cfg.MetricsAddr)
+		if bindErr != nil {
+			return fmt.Errorf("metrics server bind: %w", bindErr)
+		}
+		s.metricsServer.Addr = metricsAddr
+
 		go func() {
-			if err := s.metricsServer.ListenAndServe(); err != nil &&
+			if err := s.metricsServer.Serve(metricsLn); err != nil &&
 				!errors.Is(err, http.ErrServerClosed) {
 				s.logger.Error("Metrics server stopped", "error", err)
 			}

--- a/internal/api/server_port_fallback.go
+++ b/internal/api/server_port_fallback.go
@@ -1,0 +1,114 @@
+package api
+
+// server_port_fallback.go provides bindWithFallback, a helper that opens
+// a TCP listener on a desired address and walks port+1..+9 if the
+// canonical port is already in use. This keeps `niac daemon` runnable
+// for developers who have another service squatting on 8080 without
+// changing the documented default port (see #69).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"syscall"
+)
+
+// portFallbackMaxOffset is the maximum offset above the requested port that
+// bindWithFallback will probe. Probes are requested..requested+portFallbackMaxOffset.
+const portFallbackMaxOffset = 9
+
+// bindWithFallback opens a TCP listener on addr (host:port form). If that
+// port is in use it walks port+1..+portFallbackMaxOffset and returns the
+// first listener that binds, logging a WARN with the requested and actual
+// port via the supplied logger.
+//
+// Non-EADDRINUSE errors are returned immediately — the caller must treat
+// them as fatal (permission denied, invalid address, etc.).
+//
+// The returned address string is the actual host:port the listener is
+// bound on (suitable for assigning back into [http.Server.Addr] so
+// /__version log lines reflect reality). The caller is responsible for
+// closing the returned listener (typically by passing it to
+// [http.Server.Serve] which closes on shutdown).
+func bindWithFallback(
+	ctx context.Context,
+	logger *slog.Logger,
+	addr string,
+) (net.Listener, string, error) {
+	host, portStr, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil {
+		return nil, "", fmt.Errorf("parse listen address %q: %w", addr, splitErr)
+	}
+	port, parseErr := strconv.Atoi(portStr)
+	if parseErr != nil {
+		return nil, "", fmt.Errorf("parse port %q from %q: %w", portStr, addr, parseErr)
+	}
+
+	var lc net.ListenConfig
+
+	// Port 0 means "let the OS pick" — no fallback needed.
+	if port == 0 {
+		ln, err := lc.Listen(ctx, "tcp", addr)
+		if err != nil {
+			return nil, "", fmt.Errorf("bind %s: %w", addr, err)
+		}
+		return ln, ln.Addr().String(), nil
+	}
+
+	for offset := 0; offset <= portFallbackMaxOffset; offset++ {
+		actual := port + offset
+		candidate := net.JoinHostPort(host, strconv.Itoa(actual))
+		ln, err := lc.Listen(ctx, "tcp", candidate)
+		if err == nil {
+			if offset > 0 && logger != nil {
+				logger.Warn(
+					"requested port is in use, bound fallback port instead",
+					"requested", port,
+					"bound", actual,
+				)
+			}
+			return ln, candidate, nil
+		}
+		if !isAddrInUse(err) {
+			return nil, "", fmt.Errorf("bind %s: %w", candidate, err)
+		}
+	}
+	return nil, "", fmt.Errorf(
+		"bind %s and +1..+%d all in use",
+		addr, portFallbackMaxOffset,
+	)
+}
+
+// isAddrInUse reports whether err indicates the address-in-use condition.
+// It checks [syscall.EADDRINUSE] via [errors.Is] (works on Linux/macOS) and
+// falls back to a string match for platforms whose listener wrapping does
+// not unwrap to the syscall errno.
+func isAddrInUse(err error) bool {
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Err != nil {
+		return containsAddrInUse(opErr.Err.Error())
+	}
+	return false
+}
+
+// containsAddrInUse looks for the canonical address-in-use substring.
+// Split out so it can be unit-tested independently of platform errno
+// behaviour.
+func containsAddrInUse(msg string) bool {
+	const needle = "address already in use"
+	if len(msg) < len(needle) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(msg); i++ {
+		if msg[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/server_port_fallback_test.go
+++ b/internal/api/server_port_fallback_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// silentLogger returns a slog.Logger that discards output so tests don't
+// spam the buffer with the expected fallback WARN.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestBindWithFallback_FreePort confirms a free port is bound at offset 0.
+func TestBindWithFallback_FreePort(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	ln, bound, err := bindWithFallback(context.Background(), silentLogger(), addr)
+	if err != nil {
+		t.Fatalf("bindWithFallback returned error: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if bound != addr {
+		t.Fatalf("expected bound addr %q, got %q", addr, bound)
+	}
+}
+
+// TestBindWithFallback_FallsBackOneStep grabs a port, holds it open, then
+// expects bindWithFallback to land on requested+1.
+func TestBindWithFallback_FallsBackOneStep(t *testing.T) {
+	hold, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("hold listen: %v", err)
+	}
+	defer func() { _ = hold.Close() }()
+
+	taken := hold.Addr().(*net.TCPAddr).Port
+	addr := "127.0.0.1:" + strconv.Itoa(taken)
+
+	ln, bound, err := bindWithFallback(context.Background(), silentLogger(), addr)
+	if err != nil {
+		t.Fatalf("bindWithFallback fell through: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	wantSuffix := ":" + strconv.Itoa(taken+1)
+	if !strings.HasSuffix(bound, wantSuffix) {
+		t.Fatalf("expected bound addr to end with %q, got %q", wantSuffix, bound)
+	}
+}
+
+// TestBindWithFallback_PortZeroUsesEphemeral confirms ":0" passes through
+// without any fallback (OS picks the ephemeral port).
+func TestBindWithFallback_PortZeroUsesEphemeral(t *testing.T) {
+	ln, bound, err := bindWithFallback(context.Background(), silentLogger(), "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bindWithFallback returned error: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if strings.HasSuffix(bound, ":0") {
+		t.Fatalf("expected resolved port, got %q", bound)
+	}
+}
+
+// TestIsAddrInUse_RecognisesSyscall confirms isAddrInUse matches a wrapped
+// EADDRINUSE.
+func TestIsAddrInUse_RecognisesSyscall(t *testing.T) {
+	wrapped := &net.OpError{Op: "listen", Err: syscall.EADDRINUSE}
+	if !isAddrInUse(wrapped) {
+		t.Fatalf("expected isAddrInUse to match EADDRINUSE")
+	}
+}
+
+// TestIsAddrInUse_RejectsOtherErrors ensures unrelated errors don't match.
+func TestIsAddrInUse_RejectsOtherErrors(t *testing.T) {
+	if isAddrInUse(errors.New("some unrelated failure")) {
+		t.Fatalf("expected isAddrInUse to reject unrelated error")
+	}
+}
+
+// TestBindWithFallback_BadAddrErrors confirms a malformed addr is rejected.
+func TestBindWithFallback_BadAddrErrors(t *testing.T) {
+	_, _, err := bindWithFallback(context.Background(), silentLogger(), "not-a-real-addr")
+	if err == nil {
+		t.Fatalf("expected error parsing bad addr")
+	}
+}


### PR DESCRIPTION
Implements #69. bindWithFallback helper walks port +1..+9 on EADDRINUSE with a structured WARN. Refactors Start() to bind both API and metrics listeners synchronously so bind errors surface immediately instead of dying in a background goroutine log.