### PR TITLE
fix(vite): Stop inlining font assets as data: URLs (CSP fix)

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -45,6 +45,12 @@ export default defineConfig(({ mode }) => {
       cssCodeSplit: true,
       // Smaller chunk size warning threshold
       chunkSizeWarningLimit: 300,
+      // Never inline assets as data: URLs (Vite default is 4096 bytes). Required
+      // because @fontsource-variable ships small metric-override shim fonts that
+      // would otherwise be inlined and violate the production `font-src 'self'`
+      // CSP. With this set to 0, every asset bundles as a file under /assets/,
+      // served from same-origin and properly HTTP-cacheable.
+      assetsInlineLimit: 0,
       // Module preload optimization
       modulePreload: {
         polyfill: false, // Modern browsers don't need polyfill


### PR DESCRIPTION
## Summary

The brand-migration self-hosted Inter + JetBrains Mono via `@fontsource-variable`. Vite's default `assetsInlineLimit: 4096` was inlining small metric-override shim fonts as base64 `data:font/woff2;…` URLs, which violated the production CSP `font-src 'self'`. Result: fonts wouldn't load at runtime.

Sets `build.assetsInlineLimit: 0` so every asset bundles as a separate file under `/assets/` served from same-origin. CSP stays strict, no `data:` relaxation needed.

## Tradeoffs

| | Before (default 4 KB inline) | After (0) |
|---|---|---|
| CSP | required `data:` in `font-src` | stays `'self'` |
| HTTP caching | inlined fonts re-fetched with CSS | each font cached separately |
| CSS bundle size | bloated with base64 | smaller |
| Tiny SVGs/icons | inlined | now bundled as files (minor) |

## Verification

```
npm run build  # clean
grep -c "data:font" internal/api/ui/assets/*.css  # 0
```

## Test plan

- [ ] CI green
- [ ] After merge, manually verify fonts render in light + dark mode without CSP console errors