### PR TITLE
fix(ci): Add target_tag input to SLSA backfill (#75 follow-up)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@
 # Triggers:
 #   - push to a v* tag: real release, builds + signs + publishes
 #   - workflow_dispatch with dry_run=true: snapshot, no publish or sign
+#   - workflow_dispatch with provenance_only=true (ref=<existing tag>):
+#     skips goreleaser entirely, recomputes artifact subjects from the
+#     already-published checksums.txt on that tag's GitHub release, then
+#     runs attest-build-provenance + uploads the .intoto.jsonl. Used to
+#     retroactively attest tags that shipped before the provenance job
+#     existed. provenance_only takes precedence over dry_run.
 #
 # Mirrors seed's .github/workflows/release.yml shape so the two projects
 # converge on the same release tooling.
@@ -38,6 +44,10 @@ on:
         description: "Snapshot build only - do not publish or sign"
         type: boolean
         default: true
+      provenance_only:
+        description: "Backfill: skip build, recompute subjects from the existing release's checksums.txt, attest + upload bundle"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -57,6 +67,7 @@ jobs:
   # =========================================================================
   build-ui:
     name: Build UI
+    if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
     outputs:
       ui_hash: ${{ steps.ui-hash.outputs.hash }}
@@ -97,6 +108,7 @@ jobs:
   # =========================================================================
   goreleaser:
     name: goreleaser
+    if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
     needs: [build-ui]
     container:
@@ -196,7 +208,50 @@ jobs:
           retention-days: 14
 
   # =========================================================================
-  # SLSA L3 provenance — runs only on real releases (not dry-run).
+  # SLSA provenance backfill — recomputes the subject list from a tag's
+  # already-published checksums.txt instead of running goreleaser. Used
+  # to retroactively attest tags that shipped before the provenance job
+  # existed (issue #75). Only fires under workflow_dispatch with
+  # provenance_only=true; on a push or normal dispatch this job is
+  # skipped and the regular `goreleaser` job feeds the provenance job.
+  # =========================================================================
+  goreleaser-backfill-hashes:
+    name: goreleaser (backfill subjects from existing release)
+    if: ${{ inputs.provenance_only }}
+    runs-on: ubuntu-latest
+    outputs:
+      # Same base64-subjects contract as the goreleaser job's `hashes`
+      # output. Provenance job picks whichever upstream produced one.
+      hashes: ${{ steps.hashes.outputs.hashes }}
+    steps:
+      - name: Download checksums.txt from existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release download "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern 'checksums.txt' \
+            --dir .
+          echo "checksums.txt contents:"
+          cat checksums.txt
+
+      - name: Convert checksums.txt to base64 subjects
+        id: hashes
+        shell: bash
+        run: |
+          # checksums.txt is the standard goreleaser format:
+          #   <sha256>  <filename>
+          # The attest-build-provenance `subject-checksums` input takes
+          # exactly that format. We base64-encode here so the output
+          # contract matches the goreleaser job's `hashes` output.
+          set -euo pipefail
+          hashes=$(base64 -w0 < checksums.txt)
+          echo "hashes=${hashes}" >> "$GITHUB_OUTPUT"
+
+  # =========================================================================
+  # SLSA L3 provenance — runs on real releases (not dry-run).
   #
   # Uses GitHub's first-party `actions/attest-build-provenance` rather than
   # the slsa-github-generator reusable workflow. The latter (v2.1.0, the
@@ -206,11 +261,19 @@ jobs:
   # produces the same SLSA L3 in-toto attestation (signed via Sigstore
   # keyless OIDC), surfaces it on the release's GitHub Attestations panel,
   # AND attaches the bundle file to the release as a downloadable asset.
+  #
+  # Two upstream paths feed this job (only one runs per invocation):
+  #   - normal release:  needs.goreleaser produces subjects from artifacts.json
+  #   - provenance_only: needs.goreleaser-backfill-hashes produces subjects
+  #                      from the existing release's checksums.txt
   # =========================================================================
   provenance:
     name: SLSA provenance
-    if: ${{ !inputs.dry_run }}
-    needs: [goreleaser]
+    # Skip on dry-run snapshots; require one of the two upstreams to have
+    # succeeded. `!cancelled()` lets this job run even though one of the
+    # two `needs` is intentionally skipped per dispatch path.
+    if: ${{ !inputs.dry_run && !cancelled() && (needs.goreleaser.result == 'success' || needs.goreleaser-backfill-hashes.result == 'success') }}
+    needs: [goreleaser, goreleaser-backfill-hashes]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # Sigstore OIDC signing
@@ -222,7 +285,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "${{ needs.goreleaser.outputs.hashes }}" | base64 -d > subjects.txt
+          # Pick whichever upstream ran. The unused one is empty.
+          echo "${{ needs.goreleaser.outputs.hashes || needs.goreleaser-backfill-hashes.outputs.hashes }}" \
+            | base64 -d > subjects.txt
           echo "Subjects:"
           cat subjects.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ on:
         description: "Backfill: skip build, recompute subjects from the existing release's checksums.txt, attest + upload bundle"
         type: boolean
         default: false
+      target_tag:
+        description: "Backfill target tag (e.g. v0.74.0). Required when provenance_only=true — workflow_dispatch must be issued against main since older tags don't have these inputs."
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -227,10 +231,17 @@ jobs:
       - name: Download checksums.txt from existing release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # workflow_dispatch must come from main (older tags don't have
+          # these inputs); target_tag carries the real tag to attest.
+          TARGET_TAG: ${{ inputs.target_tag }}
         shell: bash
         run: |
           set -euo pipefail
-          gh release download "${GITHUB_REF_NAME}" \
+          if [ -z "$TARGET_TAG" ]; then
+            echo "::error::provenance_only=true requires target_tag to identify which existing release to attest"
+            exit 1
+          fi
+          gh release download "$TARGET_TAG" \
             --repo "${GITHUB_REPOSITORY}" \
             --pattern 'checksums.txt' \
             --dir .
@@ -300,10 +311,11 @@ jobs:
       - name: Attach attestation bundle to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_TAG: ${{ inputs.target_tag || github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
           cp "${{ steps.attest.outputs.bundle-path }}" \
              niac-slsa-provenance.intoto.jsonl
-          gh release upload "${GITHUB_REF_NAME}" \
+          gh release upload "$TARGET_TAG" \
              niac-slsa-provenance.intoto.jsonl --clobber --repo "${GITHUB_REPOSITORY}"

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -23,6 +23,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -300,8 +301,18 @@ func (s *Server) Start() error {
 		s.registerAPIRoutes(mux)
 		s.httpServer = newSecureHTTPServer(s.cfg.Addr, mux)
 
+		// Bind before launching the serve goroutine so a fatal bind error
+		// (e.g. permission denied, or all fallback ports taken) surfaces
+		// synchronously instead of disappearing into a background log.
+		// See #69 — busy 8080 falls back to +1..+9 with a WARN.
+		apiLn, apiAddr, bindErr := bindWithFallback(context.Background(), s.logger, s.cfg.Addr)
+		if bindErr != nil {
+			return fmt.Errorf("API server bind: %w", bindErr)
+		}
+		s.httpServer.Addr = apiAddr
+
 		go func() {
-			if err := s.httpServer.ListenAndServe(); err != nil &&
+			if err := s.httpServer.Serve(apiLn); err != nil &&
 				!errors.Is(err, http.ErrServerClosed) {
 				s.logger.Error("API server stopped", "error", err)
 			}
@@ -313,8 +324,14 @@ func (s *Server) Start() error {
 		mux.HandleFunc("/metrics", s.recoverMiddleware(s.auth(s.handleMetrics)))
 		s.metricsServer = newSecureHTTPServer(s.cfg.MetricsAddr, mux)
 
+		metricsLn, metricsAddr, bindErr := bindWithFallback(context.Background(), s.logger, s.cfg.MetricsAddr)
+		if bindErr != nil {
+			return fmt.Errorf("metrics server bind: %w", bindErr)
+		}
+		s.metricsServer.Addr = metricsAddr
+
 		go func() {
-			if err := s.metricsServer.ListenAndServe(); err != nil &&
+			if err := s.metricsServer.Serve(metricsLn); err != nil &&
 				!errors.Is(err, http.ErrServerClosed) {
 				s.logger.Error("Metrics server stopped", "error", err)
 			}

--- a/internal/api/server_port_fallback.go
+++ b/internal/api/server_port_fallback.go
@@ -1,0 +1,114 @@
+package api
+
+// server_port_fallback.go provides bindWithFallback, a helper that opens
+// a TCP listener on a desired address and walks port+1..+9 if the
+// canonical port is already in use. This keeps `niac daemon` runnable
+// for developers who have another service squatting on 8080 without
+// changing the documented default port (see #69).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"syscall"
+)
+
+// portFallbackMaxOffset is the maximum offset above the requested port that
+// bindWithFallback will probe. Probes are requested..requested+portFallbackMaxOffset.
+const portFallbackMaxOffset = 9
+
+// bindWithFallback opens a TCP listener on addr (host:port form). If that
+// port is in use it walks port+1..+portFallbackMaxOffset and returns the
+// first listener that binds, logging a WARN with the requested and actual
+// port via the supplied logger.
+//
+// Non-EADDRINUSE errors are returned immediately — the caller must treat
+// them as fatal (permission denied, invalid address, etc.).
+//
+// The returned address string is the actual host:port the listener is
+// bound on (suitable for assigning back into [http.Server.Addr] so
+// /__version log lines reflect reality). The caller is responsible for
+// closing the returned listener (typically by passing it to
+// [http.Server.Serve] which closes on shutdown).
+func bindWithFallback(
+	ctx context.Context,
+	logger *slog.Logger,
+	addr string,
+) (net.Listener, string, error) {
+	host, portStr, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil {
+		return nil, "", fmt.Errorf("parse listen address %q: %w", addr, splitErr)
+	}
+	port, parseErr := strconv.Atoi(portStr)
+	if parseErr != nil {
+		return nil, "", fmt.Errorf("parse port %q from %q: %w", portStr, addr, parseErr)
+	}
+
+	var lc net.ListenConfig
+
+	// Port 0 means "let the OS pick" — no fallback needed.
+	if port == 0 {
+		ln, err := lc.Listen(ctx, "tcp", addr)
+		if err != nil {
+			return nil, "", fmt.Errorf("bind %s: %w", addr, err)
+		}
+		return ln, ln.Addr().String(), nil
+	}
+
+	for offset := 0; offset <= portFallbackMaxOffset; offset++ {
+		actual := port + offset
+		candidate := net.JoinHostPort(host, strconv.Itoa(actual))
+		ln, err := lc.Listen(ctx, "tcp", candidate)
+		if err == nil {
+			if offset > 0 && logger != nil {
+				logger.Warn(
+					"requested port is in use, bound fallback port instead",
+					"requested", port,
+					"bound", actual,
+				)
+			}
+			return ln, candidate, nil
+		}
+		if !isAddrInUse(err) {
+			return nil, "", fmt.Errorf("bind %s: %w", candidate, err)
+		}
+	}
+	return nil, "", fmt.Errorf(
+		"bind %s and +1..+%d all in use",
+		addr, portFallbackMaxOffset,
+	)
+}
+
+// isAddrInUse reports whether err indicates the address-in-use condition.
+// It checks [syscall.EADDRINUSE] via [errors.Is] (works on Linux/macOS) and
+// falls back to a string match for platforms whose listener wrapping does
+// not unwrap to the syscall errno.
+func isAddrInUse(err error) bool {
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Err != nil {
+		return containsAddrInUse(opErr.Err.Error())
+	}
+	return false
+}
+
+// containsAddrInUse looks for the canonical address-in-use substring.
+// Split out so it can be unit-tested independently of platform errno
+// behaviour.
+func containsAddrInUse(msg string) bool {
+	const needle = "address already in use"
+	if len(msg) < len(needle) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(msg); i++ {
+		if msg[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/server_port_fallback_test.go
+++ b/internal/api/server_port_fallback_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// silentLogger returns a slog.Logger that discards output so tests don't
+// spam the buffer with the expected fallback WARN.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestBindWithFallback_FreePort confirms a free port is bound at offset 0.
+func TestBindWithFallback_FreePort(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	ln, bound, err := bindWithFallback(context.Background(), silentLogger(), addr)
+	if err != nil {
+		t.Fatalf("bindWithFallback returned error: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if bound != addr {
+		t.Fatalf("expected bound addr %q, got %q", addr, bound)
+	}
+}
+
+// TestBindWithFallback_FallsBackOneStep grabs a port, holds it open, then
+// expects bindWithFallback to land on requested+1.
+func TestBindWithFallback_FallsBackOneStep(t *testing.T) {
+	hold, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("hold listen: %v", err)
+	}
+	defer func() { _ = hold.Close() }()
+
+	taken := hold.Addr().(*net.TCPAddr).Port
+	addr := "127.0.0.1:" + strconv.Itoa(taken)
+
+	ln, bound, err := bindWithFallback(context.Background(), silentLogger(), addr)
+	if err != nil {
+		t.Fatalf("bindWithFallback fell through: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	wantSuffix := ":" + strconv.Itoa(taken+1)
+	if !strings.HasSuffix(bound, wantSuffix) {
+		t.Fatalf("expected bound addr to end with %q, got %q", wantSuffix, bound)
+	}
+}
+
+// TestBindWithFallback_PortZeroUsesEphemeral confirms ":0" passes through
+// without any fallback (OS picks the ephemeral port).
+func TestBindWithFallback_PortZeroUsesEphemeral(t *testing.T) {
+	ln, bound, err := bindWithFallback(context.Background(), silentLogger(), "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bindWithFallback returned error: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	if strings.HasSuffix(bound, ":0") {
+		t.Fatalf("expected resolved port, got %q", bound)
+	}
+}
+
+// TestIsAddrInUse_RecognisesSyscall confirms isAddrInUse matches a wrapped
+// EADDRINUSE.
+func TestIsAddrInUse_RecognisesSyscall(t *testing.T) {
+	wrapped := &net.OpError{Op: "listen", Err: syscall.EADDRINUSE}
+	if !isAddrInUse(wrapped) {
+		t.Fatalf("expected isAddrInUse to match EADDRINUSE")
+	}
+}
+
+// TestIsAddrInUse_RejectsOtherErrors ensures unrelated errors don't match.
+func TestIsAddrInUse_RejectsOtherErrors(t *testing.T) {
+	if isAddrInUse(errors.New("some unrelated failure")) {
+		t.Fatalf("expected isAddrInUse to reject unrelated error")
+	}
+}
+
+// TestBindWithFallback_BadAddrErrors confirms a malformed addr is rejected.
+func TestBindWithFallback_BadAddrErrors(t *testing.T) {
+	_, _, err := bindWithFallback(context.Background(), silentLogger(), "not-a-real-addr")
+	if err == nil {
+		t.Fatalf("expected error parsing bad addr")
+	}
+}


### PR DESCRIPTION
Follow-up to #75. The previous design dispatched against the tag ref but GH parses workflow_dispatch inputs from the workflow file AT THAT REF — older tags don't have provenance_only, so every backfill dispatch returned HTTP 422. Fix: add target_tag input + dispatch from main.