### PR TITLE
chore(lint): harmonize golangci-lint with seed/stem (#1070)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,7 +77,7 @@ linters:
     - gochecknoinits # checks that no init functions are present in Go code
     - gochecksumtype # checks exhaustiveness on Go "sum types"
     - gocognit # computes and checks the cognitive complexity of functions
-    # - goconst # too noisy for protocol/OID-heavy simulator tables
+    - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     - gocyclo # computes and checks the cyclomatic complexity of functions
     - godoclint # checks Golang's documentation practice
@@ -94,7 +94,7 @@ linters:
     - makezero # finds slice declarations with non-zero initial length
     - mirror # reports wrong mirror patterns of bytes/strings usage
     - mnd # detects magic numbers
-    # - modernize # opportunistic style suggestions; keep compatibility churn out of the gate
+    - modernize # suggests simplifications to Go code, using modern language and library features
     # - musttag # enforces field tags in (un)marshaled structs (disabled: health check endpoints stored as JSON in DB, not YAML)
     - nakedret # finds naked returns in functions greater than a specified function length
     - nestif # reports deeply nested if statements
@@ -113,7 +113,7 @@ linters:
     - recvcheck # checks for receiver type consistency
     - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
     - rowserrcheck # checks whether Err of rows is checked successfully
-    # - sloglint # API handlers intentionally use request-free logger calls in many paths
+    - sloglint # ensure consistent code style when using log/slog
     - spancheck # checks for mistakes with OpenTelemetry/Census spans
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
     - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
@@ -179,6 +179,13 @@ linters:
       # If it's higher than 0.0 (float) the check is enabled.
       # Default: 0.0
       package-average: 10.0
+
+    goconst:
+      # Minimum occurrences of a string to flag. Default 3. Bumped to 10
+      # for parity with seed/stem so protocol/OID-heavy simulator tables
+      # with 3-9 short-string occurrences aren't forced into PascalCase.
+      min-occurrences: 10
+      min-len: 3
 
     depguard:
       # Rules to apply.
@@ -500,6 +507,32 @@ linters:
       - text: 'G710: Open redirect via taint analysis'
         path: 'internal/api/tls\.go'
         linters: [ gosec ]
+      # schema.go uses intPtr/floatPtr helpers for nullable JSON Schema
+      # fields. modernize suggests inlining to Go 1.24 `new(x)` but that
+      # syntax can't infer *float64 from int literals (`new(1)` is *int);
+      # the helpers also preserve callsite intent at struct construction.
+      - text: 'newexpr: '
+        path: 'internal/api/schema.*\.go'
+        linters: [ modernize ]
+      # sse_log_handler_test.go uses NewTextHandler(io.Discard) so the tee
+      # wrapper's Handle() runs unconditionally. slog.DiscardHandler's
+      # Enabled() short-circuits propagation, breaking the test setup.
+      - path: 'internal/api/sse_log_handler_test\.go'
+        linters: [ modernize, sloglint ]
+      # JSON Schema + config-vocabulary literals repeated across api/*.go
+      # (hostname/interface/name/enabled/disabled/ips/router/ipv4/etc).
+      # These are wire-format field names + Schema "type" enums — the
+      # strings ARE the contract; consolidating to consts would force
+      # every handler to import a constants package without behavioural
+      # change.
+      - path: 'internal/api/'
+        linters: [ goconst ]
+      # Device-type domain vocabulary (router/switch/ethernet/etc) and
+      # CLI/IPC JSON field names (config/error/device/message/count/niac)
+      # repeated across cmd/niac and internal packages by design. Each
+      # is a wire/CLI vocabulary token, not a refactorable constant.
+      - linters: [ goconst ]
+        text: 'string `(router|switch|ethernet|niac|config|error|device|message|count|disabled|GET|FCS Errors)` has'
       - path: '_test\.go'
         linters:
           - bodyclose

--- a/internal/api/capture_filter.go
+++ b/internal/api/capture_filter.go
@@ -67,14 +67,14 @@ func (s *Server) handleCaptureFilterSet(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := stack.SetCaptureFilter(req.Filter); err != nil {
-		s.logger.Error("[API] Failed to set capture filter", "filter", req.Filter, "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to set capture filter", "filter", req.Filter, "error", err)
 		writeError(w, r, http.StatusBadRequest, "invalid_filter",
 			"Invalid BPF filter expression", nil)
 
 		return
 	}
 
-	s.logger.Info("[API] Capture filter set", "filter", req.Filter)
+	s.logger.InfoContext(r.Context(), "[API] Capture filter set", "filter", req.Filter)
 	s.writeJSON(w, CaptureFilterResponse{
 		Active: req.Filter != "",
 		Filter: req.Filter,
@@ -91,13 +91,13 @@ func (s *Server) handleCaptureFilterClear(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := stack.SetCaptureFilter(""); err != nil {
-		s.logger.Error("[API] Failed to clear capture filter", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to clear capture filter", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "filter_clear_failed",
 			"Failed to clear capture filter", nil)
 
 		return
 	}
 
-	s.logger.Info("[API] Capture filter cleared")
+	s.logger.InfoContext(r.Context(), "[API] Capture filter cleared")
 	s.writeJSON(w, CaptureFilterResponse{Active: false, Filter: ""})
 }

--- a/internal/api/configs.go
+++ b/internal/api/configs.go
@@ -104,13 +104,13 @@ func (s *Server) handleUserConfigByName(w http.ResponseWriter, r *http.Request) 
 }
 
 // handleUserConfigsList returns a list of user-uploaded configs.
-func (s *Server) handleUserConfigsList(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleUserConfigsList(w http.ResponseWriter, r *http.Request) {
 	configs := []UserConfig{}
 
 	for _, dir := range getUserConfigDirs() {
 		dirConfigs, err := scanUserConfigDir(dir)
 		if err != nil {
-			s.logger.Warn(fmt.Sprintf("Failed to scan config dir %s: %v", dir, err))
+			s.logger.WarnContext(r.Context(), fmt.Sprintf("Failed to scan config dir %s: %v", dir, err))
 			continue
 		}
 		configs = append(configs, dirConfigs...)
@@ -264,7 +264,7 @@ func (s *Server) handleUserConfigUpload(w http.ResponseWriter, r *http.Request) 
 	// Save the config file
 	configPath, err := saveUserConfig(safeName, []byte(req.Content))
 	if err != nil {
-		s.logger.Error("[API] Failed to save user config", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to save user config", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "write_error", "Failed to save config", nil)
 		return
 	}
@@ -333,7 +333,7 @@ func (s *Server) handleUserConfigDelete(w http.ResponseWriter, r *http.Request, 
 
 	// Delete the file
 	if err := os.Remove(configPath); err != nil {
-		s.logger.Error("[API] Failed to delete user config", "error", err, "path", configPath)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to delete user config", "error", err, "path", configPath)
 		writeError(w, r, http.StatusInternalServerError, "delete_error", "Failed to delete config", nil)
 		return
 	}

--- a/internal/api/devices_helpers.go
+++ b/internal/api/devices_helpers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"strings"
@@ -73,9 +74,7 @@ func deepCopyDevice(dev *config.Device) *config.Device {
 	copied.TrunkPorts = append([]config.TrunkPort(nil), dev.TrunkPorts...)
 	if dev.Properties != nil {
 		copied.Properties = make(map[string]string, len(dev.Properties))
-		for key, value := range dev.Properties {
-			copied.Properties[key] = value
-		}
+		maps.Copy(copied.Properties, dev.Properties)
 	}
 
 	return &copied
@@ -116,7 +115,7 @@ func (s *Server) createAndSaveDevice(
 ) (*config.Device, error) {
 	newDevice, err := createDeviceFromRequest(req)
 	if err != nil {
-		s.logger.Error("[API] Device creation failed", "error", err, "hostname", req.Hostname)
+		s.logger.ErrorContext(r.Context(), "[API] Device creation failed", "error", err, "hostname", req.Hostname)
 		writeError(w, r, http.StatusBadRequest, "device_creation_failed",
 			"Failed to create device from request", nil)
 		return nil, err

--- a/internal/api/handlers_capture.go
+++ b/internal/api/handlers_capture.go
@@ -92,7 +92,7 @@ func (s *Server) handleStandaloneCaptureStart(w http.ResponseWriter, r *http.Req
 		// natural status codes; everything else is a 500. The detail
 		// string is the daemon's error message, which is operator-
 		// readable (it's already used in the sim flow's daemon log).
-		s.logger.Error("[API] Failed to start standalone capture", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to start standalone capture", "error", err)
 		switch {
 		case errors.Is(err, ErrCaptureAlreadyRunning):
 			writeError(w, r, http.StatusConflict, "capture_already_running",
@@ -116,7 +116,7 @@ func (s *Server) handleStandaloneCaptureStart(w http.ResponseWriter, r *http.Req
 
 func (s *Server) handleStandaloneCaptureStop(w http.ResponseWriter, r *http.Request) {
 	if err := s.captureController.StopCapture(); err != nil {
-		s.logger.Error("[API] Failed to stop standalone capture", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to stop standalone capture", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "capture_stop_failed",
 			"Failed to stop capture", nil)
 		return

--- a/internal/api/handlers_library.go
+++ b/internal/api/handlers_library.go
@@ -67,7 +67,7 @@ func (s *Server) handleLibraryNetworkByName(w http.ResponseWriter, r *http.Reque
 func (s *Server) handleLibraryNetworksList(w http.ResponseWriter, r *http.Request) {
 	entries, err := s.library.ListNetworks()
 	if err != nil {
-		s.logger.Error("[API] library: list networks", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] library: list networks", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "library_list_failed",
 			"Failed to list networks", nil)
 		return
@@ -86,7 +86,7 @@ func (s *Server) handleLibraryNetworkRead(w http.ResponseWriter, r *http.Request
 			writeError(w, r, http.StatusBadRequest, "invalid_name", err.Error(), nil)
 			return
 		}
-		s.logger.Error("[API] library: read network", "name", name, "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] library: read network", "name", name, "error", err)
 		writeError(w, r, http.StatusInternalServerError, "library_read_failed",
 			"Failed to read network", nil)
 		return
@@ -115,7 +115,7 @@ func (s *Server) handleLibraryNetworkUpload(w http.ResponseWriter, r *http.Reque
 			writeError(w, r, http.StatusBadRequest, "invalid_content", err.Error(), nil)
 			return
 		}
-		s.logger.Error("[API] library: write network", "name", req.Name, "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] library: write network", "name", req.Name, "error", err)
 		writeError(w, r, http.StatusInternalServerError, "library_write_failed",
 			"Failed to save network", nil)
 		return
@@ -163,7 +163,7 @@ func (s *Server) handleLibraryFiles(w http.ResponseWriter, r *http.Request, kind
 	}
 	entries, err := s.library.ListFiles(kind)
 	if err != nil {
-		s.logger.Error("[API] library: list files", "kind", string(kind), "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] library: list files", "kind", string(kind), "error", err)
 		writeError(w, r, http.StatusInternalServerError, "library_list_failed",
 			"Failed to list "+string(kind), nil)
 		return

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -157,7 +157,7 @@ func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 	history, err := s.cfg.Storage.ListRuns(historyListLimit)
 	if err != nil {
 		// SECURITY FIX MEDIUM-6: Don't expose internal error details
-		s.logger.Error("[API] Failed to list run history", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to list run history", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "storage_error",
 			"Failed to retrieve run history", nil)
 
@@ -183,7 +183,7 @@ func (s *Server) handleConfigGet(w http.ResponseWriter, r *http.Request) {
 	doc, status, err := s.readConfigDocument()
 	if err != nil {
 		// SECURITY FIX MEDIUM-6: Don't expose internal error details
-		s.logger.Error("[API] Failed to read config", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to read config", "error", err)
 		writeError(w, r, status, "config_read_failed",
 			"Failed to read configuration", nil)
 
@@ -217,7 +217,7 @@ func (s *Server) handleConfigUpdate(w http.ResponseWriter, r *http.Request) {
 
 	doc, status, err := s.readConfigDocument()
 	if err != nil {
-		s.logger.Error("[API] Failed to read updated config", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to read updated config", "error", err)
 		writeError(w, r, status, "config_read_failed",
 			"Configuration updated but failed to retrieve", nil)
 		return
@@ -250,7 +250,7 @@ func (s *Server) validateConfigContent(
 ) (*config.Config, bool) {
 	newCfg, err := config.LoadYAMLBytes([]byte(content))
 	if err != nil {
-		s.logger.Error("[API] Config validation failed", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Config validation failed", "error", err)
 		writeError(w, r, http.StatusBadRequest, "config_invalid", "Configuration validation failed", nil)
 		return nil, false
 	}
@@ -263,7 +263,7 @@ func (s *Server) applyAndSaveConfig(
 	prevCfg := s.currentConfig()
 	if s.cfg.ApplyConfig != nil {
 		if err := s.cfg.ApplyConfig(newCfg); err != nil {
-			s.logger.Error("[API] Failed to apply config", "error", err)
+			s.logger.ErrorContext(r.Context(), "[API] Failed to apply config", "error", err)
 			writeError(w, r, http.StatusInternalServerError, "config_apply_failed",
 				"Failed to apply configuration", nil)
 			return false
@@ -274,7 +274,7 @@ func (s *Server) applyAndSaveConfig(
 		if s.cfg.ApplyConfig != nil && prevCfg != nil {
 			_ = s.cfg.ApplyConfig(prevCfg)
 		}
-		s.logger.Error("[API] Failed to write config file", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to write config file", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "config_write_failed",
 			"Failed to save configuration", nil)
 		return false
@@ -349,7 +349,7 @@ func (s *Server) handleReplay(w http.ResponseWriter, r *http.Request) {
 		state, err := s.cfg.Replay.Stop()
 		if err != nil {
 			// SECURITY FIX MEDIUM-6: Don't expose internal error details
-			s.logger.Error("[API] Failed to stop replay", "error", err)
+			s.logger.ErrorContext(r.Context(), "[API] Failed to stop replay", "error", err)
 			writeError(w, r, http.StatusInternalServerError, "replay_stop_failed",
 				"Failed to stop replay", nil)
 
@@ -509,7 +509,7 @@ func (s *Server) handleInterfaces(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		// SECURITY FIX MEDIUM-6: Don't expose internal error details
-		s.logger.Error("[API] Failed to list interfaces", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to list interfaces", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "interface_list_failed",
 			"Failed to retrieve network interfaces", nil)
 

--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -60,7 +60,7 @@ func (s *Server) handleSimulationStart(w http.ResponseWriter, r *http.Request) {
 		// SECURITY: Don't leak internal error details to the client, but
 		// log them server-side so the daemon log can be used to diagnose
 		// why a start failed (config parse, capture engine, walk file…).
-		s.logger.Error("[API] Failed to start simulation", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to start simulation", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "simulation_start_failed",
 			"Failed to start simulation", nil)
 		return
@@ -74,7 +74,7 @@ func (s *Server) handleSimulationStart(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSimulationStop(w http.ResponseWriter, r *http.Request) {
 	if err := s.daemon.StopSimulation(); err != nil {
 		// SECURITY FIX MEDIUM-6: Don't expose internal error details
-		s.logger.Error("[API] Failed to stop simulation", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to stop simulation", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "simulation_stop_failed",
 			"Failed to stop simulation", nil)
 		return

--- a/internal/api/handlers_synthesize_walk.go
+++ b/internal/api/handlers_synthesize_walk.go
@@ -170,7 +170,7 @@ func (s *Server) handleSynthesizeWalk(w http.ResponseWriter, r *http.Request) {
 	hadPrior := s.libraryFileExists(library.KindWalks, relPath)
 
 	if writeErr := s.library.WriteFile(library.KindWalks, relPath, walkBytes, true); writeErr != nil {
-		s.logger.Error("[API] synthesize-walk: write failed", "device", hostname, "error", writeErr)
+		s.logger.ErrorContext(r.Context(), "[API] synthesize-walk: write failed", "device", hostname, "error", writeErr)
 		writeError(w, r, http.StatusInternalServerError, "write_failed",
 			"Failed to write synthesised walk", nil)
 		return
@@ -182,7 +182,14 @@ func (s *Server) handleSynthesizeWalk(w http.ResponseWriter, r *http.Request) {
 	// device.snmp_config.walk_file.
 	updateErr := s.attachWalkToDevice(dev.Name, relPath)
 	if updateErr != nil {
-		s.logger.Error("[API] synthesize-walk: attach failed", "device", hostname, "error", updateErr)
+		s.logger.ErrorContext(
+			r.Context(),
+			"[API] synthesize-walk: attach failed",
+			"device",
+			hostname,
+			"error",
+			updateErr,
+		)
 		writeError(w, r, http.StatusInternalServerError, "attach_failed",
 			"Walk synthesised but could not attach to device", nil)
 		return
@@ -291,7 +298,7 @@ func (s *Server) attachWalkToDevice(hostname, relPath string) error {
 // 201 response so the UI can show "Generated walk with N OIDs".
 func countOIDLines(walk []byte) int {
 	count := 0
-	for _, line := range strings.Split(string(walk), "\n") {
+	for line := range strings.SplitSeq(string(walk), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -132,8 +132,8 @@ func (s *Server) recoverMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			if err := recover(); err != nil {
 				requestID := r.Header.Get("X-Request-ID")
 				// Log panic with stack trace
-				s.logger.Error("[API] PANIC recovered", "requestID", requestID, "error", err)
-				s.logger.Error("[API] Stack trace", "stack", string(debug.Stack()))
+				s.logger.ErrorContext(r.Context(), "[API] PANIC recovered", "requestID", requestID, "error", err)
+				s.logger.ErrorContext(r.Context(), "[API] Stack trace", "stack", string(debug.Stack()))
 
 				// Return 500 error to client
 				writeError(w, r, http.StatusInternalServerError,
@@ -168,7 +168,7 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 			// Structured audit fields (task #77): tagged event + UA so SIEM
 			// pipelines can filter and so abusive clients are identifiable
 			// beyond just IP.
-			s.logger.Warn("[API] Rate limit exceeded",
+			s.logger.WarnContext(r.Context(), "[API] Rate limit exceeded",
 				"event", "api.rate_limited",
 				"requestID", requestID,
 				"clientIP", clientIP,
@@ -204,7 +204,7 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 			// shows up as a security event in log pipelines, not just a
 			// generic API warning. tokenPresent records the outcome shape
 			// without ever logging the token value itself.
-			s.logger.Warn(
+			s.logger.WarnContext(r.Context(),
 				"[API] Unauthorized request",
 				"event", "auth.unauthorized",
 				"requestID", requestID,
@@ -226,7 +226,7 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 		if scope < required {
 			writeError(w, r, http.StatusForbidden, "forbidden",
 				"token lacks required scope", nil)
-			s.logger.Warn(
+			s.logger.WarnContext(r.Context(),
 				"[API] Forbidden request: token scope insufficient",
 				"event", "auth.forbidden_scope",
 				"requestID", requestID,

--- a/internal/api/pcap.go
+++ b/internal/api/pcap.go
@@ -343,7 +343,7 @@ func (s *Server) handlePcapUpload(w http.ResponseWriter, r *http.Request) {
 
 	result, err := analyzePcapData(pcapData, req.Filename)
 	if err != nil {
-		s.logger.Error("[API] PCAP analysis failed", "error", err, "filename", req.Filename)
+		s.logger.ErrorContext(r.Context(), "[API] PCAP analysis failed", "error", err, "filename", req.Filename)
 		writeError(w, r, http.StatusInternalServerError, "analysis_failed",
 			"Failed to analyze PCAP file", nil)
 		return

--- a/internal/api/rate_limiter.go
+++ b/internal/api/rate_limiter.go
@@ -133,7 +133,7 @@ func (s *Server) uploadRateLimit(next http.HandlerFunc) http.HandlerFunc {
 		if !s.uploadLimiter.GetLimiter(clientIP).Allow() {
 			writeError(w, r, http.StatusTooManyRequests, "upload_rate_limit_exceeded",
 				"Upload rate limit exceeded. Please wait before uploading again.", nil)
-			s.logger.Warn(
+			s.logger.WarnContext(r.Context(),
 				"[API] Upload rate limit exceeded",
 				"clientIP",
 				clientIP,
@@ -156,7 +156,7 @@ func (s *Server) writeRateLimit(next http.HandlerFunc) http.HandlerFunc {
 			if !s.writeLimiter.GetLimiter(clientIP).Allow() {
 				writeError(w, r, http.StatusTooManyRequests, "write_rate_limit_exceeded",
 					"Write rate limit exceeded. Please wait before making more changes.", nil)
-				s.logger.Warn(
+				s.logger.WarnContext(r.Context(),
 					"[API] Write rate limit exceeded",
 					"clientIP",
 					clientIP,
@@ -177,7 +177,7 @@ func (s *Server) walkRateLimit(next http.HandlerFunc) http.HandlerFunc {
 		if !s.walkLimiter.GetLimiter(clientIP).Allow() {
 			writeError(w, r, http.StatusTooManyRequests, "walk_rate_limit_exceeded",
 				"Walk file operation rate limit exceeded. Please wait before trying again.", nil)
-			s.logger.Warn(
+			s.logger.WarnContext(r.Context(),
 				"[API] Walk rate limit exceeded",
 				"clientIP",
 				clientIP,
@@ -198,7 +198,7 @@ func (s *Server) fileRateLimit(next http.HandlerFunc) http.HandlerFunc {
 		if !s.fileLimiter.GetLimiter(clientIP).Allow() {
 			writeError(w, r, http.StatusTooManyRequests, "file_rate_limit_exceeded",
 				"File listing rate limit exceeded. Please wait before trying again.", nil)
-			s.logger.Warn(
+			s.logger.WarnContext(r.Context(),
 				"[API] File rate limit exceeded",
 				"clientIP",
 				clientIP,

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -47,7 +47,7 @@ func writeError(
 	requestID := r.Header.Get("X-Request-ID")
 	if requestID != "" {
 		logger := slog.Default()
-		logger.Error(
+		logger.ErrorContext(r.Context(),
 			"[API] Error response",
 			"requestID",
 			requestID,

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -100,7 +100,7 @@ func (s *Server) handleConfigSchema(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	err := json.NewEncoder(w).Encode(schema)
 	if err != nil {
-		s.logger.Error("[API] Failed to encode schema response", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Failed to encode schema response", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	}
 }

--- a/internal/api/server_port_fallback.go
+++ b/internal/api/server_port_fallback.go
@@ -64,7 +64,7 @@ func bindWithFallback(
 		ln, err := lc.Listen(ctx, "tcp", candidate)
 		if err == nil {
 			if offset > 0 && logger != nil {
-				logger.Warn(
+				logger.WarnContext(ctx,
 					"requested port is in use, bound fallback port instead",
 					"requested", port,
 					"bound", actual,

--- a/internal/api/server_port_fallback_test.go
+++ b/internal/api/server_port_fallback_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"net"
 	"strconv"
@@ -15,7 +14,7 @@ import (
 // silentLogger returns a slog.Logger that discards output so tests don't
 // spam the buffer with the expected fallback WARN.
 func silentLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }
 
 // TestBindWithFallback_FreePort confirms a free port is bound at offset 0.

--- a/internal/api/sse_serve.go
+++ b/internal/api/sse_serve.go
@@ -50,7 +50,7 @@ func (s *Server) setupSSEConnection(
 
 	rc := http.NewResponseController(w)
 	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-		s.logger.Warn("[SSE] Could not disable write deadline", "error", err)
+		s.logger.WarnContext(r.Context(), "[SSE] Could not disable write deadline", "error", err)
 	}
 
 	client := &SSEClient{
@@ -120,7 +120,7 @@ func (s *Server) serveSSE(stream SSEStream) http.HandlerFunc {
 		sc, err := s.setupSSEConnection(w, r, stream)
 		if err != nil {
 			// SECURITY FIX #183: Don't expose internal error details
-			s.logger.Error("[API] SSE connection setup failed", "error", err)
+			s.logger.ErrorContext(r.Context(), "[API] SSE connection setup failed", "error", err)
 			writeError(w, r, http.StatusInternalServerError, "sse_not_supported",
 				"Failed to establish SSE connection", nil)
 			return

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -128,13 +128,13 @@ func (s *Server) handleTemplateByName(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleTemplatesList returns a list of available templates.
-func (s *Server) handleTemplatesList(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleTemplatesList(w http.ResponseWriter, r *http.Request) {
 	templates := []Template{}
 
 	for _, dir := range getTemplateDirs() {
 		dirTemplates, err := scanTemplateDir(dir)
 		if err != nil {
-			s.logger.Warn(fmt.Sprintf("Failed to scan template dir %s: %v", dir, err))
+			s.logger.WarnContext(r.Context(), fmt.Sprintf("Failed to scan template dir %s: %v", dir, err))
 			continue
 		}
 		templates = append(templates, dirTemplates...)

--- a/internal/api/walk.go
+++ b/internal/api/walk.go
@@ -179,23 +179,30 @@ func (s *Server) runWalkValidation(
 	if autoFix {
 		result, err := snmp.AutoFixWalkFile(validatedPath, "")
 		if err != nil {
-			s.logger.Error("[API] Walk file auto-fix error", "error", err)
+			s.logger.ErrorContext(r.Context(), "[API] Walk file auto-fix error", "error", err)
 			writeError(w, r, http.StatusInternalServerError, "fix_failed",
 				fmt.Sprintf("Failed to fix walk file: %v", err), nil)
 			return nil, false
 		}
-		s.logger.Info("[API] Walk file auto-fixed", "fixedCount", result.FixedCount, "filename", validatedPath)
+		s.logger.InfoContext(
+			r.Context(),
+			"[API] Walk file auto-fixed",
+			"fixedCount",
+			result.FixedCount,
+			"filename",
+			validatedPath,
+		)
 		return result, true
 	}
 
 	result, err := snmp.ValidateWalkFile(validatedPath)
 	if err != nil {
-		s.logger.Error("[API] Walk file validation error", "error", err)
+		s.logger.ErrorContext(r.Context(), "[API] Walk file validation error", "error", err)
 		writeError(w, r, http.StatusInternalServerError, "validation_failed",
 			fmt.Sprintf("Failed to validate walk file: %v", err), nil)
 		return nil, false
 	}
-	s.logger.Info(
+	s.logger.InfoContext(r.Context(),
 		"[API] Walk file validated",
 		"filename", validatedPath,
 		"valid", result.Valid,
@@ -239,7 +246,14 @@ func (s *Server) handleWalkValidation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.logger.Info("[API] Walk file validation request", "filename", validatedPath, "autoFix", isAutoFix || req.AutoFix)
+	s.logger.InfoContext(
+		r.Context(),
+		"[API] Walk file validation request",
+		"filename",
+		validatedPath,
+		"autoFix",
+		isAutoFix || req.AutoFix,
+	)
 
 	result, ok := s.runWalkValidation(w, r, validatedPath, isAutoFix || req.AutoFix)
 	if !ok {
@@ -423,7 +437,7 @@ func (s *Server) handleWalkBatchValidate(w http.ResponseWriter, r *http.Request)
 
 	response := buildBatchWalkResponse(walkFiles, results, totalIssues, invalidCount)
 
-	s.logger.Info(
+	s.logger.InfoContext(r.Context(),
 		"[API] Batch walk file validation",
 		"totalFiles",
 		len(walkFiles),

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -141,7 +141,7 @@ func (e *Engine) StartCaptureContext(ctx context.Context, handler func(gopacket.
 	packetSource := gopacket.NewPacketSource(e.handle, e.handle.LinkType())
 
 	if e.debugLevel >= 1 {
-		slog.Default().Info("Started packet capture", "interface", e.interfaceName)
+		slog.Default().InfoContext(ctx, "Started packet capture", "interface", e.interfaceName)
 	}
 
 	packets := packetSource.Packets()

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"net"
 	"strconv"
 	"strings"
@@ -92,9 +93,7 @@ func convertPortChannels(in []converter.PortChannel) []PortChannel {
 // custom_mibs_count) extend it rather than dropping the originals.
 func createBaseDevice(yamlDevice converter.Device) Device {
 	props := make(map[string]string, len(yamlDevice.Properties))
-	for k, v := range yamlDevice.Properties {
-		props[k] = v
-	}
+	maps.Copy(props, yamlDevice.Properties)
 	return Device{
 		Name:       yamlDevice.Name,
 		Type:       inferYAMLDeviceType(yamlDevice),

--- a/internal/library/list.go
+++ b/internal/library/list.go
@@ -200,7 +200,7 @@ func (l *Library) WriteFile(kind Kind, relPath string, content []byte, backupExi
 	if len(content) == 0 {
 		return ErrEmptyContent
 	}
-	for _, segment := range strings.Split(filepath.ToSlash(relPath), "/") {
+	for segment := range strings.SplitSeq(filepath.ToSlash(relPath), "/") {
 		if err := validateName(segment); err != nil {
 			return err
 		}
@@ -291,8 +291,8 @@ func countDevices(data []byte) (int, error) {
 
 func trimYAMLExt(name string) string {
 	for _, ext := range []string{".yaml", ".yml"} {
-		if strings.HasSuffix(name, ext) {
-			return strings.TrimSuffix(name, ext)
+		if before, ok := strings.CutSuffix(name, ext); ok {
+			return before
 		}
 	}
 	return name

--- a/internal/library/metadata.go
+++ b/internal/library/metadata.go
@@ -30,10 +30,7 @@ func parseHeaderMetadata(content []byte) (string, string) {
 	}
 
 	lines := strings.Split(string(head), "\n")
-	limit := len(lines)
-	if limit > metadataMaxScanLines {
-		limit = metadataMaxScanLines
-	}
+	limit := min(len(lines), metadataMaxScanLines)
 
 	var description, useCase, firstComment string
 	for i := range limit {

--- a/internal/protocols/dns_resolver.go
+++ b/internal/protocols/dns_resolver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -393,12 +394,12 @@ func parseIPv6PTRName(name string) (net.IP, bool) {
 
 	builder.Grow(dnsIPv6NibbleLen)
 
-	for i := len(nibbles) - 1; i >= 0; i-- {
-		if len(nibbles[i]) != 1 {
+	for _, v := range slices.Backward(nibbles) {
+		if len(v) != 1 {
 			return nil, false
 		}
 
-		builder.WriteString(nibbles[i])
+		builder.WriteString(v)
 	}
 
 	data, err := hex.DecodeString(builder.String())

--- a/internal/protocols/snmp/synth/build_test.go
+++ b/internal/protocols/snmp/synth/build_test.go
@@ -147,7 +147,7 @@ func TestSyntheticMACIsDeterministicAndLocallyAdministered(t *testing.T) {
 
 	// MACs we emit live on the ifPhysAddress lines (.1.3.6.1.2.1.2.2.1.6.<idx>).
 	// Locally-administered bit means the first octet is 02.
-	for _, line := range strings.Split(w1, "\n") {
+	for line := range strings.SplitSeq(w1, "\n") {
 		if !strings.Contains(line, ".1.3.6.1.2.1.2.2.1.6.") {
 			continue
 		}

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -117,10 +117,7 @@ func parseHeaderMetadata(content string) (string, string) {
 	head := string(buf[:n])
 
 	lines := strings.Split(head, "\n")
-	limit := len(lines)
-	if limit > metadataMaxScanLines {
-		limit = metadataMaxScanLines
-	}
+	limit := min(len(lines), metadataMaxScanLines)
 
 	var description, useCase, firstComment string
 	for i := range limit {


### PR DESCRIPTION
## Summary

Brings niac's golangci-lint setup in line with seed/stem by enabling the three linters that were intentionally disabled here: **goconst**, **modernize**, **sloglint**. All three repos now run the identical 81-linter baseline.

## What changed

- **goconst**: `min-occurrences: 10` (matches seed/stem). Scoped exclusions for:
  - `internal/api/` (JSON Schema field-name vocabulary)
  - Cross-package device-type / CLI tokens (router/switch/ethernet/niac/config/error/device/etc)
- **modernize**: enabled with autofix applied across 26 files (`slog` patterns, `maps.Copy`, range over `SplitSeq`). Two targeted exclusions:
  - `schema.go` pointer helpers — Go 1.24 `new(x)` can't infer `*float64` from int literals
  - `sse_log_handler_test.go` — `slog.DiscardHandler.Enabled()` breaks the tee-test setup
- **sloglint**: enabled; autofix converted `Info`/`Error` → `InfoContext`/`ErrorContext` using request context in scope
- Two handler signatures changed from `_ *http.Request` → `r *http.Request` because their bodies now use `r.Context()` (handleUserConfigsList, handleTemplatesList)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` passes
- [x] \`golangci-lint run\` → 0 issues