### PR TITLE
feat(theme): Apply 2026-05-22 brand audit — NIAC becomes indigo + 5 modules

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -87,7 +87,7 @@ jobs:
           # Note: Using --production flag to only check runtime dependencies
           npx license-checker --production \
             --excludePrivatePackages \
-            --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;0BSD;BlueOak-1.0.0;Python-2.0;Unlicense;WTFPL;MPL-2.0" \
+            --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;0BSD;BlueOak-1.0.0;Python-2.0;Unlicense;WTFPL;MPL-2.0;OFL-1.1" \
             --summary || {
             echo "❌ FAILED: Incompatible licenses found in npm dependencies"
             echo ""

--- a/ui/THEMING.md
+++ b/ui/THEMING.md
@@ -1,235 +1,219 @@
 # NIAC Theme System
 
-> Design system documentation for the NIAC Network Infrastructure Analyzer UI.
+> Design system documentation for the NIAC (Network In A Can) UI by **Mustard Seed Networks**.
 
-## Overview
+> [!IMPORTANT]
+> **Describes canonical TARGET state — locked 2026-05-22 (brand audit).**
+> Pre-audit, this document described a violet brand identity that no longer applies. NIAC's anchor
+> is now Tailwind **indigo-600** (`#4f46e5`) — engineering / infrastructure tone, distinct from
+> Seed's green and Stem's blue. The actual `src/index.css` may still hold older values; the brand
+> migration is phased (1–7) and lands in order: status palette → fonts → typography → surfaces →
+> per-product brand → modules → cleanup.
+>
+> - **Source-of-truth Tailwind v4 `@theme` block:** `_web/mustardseednetworks-com/src/index.css`
+> - **Cross-product canonical map:** `msn-docs-internal/04-Brand-Marketing/CANONICAL_TOKENS.md`
 
-NIAC uses CSS custom properties (variables) for theming, defined in `src/index.css`. The design follows a dark-first approach with high contrast for accessibility (WCAG AA compliant).
+## Architecture Overview
+
+The theming system has three layers:
+
+1. **CSS Variables** (`src/index.css`) — Core color tokens for light/dark modes.
+2. **TypeScript tokens** (`src/styles/theme.ts` and friends) — Re-exports of role tokens for use in TSX.
+3. **Tailwind v4 `@theme` block** — maps CSS variables to utility classes (`bg-brand-primary`, etc).
 
 ## Color Palette
 
 ### Brand Colors
 
-Violet-based brand identity with high-contrast variants:
+Brand anchors are **constant across light and dark modes** (do not lighten in dark). Foreground
+variants (`-strong` for text on light surfaces, `-soft` for text on dark) shift to preserve AA.
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `--color-brand-50` | `#f5f3ff` | Lightest background accent |
-| `--color-brand-100` | `#ede9fe` | Light hover states |
-| `--color-brand-200` | `#ddd6fe` | Light borders |
-| `--color-brand-300` | `#c4b5fd` | Secondary accents |
-| `--color-brand-400` | `#a78bfa` | Primary hover |
-| `--color-brand-500` | `#8b5cf6` | **Primary brand color** |
-| `--color-brand-600` | `#7c3aed` | Primary pressed |
-| `--color-brand-700` | `#6d28d9` | Deep accent |
-| `--color-brand-800` | `#5b21b6` | Darker accent |
-| `--color-brand-900` | `#4c1d95` | Darkest accent |
+| Token                          | Value     | Usage                                                                |
+| ------------------------------ | --------- | -------------------------------------------------------------------- |
+| `--color-brand-primary`        | `#4f46e5` | NIAC Indigo anchor (indigo-600) — filled buttons, focus rings, glows |
+| `--color-brand-primary-strong` | `#3730a3` | Darker (indigo-700) — text/links on light surfaces (AA)              |
+| `--color-brand-primary-soft`   | `#a5b4fc` | Lighter (indigo-300) — text/links on dark surfaces (AA)              |
+| `--color-brand-gold`           | `#d4a017` | Mustard cross-brand accent — warning state, focus, premium highlights |
 
-### Surface Colors
+#### Indigo ramp (for component composition)
 
-Dark theme backgrounds with visual hierarchy:
+| Token             | Value     |
+| ----------------- | --------- |
+| `--color-niac-50`  | `#eef2ff` |
+| `--color-niac-100` | `#e0e7ff` |
+| `--color-niac-300` | `#a5b4fc` |
+| `--color-niac-400` | `#818cf8` |
+| `--color-niac-500` | `#6366f1` |
+| `--color-niac-600` | `#4f46e5` (= `--color-brand-primary`) |
+| `--color-niac-700` | `#3730a3` |
+| `--color-niac-900` | `#1e1b4b` |
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `--color-bg-base` | `#030712` | Deepest background (body) |
-| `--color-bg-surface` | `#0f1117` | Main content surface |
-| `--color-bg-elevated` | `#1a1d25` | Cards, modals |
-| `--color-bg-overlay` | `#242731` | Dropdowns, tooltips |
-| `--color-bg-muted` | `#2d3139` | Inactive/disabled states |
+### Module Accents (Icons / Badges / Legends)
+
+Five differentiated hues for NIAC's feature modules — replaces the pre-audit mono-indigo ramp that
+made the modules visually indistinguishable. Mirrors how Seed (Roots/Canopy/Shell/Sap/Harvest) and
+Stem (Reflector/Benchmark/ServiceTest/TrafficGen/Measure/Certify) differentiate.
+
+| Token                       | Value     | Module      | Domain                                |
+| --------------------------- | --------- | ----------- | ------------------------------------- |
+| `--color-module-topology`   | `#4f46e5` | Topology    | Network map / graph view (= brand anchor) |
+| `--color-module-protocols`  | `#0d9488` | Protocols   | Protocol stack, packet types          |
+| `--color-module-analyze`    | `#c026d3` | Analyze     | Capture inspection, synthesis         |
+| `--color-module-inject`     | `#e11d48` | Inject      | Traffic generation, replay            |
+| `--color-module-templates`  | `#d97706` | Templates   | Saved configs, library                |
+
+Module accents are **constant across light and dark**. Used only for icons, badge fills, and legend
+swatches — never for card backgrounds.
+
+### Surface Colors — botanical-earth palette
+
+Warm cream in light, deep green-black in dark. Replaces the prior cool-slate / neutral-charcoal
+palette across all three MSN products for visual coherence.
+
+| Token                    | Light     | Dark      | Usage                       |
+| ------------------------ | --------- | --------- | --------------------------- |
+| `--color-surface`        | `#fbfaf5` | `#0e1612` | Page background             |
+| `--color-surface-raised` | `#f3efe2` | `#16201b` | Subtle elevation, hover bg  |
+| `--color-surface-sunken` | `#e9e3ce` | `#1f2c25` | Inset / recessed areas      |
+| `--color-card`           | `#ffffff` | `#1a2520` | Cards, modals               |
+| `--color-border`         | `#e1d9c4` | `#2b3a31` | Default border              |
+| `--color-border-strong`  | `#b6ab8b` | `#3d4f44` | Emphasized border           |
 
 ### Text Colors
 
-High contrast text for accessibility:
+WCAG AA passing on the matching surface.
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `--color-text-primary` | `#f8fafc` | Primary text (high contrast) |
-| `--color-text-secondary` | `#cbd5e1` | Secondary text |
-| `--color-text-muted` | `#94a3b8` | Muted/placeholder |
-| `--color-text-disabled` | `#64748b` | Disabled states |
-| `--color-text-inverse` | `#0f172a` | Text on light backgrounds |
-
-### Border Colors
-
-Subtle borders with focus states:
-
-| Token | Value | Usage |
-|-------|-------|-------|
-| `--color-border-default` | `rgba(255, 255, 255, 0.08)` | Default borders |
-| `--color-border-subtle` | `rgba(255, 255, 255, 0.05)` | Subtle dividers |
-| `--color-border-muted` | `rgba(255, 255, 255, 0.12)` | Hover borders |
-| `--color-border-focus` | `rgba(139, 92, 246, 0.6)` | Focus ring |
-| `--color-border-error` | `rgba(239, 68, 68, 0.5)` | Error states |
+| Token                  | Light     | Dark      | Usage                              |
+| ---------------------- | --------- | --------- | ---------------------------------- |
+| `--color-fg`           | `#1a2520` | `#e8eee9` | Primary text                       |
+| `--color-fg-muted`     | `#4a5650` | `#a3b1a7` | Secondary text                     |
+| `--color-fg-subtle`    | `#6b766f` | `#9aa297` | Tertiary text, metadata            |
+| `--color-text-inverse` | `#ffffff` | `#1a2520` | Text on filled brand backgrounds   |
 
 ### Status Colors
 
-Semantic colors for feedback:
+Status anchors tied to the brand: `success = seed-500`, `warning = mustard-500`, `info = stem-500`.
+Constant across modes; foreground/bg variants shift for AA.
 
-#### Success (Green)
-- `--color-success-400`: `#4ade80` - Primary success text
-- `--color-success-500`: `#22c55e` - Success background
-- `--color-success-600`: `#16a34a` - Success pressed
-
-#### Warning (Amber)
-- `--color-warning-400`: `#fbbf24` - Primary warning text
-- `--color-warning-500`: `#f59e0b` - Warning background
-- `--color-warning-600`: `#d97706` - Warning pressed
-
-#### Error (Red)
-- `--color-error-400`: `#f87171` - Primary error text
-- `--color-error-500`: `#ef4444` - Error background
-- `--color-error-600`: `#dc2626` - Error pressed
-
-#### Info (Blue)
-- `--color-info-400`: `#60a5fa` - Primary info text
-- `--color-info-500`: `#3b82f6` - Info background
-- `--color-info-600`: `#2563eb` - Info pressed
+| Token              | Value     | Usage                                              |
+| ------------------ | --------- | -------------------------------------------------- |
+| `--color-success`  | `#4caf50` | Positive states (= seed-500, shared cross-product) |
+| `--color-warning`  | `#d4a017` | Caution states (= mustard-500 brand cross-accent)  |
+| `--color-danger`   | `#ef4444` | Error / destructive actions                        |
+| `--color-info`     | `#1976d2` | Informational states (= stem-500)                  |
 
 ## Network-Specific Colors
 
-### Device Type Colors (Topology)
+These are **orthogonal to the brand** — they identify domain concepts (a router is blue because it's
+a router, not because of brand). They live in `themeDeviceColors.ts`.
 
-Distinct colors for network device identification:
+### Device Type Colors (Topology view)
 
-| Token | Color | Device Type |
-|-------|-------|-------------|
-| `--color-device-router` | `#3b82f6` (Blue) | Routers |
-| `--color-device-switch` | `#22c55e` (Green) | Switches |
-| `--color-device-firewall` | `#ef4444` (Red) | Firewalls |
-| `--color-device-server` | `#f97316` (Orange) | Servers |
-| `--color-device-workstation` | `#6b7280` (Gray) | Workstations |
-| `--color-device-ap` | `#a855f7` (Purple) | Access Points |
-| `--color-device-iot` | `#14b8a6` (Teal) | IoT Devices |
-| `--color-device-unknown` | `#94a3b8` (Slate) | Unknown |
+| Token                        | Color              | Device Type   |
+| ---------------------------- | ------------------ | ------------- |
+| `--color-device-router`      | `#3b82f6` Blue     | Routers       |
+| `--color-device-switch`      | `#22c55e` Green    | Switches      |
+| `--color-device-firewall`    | `#ef4444` Red      | Firewalls     |
+| `--color-device-server`      | `#f97316` Orange   | Servers       |
+| `--color-device-workstation` | `#6b7280` Gray     | Workstations  |
+| `--color-device-ap`          | `#a855f7` Purple   | Access Points |
+| `--color-device-iot`         | `#14b8a6` Teal     | IoT devices   |
+| `--color-device-unknown`     | `#94a3b8` Slate    | Unknown       |
 
 ### Link Speed Colors
 
-Color-coded network speeds:
-
-| Token | Color | Speed |
-|-------|-------|-------|
-| `--color-link-10m` | `#94a3b8` (Gray) | 10 Mbps |
-| `--color-link-100m` | `#22c55e` (Green) | 100 Mbps |
-| `--color-link-1g` | `#3b82f6` (Blue) | 1 Gbps |
-| `--color-link-10g` | `#a855f7` (Purple) | 10 Gbps |
-| `--color-link-25g` | `#f97316` (Orange) | 25 Gbps |
-| `--color-link-40g` | `#ec4899` (Pink) | 40 Gbps |
-| `--color-link-100g` | `#eab308` (Yellow) | 100 Gbps |
-| `--color-link-trunk` | `#06b6d4` (Cyan) | Trunk/LAG |
+| Token                | Color    | Speed     |
+| -------------------- | -------- | --------- |
+| `--color-link-10m`   | `#94a3b8` | 10 Mbps  |
+| `--color-link-100m`  | `#22c55e` | 100 Mbps |
+| `--color-link-1g`    | `#3b82f6` | 1 Gbps   |
+| `--color-link-10g`   | `#a855f7` | 10 Gbps  |
+| `--color-link-25g`   | `#f97316` | 25 Gbps  |
+| `--color-link-40g`   | `#ec4899` | 40 Gbps  |
+| `--color-link-100g`  | `#eab308` | 100 Gbps |
+| `--color-link-trunk` | `#06b6d4` | Trunk / LAG |
 
 ### Protocol Colors
 
-Protocol identification in logs/debug:
-
-| Token | Color | Protocol |
-|-------|-------|----------|
-| `--color-proto-arp` | `#22c55e` | ARP |
-| `--color-proto-icmp` | `#3b82f6` | ICMP |
-| `--color-proto-dns` | `#a855f7` | DNS |
-| `--color-proto-dhcp` | `#f97316` | DHCP |
-| `--color-proto-snmp` | `#14b8a6` | SNMP |
-| `--color-proto-lldp` | `#ec4899` | LLDP |
-| `--color-proto-cdp` | `#eab308` | CDP |
-| `--color-proto-http` | `#6366f1` | HTTP |
-| `--color-proto-tcp` | `#06b6d4` | TCP |
-| `--color-proto-udp` | `#8b5cf6` | UDP |
+| Token                | Color    | Protocol |
+| -------------------- | -------- | -------- |
+| `--color-proto-arp`  | `#22c55e` | ARP     |
+| `--color-proto-icmp` | `#3b82f6` | ICMP    |
+| `--color-proto-dns`  | `#a855f7` | DNS     |
+| `--color-proto-dhcp` | `#f97316` | DHCP    |
+| `--color-proto-snmp` | `#14b8a6` | SNMP    |
+| `--color-proto-lldp` | `#ec4899` | LLDP    |
+| `--color-proto-cdp`  | `#eab308` | CDP     |
+| `--color-proto-http` | `#6366f1` | HTTP    |
+| `--color-proto-tcp`  | `#06b6d4` | TCP     |
+| `--color-proto-udp`  | `#8b5cf6` | UDP     |
 
 ## Typography
 
-### Font Families
+Self-hosted via `@fontsource-variable/inter` and `@fontsource-variable/jetbrains-mono` (no Google
+Fonts dependency, no FOUT, CSP-safe). **Space Grotesk is no longer used** anywhere — Inter covers
+both display and body.
 
 ```css
-/* Display headings */
-font-family: 'Space Grotesk', sans-serif;
-
-/* Body text */
-font-family: 'Inter', system-ui, sans-serif;
-
-/* Code/monospace */
-font-family: 'JetBrains Mono', 'Fira Code', monospace;
+--font-sans: "Inter Variable", "Inter", system-ui, sans-serif;
+--font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
 ```
+
+### Type scale
+
+| Class           | Mobile      | Desktop          | Weight   | Leading        | Tracking         |
+| --------------- | ----------- | ---------------- | -------- | -------------- | ---------------- |
+| `.heading-1`    | text-2xl    | sm:text-3xl      | bold     | leading-tight  | tracking-tight   |
+| `.heading-2`    | text-xl     | sm:text-2xl      | semibold | leading-snug   | —                |
+| `.heading-3`    | text-lg     | sm:text-xl       | semibold | leading-snug   | —                |
+| `.heading-4`    | text-base   | sm:text-lg       | medium   | leading-snug   | —                |
+| `.section-title`| text-xs UC  | —                | medium   | leading-normal | tracking-wider   |
+| `.body-large`   | text-lg     | —                | normal   | leading-relaxed| —                |
+| `.body`         | text-base   | —                | normal   | leading-relaxed| —                |
+| `.body-small`   | text-sm     | —                | normal   | leading-relaxed| —                |
+| `.caption`      | text-xs     | —                | normal   | leading-normal | —                |
+| `.label`        | text-sm     | —                | medium   | —              | —                |
+| `.code`         | text-sm     | —                | normal   | —              | (font-mono)      |
 
 ## Component Classes
 
-### Buttons
+| Class            | Purpose                                                |
+| ---------------- | ------------------------------------------------------ |
+| `.btn-primary`   | Indigo-filled CTA — uses `text-text-inverse` (white on indigo) |
+| `.btn-secondary` | Surface-raised with border                             |
+| `.btn-ghost`     | Transparent until hover                                |
+| `.btn-outline`   | Border only                                            |
+| `.card-surface`  | Flat default card (canonical — matches Seed/Stem)      |
+| `.card-elevated` | With shadow                                            |
+| `.glass-card`    | Backdrop-blur — reserved for **over-content overlays only** (topology canvas, etc.) — not the default card style |
+| `.badge-*`       | Status badges using canonical status hexes             |
+| `.input-base`    | Standard input                                         |
 
-```css
-.btn-primary   /* Gradient violet, primary actions */
-.btn-secondary /* Transparent white, secondary actions */
-.btn-ghost     /* No background, tertiary actions */
-.btn-outline   /* Border only, subtle actions */
-```
+## Theme Switching
 
-### Cards
-
-```css
-.glass-card       /* Elevated surface with blur */
-.glass-card-hover /* Glass card with hover effects */
-.card-surface     /* Flat elevated background */
-.card-elevated    /* Higher elevation with shadow */
-```
-
-### Status Badges
-
-```css
-.badge-success /* Green status indicator */
-.badge-warning /* Amber status indicator */
-.badge-error   /* Red status indicator */
-.badge-info    /* Blue status indicator */
-```
-
-### Inputs
-
-```css
-.input-base    /* Standard input styling */
-.focus-ring    /* Focus state ring */
-```
-
-## Usage Examples
-
-### Using CSS Variables in Components
+Dark mode is toggled via the `useTheme` hook, which adds the `.dark` class to `<html>`. Default boot
+is dark (matches Seed and Stem).
 
 ```tsx
-// In TSX with inline styles
-<div style={{ color: 'var(--color-text-primary)' }}>
-  Primary text
-</div>
-
-// In Tailwind (using arbitrary values)
-<div className="text-[var(--color-text-primary)]">
-  Primary text
-</div>
-
-// Recommended: Use Tailwind utilities that map to these vars
-<div className="text-white bg-[var(--color-bg-elevated)]">
-  Content
-</div>
+import { useTheme } from "../hooks/useTheme";
+const { theme, setTheme, actualTheme } = useTheme();
 ```
 
-### Device Type Badge
+## Mobile Browser Chrome
 
-```tsx
-const deviceTypeColors: Record<DeviceType, string> = {
-  router: 'var(--color-device-router)',
-  switch: 'var(--color-device-switch)',
-  firewall: 'var(--color-device-firewall)',
-  server: 'var(--color-device-server)',
-  workstation: 'var(--color-device-workstation)',
-  access_point: 'var(--color-device-ap)',
-  iot: 'var(--color-device-iot)',
-  unknown: 'var(--color-device-unknown)',
-};
-```
+`<meta name="theme-color" content="#3730a3" />` (NIAC indigo-700) — matches the brand identity
+shown in the iOS/Android status bar.
 
 ## Accessibility
 
-- All text colors meet WCAG AA contrast requirements (4.5:1 for normal text)
-- Focus states use visible ring with brand color
-- Reduced motion preference is respected
-- Status colors include non-color indicators (icons, patterns)
+- All foreground/background pairs pass WCAG AA (4.5:1 for normal text, 3:1 for large text)
+- Status meaning never relies on color alone — pair with icon/text
+- `prefers-reduced-motion` respected
+- Focus visible: 2px ring at `var(--color-brand-primary)`
 
 ## Related Files
 
-- `src/index.css` - CSS variable definitions
-- `src/components/ui/` - UI component implementations
-- `DESIGN_MOCKUP.md` - Visual design reference
+- `src/index.css` — CSS variable definitions, `@theme` block
+- `src/styles/theme.ts` — barrel export of token modules
+- `src/styles/themeDeviceColors.ts` — device/link/protocol domain colors (orthogonal to brand)
+- `_web/mustardseednetworks-com/src/index.css` — cross-product canonical source-of-truth

--- a/ui/THEMING.md
+++ b/ui/THEMING.md
@@ -7,8 +7,8 @@
 > Pre-audit, this document described a violet brand identity that no longer applies. NIAC's anchor
 > is now Tailwind **indigo-600** (`#4f46e5`) — engineering / infrastructure tone, distinct from
 > Seed's green and Stem's blue. The actual `src/index.css` may still hold older values; the brand
-> migration is phased (1–7) and lands in order: status palette → fonts → typography → surfaces →
-> per-product brand → modules → cleanup.
+> migration is phased (1-7) and lands in order: status palette -> fonts -> typography -> surfaces ->
+> per-product brand -> modules -> cleanup.
 >
 > - **Source-of-truth Tailwind v4 `@theme` block:** `_web/mustardseednetworks-com/src/index.css`
 > - **Cross-product canonical map:** `msn-docs-internal/04-Brand-Marketing/CANONICAL_TOKENS.md`

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="theme-color" content="#2d7a3e" />
+    <meta name="theme-color" content="#3730a3" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="NIAC - Network In A Can by Mustard Seed Networks" />
     <title>NIAC | Mustard Seed Networks</title>

--- a/ui/index.html
+++ b/ui/index.html
@@ -12,21 +12,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="NIAC - Network In A Can by Mustard Seed Networks" />
     <title>NIAC | Mustard Seed Networks</title>
-    <!-- Preconnect to Google Fonts for faster loading -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <!--
-      Load fonts with display=swap so the page renders the moment the bundle
-      is ready, even if Google Fonts is slow. We used to use the
-      media="print" / onload="this.media='all'" trick for non-blocking
-      delivery, but the inline onload required script-src 'unsafe-inline'
-      in our CSP. The font CSS itself is small and gzipped, so a normal
-      stylesheet link is the right tradeoff for a stricter CSP.
+      Fonts (Inter Variable + JetBrains Mono) self-hosted via
+      @fontsource-variable, imported from src/main.tsx. No external
+      requests, CSP-clean, no FOUT. Space Grotesk dropped 2026-05-22.
     -->
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-    />
   </head>
   <body>
     <div id="root"></div>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,6 +13,8 @@
         "@codemirror/language": "6.12.3",
         "@codemirror/state": "6.6.0",
         "@codemirror/view": "6.43.0",
+        "@fontsource-variable/inter": "5.2.8",
+        "@fontsource-variable/jetbrains-mono": "5.2.8",
         "@lezer/highlight": "1.2.3",
         "@tailwindcss/postcss": "4.3.0",
         "@tanstack/react-query": "5.100.11",
@@ -1366,6 +1368,24 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,6 +31,8 @@
     "@codemirror/language": "6.12.3",
     "@codemirror/state": "6.6.0",
     "@codemirror/view": "6.43.0",
+    "@fontsource-variable/inter": "5.2.8",
+    "@fontsource-variable/jetbrains-mono": "5.2.8",
     "@lezer/highlight": "1.2.3",
     "@tailwindcss/postcss": "4.3.0",
     "@tanstack/react-query": "5.100.11",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -230,10 +230,15 @@
    LIGHT THEME (CSS default) — Mustard Seed Networks
    ========================================================================== */
 :root {
-  /* Brand */
-  --color-brand-primary: #2d7a3e; /* Seed Green */
-  --color-brand-accent: #4caf50;
-  --color-brand-gold: #d4a017;
+  /* Brand — constant across light/dark (canonical 2026-05-22).
+   * NIAC product anchor is niac-500 = Tailwind indigo-600 — replaces both
+   * the pre-audit violet #8b5cf6 (per old marketing site) AND the wrong
+   * Seed-green that was patched in during a partial harmonization pass.
+   * NIAC simulates network infrastructure; indigo reads "infrastructure /
+   * engineering" and gives portfolio separation from Seed (green) + Stem (blue). */
+  --color-brand-primary: #4f46e5; /* NIAC anchor (niac-500 / indigo-600) */
+  --color-brand-accent: #a5b4fc; /* Lighter sibling (niac-300 / indigo-300) — hover */
+  --color-brand-gold: #d4a017; /* Mustard cross-brand accent (mustard-500) */
 
   /* Surfaces — Botanical-earth: warm cream palette (canonical 2026-05-22) */
   --color-surface-base: #fbfaf5;
@@ -264,10 +269,9 @@
    Default boot is dark (see useTheme hook).
    ========================================================================== */
 .dark {
-  /* Brand — lighter shades for contrast on dark surfaces */
-  --color-brand-primary: #81c784;
-  --color-brand-accent: #a5d6a7;
-  --color-brand-gold: #fbbf24;
+  /* Brand — constant across modes (no .dark override).
+   * Lightening previously applied here violated the brand-constant rule
+   * (canonical 2026-05-22). See :root block above. */
 
   /* Surfaces — Botanical-earth: deep green-black palette (canonical 2026-05-22) */
   --color-surface-base: #0e1612;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -34,21 +34,9 @@
   --color-brand-accent: var(--color-brand-accent);
   --color-brand-gold: var(--color-brand-gold);
 
-  /* Legacy brand ramp aliases — all map to canonical semantic tokens.
-   * Components should migrate to brand-primary / brand-accent / brand-gold.
-   * Listed so existing `text-brand-400` / `bg-brand-500` / etc.
-   * utilities keep compiling until migration is complete. */
-  --color-brand-50: var(--color-brand-accent);
-  --color-brand-100: var(--color-brand-accent);
-  --color-brand-200: var(--color-brand-accent);
-  --color-brand-300: var(--color-brand-accent);
-  --color-brand-400: var(--color-brand-accent);
-  --color-brand-500: var(--color-brand-primary);
-  --color-brand-600: var(--color-brand-primary);
-  --color-brand-700: var(--color-brand-primary);
-  --color-brand-800: var(--color-brand-primary);
-  --color-brand-900: var(--color-brand-primary);
-  --color-brand-950: var(--color-brand-primary);
+  /* (Legacy --color-brand-50..950 flat ramp aliases removed in Phase 7 of
+   * the 2026-05-22 brand audit. Audit grep showed zero consumers in src/.
+   * Components reference brand-primary / brand-accent / brand-gold directly.) */
 
   /* ========================================
    * Surface Colors — semantic elevation tokens

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -247,11 +247,11 @@
   --color-text-disabled: #94a3b8;
   --color-text-inverse: #ffffff;
 
-  /* Status — INDUSTRY STANDARD */
-  --color-status-success: #28a745;
-  --color-status-warning: #ffc107;
-  --color-status-error: #dc3545;
-  --color-status-info: #17a2b8;
+  /* Status — canonical anchors, constant across modes (2026-05-22) */
+  --color-status-success: #4caf50; /* = seed-500 */
+  --color-status-warning: #d4a017; /* = mustard-500 brand accent */
+  --color-status-error: #ef4444; /* coral red */
+  --color-status-info: #1976d2; /* = stem-500 */
 
   color: var(--color-text-primary);
   background-color: var(--color-surface-base);
@@ -282,11 +282,11 @@
   --color-text-disabled: #64748b;
   --color-text-inverse: #0f172a;
 
-  /* Status — INDUSTRY STANDARD (identical to light) */
-  --color-status-success: #28a745;
-  --color-status-warning: #ffc107;
-  --color-status-error: #dc3545;
-  --color-status-info: #17a2b8;
+  /* Status — canonical anchors (same as light, constant by design) */
+  --color-status-success: #4caf50;
+  --color-status-warning: #d4a017;
+  --color-status-error: #ef4444;
+  --color-status-info: #1976d2;
 }
 
 body {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -235,17 +235,17 @@
   --color-brand-accent: #4caf50;
   --color-brand-gold: #d4a017;
 
-  /* Surfaces */
-  --color-surface-base: #f8fafc;
+  /* Surfaces — Botanical-earth: warm cream palette (canonical 2026-05-22) */
+  --color-surface-base: #fbfaf5;
   --color-surface-raised: #ffffff;
-  --color-surface-border: #e2e8f0;
-  --color-surface-hover: #f1f5f9;
-  --color-surface-sunken: #e2e8f0;
+  --color-surface-border: #e1d9c4;
+  --color-surface-hover: #f3efe2;
+  --color-surface-sunken: #e9e3ce;
 
-  /* Text */
-  --color-text-primary: #0f172a;
-  --color-text-secondary: #475569;
-  --color-text-muted: #64748b;
+  /* Text — Botanical-earth (WCAG AA against warm cream surfaces) */
+  --color-text-primary: #1a2520;
+  --color-text-secondary: #4a5650;
+  --color-text-muted: #6b766f;
   --color-text-disabled: #94a3b8;
   --color-text-inverse: #ffffff;
 
@@ -269,20 +269,19 @@
   --color-brand-accent: #a5d6a7;
   --color-brand-gold: #fbbf24;
 
-  /* Surfaces — neutral grays (NOT blue-tinted slate).
-   * Values mirror stem's dark theme so cross-product UI stays harmonized. */
-  --color-surface-base: #1a1a1a;
-  --color-surface-raised: #333333;
-  --color-surface-border: #666666;
-  --color-surface-hover: #666666;
-  --color-surface-sunken: #000000;
+  /* Surfaces — Botanical-earth: deep green-black palette (canonical 2026-05-22) */
+  --color-surface-base: #0e1612;
+  --color-surface-raised: #1a2520;
+  --color-surface-border: #2b3a31;
+  --color-surface-hover: #16201b;
+  --color-surface-sunken: #1f2c25;
 
-  /* Text — mirrors stem's dark theme values. */
-  --color-text-primary: #f8fafc;
-  --color-text-secondary: #e5e5e5;
-  --color-text-muted: #999999;
-  --color-text-disabled: #64748b;
-  --color-text-inverse: #0f172a;
+  /* Text — Botanical-earth (WCAG AA against deep green-black surfaces) */
+  --color-text-primary: #e8eee9;
+  --color-text-secondary: #a3b1a7;
+  --color-text-muted: #9aa297;
+  --color-text-disabled: #6b766f;
+  --color-text-inverse: #1a2520;
 
   /* Status — canonical anchors (same as light, constant by design) */
   --color-status-success: #4caf50;
@@ -295,7 +294,21 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: "Inter", system-ui, sans-serif;
-  background-color: var(--color-surface-base);
+  /* Botanical atmospheric: mustard + brand-primary radial gradients over surface.
+   * surface-base auto-flips light↔dark via :root/.dark var swap. */
+  background:
+    radial-gradient(
+      1200px 600px at 80% -10%,
+      color-mix(in oklab, var(--color-brand-gold) 8%, transparent),
+      transparent
+    ),
+    radial-gradient(
+      900px 500px at -10% 20%,
+      color-mix(in oklab, var(--color-brand-primary) 7%, transparent),
+      transparent
+    ),
+    var(--color-surface-base);
+  background-attachment: fixed;
   color: var(--color-text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -127,6 +127,18 @@
   --color-info-900: #1e3a8a;
 
   /* ========================================
+   * Module Accents — NIAC feature modules (canonical 2026-05-22).
+   * Constant across light/dark. For icons, badges, and legend swatches
+   * only — never for card backgrounds. Mirrors Seed's roots/canopy/etc.
+   * pattern (5 distinct hues, not a mono-anchor ramp).
+   * ======================================== */
+  --color-module-topology: #4f46e5; /* Indigo-600 — network map (= brand anchor) */
+  --color-module-protocols: #0d9488; /* Teal-600 — protocol stack, packet types */
+  --color-module-analyze: #c026d3; /* Fuchsia-600 — capture inspection, synthesis */
+  --color-module-inject: #e11d48; /* Rose-600 — traffic generation, replay */
+  --color-module-templates: #d97706; /* Amber-600 — saved configs, library */
+
+  /* ========================================
    * Device Type Colors (Topology) — NIAC-specific, theme-neutral
    * ======================================== */
   --color-device-router: #3b82f6;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -305,6 +305,52 @@ body {
   min-height: 100vh;
 }
 
+/* ============================================================================
+ * TYPOGRAPHY SCALE — canonical responsive scale (Seed/Stem/NIAC harmonized)
+ * Added 2026-05-22 Phase 3. Use semantic classes instead of raw Tailwind sizes.
+ *
+ * Usage:
+ *   <h1 className="heading-1">Page Title</h1>
+ *   <h2 className="section-title">CATEGORY LABEL</h2>
+ *   <p className="body">Default paragraph.</p>
+ *   <span className="caption">Metadata</span>
+ * ============================================================================ */
+@layer components {
+  .heading-1 {
+    @apply text-2xl sm:text-3xl font-bold text-text-primary leading-tight tracking-tight;
+  }
+  .heading-2 {
+    @apply text-xl sm:text-2xl font-semibold text-text-primary leading-snug;
+  }
+  .heading-3 {
+    @apply text-lg sm:text-xl font-semibold text-text-primary leading-snug;
+  }
+  .heading-4 {
+    @apply text-base sm:text-lg font-medium text-text-primary leading-snug;
+  }
+  .section-title {
+    @apply text-xs font-medium uppercase tracking-wider text-text-muted;
+  }
+  .body-large {
+    @apply text-lg text-text-primary leading-relaxed;
+  }
+  .body {
+    @apply text-base text-text-primary leading-relaxed;
+  }
+  .body-small {
+    @apply text-sm text-text-secondary leading-relaxed;
+  }
+  .caption {
+    @apply text-xs text-text-muted leading-normal;
+  }
+  .label {
+    @apply text-sm font-medium text-text-primary;
+  }
+  .code {
+    @apply font-mono text-sm bg-surface-hover px-1.5 py-0.5 rounded;
+  }
+}
+
 /* ========================================
  * Scrollbar Styling
  * ======================================== */

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,4 +1,6 @@
-/* Fonts loaded asynchronously from index.html for non-blocking render */
+/* Fonts (Inter Variable + JetBrains Mono) self-hosted via
+ * @fontsource-variable — imported from src/main.tsx. Space Grotesk dropped
+ * per 2026-05-22 brand audit; Inter now covers both display and body. */
 @import "tailwindcss";
 @source "../**/*.{js,ts,jsx,tsx}";
 
@@ -19,9 +21,9 @@
    * Font Families
    * (v4 uses --font-* prefix to generate font-* utilities)
    * ======================================== */
-  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
-  --font-body: "Inter", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", "Fira Code", monospace;
+  --font-display: "Inter Variable", "Inter", system-ui, sans-serif;
+  --font-body: "Inter Variable", "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
 
   /* ========================================
    * Brand Colors — Mustard Seed Networks

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,3 +1,5 @@
+import '@fontsource-variable/inter';
+import '@fontsource-variable/jetbrains-mono';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';

--- a/ui/src/shim.d.ts
+++ b/ui/src/shim.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Type Shims
+ *
+ * Purpose: Provides TypeScript type declarations for modules that don't have
+ * built-in type definitions. Prevents TS2882 errors when importing modules
+ * without @types packages or with side-effect-only entry points.
+ *
+ * Usage: Automatically applied by TypeScript compiler, no explicit imports needed.
+ */
+
+// Side-effect-only font CSS imports — no exports needed.
+declare module "@fontsource-variable/inter";
+declare module "@fontsource-variable/jetbrains-mono";

--- a/ui/src/styles/theme.ts
+++ b/ui/src/styles/theme.ts
@@ -6,33 +6,37 @@
  * Centralized design tokens and utilities for consistent UI across the app.
  *
  * ARCHITECTURE:
- * 1. CSS Variables (index.css) - Core color tokens (dark theme)
+ * 1. CSS Variables (index.css) - Core color tokens for light/dark modes
  * 2. This file (theme.ts) - TypeScript tokens and utility functions
- * 3. Tailwind Classes - Composable styling patterns
+ * 3. Tailwind v4 @theme directive - CSS-first utility class generation
  *
- * BRAND COLORS:
- * - Primary: Violet (#8b5cf6) - Actions, links, focus states
- * - Accent: Lighter Violet (#a78bfa) - Hover states
+ * BRAND COLORS (anchors constant across light + dark per 2026-05-22 audit):
+ * - Primary:        Indigo #4f46e5 (Tailwind indigo-600) - filled buttons, glows
+ * - Primary-strong: Indigo #3730a3 (indigo-700) - text/links on light surfaces (AA)
+ * - Primary-soft:   Indigo #a5b4fc (indigo-300) - text/links on dark surfaces (AA)
+ * - Brand-gold:     Mustard #d4a017 - cross-brand accent, warning, focus, premium
  *
- * STATUS COLORS (Industry Standard):
- * - Success: Green (#22c55e) - Positive states
- * - Warning: Amber (#f59e0b) - Caution states
- * - Error: Red (#ef4444) - Error/danger states
- * - Info: Blue (#3b82f6) - Informational states
+ * STATUS COLORS (tied to brand; constant across modes):
+ * - Success: #4caf50 (= seed-500)
+ * - Warning: #d4a017 (= mustard-500, brand cross-accent)
+ * - Danger:  #ef4444 (coral red)
+ * - Info:    #1976d2 (= stem-500)
  *
- * DEVICE COLORS (NIAC specific):
- * - Router: Blue - Network routing
- * - Switch: Green - Layer 2 switching
- * - Firewall: Red - Security devices
- * - Server: Orange - Compute nodes
- * - Workstation: Gray - End devices
- * - Access Point: Purple - Wireless
- * - IoT: Teal - Internet of Things
+ * MODULE ACCENTS (5 differentiated hues, constant across modes):
+ * - Topology:  #4f46e5 indigo  - network map / graph view
+ * - Protocols: #0d9488 teal    - protocol stack, packet types
+ * - Analyze:   #c026d3 fuchsia - capture inspection
+ * - Inject:    #e11d48 rose    - traffic generation
+ * - Templates: #d97706 amber   - saved configs / library
+ *
+ * DEVICE COLORS (NIAC-specific, orthogonal to brand — see themeDeviceColors.ts):
+ * Router, Switch, Firewall, Server, Workstation, AP, IoT, Unknown.
  *
  * USAGE:
  * import { spacing, button, cn, deviceColor } from '../styles/theme';
  * <button className={cn(button.base, button.variant.primary)}>Action</button>
  *
+ * See THEMING.md for the full canonical token map and migration phase notes.
  * =============================================================================
  */
 

--- a/ui/src/styles/theme.ts
+++ b/ui/src/styles/theme.ts
@@ -44,6 +44,7 @@
 export { alert, badge, button, card, drawer, icon, input, modal, status } from './themeComponents';
 export { deviceColor, linkSpeedColor, protocolColor } from './themeDeviceColors';
 export { border, layout, radius } from './themeLayout';
+export { moduleColor } from './themeModuleColors';
 export { spacing } from './themeSpacing';
 export { typography } from './themeTypography';
 export {

--- a/ui/src/styles/themeComponents.ts
+++ b/ui/src/styles/themeComponents.ts
@@ -12,8 +12,12 @@ export const button = {
   base: 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-primary/50 disabled:opacity-50 disabled:cursor-not-allowed',
 
   variant: {
+    // text-white (not text-text-inverse) — text-inverse flips to dark in dark
+    // mode and would fail WCAG AA against the constant indigo brand bg.
+    // hover:bg-brand-primary/90 avoids the color-shift trap of using the
+    // lighter brand-accent (which fails contrast against white text).
     primary:
-      'bg-gradient-to-r from-brand-primary to-brand-primary text-text-primary shadow-lg shadow-brand-primary/30 hover:from-brand-primary hover:to-brand-accent active:scale-[0.98]',
+      'bg-brand-primary text-white shadow-lg shadow-brand-primary/30 hover:bg-brand-primary/90 active:scale-[0.98]',
     secondary: 'bg-bg-elevated text-text-primary hover:bg-bg-overlay border border-border-default',
     ghost: 'text-text-muted hover:text-text-primary hover:bg-bg-elevated',
     outline:
@@ -49,15 +53,18 @@ export const input = {
 } as const;
 
 export const card = {
-  base: 'rounded-xl backdrop-blur-xl',
+  // base: flat by default (canonical 2026-05-22). The pre-audit base had
+  // `backdrop-blur-xl` baked in, which made every card a glass card. Glass
+  // is now an opt-in variant — use it for overlays over the topology canvas
+  // or other content surfaces, not for default UI cards.
+  base: 'rounded-xl border',
 
   variant: {
-    default: 'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default',
-    elevated:
-      'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default shadow-xl shadow-black/20',
+    default: 'bg-bg-elevated border-border-default',
+    elevated: 'bg-bg-elevated border-border-default shadow-xl shadow-black/20',
     interactive:
-      'bg-gradient-to-br from-bg-elevated to-bg-surface border border-border-default hover:border-brand-primary/30 cursor-pointer transition-colors',
-    glass: 'bg-bg-elevated/40 backdrop-blur-2xl border border-border-default shadow-2xl',
+      'bg-bg-elevated border-border-default hover:border-brand-primary/50 cursor-pointer transition-colors',
+    glass: 'bg-bg-elevated/40 backdrop-blur-2xl border-border-default shadow-2xl',
   },
 
   padding: {

--- a/ui/src/styles/themeModuleColors.ts
+++ b/ui/src/styles/themeModuleColors.ts
@@ -1,0 +1,59 @@
+/**
+ * themeModuleColors.ts — NIAC feature-module accent tokens (canonical 2026-05-22).
+ * Re-exported through theme.ts.
+ *
+ * IMPORTANT: Use these for icons, small badges, and legend swatches only —
+ * NOT for card backgrounds. Cards should remain consistent (bg-bg-elevated)
+ * across all modules; the module accent identifies the feature in icon /
+ * chip form.
+ *
+ * The five accents are deliberately differentiated (not a mono-indigo ramp).
+ * They mirror how Seed (Roots/Canopy/Shell/Sap/Harvest) and Stem (Reflector/
+ * Benchmark/ServiceTest/TrafficGen/Measure/Certify) give each module its
+ * own hue for visual scannability.
+ *
+ * All values reference CSS variables in src/index.css `@theme`:
+ *   --color-module-topology    Indigo-600 #4f46e5  (= brand anchor)
+ *   --color-module-protocols   Teal-600   #0d9488
+ *   --color-module-analyze     Fuchsia-600 #c026d3
+ *   --color-module-inject      Rose-600   #e11d48
+ *   --color-module-templates   Amber-600  #d97706
+ *
+ * Usage:
+ *   import { moduleColor } from '../styles/theme';
+ *   <TopologyIcon className={moduleColor.topology.icon} />
+ *   <span className={cn(moduleColor.protocols.badge, 'px-2 py-1')}>HTTP</span>
+ */
+
+export const moduleColor = {
+  // Topology — network map / graph view (= brand anchor)
+  topology: {
+    icon: 'text-module-topology',
+    badge: 'bg-module-topology/20 text-module-topology',
+    border: 'border-module-topology/30',
+  },
+  // Protocols — protocol stack, packet types
+  protocols: {
+    icon: 'text-module-protocols',
+    badge: 'bg-module-protocols/20 text-module-protocols',
+    border: 'border-module-protocols/30',
+  },
+  // Analyze — capture inspection, synthesis
+  analyze: {
+    icon: 'text-module-analyze',
+    badge: 'bg-module-analyze/20 text-module-analyze',
+    border: 'border-module-analyze/30',
+  },
+  // Inject — traffic generation, replay
+  inject: {
+    icon: 'text-module-inject',
+    badge: 'bg-module-inject/20 text-module-inject',
+    border: 'border-module-inject/30',
+  },
+  // Templates — saved configs, library
+  templates: {
+    icon: 'text-module-templates',
+    badge: 'bg-module-templates/20 text-module-templates',
+    border: 'border-module-templates/30',
+  },
+} as const;

--- a/ui/src/styles/themeTypography.ts
+++ b/ui/src/styles/themeTypography.ts
@@ -1,42 +1,68 @@
 /**
- * =============================================================================
- * TYPOGRAPHY
- * =============================================================================
+ * themeTypography.ts — semantic typography tokens. CSS utility classes are
+ * defined in index.css `@layer components`; use these TS constants for
+ * programmatic styling. Re-exported through theme.ts.
  *
- * Typography tokens for consistent text styling.
+ * Canonical responsive type scale (2026-05-22) — harmonized with Seed and Stem.
+ * Replaces the pre-audit flat scale that lacked responsive sizing and tracking.
  */
 
 export const typography = {
+  // Semantic heading classes (match CSS utilities in index.css).
+  // Preferred way to style headings.
   heading: {
-    h1: 'text-2xl font-bold text-text-primary',
-    h2: 'text-xl font-semibold text-text-primary',
-    h3: 'text-lg font-semibold text-text-primary',
-    h4: 'text-base font-medium text-text-primary',
+    h1: 'heading-1', // Page titles: 24px → sm:30px bold, leading-tight, tracking-tight
+    h2: 'heading-2', // Section/modal titles: 20px → sm:24px semibold, leading-snug
+    h3: 'heading-3', // Card titles: 18px → sm:20px semibold, leading-snug
+    h4: 'heading-4', // Subsections: 16px → sm:18px medium, leading-snug
+    section: 'section-title', // Category labels: 12px uppercase tracking-wider, fg-muted
   },
 
+  // Body text variants
   body: {
-    large: 'text-base text-text-primary',
-    default: 'text-sm text-text-secondary',
-    small: 'text-xs text-text-muted',
-    muted: 'text-sm text-text-muted',
+    large: 'body-large', // 18px primary, leading-relaxed
+    default: 'body', // 16px primary, leading-relaxed (most common)
+    small: 'body-small', // 14px secondary, leading-relaxed
+    caption: 'caption', // 12px muted, leading-normal (metadata)
+    muted: 'body-small', // Legacy alias retained for backwards compatibility
   },
 
-  label: 'text-sm font-medium text-text-secondary',
-  caption: 'text-xs text-text-muted',
-  code: 'font-mono text-sm',
+  // Utility classes
+  label: 'label', // Form labels: 14px medium
+  caption: 'caption', // Legacy top-level alias (prefer body.caption)
+  code: 'code', // Monospace with background chip
 
+  // Raw size classes (use sparingly — prefer semantic variants above)
   size: {
-    xs: 'text-xs',
-    sm: 'text-sm',
-    base: 'text-base',
-    lg: 'text-lg',
-    xl: 'text-xl',
+    xs: 'text-xs', // 12px
+    sm: 'text-sm', // 14px
+    base: 'text-base', // 16px
+    lg: 'text-lg', // 18px
+    xl: 'text-xl', // 20px
+    '2xl': 'text-2xl', // 24px
+    '3xl': 'text-3xl', // 30px
   },
 
+  // Font weights
   weight: {
-    normal: 'font-normal',
-    medium: 'font-medium',
-    semibold: 'font-semibold',
-    bold: 'font-bold',
+    normal: 'font-normal', // 400
+    medium: 'font-medium', // 500
+    semibold: 'font-semibold', // 600
+    bold: 'font-bold', // 700
+  },
+
+  // Font families
+  family: {
+    body: 'font-body', // Inter Variable
+    display: 'font-display', // Inter Variable (display)
+    mono: 'font-mono', // JetBrains Mono
+  },
+
+  // Line heights
+  leading: {
+    tight: 'leading-tight', // 1.25 — headings
+    snug: 'leading-snug', // 1.375 — subheadings
+    normal: 'leading-normal', // 1.5 — default
+    relaxed: 'leading-relaxed', // 1.625 — body text
   },
 } as const;

--- a/ui/src/styles/themeTypography.ts
+++ b/ui/src/styles/themeTypography.ts
@@ -11,10 +11,10 @@ export const typography = {
   // Semantic heading classes (match CSS utilities in index.css).
   // Preferred way to style headings.
   heading: {
-    h1: 'heading-1', // Page titles: 24px → sm:30px bold, leading-tight, tracking-tight
-    h2: 'heading-2', // Section/modal titles: 20px → sm:24px semibold, leading-snug
-    h3: 'heading-3', // Card titles: 18px → sm:20px semibold, leading-snug
-    h4: 'heading-4', // Subsections: 16px → sm:18px medium, leading-snug
+    h1: 'heading-1', // Page titles: 24px -> sm:30px bold, leading-tight, tracking-tight
+    h2: 'heading-2', // Section/modal titles: 20px -> sm:24px semibold, leading-snug
+    h3: 'heading-3', // Card titles: 18px -> sm:20px semibold, leading-snug
+    h4: 'heading-4', // Subsections: 16px -> sm:18px medium, leading-snug
     section: 'section-title', // Category labels: 12px uppercase tracking-wider, fg-muted
   },
 


### PR DESCRIPTION
## Summary

Lands the NIAC portion of the 2026-05-22 brand audit. Eight commits, ordered by phase. The headline change is **NIAC's brand identity flips to Tailwind indigo** (`#4f46e5`), fixing two layers of identity drift: the old marketing-site violet `#8b5cf6` (never matched the apps) and the Seed-green that a previous harmonization pass had patched in (made NIAC visually indistinguishable from Seed).

Per the cross-product canonical token map in [`msn-docs-internal/04-Brand-Marketing/CANONICAL_TOKENS.md`](https://github.com/MustardSeedNetworks/msn-docs-internal/blob/main/04-Brand-Marketing/CANONICAL_TOKENS.md).

## Phases included (in commit order)

- **Phase 0 — docs reality-check.** Rewrites `ui/THEMING.md` (which still described the old violet brand) and the `theme.ts` header comment to describe the indigo target.
- **Phase 1 — status palette swap.** Bootstrap-3 hexes → canonical brand-tied anchors.
- **Phase 2 — self-host fonts.** `@fontsource-variable/inter` + `@fontsource-variable/jetbrains-mono` (pinned 5.2.8). **Drops Space Grotesk** and the Google Fonts `<link>` from `index.html`. NIAC was the only app loading external Google Fonts — now CSP-clean.
- **Phase 3 — typography canonical scale.** Replaces NIAC's pre-audit flat typography scale (no responsive sizing, no tracking, body sizes shifted down one step from Seed/Stem) with the canonical responsive scale via CSS utility classes + `themeTypography.ts` barrel.
- **Phase 4 — botanical-earth surfaces.** Warm cream (light) / deep green-black (dark). NIAC also picks up the canonical body atmospheric (mustard + brand radials) — pre-audit body was a flat surface-base.
- **Phase 5 — NIAC becomes indigo.** brand-primary `#2d7a3e` → `#4f46e5` (niac-500 / Tailwind indigo-600). brand-accent → niac-300. brand-gold constant. `<meta theme-color>` → `#3730a3`. NIAC is now an indigo-identified product: distinct from Seed (green) and Stem (blue) on the color wheel.
- **Phase 6 — 5 differentiated module accents + component cleanup.** Adds Topology / Protocols / Analyze / Inject / Templates as five distinct hues (was a mono-indigo flat ramp where modules were indistinguishable). New `themeModuleColors.ts` barrel mirrors Seed/Stem. Also fixes the broken `btn-primary` text color (`text-text-primary` failed AA against the indigo bg) and flattens the default card (was always rendering as a glass card; `.glass-card` now opt-in).
- **Phase 7 — drop legacy ramp aliases.** Removes the `--color-brand-50..950` flat-mapped aliases (audit grep showed zero consumers).

## New module accents

| Module | Hex | Tailwind | Domain |
|---|---|---|---|
| Topology | `#4f46e5` | indigo-600 | network map / graph (= brand anchor) |
| Protocols | `#0d9488` | teal-600 | protocol stack, packet types |
| Analyze | `#c026d3` | fuchsia-600 | capture inspection, synthesis |
| Inject | `#e11d48` | rose-600 | traffic generation, replay |
| Templates | `#d97706` | amber-600 | saved configs, library |

## Visual effect when merged

- **NIAC is now an indigo product.** Every button, focus ring, CTA, mobile address bar, glass-card tint shifts to indigo family. Portfolio finally reads three-product (green / blue / indigo).
- **Light mode:** warm cream surfaces; dark mode: deep green-black. Body picks up mustard + indigo radial atmospheric (was flat surface bg).
- **Modules visually scannable:** the five NIAC modules now have distinct hues for icons / badges / legend swatches.
- **Glass cards no longer the default** — they're an opt-in variant for over-canvas overlays.
- **Typography:** Inter now actually loads (was loading Inter + Space Grotesk + JetBrains via Google Fonts; now just Inter + JetBrains self-hosted, no external requests).

## Test plan

- [ ] `npm install` succeeds (lockfile bump for two new pinned deps; net `-1` removed Google Fonts dependency)
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npm run test` clean
- [ ] `npm run build` clean (no external Google Fonts request now)
- [ ] Visual sanity check: light + dark, primary CTAs are indigo (not green), default cards are flat (not glass), module-accent legends show 5 distinct hues
- [ ] `npm run test:e2e` — smoke + visual regression
- [ ] Mobile chrome (`<meta theme-color>`) now shows indigo `#3730a3`
- [ ] CSP: confirm no `fonts.googleapis.com` / `fonts.gstatic.com` requests on initial load