### PR TITLE
chore(docker): expose canonical TLS ports per CLAUDE.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,14 @@ RUN setcap 'cap_net_raw,cap_net_admin=+ep' /usr/bin/niac
 
 USER niac
 WORKDIR /var/lib/niac
-EXPOSE 8080
+# Per CLAUDE.md Default Ports table:
+#   8445 = TLS canonical (post-Wave-1 / niac#663 HTTPS-required)
+#   8044 = HTTP->HTTPS 308 redirector
+# Note: CMD below uses --listen :8080 for back-compat with existing
+# deployment scripts (per cmd_daemon.go comment). EXPOSE here reflects
+# the canonical ports for net-new deployments; override CMD to use
+# them.
+EXPOSE 8445 8044 8080
 
 # OCI labels for traceability.
 ARG VERSION=dev


### PR DESCRIPTION
## Summary
Container EXPOSE was `8080` (legacy HTTP port per `cmd_daemon.go` back-compat note). CLAUDE.md Default Ports table mandates `8445` (TLS, post-Wave-1 / #663) + `8044` (HTTP->HTTPS redirector). Adding both alongside the legacy 8080 so net-new deployments work without overriding EXPOSE.

## CMD intentionally unchanged
`daemon --listen :8080` is the documented back-compat default. Users moving to canonical ports override CMD at runtime.

## Audit context
Cross-repo Dockerfile harmonization. seed gets `8042` HTTP-redirector EXPOSE in sibling PR; stem already correct.

## Verification
- Static change to EXPOSE only — no runtime behavior change.