### PR TITLE
ci(ui): gate Storybook build in Frontend job (Wave 5 / niac-W5-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,16 @@ jobs:
           path: internal/api/ui/
           retention-days: 1
 
+      - name: Build Storybook
+        run: npm run build-storybook -- --output-dir storybook-static --quiet
+
+      - name: Upload Storybook static
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: storybook-static
+          path: ui/storybook-static/
+          retention-days: 7
+
   # ===========================================================================
   # Security Scanning
   # ===========================================================================


### PR DESCRIPTION
## Summary

Wave 5 task **niac-W5-3** — final piece of the niac Storybook track. Adds \`storybook build\` to the Frontend CI job. Mirrors what landed in seed#1061 and stem#242 — broken stories fail CI rather than passing tsc + vitest unnoticed.

## What it catches

- Orphan story files (the BaseCard/Skeleton class)
- Broken decorator type signatures
- Args/props drift
- The \`storybook/test\` rename trap

## Stack position

Depends on:
- **#639** (primitive stories) — provides 7 working stories to build
- **#638** (Storybook scaffold) — provides the build script + addons
- **#637** (biome pin) — without this, lint pre-commit crashes

Without the scaffold (#638), this step would fail at "command not found".

## Verification

\`npm run build-storybook\` completes locally against the #639 base.

## Wave 5 niac track — COMPLETE

| # | Task | PR |
|---|---|---|
| niac-biome | biome 2.4.15 → 2.4.10 pin | #637 |
| niac-W5-1 | Storybook scaffold (closes #636) | #638 |
| niac-W5-2 | 7 primitive stories | #639 |
| **niac-W5-3** | **CI Storybook gate** | **this PR** |

## Backlog

\`niac-W5-2b\` (#34) — stories for the remaining 14 primitives (BaseCard, Breadcrumbs, Card, CommandPalette, ConnectionStatus, InputModal, Layout, PageLoader, Sidebar, Skeleton, StatusBadge, StatusConfig, ToastContainer, Typography). Deferred as a separate small PR.