### PR TITLE
feat(stories): cover 8 more src/ui/ primitives (Wave 5 / niac-W5-2b)

### DIFF
--- a/ui/src/ui/BaseCard.stories.tsx
+++ b/ui/src/ui/BaseCard.stories.tsx
@@ -1,0 +1,83 @@
+/**
+ * BaseCard primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * Exercises the loading/error/empty/data render branches. BaseCard
+ * is a generic wrapper that derives status from data + a getStatus
+ * function and renders via a children render-prop.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Database } from 'lucide-react';
+import { BaseCard } from './BaseCard';
+
+interface Sample {
+  ip: string;
+  uptime: string;
+  packets: number;
+}
+
+const meta: Meta<typeof BaseCard<Sample>> = {
+  title: 'UI/BaseCard',
+  component: BaseCard<Sample>,
+  parameters: { layout: 'centered' },
+};
+export default meta;
+
+type Story = StoryObj<typeof BaseCard<Sample>>;
+
+const sample: Sample = { ip: '192.168.1.42', uptime: '4h 22m', packets: 18234 };
+
+const renderRow = (d: Sample) => (
+  <dl className="grid grid-cols-2 gap-1 text-sm">
+    <dt className="text-text-muted">IP</dt>
+    <dd>{d.ip}</dd>
+    <dt className="text-text-muted">Uptime</dt>
+    <dd>{d.uptime}</dd>
+    <dt className="text-text-muted">Packets</dt>
+    <dd>{d.packets.toLocaleString()}</dd>
+  </dl>
+);
+
+export const WithData: Story = {
+  args: {
+    title: 'Device',
+    subtitle: 'eth0',
+    icon: <Database className="w-4 h-4" />,
+    data: sample,
+    getStatus: () => 'success',
+    children: renderRow,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: 'Device',
+    icon: <Database className="w-4 h-4" />,
+    data: null,
+    loading: true,
+    getStatus: () => 'unknown',
+    children: renderRow,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    title: 'Device',
+    icon: <Database className="w-4 h-4" />,
+    data: null,
+    emptyMessage: 'No devices configured',
+    getStatus: () => 'unknown',
+    children: renderRow,
+  },
+};
+
+export const ErrorState: Story = {
+  name: 'Error',
+  args: {
+    title: 'Device',
+    icon: <Database className="w-4 h-4" />,
+    data: null,
+    error: 'Failed to fetch device state (connection refused).',
+    getStatus: () => 'error',
+    children: renderRow,
+  },
+};

--- a/ui/src/ui/Card.stories.tsx
+++ b/ui/src/ui/Card.stories.tsx
@@ -1,0 +1,52 @@
+/**
+ * Card primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * Covers the 4 variants (default/elevated/outlined/ghost), the
+ * StatusCard composite, and the CardContent inner wrapper.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Card, CardContent, StatusCard } from './Card';
+
+const meta: Meta<typeof Card> = {
+  title: 'UI/Card',
+  component: Card,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'elevated', 'outlined', 'ghost'] },
+    hover: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+const SampleBody = (
+  <CardContent>
+    <p className="text-text-primary">Card body content.</p>
+    <p className="text-text-muted text-sm mt-1">Secondary detail line.</p>
+  </CardContent>
+);
+
+export const Default: Story = { args: { variant: 'default', children: SampleBody } };
+export const Elevated: Story = { args: { variant: 'elevated', children: SampleBody } };
+export const Outlined: Story = { args: { variant: 'outlined', children: SampleBody } };
+export const Ghost: Story = { args: { variant: 'ghost', children: SampleBody } };
+export const Hoverable: Story = { args: { variant: 'default', hover: true, children: SampleBody } };
+
+export const StatusSuccess: Story = {
+  name: 'StatusCard / success',
+  render: () => (
+    <StatusCard title="Daemon" subtitle="Running for 4h 22m" status="success">
+      <p className="text-text-muted text-sm">All protocol bindings nominal.</p>
+    </StatusCard>
+  ),
+};
+
+export const StatusError: Story = {
+  name: 'StatusCard / error',
+  render: () => (
+    <StatusCard title="Daemon" subtitle="Last restart 12s ago" status="error">
+      <p className="text-text-muted text-sm">DHCP module failed to bind to eth0.</p>
+    </StatusCard>
+  ),
+};

--- a/ui/src/ui/InputModal.stories.tsx
+++ b/ui/src/ui/InputModal.stories.tsx
@@ -1,0 +1,62 @@
+/**
+ * InputModal primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * Single-field prompt modal — covers the tone matrix + defaultValue.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { InputModal } from './InputModal';
+
+const meta: Meta<typeof InputModal> = {
+  title: 'UI/InputModal',
+  component: InputModal,
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    submitTone: { control: 'select', options: ['violet', 'blue', 'green', 'red'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof InputModal>;
+
+const noop = () => undefined;
+const onSubmit = (_value: string) => undefined;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    title: 'Rename device',
+    message: 'Enter a new name for this device.',
+    placeholder: 'router-01',
+    submitLabel: 'Rename',
+    submitTone: 'violet',
+    onSubmit,
+    onCancel: noop,
+  },
+};
+
+export const WithDefaultValue: Story = {
+  args: {
+    isOpen: true,
+    title: 'Edit hostname',
+    message: 'This hostname is announced in DHCP, LLDP, and CDP.',
+    defaultValue: 'router-01',
+    submitLabel: 'Save',
+    submitTone: 'blue',
+    onSubmit,
+    onCancel: noop,
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    isOpen: true,
+    title: 'Type DELETE to confirm',
+    message: 'This action cannot be undone.',
+    placeholder: 'DELETE',
+    submitLabel: 'Delete',
+    submitTone: 'red',
+    onSubmit,
+    onCancel: noop,
+  },
+};

--- a/ui/src/ui/Layout.stories.tsx
+++ b/ui/src/ui/Layout.stories.tsx
@@ -1,0 +1,58 @@
+/**
+ * Layout primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * Covers PageShell, PageHeader, and StatusIndicator. PrimaryNav is
+ * deferred — it needs a React Router context the storybook shell
+ * doesn't provide by default.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Database, Plus } from 'lucide-react';
+import { Button } from './Button';
+import { PageHeader, PageShell, StatusIndicator } from './Layout';
+
+const meta: Meta = {
+  title: 'UI/Layout',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const PageShellExample: Story = {
+  name: 'PageShell',
+  render: () => (
+    <PageShell>
+      <div className="p-6 rounded-md border border-border-muted bg-bg-elevated text-text-primary">
+        PageShell wraps the routed page with a gradient background and a constrained-width inner
+        container.
+      </div>
+    </PageShell>
+  ),
+};
+
+export const PageHeaderExample: Story = {
+  name: 'PageHeader',
+  render: () => (
+    <PageShell>
+      <PageHeader
+        title="Devices"
+        description="Simulated hosts visible on the data plane."
+        icon={Database}
+        actions={<Button leftIcon={<Plus className="w-4 h-4" />}>Add device</Button>}
+      />
+    </PageShell>
+  ),
+};
+
+export const StatusIndicatorMatrix: Story = {
+  name: 'StatusIndicator / all states',
+  render: () => (
+    <div className="p-8 flex flex-col gap-3">
+      <StatusIndicator status="online" label="Online" />
+      <StatusIndicator status="warning" label="Warning" pulse />
+      <StatusIndicator status="error" label="Error" />
+      <StatusIndicator status="offline" label="Offline" />
+      <StatusIndicator status="pending" label="Pending" pulse />
+    </div>
+  ),
+};

--- a/ui/src/ui/PageLoader.stories.tsx
+++ b/ui/src/ui/PageLoader.stories.tsx
@@ -1,0 +1,18 @@
+/**
+ * PageLoader primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * Full-page loading shell shown during code-split chunk fetch.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PageLoader } from './PageLoader';
+
+const meta: Meta<typeof PageLoader> = {
+  title: 'UI/PageLoader',
+  component: PageLoader,
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj<typeof PageLoader>;
+
+export const Default: Story = {};

--- a/ui/src/ui/Skeleton.stories.tsx
+++ b/ui/src/ui/Skeleton.stories.tsx
@@ -1,0 +1,41 @@
+/**
+ * Skeleton primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * All variants (text/circular/rectangular), sizing, multi-line text.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Skeleton } from './Skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'UI/Skeleton',
+  component: Skeleton,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: { control: 'select', options: ['text', 'circular', 'rectangular'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Text: Story = { args: { variant: 'text', width: 220 } };
+export const TextMultiLine: Story = { args: { variant: 'text', lines: 4, width: 280 } };
+export const Circular: Story = { args: { variant: 'circular', width: 48, height: 48 } };
+export const Rectangular: Story = { args: { variant: 'rectangular', width: 280, height: 120 } };
+
+export const CardSkeleton: Story = {
+  name: 'Composed: card placeholder',
+  render: () => (
+    <div className="w-72 p-4 border border-border-muted rounded-md space-y-3">
+      <div className="flex items-center gap-3">
+        <Skeleton variant="circular" width={40} height={40} />
+        <div className="flex-1 space-y-2">
+          <Skeleton variant="text" width="60%" />
+          <Skeleton variant="text" width="40%" />
+        </div>
+      </div>
+      <Skeleton variant="rectangular" height={80} />
+      <Skeleton variant="text" lines={3} />
+    </div>
+  ),
+};

--- a/ui/src/ui/StatusBadge.stories.tsx
+++ b/ui/src/ui/StatusBadge.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * StatusBadge primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * Status matrix × icon/dot variants × sizes.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { StatusBadge } from './StatusBadge';
+
+const meta: Meta<typeof StatusBadge> = {
+  title: 'UI/StatusBadge',
+  component: StatusBadge,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['success', 'warning', 'error', 'loading', 'unknown', 'info'],
+    },
+    variant: { control: 'select', options: ['icon', 'dot'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StatusBadge>;
+
+export const Success: Story = { args: { status: 'success', variant: 'icon' } };
+export const Warning: Story = { args: { status: 'warning', variant: 'icon' } };
+export const ErrorState: Story = {
+  name: 'Error',
+  args: { status: 'error', variant: 'icon' },
+};
+export const Loading: Story = { args: { status: 'loading', variant: 'icon' } };
+export const Info: Story = { args: { status: 'info', variant: 'icon' } };
+export const Unknown: Story = { args: { status: 'unknown', variant: 'icon' } };
+
+export const DotVariant: Story = { args: { status: 'success', variant: 'dot' } };
+
+export const FullMatrix: Story = {
+  render: () => (
+    <div className="grid grid-cols-6 gap-3 items-center">
+      {(['success', 'warning', 'error', 'loading', 'unknown', 'info'] as const).map((s) => (
+        <StatusBadge key={s} status={s} variant="icon" />
+      ))}
+      {(['success', 'warning', 'error', 'loading', 'unknown', 'info'] as const).map((s) => (
+        <StatusBadge key={`dot-${s}`} status={s} variant="dot" />
+      ))}
+    </div>
+  ),
+};

--- a/ui/src/ui/Typography.stories.tsx
+++ b/ui/src/ui/Typography.stories.tsx
@@ -1,0 +1,40 @@
+/**
+ * Typography primitive stories (Wave 5 / niac-W5-2b).
+ *
+ * Showcases the typography scale (H1-H4, P, SmallText, Caption) plus
+ * the AccentLink helper.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AccentLink, Caption, H1, H2, H3, H4, P, SmallText } from './Typography';
+
+const meta: Meta = {
+  title: 'UI/Typography',
+  parameters: { layout: 'padded' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Scale: Story = {
+  render: () => (
+    <div className="space-y-3 max-w-xl">
+      <H1>H1 — Heading One</H1>
+      <H2>H2 — Heading Two</H2>
+      <H3>H3 — Heading Three</H3>
+      <H4>H4 — Heading Four</H4>
+      <P>P — Body paragraph. The quick brown fox jumps over the lazy dog.</P>
+      <SmallText>SmallText — secondary helper line.</SmallText>
+      <Caption>Caption — finest print, often used for labels.</Caption>
+    </div>
+  ),
+};
+
+export const AccentLinkExample: Story = {
+  name: 'AccentLink',
+  render: () => (
+    <P>
+      Visit the <AccentLink href="https://mustardseed.io">mustardseed.io</AccentLink> docs for more
+      detail.
+    </P>
+  ),
+};


### PR DESCRIPTION
## Summary

Wave 5 follow-up to #639. Adds Storybook coverage for **8 more primitives** — 32 new variants total.

## New stories

| Primitive | Variants |
|---|---|
| **Card** | Default + 3 variants (elevated/outlined/ghost) + Hoverable + StatusCard success/error (7) |
| **BaseCard** | WithData + Loading + Empty + Error (4 — generic render-prop card) |
| **Skeleton** | Text + TextMultiLine + Circular + Rectangular + CardSkeleton composite (5) |
| **StatusBadge** | All 6 statuses + DotVariant + FullMatrix (8) |
| **Typography** | Scale (H1-Caption) + AccentLink (2) |
| **PageLoader** | Default (1) |
| **InputModal** | Default + WithDefaultValue + Destructive (3) |
| **Layout** | PageShell + PageHeader + StatusIndicatorMatrix (3) |

## Deferred (need heavy mocks — separate follow-up)

These 6 primitives need context wrappers Storybook doesn't provide by default. Worth a separate small PR with decorators:

- **Breadcrumbs** — React Router context
- **CommandPalette** — keyboard + router
- **ConnectionStatus** — WebSocket polling
- **Sidebar** — Router + full nav tree
- **ToastContainer** — Zustand UI store
- **StatusConfig** — helpers only, no component (skip)

After this PR: **15 of 21** \`src/ui/\` primitives have stories.

## Stack position

Depends on #639 (the first 7 stories) and transitively #638 (scaffold) + #637 (biome pin).

## Verification

- \`npm run lint\` clean (228 files)
- \`npm run build-storybook\` completes
- All new variants render

## Out of scope (separate PRs, per direction)

- Node 26.2.0 bump — standalone PR per repo
- TypeScript 6.0.3 bump — standalone PR per repo