### PR TITLE
fix(ci): Unescape apostrophe in target_tag description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ on:
         type: boolean
         default: false
       target_tag:
-        description: "Backfill target tag (e.g. v0.74.0). Required when provenance_only=true — workflow_dispatch must be issued against main since older tags don\'t have these inputs."
+        description: "Backfill target tag (e.g. v0.74.0). Required when provenance_only=true — workflow_dispatch must be issued against main since older tags don't have these inputs."
         type: string
         default: ""
 


### PR DESCRIPTION
Follow-up to the backfill target_tag PRs. The description string used \' which YAML rejects as an unknown escape in double-quoted strings. GitHub silently fell back to the file path as the workflow name and reported 'Workflow does not have workflow_dispatch trigger' on dispatch attempts. Fix: use plain ' since double-quoted YAML doesn't require it escaped.