### PR TITLE
chore(deps): Bump TypeScript 5.9.3 → 6.0.3 (Wave 5 cross-repo parity)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -48,7 +48,7 @@
         "playwright": "1.60.0",
         "postcss": "8.5.14",
         "rollup-plugin-visualizer": "5.14.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite": "7.3.3",
         "vitest": "4.1.6",
         "zod": "4.4.3"
@@ -5034,9 +5034,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -64,7 +64,7 @@
     "playwright": "1.60.0",
     "postcss": "8.5.14",
     "rollup-plugin-visualizer": "5.14.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "7.3.3",
     "vitest": "4.1.6",
     "zod": "4.4.3"


### PR DESCRIPTION
## Summary

Bumps TypeScript from **5.9.3 → 6.0.3** for niac. Seed + stem are already on 6.0.3; this brings niac to parity.

## Verification

- \`npx tsc --version\` → 6.0.3
- \`npx tsc --noEmit\` → clean, 0 errors
- No code changes required — the niac UI was already TS 6-clean by accident

## Files

- \`ui/package.json\` — typescript "5.9.3" → "6.0.3" (exact pin per CLAUDE.md)
- \`ui/package-lock.json\` — pulled

## Cross-repo

This is the niac side of Wave 5 / task #31. Seed + stem already on 6.0.3:

\`\`\`
seed:  "typescript": "6.0.3",
stem:  "typescript": "6.0.3",
niac:  "typescript": "5.9.3"  ← bumping here
\`\`\`

## Doc note

The project-wide \`CLAUDE.md\` required-versions table still lists 5.9.3. That can be updated lazily on the next CLAUDE.md edit; not blocking.