### PR TITLE
fix(tsconfig): Drop deprecated baseUrl from tsconfig.app.json (TS 6 compat)

### DIFF
--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -17,10 +17,10 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Path aliases */
-    "baseUrl": ".",
+    /* Path aliases. In TS 6+ `paths` works without `baseUrl` —
+       patterns are resolved relative to the tsconfig file's location. */
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
 
     /* Linting - TypeScript 5.9 strict mode */


### PR DESCRIPTION
## Summary

Hotfix on main. After #644 merged (TypeScript 5.9.3 → 6.0.3), CI started failing on every PR with:

\`\`\`
tsconfig.app.json(21,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
\`\`\`

## Fix

Drop \`baseUrl: "."\` and change \`paths\` from \`["src/*"]\` to \`["./src/*"]\`. In TS 6+, \`paths\` patterns resolve relative to the tsconfig location without a separate \`baseUrl\` — the explicit \`./\` prefix preserves identical resolution semantics.

This is forward-compatible: no \`ignoreDeprecations\` suppression needed, no behavior change, and TS 7's removal of \`baseUrl\` won't break us.

## Verification

\`npx tsc --noEmit -p tsconfig.app.json\` clean.

## Unblocks

Niac's open story-stack: #638, #639, #640, #641, #645 — all currently failing CI because Frontend (TypeScript) blocks on the deprecation error.