### PR TITLE
ci: Pass --http to niac daemon in E2E + Lighthouse jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,7 +657,7 @@ jobs:
 
       - name: Start backend server
         run: |
-          nohup ./niac daemon --listen 127.0.0.1:8080 > server.log 2>&1 &
+          nohup ./niac daemon --http --listen 127.0.0.1:8080 > server.log 2>&1 &
           echo "Waiting for server to start..."
           for i in {1..30}; do
             if curl -sf http://localhost:8080/__version 2>/dev/null; then
@@ -738,7 +738,7 @@ jobs:
 
       - name: Start server
         run: |
-          nohup ./niac daemon --listen 127.0.0.1:8080 > server.log 2>&1 &
+          nohup ./niac daemon --http --listen 127.0.0.1:8080 > server.log 2>&1 &
           for i in {1..30}; do
             if curl -sf http://localhost:8080/__version 2>/dev/null; then
               echo "Server ready"


### PR DESCRIPTION
## Summary

Second hotfix in the niac CI chain. After #643 fixed the loopback bind, E2E + Lighthouse now hit:

\`\`\`
http: TLS handshake error from 127.0.0.1:XXXX: client sent an HTTP request to an HTTPS server
\`\`\`

Wave 1 made TLS the default — \`niac daemon\` now serves HTTPS on \`:8445\` by default. CI's \`curl http://localhost:8080/__version\` health check fails because the daemon now speaks TLS.

## Fix

Pass \`--http\` to the daemon command in both CI E2E + Lighthouse jobs. Per \`niac daemon --help\`:

\`\`\`
--http  Run HTTP-only on :8080 (equivalent to --tls=false)
\`\`\`

This is the documented way to opt back to plain HTTP for tests; the production deployment continues using TLS.

## Why now (and not in #643)

#643 was based on the assumption that loopback HTTP still worked. It does for the bind guard, but the TLS default change happened concurrently and wasn't surfaced until now (the loopback fix unblocked the daemon enough to start, only for the curl to hit TLS).

## Unblocks

niac's release-please workflow. niac CI overall fails when E2E + Lighthouse fail (workflow_run conclusion is "failure"), even though CI Complete (the required check) excludes them. With this fix, release-please will fire on the next merge to main.