### PR TITLE
fix(ci): inject UIBuildHash ldflag (Universal Build Contract)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,8 +567,19 @@ jobs:
           CGO_ENABLED: '1'
         run: |
           VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # UI build hash matches Makefile recipe; mandatory per CLAUDE.md
+          # Universal Build Contract.
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          echo "UI_BUILD_HASH=${UI_BUILD_HASH}"
+
           go build -trimpath -buildvcs=false \
-            -ldflags="-s -w -X github.com/krisarmstrong/niac-go/internal/version.Version=${VERSION}" \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/niac-go/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/niac-go/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/niac-go/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
             -o niac-${{ matrix.os }}-${{ matrix.arch }} ./cmd/niac
 
       - name: Verify binary
@@ -620,7 +631,18 @@ jobs:
         run: npm ci
 
       - name: Build backend
-        run: go build -o niac ./cmd/niac
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          go build -trimpath -buildvcs=false \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/niac-go/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/niac-go/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/niac-go/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
+            -o niac ./cmd/niac
 
       - name: Install Playwright browsers
         working-directory: ui
@@ -698,7 +720,18 @@ jobs:
           path: internal/api/ui/
 
       - name: Build backend
-        run: go build -o niac ./cmd/niac
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          go build -trimpath -buildvcs=false \
+            -ldflags="-s -w \
+              -X github.com/krisarmstrong/niac-go/internal/version.Version=${VERSION} \
+              -X github.com/krisarmstrong/niac-go/internal/version.Commit=${COMMIT} \
+              -X github.com/krisarmstrong/niac-go/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/krisarmstrong/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
+            -o niac ./cmd/niac
 
       - name: Start server
         run: |


### PR DESCRIPTION
## Summary
CLAUDE.md mandate (Universal Build Contract): "Every build embeds version, commit, buildTime, uiBuildHash." The Makefiles correctly compute and inject all four via `-X` ldflags. CI was using raw `go build` without those ldflags — binaries built by CI returned `"unknown"` for `uiBuildHash` on `/__version`, silently violating the contract.

## What changed
For every `go build` in `.github/workflows/ci.yml`:
1. Compute `VERSION` (git describe), `COMMIT` (git rev-parse), `BUILD_TIME` (UTC ISO-8601)
2. Compute `UI_BUILD_HASH` using the same `find ... -exec md5sum | sort | md5sum` pipeline the Makefile uses
3. Pass all four as `-X .../internal/version.{Version,Commit,BuildTime,UIBuildHash}=...` ldflags

CI-built artifacts now satisfy the same `/__version` contract as Makefile-built ones.

## Verification
- [x] yaml syntax valid
- [ ] CI green (binary built, `UI_BUILD_HASH=...` echoed before each `go build`)
- [ ] Sibling PRs land in stem/niac with the same change

## Closes follow-up issue

Closes #677