### PR TITLE
test: add JSDoM polyfills (matchMedia, ResizeObserver, IntersectionObserver)

### DIFF
--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,33 +1,47 @@
 /**
  * Test Setup
  *
- * This file is run before each test file.
- * Configure global test utilities, mocks, and matchers here.
+ * Provides shared test configuration and JSDoM polyfills for Vitest.
+ * Universal polyfill baseline shared across seed/stem/niac.
  */
 
 import '@testing-library/jest-dom';
-import { afterAll, beforeAll } from 'vitest';
+import { vi } from 'vitest';
 
-// Global test setup
-beforeAll(() => {
-  // Setup before all tests
-});
+// ============================================================
+// JSDoM polyfills — common browser APIs not implemented by JSDoM
+// Universal baseline shared across seed/stem/niac test setups.
+// ============================================================
 
-afterAll(() => {
-  // Cleanup after all tests
-});
-
-// Mock window.matchMedia for component tests
+// matchMedia: dark-mode detection, responsive hooks, prefers-reduced-motion
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: (query: string) => ({
     matches: false,
     media: query,
     onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
+    addListener: vi.fn(), // legacy API still used by some libs
+    removeListener: vi.fn(), // legacy
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
   }),
 });
+
+// ResizeObserver: used by xyflow, codemirror, recharts, headlessui
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+})) as unknown as typeof ResizeObserver;
+
+// IntersectionObserver: used by lazy loading, infinite scroll
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+  takeRecords: vi.fn(() => []),
+  root: null,
+  rootMargin: '',
+  thresholds: [],
+})) as unknown as typeof IntersectionObserver;


### PR DESCRIPTION
## Summary
Adds universal JSDoM polyfills (`matchMedia`, `ResizeObserver`, `IntersectionObserver`) so the 3 repos share a common test-setup baseline.

## Why
JSDoM does not implement these browser APIs. React components that use dark-mode detection, virtualized lists, or lazy loading throw `... is not defined` when tested.

## Verification
- [x] All existing tests pass (60 tests)
- [ ] CI green