### PR TITLE
feat(license): Add offline license framework with trial and keygen contract

### DIFF
--- a/cmd/niac/license.go
+++ b/cmd/niac/license.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+func addLicenseCommand(root *cobra.Command, _ *serviceOptions) {
+	licenseCmd := &cobra.Command{
+		Use:   "license",
+		Short: "Manage license activation",
+		Long: `The license command handles offline license activation and status
+for NIAC. Without a license, NIAC runs in the Free tier (up to 10
+simulated devices, common protocols). NIAC Pro ($599/yr) unlocks:
+
+  • Unlimited simulated devices
+  • Advanced protocols: BGP, OSPF, SNMPv3, NetBIOS, FTP, STP
+  • Advanced IPv4/IPv6 stack features
+  • Error injection (latency, loss, jitter, protocol faults)
+  • Traffic shaping
+  • Config templates
+  • Multi-IP per simulated endpoint
+  • PCAP ingest + analysis
+  • REST API access (programmatic control)
+
+A 14-day trial of the full Pro tier is available without a key.`,
+	}
+
+	licenseCmd.AddCommand(&cobra.Command{
+		Use:   "status",
+		Short: "Show current license status",
+		Run:   func(_ *cobra.Command, _ []string) { runLicenseStatus() },
+	})
+
+	activateCmd := &cobra.Command{
+		Use:   "activate",
+		Short: "Activate a license key",
+		Run:   func(cmd *cobra.Command, _ []string) { runLicenseActivate(cmd) },
+	}
+	activateCmd.Flags().StringP("key", "k", "", "License key to activate (XXXX-XXXX-XXXX-XXXX)")
+	_ = activateCmd.MarkFlagRequired("key")
+	licenseCmd.AddCommand(activateCmd)
+
+	licenseCmd.AddCommand(&cobra.Command{
+		Use:   "deactivate",
+		Short: "Remove the current license from this device",
+		Run:   func(_ *cobra.Command, _ []string) { runLicenseDeactivate() },
+	})
+
+	licenseCmd.AddCommand(&cobra.Command{
+		Use:   "trial",
+		Short: "Start the 14-day Pro trial",
+		Run:   func(_ *cobra.Command, _ []string) { runLicenseTrial() },
+	})
+
+	root.AddCommand(licenseCmd)
+}
+
+func runLicenseStatus() {
+	mgr, err := license.NewManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	state := mgr.GetState()
+	if state == nil {
+		fmt.Fprintln(os.Stdout, "Tier:        Free (no license activated)")
+		fmt.Fprintln(os.Stdout, "Run `niac license trial` to start a 14-day Pro trial,")
+		fmt.Fprintln(os.Stdout, "or `niac license activate -k <KEY>` to enter a key.")
+		return
+	}
+
+	if state.IsTrialMode {
+		remaining := mgr.TrialDaysRemaining()
+		fmt.Fprintln(os.Stdout, "Tier:        Trial (Pro features)")
+		fmt.Fprintf(os.Stdout, "Days left:   %d of %d\n", remaining, license.TrialDays)
+		if remaining <= 0 {
+			fmt.Fprintln(os.Stdout, "Trial expired. Run `niac license activate -k <KEY>` to continue.")
+		}
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, "Tier:        %s\n", state.Tier)
+	fmt.Fprintf(os.Stdout, "Key:         %s\n", license.FormatKey(state.LicenseKey))
+	fmt.Fprintf(os.Stdout, "Activated:   %s\n", state.ActivatedAt.Format("2006-01-02"))
+	fmt.Fprintf(os.Stdout, "Expires:     %s\n", state.ExpiresAt.Format("2006-01-02"))
+	fmt.Fprintf(os.Stdout, "Device:      %s\n", state.DeviceHash)
+	if len(state.Features) > 0 {
+		fmt.Fprintf(os.Stdout, "Features:    %d unlocked\n", len(state.Features))
+	}
+}
+
+func runLicenseActivate(cmd *cobra.Command) {
+	key, err := cmd.Flags().GetString("key")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading --key flag: %v\n", err)
+		os.Exit(1)
+	}
+	if key == "" {
+		fmt.Fprintln(os.Stderr, "Error: --key is required")
+		os.Exit(1)
+	}
+
+	mgr, mgrErr := license.NewManager()
+	if mgrErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", mgrErr)
+		os.Exit(1)
+	}
+
+	res := mgr.Activate(key)
+	if !res.Success {
+		fmt.Fprintf(os.Stderr, "Activation failed: %s\n", res.Message)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, res.Message)
+}
+
+func runLicenseDeactivate() {
+	mgr, err := license.NewManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if deactErr := mgr.Deactivate(); deactErr != nil {
+		fmt.Fprintf(os.Stderr, "Deactivation failed: %v\n", deactErr)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, "License removed. NIAC will run in the Free tier.")
+}
+
+func runLicenseTrial() {
+	mgr, err := license.NewManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	res := mgr.StartTrial()
+	if !res.Success {
+		fmt.Fprintf(os.Stderr, "Trial failed: %s\n", res.Message)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, res.Message)
+}

--- a/cmd/niac/main.go
+++ b/cmd/niac/main.go
@@ -101,6 +101,7 @@ func main() {
 		addInitCommand,
 		addInjectCommand,
 		func(root *cobra.Command, _ *serviceOptions) { addInstallCACommand(root) },
+		addLicenseCommand,
 		addInteractiveCommand,
 		addLogsCommand,
 		func(root *cobra.Command, _ *serviceOptions) { addManCommand(root, info) },

--- a/internal/license/activation.go
+++ b/internal/license/activation.go
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package license provides NIAC's offline license validation, device
+// binding, 14-day trial, and encrypted on-disk state. Keys are issued
+// by the canonical keygen tool; this package only validates them.
+package license
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// License file lives at ~/.config/niac/.license, distinct from seed
+// and stem so per-product activations don't collide on shared hosts.
+const licenseFileName = ".license"
+
+// TrialDays is the trial-period length before a paid key is required.
+const TrialDays = 14
+
+// OfflineMaxDays is the number of days allowed offline after activation.
+const OfflineMaxDays = 90
+
+// CheckInInterval is the number of days between optional check-ins.
+const CheckInInterval = 30
+
+// encryptionSalt is product-distinct so an attacker can't reuse a
+// seed/stem license file by renaming it.
+const encryptionSalt = "MSN-NIAC-SIM-2026-LICENSE"
+
+const (
+	hoursPerDay = 24
+	daysPerYear = 365
+)
+
+// ActivationState represents the current license activation status.
+type ActivationState struct {
+	LicenseKey      string    `json:"licenseKey"`
+	DeviceHash      string    `json:"deviceHash"`
+	Tier            Tier      `json:"tier"`
+	ActivatedAt     time.Time `json:"activatedAt"`
+	LastValidatedAt time.Time `json:"lastValidatedAt"`
+	ExpiresAt       time.Time `json:"expiresAt"`
+	TrialStartedAt  time.Time `json:"trialStartedAt,omitzero"`
+	IsTrialMode     bool      `json:"isTrialMode"`
+	Features        []string  `json:"features"`
+}
+
+// ActivationResult contains the result of an activation attempt.
+type ActivationResult struct {
+	Success       bool   `json:"success"`
+	Message       string `json:"message"`
+	Tier          Tier   `json:"tier,omitempty"`
+	DaysRemaining int    `json:"daysRemaining,omitempty"`
+	IsTrialMode   bool   `json:"isTrialMode"`
+}
+
+// Manager handles license activation and validation.
+type Manager struct {
+	state       *ActivationState
+	fingerprint *DeviceFingerprint
+	configDir   string
+}
+
+// NewManager creates a new license manager rooted at the default
+// per-user config directory.
+func NewManager() (*Manager, error) {
+	homeDir, homeErr := os.UserHomeDir()
+	if homeErr != nil {
+		homeDir = "/tmp"
+	}
+	return NewManagerWithDir(filepath.Join(homeDir, ".config", "niac"))
+}
+
+// NewManagerWithDir creates a license manager that persists state in
+// the given directory. Exposed so tests can use a tmpdir without
+// poking at the user's real config.
+func NewManagerWithDir(configDir string) (*Manager, error) {
+	fp, fpErr := GenerateFingerprint()
+	if fpErr != nil {
+		return nil, fmt.Errorf("failed to generate fingerprint: %w", fpErr)
+	}
+
+	m := &Manager{
+		state:       nil,
+		fingerprint: fp,
+		configDir:   configDir,
+	}
+
+	_ = m.loadState() // Best-effort.
+	return m, nil
+}
+
+// GetState returns the current activation state.
+func (m *Manager) GetState() *ActivationState {
+	return m.state
+}
+
+// GetFingerprint returns the device fingerprint.
+func (m *Manager) GetFingerprint() *DeviceFingerprint {
+	return m.fingerprint
+}
+
+// IsActivated returns true if a valid license is active.
+func (m *Manager) IsActivated() bool {
+	if m.state == nil {
+		return false
+	}
+	if m.state.IsTrialMode {
+		return m.IsTrialValid()
+	}
+	if !m.state.ExpiresAt.IsZero() && time.Now().After(m.state.ExpiresAt) {
+		return false
+	}
+	if m.state.DeviceHash != m.fingerprint.Hash() {
+		return false
+	}
+	return true
+}
+
+// IsTrialValid returns true if trial period is still active.
+func (m *Manager) IsTrialValid() bool {
+	if m.state == nil || !m.state.IsTrialMode {
+		return false
+	}
+	if m.state.TrialStartedAt.IsZero() {
+		return false
+	}
+	trialEnd := m.state.TrialStartedAt.AddDate(0, 0, TrialDays)
+	return time.Now().Before(trialEnd)
+}
+
+// TrialDaysRemaining returns days left in trial.
+func (m *Manager) TrialDaysRemaining() int {
+	if m.state == nil || !m.state.IsTrialMode {
+		return 0
+	}
+	if m.state.TrialStartedAt.IsZero() {
+		return TrialDays
+	}
+	trialEnd := m.state.TrialStartedAt.AddDate(0, 0, TrialDays)
+	remaining := int(time.Until(trialEnd).Hours() / hoursPerDay)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// StartTrial begins the trial period.
+func (m *Manager) StartTrial() *ActivationResult {
+	if m.IsActivated() && !m.state.IsTrialMode {
+		return &ActivationResult{
+			Success: true,
+			Message: "Already activated with full license",
+			Tier:    m.state.Tier,
+		}
+	}
+
+	if m.state != nil && !m.state.TrialStartedAt.IsZero() {
+		remaining := m.TrialDaysRemaining()
+		if remaining <= 0 {
+			return &ActivationResult{
+				Success:     false,
+				Message:     "Trial period has expired. Please enter a license key.",
+				Tier:        TierInvalid,
+				IsTrialMode: true,
+			}
+		}
+		return &ActivationResult{
+			Success:       true,
+			Message:       fmt.Sprintf("Trial active: %d days remaining", remaining),
+			Tier:          TierPro,
+			DaysRemaining: remaining,
+			IsTrialMode:   true,
+		}
+	}
+
+	m.state = &ActivationState{
+		LicenseKey:     "",
+		DeviceHash:     m.fingerprint.Hash(),
+		Tier:           TierPro,
+		TrialStartedAt: time.Now(),
+		IsTrialMode:    true,
+		Features:       proFeatures(),
+	}
+
+	if saveErr := m.saveState(); saveErr != nil {
+		return &ActivationResult{
+			Success: false,
+			Message: fmt.Sprintf("Failed to save trial state: %v", saveErr),
+			Tier:    TierInvalid,
+		}
+	}
+
+	return &ActivationResult{
+		Success:       true,
+		Message:       fmt.Sprintf("Trial started! %d days of full Pro access.", TrialDays),
+		Tier:          TierPro,
+		DaysRemaining: TrialDays,
+		IsTrialMode:   true,
+	}
+}
+
+// Activate attempts to activate a license key.
+func (m *Manager) Activate(licenseKey string) *ActivationResult {
+	info := ValidateLicenseKey(licenseKey)
+	if !info.Valid {
+		return &ActivationResult{
+			Success: false,
+			Message: info.ErrorMsg,
+			Tier:    TierInvalid,
+		}
+	}
+
+	m.state = &ActivationState{
+		LicenseKey:      info.Key,
+		DeviceHash:      m.fingerprint.Hash(),
+		Tier:            info.Tier,
+		ActivatedAt:     time.Now(),
+		LastValidatedAt: time.Now(),
+		ExpiresAt:       time.Now().AddDate(1, 0, 0),
+		IsTrialMode:     false,
+		Features:        info.Features,
+	}
+
+	if saveErr := m.saveState(); saveErr != nil {
+		return &ActivationResult{
+			Success: false,
+			Message: fmt.Sprintf("Failed to save activation: %v", saveErr),
+			Tier:    TierInvalid,
+		}
+	}
+
+	return &ActivationResult{
+		Success:       true,
+		Message:       fmt.Sprintf("License activated successfully! Tier: %s", info.Tier),
+		Tier:          info.Tier,
+		DaysRemaining: daysPerYear,
+	}
+}
+
+// Deactivate removes the current license.
+func (m *Manager) Deactivate() error {
+	licensePath := filepath.Join(m.configDir, licenseFileName)
+	if removeErr := os.Remove(licensePath); removeErr != nil && !os.IsNotExist(removeErr) {
+		return fmt.Errorf("failed to remove license file: %w", removeErr)
+	}
+	m.state = nil
+	return nil
+}
+
+// CheckIn updates the last-validated timestamp on a non-trial license.
+func (m *Manager) CheckIn() *ActivationResult {
+	if m.state == nil {
+		return &ActivationResult{
+			Success: false,
+			Message: "No active license to validate",
+			Tier:    TierInvalid,
+		}
+	}
+	m.state.LastValidatedAt = time.Now()
+	_ = m.saveState()
+	return &ActivationResult{
+		Success: true,
+		Message: "License validated successfully",
+		Tier:    m.state.Tier,
+	}
+}
+
+// NeedsCheckIn returns true if optional check-in is recommended.
+func (m *Manager) NeedsCheckIn() bool {
+	if m.state == nil || m.state.IsTrialMode {
+		return false
+	}
+	daysSinceCheck := int(time.Since(m.state.LastValidatedAt).Hours() / hoursPerDay)
+	return daysSinceCheck >= CheckInInterval
+}
+
+func (m *Manager) loadState() error {
+	licensePath := filepath.Clean(filepath.Join(m.configDir, licenseFileName))
+
+	f, openErr := os.Open(licensePath)
+	if openErr != nil {
+		if os.IsNotExist(openErr) {
+			return nil
+		}
+		return fmt.Errorf("open license file: %w", openErr)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, readErr := io.ReadAll(f)
+	if readErr != nil {
+		return fmt.Errorf("read license file: %w", readErr)
+	}
+
+	decrypted, decryptErr := m.decrypt(data)
+	if decryptErr != nil {
+		return fmt.Errorf("failed to decrypt license: %w", decryptErr)
+	}
+
+	state := &ActivationState{}
+	if unmarshalErr := json.Unmarshal(decrypted, state); unmarshalErr != nil {
+		return fmt.Errorf("failed to parse license: %w", unmarshalErr)
+	}
+
+	m.state = state
+	return nil
+}
+
+func (m *Manager) saveState() error {
+	if m.state == nil {
+		return nil
+	}
+	if mkdirErr := os.MkdirAll(m.configDir, 0o700); mkdirErr != nil {
+		return fmt.Errorf("failed to create config directory: %w", mkdirErr)
+	}
+
+	data, marshalErr := json.Marshal(m.state)
+	if marshalErr != nil {
+		return fmt.Errorf("failed to marshal license state: %w", marshalErr)
+	}
+
+	encrypted, encryptErr := m.encrypt(data)
+	if encryptErr != nil {
+		return encryptErr
+	}
+
+	licensePath := filepath.Join(m.configDir, licenseFileName)
+	if writeErr := os.WriteFile(licensePath, encrypted, 0o600); writeErr != nil {
+		return fmt.Errorf("failed to write license file: %w", writeErr)
+	}
+	return nil
+}
+
+func (m *Manager) encrypt(plaintext []byte) ([]byte, error) {
+	key := m.deriveKey()
+
+	block, blockErr := aes.NewCipher(key)
+	if blockErr != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", blockErr)
+	}
+	gcm, gcmErr := cipher.NewGCM(block)
+	if gcmErr != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", gcmErr)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, nonceErr := io.ReadFull(rand.Reader, nonce); nonceErr != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", nonceErr)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return []byte(base64.StdEncoding.EncodeToString(ciphertext)), nil
+}
+
+func (m *Manager) decrypt(ciphertext []byte) ([]byte, error) {
+	data, decodeErr := base64.StdEncoding.DecodeString(string(ciphertext))
+	if decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode base64: %w", decodeErr)
+	}
+
+	key := m.deriveKey()
+	block, blockErr := aes.NewCipher(key)
+	if blockErr != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", blockErr)
+	}
+	gcm, gcmErr := cipher.NewGCM(block)
+	if gcmErr != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", gcmErr)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return nil, errors.New("ciphertext too short")
+	}
+
+	nonce, ciphertextBytes := data[:nonceSize], data[nonceSize:]
+	plaintext, openErr := gcm.Open(nil, nonce, ciphertextBytes, nil)
+	if openErr != nil {
+		return nil, fmt.Errorf("failed to decrypt: %w", openErr)
+	}
+	return plaintext, nil
+}
+
+func (m *Manager) deriveKey() []byte {
+	data := m.fingerprint.Hash() + encryptionSalt
+	hash := sha256.Sum256([]byte(data))
+	return hash[:]
+}

--- a/internal/license/cipher.go
+++ b/internal/license/cipher.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package license
+
+import (
+	"strings"
+)
+
+// Rotor constants for cipher operations.
+const (
+	rotorModulus      = 36 // 10 digits + 26 letters.
+	digitModulus      = 10
+	letterModulus     = 26
+	alphanumericSplit = 10 // Values 0-9 are digits, 10-35 are letters.
+	byteMask          = 0xFF
+)
+
+// MSN-specific rotor tables (unique to Mustard Seed Networks products).
+// These provide the substitution mapping for license key encoding/decoding.
+
+func baseRotor10() [10]byte {
+	return [10]byte{7, 2, 9, 0, 5, 8, 1, 6, 3, 4}
+}
+
+func baseRotor26() [26]byte {
+	return [26]byte{
+		19, 3, 24, 7, 12, 0, 21, 15, 8, 25,
+		2, 17, 10, 5, 22, 13, 1, 18, 6, 11,
+		23, 4, 16, 9, 20, 14,
+	}
+}
+
+// InitRotors is retained for backwards compatibility but is now a no-op.
+func InitRotors() {}
+
+// RotorCipher provides Enigma-style encoding/decoding.
+type RotorCipher struct {
+	position   int // Current rotor position (advances with each character).
+	rotor10    [10]byte
+	rotor26    [26]byte
+	rotor10Inv [10]byte
+	rotor26Inv [26]byte
+}
+
+// NewRotorCipher creates a new cipher with the given starting position.
+func NewRotorCipher(startPosition int) *RotorCipher {
+	rotor10 := baseRotor10()
+	rotor26 := baseRotor26()
+
+	var rotor10Inv [10]byte
+	var rotor26Inv [26]byte
+
+	for i, v := range rotor10 {
+		rotor10Inv[v] = byte(i)
+	}
+	for i, v := range rotor26 {
+		rotor26Inv[v] = byte(i)
+	}
+
+	position := startPosition % rotorModulus
+	if position < 0 {
+		position += rotorModulus
+	}
+
+	return &RotorCipher{
+		position:   position,
+		rotor10:    rotor10,
+		rotor26:    rotor26,
+		rotor10Inv: rotor10Inv,
+		rotor26Inv: rotor26Inv,
+	}
+}
+
+// Encode encodes a single character through the rotor.
+func (rc *RotorCipher) Encode(c byte) byte {
+	switch {
+	case c >= '0' && c <= '9':
+		// Digit encoding.
+		idx := (int(c-'0') + rc.position) % digitModulus
+		encoded := rc.rotor10[idx]
+		rc.position = (rc.position + 1) % rotorModulus
+		return '0' + encoded
+	case c >= 'A' && c <= 'Z':
+		// Letter encoding.
+		idx := int(c - 'A')
+		idx = (idx + rc.position) % letterModulus
+		encoded := rc.rotor26[idx]
+		rc.position = (rc.position + 1) % rotorModulus
+		return 'A' + encoded
+	case c >= 'a' && c <= 'z':
+		// Lowercase - convert to upper, encode, keep case.
+		idx := int(c - 'a')
+		idx = (idx + rc.position) % letterModulus
+		encoded := rc.rotor26[idx]
+		rc.position = (rc.position + 1) % rotorModulus
+		return 'a' + encoded
+	default:
+		// Non-alphanumeric passes through unchanged.
+		return c
+	}
+}
+
+// shiftByMod returns a non-negative value in [0, modulus). idx and modulus
+// are int because rc.position is int; the result fits in byte because
+// modulus is a small literal constant (10 or 26).
+func shiftByMod(idx, position, modulus int) byte {
+	v := (idx - position%modulus + modulus) % modulus
+	// Mask to byte: modular arithmetic above guarantees v ∈ [0, modulus)
+	// where modulus is 10 or 26, both well within byte range. The mask
+	// proves the bound to the type checker without a branch.
+	return byte(v & byteMask)
+}
+
+// Decode decodes a single character through the inverse rotor.
+func (rc *RotorCipher) Decode(c byte) byte {
+	switch {
+	case c >= '0' && c <= '9':
+		// Digit decoding.
+		shift := shiftByMod(int(rc.rotor10Inv[int(c-'0')]), rc.position, digitModulus)
+		rc.position = (rc.position + 1) % rotorModulus
+		return '0' + shift
+	case c >= 'A' && c <= 'Z':
+		// Letter decoding.
+		shift := shiftByMod(int(rc.rotor26Inv[int(c-'A')]), rc.position, letterModulus)
+		rc.position = (rc.position + 1) % rotorModulus
+		return 'A' + shift
+	case c >= 'a' && c <= 'z':
+		// Lowercase decoding.
+		shift := shiftByMod(int(rc.rotor26Inv[int(c-'a')]), rc.position, letterModulus)
+		rc.position = (rc.position + 1) % rotorModulus
+		return 'a' + shift
+	default:
+		return c
+	}
+}
+
+// EncodeString encodes an entire string.
+func (rc *RotorCipher) EncodeString(s string) string {
+	result := make([]byte, len(s))
+	for i := range len(s) {
+		result[i] = rc.Encode(s[i])
+	}
+	return string(result)
+}
+
+// DecodeString decodes an entire string.
+func (rc *RotorCipher) DecodeString(s string) string {
+	result := make([]byte, len(s))
+	for i := range len(s) {
+		result[i] = rc.Decode(s[i])
+	}
+	return string(result)
+}
+
+// CalculateChecksum generates a 2-character checksum for a string.
+// Uses a simple polynomial hash that's quick to compute offline.
+func CalculateChecksum(s string) string {
+	s = strings.ToUpper(s)
+	var sum1, sum2 int
+
+	for i, c := range s {
+		val := 0
+		if c >= '0' && c <= '9' {
+			val = int(c - '0')
+		} else if c >= 'A' && c <= 'Z' {
+			val = int(c-'A') + alphanumericSplit
+		}
+
+		// Polynomial accumulation with position weighting.
+		sum1 = (sum1 + val*(i+1)) % rotorModulus
+		sum2 = (sum2 + val*val + i) % rotorModulus
+	}
+
+	// Convert to alphanumeric.
+	c1 := toAlphanumeric(sum1)
+	c2 := toAlphanumeric(sum2)
+
+	return string([]byte{c1, c2})
+}
+
+// ValidateChecksum checks if the last 2 characters are a valid checksum.
+func ValidateChecksum(s string) bool {
+	const minLength = 3
+	if len(s) < minLength {
+		return false
+	}
+	s = strings.ToUpper(s)
+	payload := s[:len(s)-2]
+	checksum := s[len(s)-2:]
+	return CalculateChecksum(payload) == checksum
+}
+
+// toAlphanumeric converts a value 0-35 to 0-9 or A-Z.
+func toAlphanumeric(val int) byte {
+	// Defensive: by construction val is always in [0, alphanumericSplit+25],
+	// but an explicit guard keeps gosec G115 happy and prevents panics from
+	// hypothetical caller bugs.
+	if val < 0 || val >= alphanumericSplit+26 {
+		return '?'
+	}
+	if val < alphanumericSplit {
+		return '0' + byte(val)
+	}
+	return 'A' + byte(val-alphanumericSplit)
+}
+
+// fromAlphanumeric converts 0-9 or A-Z to a value 0-35.
+// Currently unused but kept for future license parsing.
+func fromAlphanumeric(c byte) int {
+	if c >= '0' && c <= '9' {
+		return int(c - '0')
+	}
+	if c >= 'A' && c <= 'Z' {
+		return int(c-'A') + alphanumericSplit
+	}
+	if c >= 'a' && c <= 'z' {
+		return int(c-'a') + alphanumericSplit
+	}
+	return 0
+}

--- a/internal/license/cipher_internal_test.go
+++ b/internal/license/cipher_internal_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package license
+
+import "testing"
+
+// TestFromAlphanumeric verifies the digit/letter→int mapping used by
+// the rotor cipher's checksum helpers. Kept in a package-internal
+// test so the helper stays exercised even when callers don't.
+func TestFromAlphanumeric(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   byte
+		want int
+	}{
+		{'0', 0},
+		{'9', 9},
+		{'A', 10},
+		{'Z', 35},
+		// Lowercase normalizes to its uppercase value.
+		{'a', 10},
+		{'z', 35},
+		// Anything outside [0-9A-Za-z] maps to 0.
+		{'!', 0},
+		{'/', 0},
+	}
+	for _, c := range cases {
+		if got := fromAlphanumeric(c.in); got != c.want {
+			t.Errorf("fromAlphanumeric(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/license/fingerprint.go
+++ b/internal/license/fingerprint.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package license
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"iter"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Fingerprint constants.
+const (
+	defaultMAC        = "00:00:00:00:00:00"
+	hashLength        = 16 // First 16 hex characters (64 bits of entropy).
+	commandTimeout    = 5  // Seconds for external command timeout.
+	splitPartsCount   = 2  // Expected parts when splitting on : or =.
+	defaultLinuxCPU   = "LINUX-DEFAULT"
+	defaultDarwinCPU  = "DARWIN-DEFAULT"
+	defaultLinuxDisk  = "LINUX-DISK"
+	defaultDarwinDisk = "DARWIN-DISK"
+	unknownSerial     = "UNKNOWN"
+)
+
+// DeviceFingerprint contains hardware identifiers for device binding.
+type DeviceFingerprint struct {
+	MACAddress string `json:"mac"`
+	CPUSerial  string `json:"cpu"`
+	DiskSerial string `json:"disk"`
+	Hostname   string `json:"hostname"`
+	Platform   string `json:"platform"`
+}
+
+// GenerateFingerprint creates a unique device fingerprint.
+// The result is cached after the first call since hardware IDs don't change.
+func GenerateFingerprint() (*DeviceFingerprint, error) {
+	fp := &DeviceFingerprint{
+		MACAddress: "",
+		CPUSerial:  "",
+		DiskSerial: "",
+		Hostname:   "",
+		Platform:   runtime.GOOS,
+	}
+
+	hostname, err := os.Hostname()
+	if err == nil {
+		fp.Hostname = hostname
+	}
+
+	fp.MACAddress = getPrimaryMAC()
+	fp.CPUSerial = getCPUSerial()
+	fp.DiskSerial = getDiskSerial()
+
+	return fp, nil
+}
+
+// Hash returns a 16-character hash of the fingerprint.
+func (fp *DeviceFingerprint) Hash() string {
+	data := fmt.Sprintf("%s|%s|%s|%s|%s",
+		fp.MACAddress,
+		fp.CPUSerial,
+		fp.DiskSerial,
+		fp.Hostname,
+		fp.Platform,
+	)
+
+	hash := sha256.Sum256([]byte(data))
+	hexHash := hex.EncodeToString(hash[:])
+
+	// Return first 16 characters (64 bits of entropy).
+	return strings.ToUpper(hexHash[:hashLength])
+}
+
+// String returns a human-readable representation.
+func (fp *DeviceFingerprint) String() string {
+	const maskShowChars = 8
+	const cpuDiskMaskChars = 4
+	return fmt.Sprintf("MAC=%s CPU=%s DISK=%s HOST=%s",
+		maskString(fp.MACAddress, maskShowChars),
+		maskString(fp.CPUSerial, cpuDiskMaskChars),
+		maskString(fp.DiskSerial, cpuDiskMaskChars),
+		fp.Hostname,
+	)
+}
+
+// getPrimaryMAC returns the MAC address of the first non-loopback interface.
+func getPrimaryMAC() string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return defaultMAC
+	}
+
+	for _, iface := range interfaces {
+		// Skip loopback and interfaces without MAC.
+		if iface.Flags&net.FlagLoopback != 0 || len(iface.HardwareAddr) == 0 {
+			continue
+		}
+		// Skip virtual interfaces (common patterns).
+		name := strings.ToLower(iface.Name)
+		if strings.HasPrefix(name, "veth") ||
+			strings.HasPrefix(name, "docker") ||
+			strings.HasPrefix(name, "br-") ||
+			strings.HasPrefix(name, "virbr") {
+			continue
+		}
+		return iface.HardwareAddr.String()
+	}
+
+	return defaultMAC
+}
+
+// getCPUSerial returns CPU serial number (platform-specific).
+func getCPUSerial() string {
+	switch runtime.GOOS {
+	case "linux":
+		return getLinuxCPUSerial()
+	case "darwin":
+		return getDarwinCPUSerial()
+	default:
+		return unknownSerial
+	}
+}
+
+// splitLines returns an iterator over lines in a string.
+func splitLines(s string) iter.Seq[string] {
+	return strings.SplitSeq(s, "\n")
+}
+
+// getLinuxCPUSerial reads CPU serial from /proc/cpuinfo or dmidecode.
+func getLinuxCPUSerial() string {
+	// Try /proc/cpuinfo first (works on ARM).
+	data, err := os.ReadFile("/proc/cpuinfo")
+	if err == nil {
+		for line := range splitLines(string(data)) {
+			if strings.HasPrefix(line, "Serial") {
+				parts := strings.Split(line, ":")
+				if len(parts) == splitPartsCount {
+					return strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	}
+
+	// Try dmidecode (requires root).
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "dmidecode", "-s", "processor-id").Output()
+	if err == nil {
+		serial := strings.TrimSpace(string(out))
+		if serial != "" {
+			return serial
+		}
+	}
+
+	// Try /sys/class/dmi/id/product_serial.
+	data, err = os.ReadFile("/sys/class/dmi/id/product_serial")
+	if err == nil {
+		return strings.TrimSpace(string(data))
+	}
+
+	return defaultLinuxCPU
+}
+
+// getDarwinCPUSerial reads hardware UUID on macOS.
+func getDarwinCPUSerial() string {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
+	if err != nil {
+		return defaultDarwinCPU
+	}
+
+	for line := range splitLines(string(out)) {
+		if strings.Contains(line, "IOPlatformUUID") {
+			parts := strings.Split(line, "=")
+			if len(parts) == splitPartsCount {
+				uuid := strings.TrimSpace(parts[1])
+				uuid = strings.Trim(uuid, "\"")
+				return uuid
+			}
+		}
+	}
+
+	return defaultDarwinCPU
+}
+
+// getDiskSerial returns root disk serial number.
+func getDiskSerial() string {
+	switch runtime.GOOS {
+	case "linux":
+		return getLinuxDiskSerial()
+	case "darwin":
+		return getDarwinDiskSerial()
+	default:
+		return unknownSerial
+	}
+}
+
+// getLinuxDiskSerial reads disk serial from /sys or udevadm.
+func getLinuxDiskSerial() string {
+	// Try common disk paths.
+	diskPaths := []string{
+		"/sys/block/sda/device/serial",
+		"/sys/block/nvme0n1/device/serial",
+		"/sys/block/vda/serial",
+	}
+
+	for _, path := range diskPaths {
+		// Read from known system paths.
+		f, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(f)
+		_ = f.Close()
+		if err == nil {
+			serial := strings.TrimSpace(string(data))
+			if serial != "" {
+				return serial
+			}
+		}
+	}
+
+	// Try udevadm.
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "udevadm", "info", "--query=property", "--name=/dev/sda").Output()
+	if err == nil {
+		for line := range splitLines(string(out)) {
+			if serial, found := strings.CutPrefix(line, "ID_SERIAL="); found {
+				return serial
+			}
+		}
+	}
+
+	return defaultLinuxDisk
+}
+
+// getDarwinDiskSerial reads disk serial on macOS.
+func getDarwinDiskSerial() string {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "system_profiler", "SPSerialATADataType").Output()
+	if err == nil {
+		for line := range splitLines(string(out)) {
+			if strings.Contains(line, "Serial Number") {
+				parts := strings.Split(line, ":")
+				if len(parts) == splitPartsCount {
+					return strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	}
+
+	// Try NVMe.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), commandTimeout*time.Second)
+	defer cancel2()
+	out, err = exec.CommandContext(ctx2, "system_profiler", "SPNVMeDataType").Output()
+	if err == nil {
+		for line := range splitLines(string(out)) {
+			if strings.Contains(line, "Serial Number") {
+				parts := strings.Split(line, ":")
+				if len(parts) == splitPartsCount {
+					return strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	}
+
+	return defaultDarwinDisk
+}
+
+// maskString masks a string for display, showing only first N chars.
+func maskString(s string, show int) string {
+	if len(s) <= show {
+		return s
+	}
+	return s[:show] + "****"
+}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package license_test
+
+import (
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+func TestTierString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		tier license.Tier
+		want string
+	}{
+		{license.TierFree, "Free"},
+		{license.TierPro, "Pro"},
+		{license.TierInvalid, "Invalid"},
+	}
+	for _, c := range cases {
+		if got := c.tier.String(); got != c.want {
+			t.Errorf("Tier(%d).String() = %q, want %q", c.tier, got, c.want)
+		}
+	}
+}
+
+func TestGenerateAndValidateRoundTrip(t *testing.T) {
+	t.Parallel()
+	key, err := license.GenerateLicenseKey("5001", "ABCDEFG", license.TierPro)
+	if err != nil {
+		t.Fatalf("GenerateLicenseKey: %v", err)
+	}
+	info := license.ValidateLicenseKey(key)
+	if !info.Valid {
+		t.Fatalf("ValidateLicenseKey(%q): not valid (err=%q)", key, info.ErrorMsg)
+	}
+	if info.ProductCode != "5001" {
+		t.Errorf("ProductCode = %q, want 5001", info.ProductCode)
+	}
+	if info.Tier != license.TierPro {
+		t.Errorf("Tier = %v, want Pro", info.Tier)
+	}
+}
+
+func TestValidateRejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"empty", ""},
+		{"too short", "AAAA-BBBB"},
+		{"too long", "AAAA-BBBB-CCCC-DDDD-EEEE"},
+		{"non-alphanumeric", "AAAA-BBBB-CCCC-D!DD"},
+		{"bad checksum", "AAAA-BBBB-CCCC-DDDD"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			info := license.ValidateLicenseKey(c.key)
+			if info.Valid {
+				t.Errorf("expected invalid, got valid (key=%q)", c.key)
+			}
+			if info.ErrorMsg == "" {
+				t.Errorf("expected non-empty ErrorMsg")
+			}
+		})
+	}
+}
+
+// TestKeygenContract pins the cross-tool cipher contract. The key
+// below was produced by the canonical keygen tool
+// (msn-internal-tools/keygen) and MUST validate identically in every
+// product's license package. Stem locked vectors in stem PR #266 and
+// seed locked theirs in seed PR #1095 — this is NIAC's contribution
+// to the same shared spec.
+//
+// Anchored to keygen v2.0.0 (2026-05-21).
+func TestKeygenContract(t *testing.T) {
+	t.Parallel()
+	vector := keygenVector{
+		name:    "niac-pro / serial NIACPRO",
+		key:     "WQ57-20TQ-NGVZ-P2YC",
+		tier:    license.TierPro,
+		product: "5001",
+		serial:  "NIACPRO",
+		features: []string{
+			"unlimited_devices",
+			"bgp", "ospf", "snmpv3", "netbios", "ftp", "stp",
+			"ipv6_advanced", "error_injection", "traffic_shaping",
+			"config_templates", "multi_ip", "pcap_ingest", "rest_api",
+		},
+	}
+	assertKeygenVector(t, vector)
+}
+
+type keygenVector struct {
+	name     string
+	key      string
+	tier     license.Tier
+	product  string
+	serial   string
+	features []string
+}
+
+func assertKeygenVector(t *testing.T, v keygenVector) {
+	t.Helper()
+	info := license.ValidateLicenseKey(v.key)
+	if !info.Valid {
+		t.Fatalf("Valid = false, want true (err=%q)", info.ErrorMsg)
+	}
+	if info.Tier != v.tier {
+		t.Errorf("Tier = %v, want %v", info.Tier, v.tier)
+	}
+	if info.ProductCode != v.product {
+		t.Errorf("ProductCode = %q, want %q", info.ProductCode, v.product)
+	}
+	if info.Serial != v.serial {
+		t.Errorf("Serial = %q, want %q", info.Serial, v.serial)
+	}
+	if len(info.Features) != len(v.features) {
+		t.Errorf("Features count = %d, want %d (got %v)",
+			len(info.Features), len(v.features), info.Features)
+	}
+	for _, f := range v.features {
+		if !info.HasFeature(f) {
+			t.Errorf("missing feature %q (got %v)", f, info.Features)
+		}
+	}
+}
+
+func TestActivationLifecycle(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	mgr, err := license.NewManagerWithDir(tmp)
+	if err != nil {
+		t.Fatalf("NewManagerWithDir: %v", err)
+	}
+
+	if mgr.IsActivated() {
+		t.Error("expected !IsActivated on fresh manager")
+	}
+
+	trial := mgr.StartTrial()
+	if !trial.Success || !trial.IsTrialMode || trial.Tier != license.TierPro {
+		t.Errorf("StartTrial unexpected: %+v", trial)
+	}
+	if !mgr.IsActivated() || !mgr.IsTrialValid() {
+		t.Error("expected trial to be active")
+	}
+
+	key, _ := license.GenerateLicenseKey("5001", "ABCDEFG", license.TierPro)
+	res := mgr.Activate(key)
+	if !res.Success || res.Tier != license.TierPro {
+		t.Errorf("Activate unexpected: %+v", res)
+	}
+	if mgr.GetState().IsTrialMode {
+		t.Error("expected non-trial state after Activate")
+	}
+
+	mgr2, err := license.NewManagerWithDir(tmp)
+	if err != nil {
+		t.Fatalf("reload NewManagerWithDir: %v", err)
+	}
+	if !mgr2.IsActivated() {
+		t.Error("expected reloaded state to be activated")
+	}
+	if mgr2.GetState().Tier != license.TierPro {
+		t.Errorf("reloaded tier = %v, want Pro", mgr2.GetState().Tier)
+	}
+
+	if deactErr := mgr2.Deactivate(); deactErr != nil {
+		t.Fatalf("Deactivate: %v", deactErr)
+	}
+	if mgr2.IsActivated() {
+		t.Error("expected !IsActivated after Deactivate")
+	}
+}

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package license
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+/*
+NIAC License Key Format (16 characters, identical to the format used
+by Seed and Stem — keys are produced by the canonical keygen tool
+and the rotor cipher is byte-compatible across products).
+
++------+--------+-------+------+----------+
+| CC   | PPPP   |SSSSSSS| T    | XX       |
+|Check |Product |Serial |Tier  | Checksum |
++------+--------+-------+------+----------+
+
+Positions:
+  0-1:  Checksum prefix (encoded validation).
+  2-5:  Product code (5001 = NIAC Pro).
+  6-12: Serial number (unique per license).
+  13:   Tier (1 = Pro; NIAC has one paid tier).
+  14-15: Checksum suffix.
+
+Free is the unlicensed tier — no key required. Pro requires a valid
+5001 key.
+*/
+
+const (
+	keyLength         = 16
+	productCodeLength = 4
+	serialLength      = 7
+	checksumLength    = 2
+	cipherStartPos    = 7
+	defaultMaxDevices = 3
+)
+
+// Tier represents the license tier.
+type Tier int
+
+// License tier constants. Numeric values match the tier digit embedded
+// in the license key (position 13 of the encoded key). NIAC has a
+// single paid tier; the wire digit '1' is consistent with keygen's
+// productCatalog entry for 5001.
+const (
+	// TierInvalid represents an invalid or unrecognized license tier.
+	TierInvalid Tier = -1
+	// TierFree is the unlicensed tier. No key needed; only the basic
+	// feature set (up to 10 simulated devices, common protocols) is
+	// available.
+	TierFree Tier = 0
+	// TierPro unlocks the full NIAC feature set (unlimited devices,
+	// advanced protocols, error injection, etc.). Wire tier digit 1.
+	TierPro Tier = 1
+)
+
+const (
+	errProductCodeMismatch = "Product code mismatch for tier"
+	// ErrLicenseKeyLength is the key-length validation error string.
+	ErrLicenseKeyLength = "License key must be 16 characters"
+)
+
+// String returns the tier name.
+func (t Tier) String() string {
+	switch t {
+	case TierInvalid:
+		return "Invalid"
+	case TierFree:
+		return "Free"
+	case TierPro:
+		return "Pro"
+	}
+	return "Invalid"
+}
+
+// Info contains parsed license information.
+type Info struct {
+	Key         string    `json:"key"`
+	Valid       bool      `json:"valid"`
+	Tier        Tier      `json:"tier"`
+	ProductCode string    `json:"productCode"`
+	Serial      string    `json:"serial"`
+	Activated   bool      `json:"activated"`
+	ActivatedAt time.Time `json:"activatedAt,omitzero"`
+	ExpiresAt   time.Time `json:"expiresAt,omitzero"`
+	DeviceHash  string    `json:"deviceHash,omitempty"`
+	MaxDevices  int       `json:"maxDevices"`
+	Features    []string  `json:"features"`
+	ErrorMsg    string    `json:"error,omitempty"`
+}
+
+// ValidateLicenseKey performs offline validation of a license key.
+func ValidateLicenseKey(key string) *Info {
+	info := &Info{
+		Key:         key,
+		Valid:       false,
+		Tier:        TierInvalid,
+		ProductCode: "",
+		Serial:      "",
+		MaxDevices:  defaultMaxDevices,
+	}
+
+	normalized := normalizeKey(key)
+	if len(normalized) != keyLength {
+		info.ErrorMsg = ErrLicenseKeyLength
+		return info
+	}
+
+	if !validKeyChars(normalized) {
+		info.ErrorMsg = "License key contains invalid characters"
+		return info
+	}
+
+	cipher := NewRotorCipher(cipherStartPos)
+	decoded := cipher.DecodeString(normalized)
+
+	if !validateKeyChecksum(decoded) {
+		info.ErrorMsg = "License key failed checksum validation"
+		return info
+	}
+
+	info.ProductCode = decoded[2:6]
+	info.Serial = decoded[6:13]
+	tierChar := decoded[13]
+
+	switch tierChar {
+	case '1':
+		info.Tier = TierPro
+		info.Features = proFeatures()
+	default:
+		info.ErrorMsg = "Invalid license tier"
+		return info
+	}
+
+	switch info.ProductCode {
+	case "5001":
+		if info.Tier != TierPro {
+			info.ErrorMsg = errProductCodeMismatch
+			return info
+		}
+	default:
+		info.ErrorMsg = "Unknown product code"
+		return info
+	}
+
+	info.Valid = true
+	return info
+}
+
+var keyCharRE = regexp.MustCompile(`^[0-9A-Z]+$`)
+
+func validKeyChars(s string) bool {
+	return keyCharRE.MatchString(s)
+}
+
+func validateKeyChecksum(key string) bool {
+	payload := key[2:14]
+	expected := CalculateChecksum(payload)
+	prefixMatch := key[0:2] == expected
+	suffixMatch := key[14:16] == expected
+	return prefixMatch && suffixMatch
+}
+
+// GenerateLicenseKey creates a new license key (for testing — production
+// keys are issued by the keygen tool).
+func GenerateLicenseKey(productCode string, serial string, tier Tier) (string, error) {
+	if len(productCode) != productCodeLength {
+		return "", errors.New("product code must be 4 characters")
+	}
+	if len(serial) != serialLength {
+		return "", errors.New("serial must be 7 characters")
+	}
+	if tier != TierPro {
+		return "", errors.New("invalid tier (NIAC has only TierPro)")
+	}
+
+	payload := productCode + serial + fmt.Sprintf("%d", tier)
+	checksum := CalculateChecksum(payload)
+	fullKey := checksum[0:checksumLength] + payload + checksum
+	cipher := NewRotorCipher(cipherStartPos)
+	encoded := cipher.EncodeString(fullKey)
+	return strings.ToUpper(encoded), nil
+}
+
+func normalizeKey(key string) string {
+	key = strings.ReplaceAll(key, "-", "")
+	key = strings.ReplaceAll(key, " ", "")
+	key = strings.ReplaceAll(key, ".", "")
+	return strings.ToUpper(key)
+}
+
+// FormatKey formats a license key for display (adds dashes).
+func FormatKey(key string) string {
+	key = normalizeKey(key)
+	if len(key) != keyLength {
+		return key
+	}
+	return key[0:4] + "-" + key[4:8] + "-" + key[8:12] + "-" + key[12:16]
+}
+
+// HasFeature checks if the license includes a specific feature.
+func (li *Info) HasFeature(feature string) bool {
+	return slices.Contains(li.Features, feature)
+}
+
+// CanRunPro returns true if the license allows Pro features.
+func (li *Info) CanRunPro() bool {
+	return li.Valid && li.Tier >= TierPro
+}
+
+// proFeatures returns the feature list granted to NIAC Pro (product
+// code 5001). Mirrors keygen's productCatalog.
+func proFeatures() []string {
+	return []string{
+		"unlimited_devices",
+		"bgp", "ospf", "snmpv3", "netbios", "ftp", "stp",
+		"ipv6_advanced", "error_injection", "traffic_shaping",
+		"config_templates", "multi_ip", "pcap_ingest", "rest_api",
+	}
+}


### PR DESCRIPTION
## Summary

Phase E (mirrors seed Phase D-1): NIAC's first license enforcement layer. **Free** tier remains the default (no key required; up to 10 simulated devices, common protocols). **NIAC Pro (\$599/yr)** unlocks the full feature set per keygen's productCatalog entry \`5001\`.

This PR ships the framework + CLI + contract. **Per-feature gating** (limiting Free tier to 10 devices, gating BGP/OSPF/SNMPv3/etc. behind Pro) lands in follow-ups so each gate can be designed and reviewed in isolation.

## What lands

### \`internal/license/\` — new package

- \`cipher.go\` + \`fingerprint.go\` vendored from stem. Cipher is **behaviorally byte-compatible** with the canonical keygen tool — \`TestKeygenContract\` pins this with key \`WQ57-20TQ-NGVZ-P2YC\` (niac-pro / serial \`NIACPRO\`).
- \`validator.go\` — NIAC tier matrix (\`TierFree\` / \`TierPro\`), \`5001\` product code, \`proFeatures()\` mirroring keygen exactly.
- \`activation.go\` — 14-day Pro trial, AES-GCM encrypted on-disk state bound to device fingerprint, distinct salt (\`MSN-NIAC-SIM-2026-LICENSE\`) + config path (\`~/.config/niac/.license\`) so seed/stem activations never collide on a shared host.
- Tests including round-trip generation, lifecycle, internal cipher helpers, and \`TestKeygenContract\`.

### \`cmd/niac/license.go\` — new CLI

\`\`\`
niac license status      # show current tier + features + expiry
niac license trial       # start 14-day Pro trial
niac license activate -k <KEY>
niac license deactivate
\`\`\`

Parent \`niac license\` (no subcommand) delegates to cobra's auto-help. Registered in \`cmd/niac/main.go\` via the standard \`builders\` slice pattern.

## Cross-tool contract status

Each product's \`TestKeygenContract\` locks one or more keygen-issued keys. As long as all three pass, all three speak keygen's language.

| Tool | Key | PR |
|---|---|---|
| stem | \`7C27-20MY-ZHXR-C95U\` (stem-pro / \`ROUNDTR\`) | merged #266 |
| seed | \`Q207-20AG-LLZR-C2C8\` (seed-starter) + \`MN07-25AG-LLVZ-P9GH\` (seed-pro) | merged #1095 |
| niac | \`WQ57-20TQ-NGVZ-P2YC\` (niac-pro / \`NIACPRO\`) | **this PR** |

## Explicitly out of scope (filed as follow-ups)

- **Per-feature tier gates** — separate per-protocol PRs (gate BGP/OSPF/SNMPv3/etc. behind Pro; cap Free tier at 10 devices)
- **License status surfaced on a web/REST endpoint** — NIAC's web UI is smaller than seed's; will mirror seed PR #1098's pattern once needed

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test -short ./...\` — all 27 packages pass
- [x] \`golangci-lint run\` — 0 issues
- [x] Round-trip with keygen v2.0.0 confirmed for niac-pro
- [ ] CI green