### PR TITLE
feat(stories): primitive Storybook coverage for src/ui/ (Wave 5 / niac-W5-2)

### DIFF
--- a/ui/src/ui/Alert.stories.tsx
+++ b/ui/src/ui/Alert.stories.tsx
@@ -1,0 +1,60 @@
+/**
+ * Alert primitive stories (Wave 5 / #636).
+ *
+ * All 4 statuses, dismissible variant, rich-content body.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Alert } from './Alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'UI/Alert',
+  component: Alert,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    status: { control: 'select', options: ['success', 'error', 'warning', 'info'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Alert>;
+
+export const Success: Story = {
+  args: { status: 'success', children: 'Configuration saved successfully.' },
+};
+export const ErrorAlert: Story = {
+  name: 'Error',
+  args: { status: 'error', children: 'Failed to connect to the simulator daemon.' },
+};
+export const Warning: Story = {
+  args: { status: 'warning', children: 'The selected interface is currently down.' },
+};
+export const Info: Story = {
+  args: { status: 'info', children: 'Changes take effect after the next simulation cycle.' },
+};
+
+export const Dismissible: Story = {
+  args: {
+    status: 'info',
+    children: 'You can dismiss this alert.',
+    onDismiss: () => undefined,
+  },
+};
+
+export const RichContent: Story = {
+  args: {
+    status: 'warning',
+    children: (
+      <div className="space-y-1">
+        <p className="font-medium">License renewal due in 7 days</p>
+        <p className="text-sm">
+          Renew via Settings → License or contact{' '}
+          <a className="underline" href="mailto:support@mustardseed.io">
+            support@mustardseed.io
+          </a>
+          .
+        </p>
+      </div>
+    ),
+    onDismiss: () => undefined,
+  },
+};

--- a/ui/src/ui/Button.stories.tsx
+++ b/ui/src/ui/Button.stories.tsx
@@ -1,0 +1,82 @@
+/**
+ * Button primitive stories (Wave 5 / #636).
+ *
+ * Covers the variant × tone × size matrix, disabled + loading
+ * states, and the left/right icon slots.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArrowRight, Check, Trash2 } from 'lucide-react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'UI/Button',
+  component: Button,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: { control: 'select', options: ['solid', 'outline', 'ghost', 'secondary'] },
+    tone: { control: 'select', options: ['violet', 'red', 'green', 'blue', 'gray'] },
+    size: { control: 'select', options: ['xs', 'sm', 'md', 'lg'] },
+    disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+  },
+  args: { children: 'Button' },
+};
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = { args: { variant: 'solid', tone: 'violet', size: 'md' } };
+export const Outline: Story = { args: { variant: 'outline', tone: 'violet' } };
+export const Ghost: Story = { args: { variant: 'ghost', tone: 'gray' } };
+export const Secondary: Story = { args: { variant: 'secondary' } };
+
+export const Destructive: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'red',
+    leftIcon: <Trash2 className="w-4 h-4" />,
+    children: 'Delete',
+  },
+};
+export const Success: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'green',
+    leftIcon: <Check className="w-4 h-4" />,
+    children: 'Confirm',
+  },
+};
+export const WithRightIcon: Story = {
+  args: {
+    variant: 'solid',
+    tone: 'blue',
+    rightIcon: <ArrowRight className="w-4 h-4" />,
+    children: 'Next',
+  },
+};
+
+export const Disabled: Story = { args: { disabled: true } };
+export const Loading: Story = { args: { loading: true, children: 'Submitting…' } };
+
+export const SizeMatrix: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Button size="xs">XS</Button>
+      <Button size="sm">SM</Button>
+      <Button size="md">MD</Button>
+      <Button size="lg">LG</Button>
+    </div>
+  ),
+};
+
+export const ToneMatrix: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Button tone="violet">Violet</Button>
+      <Button tone="red">Red</Button>
+      <Button tone="green">Green</Button>
+      <Button tone="blue">Blue</Button>
+      <Button tone="gray">Gray</Button>
+    </div>
+  ),
+};

--- a/ui/src/ui/ConfirmModal.stories.tsx
+++ b/ui/src/ui/ConfirmModal.stories.tsx
@@ -1,0 +1,96 @@
+/**
+ * ConfirmModal primitive stories (Wave 5 / #636).
+ *
+ * Destructive/neutral/info variants plus a custom-icon and a
+ * rich-message example.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AlertTriangle, Trash2 } from 'lucide-react';
+import { ConfirmModal } from './ConfirmModal';
+
+const meta: Meta<typeof ConfirmModal> = {
+  title: 'UI/ConfirmModal',
+  component: ConfirmModal,
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    confirmTone: { control: 'select', options: ['red', 'violet', 'blue', 'green'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ConfirmModal>;
+
+const noop = () => undefined;
+
+export const DestructiveDelete: Story = {
+  args: {
+    isOpen: true,
+    title: 'Delete device?',
+    message: 'This permanently removes the device and its simulation history.',
+    confirmLabel: 'Delete',
+    cancelLabel: 'Cancel',
+    confirmTone: 'red',
+    icon: <Trash2 className="w-6 h-6" />,
+    onConfirm: noop,
+    onCancel: noop,
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    isOpen: true,
+    title: 'Restart simulator?',
+    message: 'In-flight protocol sessions will be interrupted.',
+    confirmLabel: 'Restart',
+    confirmTone: 'violet',
+    onConfirm: noop,
+    onCancel: noop,
+  },
+};
+
+export const Info: Story = {
+  args: {
+    isOpen: true,
+    title: 'Apply changes?',
+    message: 'The configuration takes effect immediately and survives restart.',
+    confirmLabel: 'Apply',
+    confirmTone: 'blue',
+    onConfirm: noop,
+    onCancel: noop,
+  },
+};
+
+export const WithCustomIcon: Story = {
+  args: {
+    isOpen: true,
+    title: 'Switch protocol set?',
+    message: 'Active protocol bindings will be dropped and re-initialized.',
+    confirmLabel: 'Switch',
+    confirmTone: 'violet',
+    icon: <AlertTriangle className="w-6 h-6" />,
+    onConfirm: noop,
+    onCancel: noop,
+  },
+};
+
+export const RichMessage: Story = {
+  args: {
+    isOpen: true,
+    title: 'Bulk delete devices?',
+    message: (
+      <div className="space-y-2">
+        <p>You're about to delete 18 devices:</p>
+        <ul className="list-disc list-inside text-sm text-text-muted">
+          <li>15 routers</li>
+          <li>3 switches</li>
+        </ul>
+        <p className="text-status-error text-sm font-medium">This cannot be undone.</p>
+      </div>
+    ),
+    confirmLabel: 'Delete all',
+    confirmTone: 'red',
+    onConfirm: noop,
+    onCancel: noop,
+  },
+};

--- a/ui/src/ui/Input.stories.tsx
+++ b/ui/src/ui/Input.stories.tsx
@@ -1,0 +1,52 @@
+/**
+ * Input primitive stories (Wave 5 / #636).
+ *
+ * label/hint/error decorations, leftIcon/rightIcon slots, password
+ * and disabled states.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Lock, Mail } from 'lucide-react';
+import { Input } from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'UI/Input',
+  component: Input,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    hint: { control: 'text' },
+    error: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = { args: { label: 'Username', placeholder: 'admin' } };
+
+export const WithHint: Story = {
+  args: { label: 'API token', placeholder: 'nia_…', hint: 'Found in Settings → API' },
+};
+
+export const WithError: Story = {
+  args: { label: 'Email', placeholder: 'you@example.com', error: 'Email is required' },
+};
+
+export const WithLeftIcon: Story = {
+  args: { label: 'Email', placeholder: 'you@example.com', leftIcon: <Mail className="w-4 h-4" /> },
+};
+
+export const Password: Story = {
+  args: {
+    label: 'Password',
+    type: 'password',
+    placeholder: '••••••••',
+    leftIcon: <Lock className="w-4 h-4" />,
+  },
+};
+
+export const Disabled: Story = {
+  args: { label: 'Locked field', value: 'cannot edit', disabled: true },
+};

--- a/ui/src/ui/Modal.stories.tsx
+++ b/ui/src/ui/Modal.stories.tsx
@@ -1,0 +1,99 @@
+/**
+ * Modal primitive stories (Wave 5 / #636).
+ *
+ * Size matrix, showCloseButton/closeOnBackdropClick/closeOnEscape
+ * flag combinations, with-title vs no-title shells.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Button } from './Button';
+import { Modal } from './Modal';
+
+const meta: Meta<typeof Modal> = {
+  title: 'UI/Modal',
+  component: Modal,
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg', 'xl', 'full'] },
+    isOpen: { control: 'boolean' },
+    showCloseButton: { control: 'boolean' },
+    closeOnBackdropClick: { control: 'boolean' },
+    closeOnEscape: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+const SampleBody = () => (
+  <div className="space-y-2">
+    <p>Modal content goes here.</p>
+    <p className="text-text-muted text-sm">A second paragraph to show vertical rhythm.</p>
+  </div>
+);
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    title: 'Default modal',
+    onClose: () => undefined,
+    children: <SampleBody />,
+  },
+};
+
+export const NoTitleNoCloseButton: Story = {
+  args: {
+    isOpen: true,
+    showCloseButton: false,
+    onClose: () => undefined,
+    children: <SampleBody />,
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    isOpen: true,
+    size: 'sm',
+    title: 'Small',
+    onClose: () => undefined,
+    children: <SampleBody />,
+  },
+};
+export const LargeSize: Story = {
+  args: {
+    isOpen: true,
+    size: 'lg',
+    title: 'Large',
+    onClose: () => undefined,
+    children: <SampleBody />,
+  },
+};
+export const FullSize: Story = {
+  args: {
+    isOpen: true,
+    size: 'full',
+    title: 'Full width',
+    onClose: () => undefined,
+    children: <SampleBody />,
+  },
+};
+
+export const InteractiveToggle: Story = {
+  args: {
+    isOpen: false,
+    title: 'Trigger demo',
+    onClose: () => undefined,
+    children: <SampleBody />,
+  },
+  render: function interactiveRender(args) {
+    const [open, setOpen] = useState(false);
+    return (
+      <div className="p-8">
+        <Button onClick={() => setOpen(true)}>Open modal</Button>
+        <Modal {...args} isOpen={open} onClose={() => setOpen(false)}>
+          <SampleBody />
+        </Modal>
+      </div>
+    );
+  },
+};

--- a/ui/src/ui/Tag.stories.tsx
+++ b/ui/src/ui/Tag.stories.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tag primitive stories (Wave 5 / #636).
+ *
+ * Full colorScheme matrix.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Tag } from './Tag';
+
+const meta: Meta<typeof Tag> = {
+  title: 'UI/Tag',
+  component: Tag,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    colorScheme: {
+      control: 'select',
+      options: ['gray', 'red', 'green', 'blue', 'yellow', 'purple', 'violet', 'cyan'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tag>;
+
+export const Default: Story = { args: { children: 'Default', colorScheme: 'gray' } };
+export const Green: Story = { args: { children: 'Active', colorScheme: 'green' } };
+export const Red: Story = { args: { children: 'Error', colorScheme: 'red' } };
+export const Blue: Story = { args: { children: 'Info', colorScheme: 'blue' } };
+export const Yellow: Story = { args: { children: 'Warning', colorScheme: 'yellow' } };
+export const Violet: Story = { args: { children: 'Beta', colorScheme: 'violet' } };
+
+export const ColorMatrix: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Tag colorScheme="gray">Gray</Tag>
+      <Tag colorScheme="red">Red</Tag>
+      <Tag colorScheme="green">Green</Tag>
+      <Tag colorScheme="blue">Blue</Tag>
+      <Tag colorScheme="yellow">Yellow</Tag>
+      <Tag colorScheme="purple">Purple</Tag>
+      <Tag colorScheme="violet">Violet</Tag>
+      <Tag colorScheme="cyan">Cyan</Tag>
+    </div>
+  ),
+};

--- a/ui/src/ui/Tooltip.stories.tsx
+++ b/ui/src/ui/Tooltip.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tooltip primitive stories (Wave 5 / #636).
+ *
+ * All four sides (top/bottom/left/right), text and rich-content
+ * bubbles.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Tooltip } from './Tooltip';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'UI/Tooltip',
+  component: Tooltip,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    side: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+const Trigger = () => (
+  <span className="inline-block px-3 py-2 rounded border border-border-muted bg-bg-muted/20 text-text-secondary">
+    hover me
+  </span>
+);
+
+export const Top: Story = {
+  args: { side: 'top', text: 'Tooltip on top', children: <Trigger /> },
+};
+export const Bottom: Story = {
+  args: { side: 'bottom', text: 'Tooltip on bottom', children: <Trigger /> },
+};
+export const Left: Story = {
+  args: { side: 'left', text: 'Tooltip on left', children: <Trigger /> },
+};
+export const Right: Story = {
+  args: { side: 'right', text: 'Tooltip on right', children: <Trigger /> },
+};
+
+export const RichContent: Story = {
+  args: {
+    side: 'top',
+    text: (
+      <div className="space-y-1">
+        <p className="font-medium">SNMPv3 user</p>
+        <p className="text-xs text-text-muted">authPriv with SHA-256/AES-128</p>
+      </div>
+    ),
+    children: <Trigger />,
+  },
+};
+
+export const NoText: Story = {
+  args: { children: <Trigger /> },
+  parameters: {
+    docs: {
+      description: { story: 'When `text` is omitted, the wrapper renders children unchanged.' },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Wave 5 task **niac-W5-2**. Adds 7 high-leverage primitive stories on top of the scaffold from #638. Covers the 7 most-used UI primitives in \`src/ui/\`; the remaining 14 (BaseCard, Breadcrumbs, Card, CommandPalette, ConnectionStatus, InputModal, Layout, PageLoader, Sidebar, Skeleton, StatusBadge, StatusConfig, ToastContainer, Typography) deferred to a follow-up to keep this PR reviewable.

## New stories — 47 variants across 7 primitives

| Primitive | Variants |
|---|---|
| **Button** | Default, Outline, Ghost, Secondary, Destructive, Success, WithRightIcon, Disabled, Loading + SizeMatrix + ToneMatrix (11) |
| **Modal** | Default, NoTitleNoCloseButton, Small, Large, Full, InteractiveToggle (6) |
| **Input** | Default, WithHint, WithError, WithLeftIcon, Password, Disabled (6) |
| **ConfirmModal** | DestructiveDelete, Neutral, Info, WithCustomIcon, RichMessage (5) |
| **Alert** | Success, Error, Warning, Info, Dismissible, RichContent (6) |
| **Tag** | Default + 5 named colors + ColorMatrix (7) |
| **Tooltip** | Top, Bottom, Left, Right + RichContent + NoText (6) |

## Stack position

Depends on **#638** (Storybook scaffold) and transitively on **#637** (biome pin). Branch based on \`chore/wave5-storybook-scaffold\`.

Order to merge:
1. #637 (biome pin)
2. #638 (scaffold) — closes #636
3. **This PR (niac-W5-2)** — primitive stories
4. niac-W5-3 (CI Storybook gate) — to follow

## Follow-up scope

A separate small PR will cover the remaining 14 primitives (mostly compound/layout components that need slightly more thought):
- BaseCard, Breadcrumbs, Card, CommandPalette
- ConnectionStatus, InputModal, Layout, PageLoader, Sidebar
- Skeleton, StatusBadge, StatusConfig, ToastContainer, Typography

## Verification

- \`npm run lint\` clean (220 files)
- \`npm run build-storybook\` completes
- All 47 variants render in the static build