### PR TITLE
ci: Bind niac daemon to 127.0.0.1 in E2E + Lighthouse jobs (Wave 5 / #36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,7 +647,7 @@ jobs:
 
       - name: Start backend server
         run: |
-          nohup ./niac daemon --listen :8080 > server.log 2>&1 &
+          nohup ./niac daemon --listen 127.0.0.1:8080 > server.log 2>&1 &
           echo "Waiting for server to start..."
           for i in {1..30}; do
             if curl -sf http://localhost:8080/__version 2>/dev/null; then
@@ -728,7 +728,7 @@ jobs:
 
       - name: Start server
         run: |
-          nohup ./niac daemon --listen :8080 > server.log 2>&1 &
+          nohup ./niac daemon --listen 127.0.0.1:8080 > server.log 2>&1 &
           for i in {1..30}; do
             if curl -sf http://localhost:8080/__version 2>/dev/null; then
               echo "Server ready"


### PR DESCRIPTION
## Summary

Fixes the two long-standing red checks on every niac PR (**E2E Browser Tests** and **Lighthouse Audit**). Both have been failing identically with:

\`\`\`
Error: niac refuses to bind a non-loopback address without an API token.
\`\`\`

## Root cause

Wave 2 added a security guard that refuses to bind the daemon to a non-loopback address unless \`NIAC_API_TOKEN\` is set. CI was passing \`--listen :8080\` (all interfaces) which trips the guard on every run.

## Fix

Pin both daemon spawns in \`.github/workflows/ci.yml\` to \`127.0.0.1:8080\`:

| Line | Job |
|---|---|
| 650 | E2E Browser Tests |
| 731 | Lighthouse Audit |

Playwright + Lighthouse both run on the same host as the daemon, so loopback is the correct choice — and matches the guard's intent (non-loopback binding should require auth).

## Why now

Both jobs are advisory (deliberately excluded from \`CI Complete\` per the workflow comment) so the failures don't block merge, but the red noise was:
1. Hiding actual regressions if they ever appeared
2. Signalling false-failure to reviewers
3. Adding visible drag to every PR

This was flagged as Wave 5 task #36.

## Verification

Cannot run E2E locally without spinning up the full niac daemon, but the fix is mechanical: the guard rejects \`:8080\` (unspecified) and accepts \`127.0.0.1:8080\` (loopback). The next CI run on any PR will confirm.

## Closes

Wave 5 / task #36 (niac E2E + Lighthouse failures)