### PR TITLE
fix(e2e): switch fullstack config to HTTPS for TLS-only daemon

### DIFF
--- a/ui/playwright.fullstack.config.ts
+++ b/ui/playwright.fullstack.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Fullstack tier runs against a real niac daemon. Since #663 (Require HTTPS
+// unconditionally), the daemon is HTTPS-only with an auto-generated self-signed
+// cert. We keep port 18080 dedicated to the fullstack tier so it can coexist
+// with a dev daemon on canonical 8445.
 const port = process.env.E2E_FULLSTACK_PORT ?? '18080';
-const baseURL = process.env.E2E_BASE_URL ?? `http://localhost:${port}`;
+const baseURL = process.env.E2E_BASE_URL ?? `https://localhost:${port}`;
 
 export default defineConfig({
   testDir: './e2e/fullstack',
@@ -23,6 +27,7 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'on-first-retry',
+    // Self-signed cert from auto-generation; required even in CI for this tier.
     ignoreHTTPSErrors: true,
   },
   projects: [
@@ -38,5 +43,6 @@ export default defineConfig({
         url: `${baseURL}/__version`,
         reuseExistingServer: !process.env.CI,
         timeout: 120000,
+        ignoreHTTPSErrors: true,
       },
 });


### PR DESCRIPTION
## Summary
- #663 made the daemon HTTPS-unconditional and removed the `--http` flag, but `ui/playwright.fullstack.config.ts` still constructed `http://localhost:${port}` as the baseURL. The fullstack tier could not connect to the daemon — `webServer` URL health-check would hang and any test using `baseURL` would fail.
- Switched the default baseURL scheme to `https://`. Daemon auto-generates a self-signed cert on startup; `ignoreHTTPSErrors` stays `true` for this tier and is now also set on the `webServer` block so Playwright's startup probe accepts the cert.
- Port stays at `18080` (dedicated fullstack tier) so it coexists with a dev daemon running on canonical `8445`.

## Test plan
- [ ] `npm run test:e2e:fullstack` connects to the daemon (no infrastructure hangs).
- [ ] `~/Developer/.e2e-remediation-2026q2/verify.sh niac` shows "NIAC fullstack: scheme OK" (already green locally).

## Context
Part of Phase 0.5 E2E remediation. See `~/Developer/.e2e-remediation-2026q2/PLAN.md` for the broader plan and `broken-tests-2026-05-25.md` for the audit that surfaced this. Conventions doc is `msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md`.