### PR TITLE
chore(ci): replace manual gitleaks curl with gitleaks-action

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,19 @@
+name: 'Setup Go'
+description: 'Set up Go with caching and module download'
+inputs:
+  go-version-file:
+    description: 'Path to go.mod file'
+    required: false
+    default: 'go.mod'
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+        cache: false
+
+    - name: Download Go modules
+      shell: bash
+      run: go mod download

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,20 @@
+name: 'Setup Node.js'
+description: 'Set up Node.js with npm caching'
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '26.2.0'
+  working-directory:
+    description: 'Working directory for npm'
+    required: false
+    default: 'ui'
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+        cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,13 +283,10 @@ jobs:
           npm ci
           npm audit --audit-level=high || true
 
-      - name: Install gitleaks
-        run: |
-          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz gitleaks
-          sudo mv gitleaks /usr/local/bin/
-
       - name: Run gitleaks
-        run: gitleaks detect --source . --no-banner --redact --exit-code 1
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
         # Trivy moved to v-prefixed tags between 0.35 and 0.36; the bare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
@@ -175,20 +172,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '26.2.0'
-          cache: 'npm'
-          cache-dependency-path: ui/package-lock.json
+        uses: ./.github/actions/setup-node
 
       - name: Build embedded UI assets
         working-directory: ui
@@ -214,11 +204,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '26.2.0'
-          cache: 'npm'
-          cache-dependency-path: ui/package-lock.json
+        uses: ./.github/actions/setup-node
 
       - name: Install dependencies
         run: npm ci
@@ -267,10 +253,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
@@ -292,11 +275,7 @@ jobs:
           sarif_file: gosec-results.sarif
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '26.2.0'
-          cache: 'npm'
-          cache-dependency-path: ui/package-lock.json
+        uses: ./.github/actions/setup-node
 
       - name: Run npm audit
         working-directory: ui
@@ -568,10 +547,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
@@ -623,17 +599,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '26.2.0'
-          cache: 'npm'
-          cache-dependency-path: ui/package-lock.json
+        uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
@@ -712,17 +681,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '26.2.0'
-          cache: 'npm'
-          cache-dependency-path: ui/package-lock.json
+        uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev


### PR DESCRIPTION
## Summary
Swap the two-step manual `curl | tar | sudo mv` install + `gitleaks detect` run for `gitleaks/gitleaks-action@v2.3.9`. Matches seed and stem; brings niac in line with the cross-repo pattern.

## What changed
- Removed manual gitleaks install (curl → tar → sudo mv to /usr/local/bin/)
- Removed standalone `gitleaks detect` run step
- Added single `uses: gitleaks/gitleaks-action@v2.3.9` step with `GITHUB_TOKEN` env

Net: −6 lines, +3 lines

## Why
- Action ships its own gitleaks binary (no more static `v8.21.2` URL pin to babysit)
- Dependabot can bump the action's SHA automatically
- `GITHUB_TOKEN` wired for PR comments on detected secrets
- Matches seed/stem exactly

## Stacking
- Base: `chore/composite-setup-actions` (depends on #673)

## Verification
- [x] YAML valid
- [x] 0 remaining gitleaks curl/tar references
- [ ] CI green