### PR TITLE
fix(ci): switch e2e + lighthouse to HTTPS for TLS-only daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,7 +646,9 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: ui
-        run: npx playwright install --with-deps chromium
+        # Per msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md, every PR
+        # runs Chromium (covers Chrome + Edge) and WebKit (covers Safari).
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Start backend server
         run: |
@@ -672,7 +674,9 @@ jobs:
         env:
           E2E_BASE_URL: https://localhost:8445
           PLAYWRIGHT_IGNORE_HTTPS_ERRORS: "true"
-        run: npx playwright test --project=chromium --reporter=html
+        # Both chromium and webkit run per E2E_CONVENTIONS — Firefox/mobile/
+        # tablet/visual projects were deleted from playwright.config.ts.
+        run: npx playwright test --reporter=html
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,10 +650,13 @@ jobs:
 
       - name: Start backend server
         run: |
-          nohup ./niac daemon --http --listen 127.0.0.1:8080 > server.log 2>&1 &
+          # Backend is HTTPS-only since #663 (the --http flag was removed and
+          # the legacy HTTP listener deleted). Self-signed cert auto-generated
+          # on first start. Use canonical TLS port 8445 per CLAUDE.md.
+          nohup ./niac daemon --listen 127.0.0.1:8445 > server.log 2>&1 &
           echo "Waiting for server to start..."
           for i in {1..30}; do
-            if curl -sf http://localhost:8080/__version 2>/dev/null; then
+            if curl -skf https://localhost:8445/__version 2>/dev/null; then
               echo "Server ready after $i attempts"
               exit 0
             fi
@@ -667,7 +670,8 @@ jobs:
       - name: Run Playwright E2E tests
         working-directory: ui
         env:
-          E2E_BASE_URL: http://localhost:8080
+          E2E_BASE_URL: https://localhost:8445
+          PLAYWRIGHT_IGNORE_HTTPS_ERRORS: "true"
         run: npx playwright test --project=chromium --reporter=html
 
       - name: Upload Playwright report
@@ -735,9 +739,11 @@ jobs:
 
       - name: Start server
         run: |
-          nohup ./niac daemon --http --listen 127.0.0.1:8080 > server.log 2>&1 &
+          # Backend is HTTPS-only since #663. Self-signed cert auto-generated.
+          # Use canonical TLS port 8445.
+          nohup ./niac daemon --listen 127.0.0.1:8445 > server.log 2>&1 &
           for i in {1..30}; do
-            if curl -sf http://localhost:8080/__version 2>/dev/null; then
+            if curl -skf https://localhost:8445/__version 2>/dev/null; then
               echo "Server ready"
               exit 0
             fi
@@ -750,7 +756,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12.6.2
         with:
           urls: |
-            http://localhost:8080
+            https://localhost:8445
           uploadArtifacts: true
           temporaryPublicStorage: true
 


### PR DESCRIPTION
## Summary

The daemon was made HTTPS-unconditional in #663 — the `--http` flag was removed and the legacy HTTP listener deleted. The CI workflow still spawned the daemon with `--http --listen 127.0.0.1:8080`, which now fails with `Error: unknown flag: --http`, so both the **E2E Browser Tests** job and the **Lighthouse Audit** job have been failing on every PR.

Updated both Start steps:
- Dropped the dead `--http` flag
- Use canonical TLS port `8445` per CLAUDE.md
- `curl` probes use `https` + `-k`
- `E2E_BASE_URL` points to `https`
- Added `PLAYWRIGHT_IGNORE_HTTPS_ERRORS` in case the Playwright config is later gated to `!CI` — the auto-generated self-signed cert isn't in the CA store
- Lighthouse URL switched to `https`

## Why this is needed
The last few PRs that touched E2E (#699, #700) merged with these checks red because they weren't required, but the noise was masking real failures going forward. This restores genuine E2E signal on the repo.

## Test plan
- [ ] CI's E2E Browser Tests job goes green on this PR.
- [ ] CI's Lighthouse Audit goes green.
- [ ] No other jobs regress.