### PR TITLE
docs(readme): add Security + Contributing section references

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ date stated in the LICENSE file. Matches the licensing on seed and stem.
 
 For commercial licensing inquiries: `kris.armstrong@gmail.com`.
 
+## Security
+
+See [SECURITY.md](SECURITY.md) for the vulnerability-disclosure policy.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Related projects
 
 NIAC is the simulator. Two sibling tools complete the Mustard Seed Networks


### PR DESCRIPTION
## Summary
README didn't link to `SECURITY.md` / `CONTRIBUTING.md` — discoverability hit. Adding the canonical 2-section block (matches seed's pattern) before "Related projects".

Phase B of remaining-cleanup. No rewrite of existing sections; just 2 short references.