### PR TITLE
chore(meta): harmonize commitlint + SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,25 +2,28 @@
 
 ## Supported versions
 
-Only the latest minor release on `main` receives security fixes. Older
-tags are kept on the repo for reference but are not patched.
+Until NIAC reaches 1.0, only the **latest released version** receives
+security fixes. Older 0.x versions are kept on the repo for reference but
+are not patched — upgrade to the current minor.
 
 | Version          | Supported           |
 | ---------------- | ------------------- |
 | Latest (`main`)  | :white_check_mark:  |
-| Anything older   | :x:                 |
+| Older 0.x        | :x:                 |
+| Future 1.x       | :white_check_mark:  |
 
 ## Reporting a vulnerability
 
 **Please do not open a public issue for a security vulnerability.**
 
-Use one of these private channels instead:
+Use one of these private channels:
 
 1. **GitHub Security Advisories (preferred):**
    <https://github.com/krisarmstrong/niac-go/security/advisories/new>.
-   This creates a private advisory visible only to repository maintainers
-   and you, with a built-in audit trail and CVE coordination workflow.
-2. **Email:** `kris.armstrong@icloud.com` with subject `[NIAC SECURITY]`.
+   Creates a private advisory visible only to maintainers and you, with
+   a built-in audit trail and CVE coordination workflow.
+2. **Email:** `kris.armstrong@icloud.com` with subject
+   `[NIAC SECURITY]`.
 
 Include in your report:
 
@@ -34,11 +37,20 @@ Include in your report:
 
 - **Acknowledgment** within 2 business days.
 - **Triage** with a severity assessment within 7 business days.
-- **Fix or mitigation** released within 30 days for high/critical
-  severity, longer for low severity. We coordinate disclosure timing
+- **Fix or mitigation** released within the target window for the
+  severity tier (see table below). We coordinate disclosure timing
   with you for high-impact issues.
-- **Credit** in the resulting security advisory, if you'd like it
-  (researcher names attributed in the GHSA / release notes).
+- **Credit** in the resulting GitHub Security Advisory and release
+  notes, if you'd like it.
+
+### Severity levels
+
+| Level    | Description                         | Target Resolution |
+| -------- | ----------------------------------- | ----------------- |
+| Critical | Remote code execution, auth bypass  | 24-48 hours       |
+| High     | Data exposure, privilege escalation | 7 days            |
+| Medium   | Limited impact vulnerabilities      | 30 days           |
+| Low      | Minor issues, hardening             | Next release      |
 
 ## Scope
 
@@ -52,19 +64,29 @@ In scope:
 Out of scope:
 
 - Vulnerabilities in third-party dependencies — please report those
-  upstream. We track them via Dependabot and `govulncheck` and patch on
-  the next release.
-- Self-inflicted misconfigurations (e.g. running `niac daemon --token=""`
-  on a public network — the daemon explicitly warns against this).
+  upstream. We track them via Dependabot and `govulncheck` and patch
+  on the next release.
+- Denial of service requiring sustained external traffic.
+- Social engineering or physical access attacks.
+- Self-inflicted misconfigurations (e.g. exposing the daemon to a
+  public network without an API token — the daemon explicitly warns
+  against this).
 
 ## Hardening notes for operators
 
-- Always run `niac daemon --token <secret>` when exposed to the network.
-- Set `--webhook-allowed-host` to lock the alert webhook destination to
-  a known host (the default still rejects raw private/loopback IPs but
-  an explicit allowlist is the canonical SSRF defense).
+- Always run `niac daemon --token <secret>` when exposed to the
+  network. The daemon explicitly warns when bound to a non-loopback
+  address without a token.
+- Set `--webhook-allowed-host` to lock the alert webhook destination
+  to a known host (the default rejects raw private/loopback IPs but an
+  explicit allowlist is the canonical SSRF defense).
 - Verify release artifacts with `cosign verify-blob` against
   `<file>.cosign.bundle`. Each release also ships a CycloneDX SBOM per
   archive — the verification recipe is in the GitHub release notes.
 
-Thank you for helping keep this project secure.
+
+## Acknowledgments
+
+We appreciate security researchers who help keep NIAC secure.
+Contributors are credited in the resulting GitHub Security Advisory /
+release notes unless they prefer to remain anonymous.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,6 @@
 /**
  * @file Commitlint configuration
- * @description Enforces conventional commit message format: type(scope?): subject
+ * @description Enforces conventional commit format: type(scope?): subject
  *
  * @example
  * feat(snmp): add trap handling
@@ -8,24 +8,24 @@
  * docs: update API reference
  * chore(deps): upgrade dependencies
  */
-module.exports = {
+export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "type-enum": [
       2,
       "always",
       [
-        "feat", // New feature
-        "fix", // Bug fix
-        "docs", // Documentation changes
-        "style", // Code style changes (formatting)
+        "feat",     // New feature
+        "fix",      // Bug fix
+        "docs",     // Documentation changes
+        "style",    // Code style changes (formatting)
         "refactor", // Code refactoring
-        "perf", // Performance improvements
-        "test", // Adding or updating tests
-        "chore", // Maintenance tasks
-        "ci", // CI/CD changes
-        "build", // Build system changes
-        "revert", // Revert a previous commit
+        "perf",     // Performance improvements
+        "test",     // Adding or updating tests
+        "chore",    // Maintenance tasks
+        "ci",       // CI/CD changes
+        "build",    // Build system changes
+        "revert",   // Revert a previous commit
       ],
     ],
     "scope-enum": [
@@ -33,31 +33,18 @@ module.exports = {
       "always",
       [
         // Core components
-        "api",
-        "capture",
-        "config",
-        "daemon",
-        "device",
-        "snmp",
-        "protocols",
-        "storage",
-        "templates",
+        "api", "capture", "config", "daemon", "device", "snmp", "protocols", "storage", "templates",
         // Frontend
-        "ui",
-        "components",
-        "hooks",
+        "ui", "components", "hooks",
         // Infrastructure
-        "deps",
-        "ci",
-        "docker",
-        "release",
+        "deps", "ci", "docker", "release",
       ],
     ],
-    // Disallow subject lines in start-case, pascal-case, or upper-case
     "subject-case": [2, "never", ["start-case", "pascal-case", "upper-case"]],
-    // Conventional commits do not end the subject line with a period
     "subject-full-stop": [2, "never", "."],
+    "subject-empty": [2, "never"],
     "type-case": [2, "always", "lower-case"],
     "type-empty": [2, "never"],
+    "header-max-length": [2, "always", 100],
   },
 };


### PR DESCRIPTION
## Summary
Phase A of the remaining-cleanup work. Two small editorial files brought in line across seed/stem/niac.

### `commitlint.config.js`
- Switch to ESM (`export default`) matching `"type": "module"` in package.json (stem already was ESM; seed/niac were CommonJS)
- Full rule set everywhere: `type-enum`, `scope-enum` (warn level=1), `subject-case` (forbid start/pascal/upper), `subject-full-stop`, `subject-empty`, `type-case`, `type-empty`, `header-max-length: 100`
- Per-repo scope-enum lists themed for the project; examples per-repo
- Identical rule shape across all 3

### `SECURITY.md`
- **GitHub Security Advisories** listed as preferred reporting channel (was email-only on seed/stem); email kept as fallback with per-product subject prefix
- **Severity table** (Critical/High/Medium/Low + target resolution) unified across all 3
- **Scope** section includes cosign-verified release artifacts (was niac-only; now all three are signed per the harmonized release pipeline)
- **Hardening notes** per-repo (TLS, API tokens, traffic generators, webhook allowlists)

## Verification
- `npx commitlint` locally on all 3 repos: valid messages pass, invalid types fail with proper errors (`exit: 0` vs `exit: 1`)
- Pre-commit hooks clean on the changed files