### PR TITLE
feat(license): add per-route feature gating framework

### DIFF
--- a/internal/api/middleware_license.go
+++ b/internal/api/middleware_license.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+// middleware_license.go provides per-route license-tier gating for NIAC.
+// Wrap any handler that exposes a paid feature with s.requireFeature
+// so the route returns 402 Payment Required when the active license
+// doesn't cover the feature. Mirrors seed's gating framework.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+// errCodeTierTooLow is the standard error code for routes blocked by
+// the license tier. UIs key off this code to render the upgrade hint.
+const errCodeTierTooLow = "TIER_TOO_LOW"
+
+// FeatureGateResponse is the JSON body returned with a 402 Payment
+// Required when a request hits a feature it isn't licensed for.
+type FeatureGateResponse struct {
+	Error           string `json:"error"`
+	Code            string `json:"code"`
+	RequiredFeature string `json:"requiredFeature"`
+	CurrentTier     string `json:"currentTier"`
+	UpgradeMessage  string `json:"upgradeMessage"`
+}
+
+// requireFeature wraps `next` so it only runs when the active license
+// includes `feature`. Returns 402 Payment Required with a structured
+// upgrade hint otherwise.
+//
+// A nil license manager is treated as "license disabled" (dev / test
+// builds) and permits all features so the gating layer never breaks
+// local workflows.
+func (s *Server) requireFeature(feature string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		mgr := s.license
+		if mgr == nil || mgr.HasFeature(feature) {
+			next(w, r)
+			return
+		}
+
+		tierName := license.TierFree.String()
+		if st := mgr.GetState(); st != nil {
+			tierName = st.Tier.String()
+		}
+
+		resp := FeatureGateResponse{
+			Error:           "Feature requires the Pro tier",
+			Code:            errCodeTierTooLow,
+			RequiredFeature: feature,
+			CurrentTier:     tierName,
+			UpgradeMessage: "Start a 14-day Pro trial with `niac license trial` " +
+				"or activate a Pro key with `niac license activate -k <KEY>`.",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
+			slog.ErrorContext(r.Context(),
+				"failed to encode feature-gate response", "error", encErr)
+		}
+	}
+}

--- a/internal/api/middleware_license_internal_test.go
+++ b/internal/api/middleware_license_internal_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+// nopHandler is a handler that records whether it was reached and
+// writes a fixed 200 body. Used to verify the middleware short-circuits
+// on a feature-gate failure.
+func nopHandler(seen *bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		*seen = true
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// newGateTestServer returns a bare Server with the supplied license
+// manager wired in. We avoid newTestServer here because gating doesn't
+// need the protocol stack — keeping the setup minimal makes the test's
+// intent clearer.
+func newGateTestServer(t *testing.T, mgr *license.Manager) *Server {
+	t.Helper()
+	return &Server{
+		logger:  slog.Default(),
+		license: mgr,
+	}
+}
+
+// freshManager returns a license.Manager rooted at a temp dir so each
+// test gets an isolated, deactivated state.
+func freshManager(t *testing.T) *license.Manager {
+	t.Helper()
+	mgr, err := license.NewManagerWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManagerWithDir: %v", err)
+	}
+	return mgr
+}
+
+func TestRequireFeature_AllowsWhenLicenseDisabled(t *testing.T) {
+	t.Parallel()
+	s := newGateTestServer(t, nil)
+
+	called := false
+	h := s.requireFeature("any_feature", nopHandler(&called))
+	req := httptest.NewRequest(http.MethodGet, "/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if !called {
+		t.Error("expected handler to run when license manager is nil")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestRequireFeature_AllowsWhenFeaturePresent(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	s := newGateTestServer(t, mgr)
+
+	called := false
+	h := s.requireFeature("rest_api", nopHandler(&called))
+	req := httptest.NewRequest(http.MethodGet, "/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if !called {
+		t.Error("expected handler to run when trial license has the feature")
+	}
+}
+
+func TestRequireFeature_Blocks402WhenFeatureAbsent(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	s := newGateTestServer(t, mgr)
+
+	called := false
+	h := s.requireFeature("nonexistent_feature_xyz", nopHandler(&called))
+	req := httptest.NewRequest(http.MethodGet, "/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if called {
+		t.Error("handler should not run when feature is missing")
+	}
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want 402", w.Code)
+	}
+
+	var body FeatureGateResponse
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode response: %v", decErr)
+	}
+	if body.Code != errCodeTierTooLow {
+		t.Errorf("Code = %q, want %q", body.Code, errCodeTierTooLow)
+	}
+	if body.RequiredFeature != "nonexistent_feature_xyz" {
+		t.Errorf("RequiredFeature = %q, want %q",
+			body.RequiredFeature, "nonexistent_feature_xyz")
+	}
+	if body.UpgradeMessage == "" {
+		t.Error("expected non-empty UpgradeMessage")
+	}
+}
+
+func TestRequireFeature_NoLicenseReturnsFreeTier(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	// No StartTrial / Activate — state stays nil ⇒ Free tier.
+	s := newGateTestServer(t, mgr)
+
+	h := s.requireFeature("bgp", nopHandler(new(bool)))
+	req := httptest.NewRequest(http.MethodGet, "/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402", w.Code)
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.CurrentTier != license.TierFree.String() {
+		t.Errorf("CurrentTier = %q, want %q",
+			body.CurrentTier, license.TierFree.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/krisarmstrong/niac-go/internal/config"
 	"github.com/krisarmstrong/niac-go/internal/library"
+	"github.com/krisarmstrong/niac-go/internal/license"
 	"github.com/krisarmstrong/niac-go/internal/protocols"
 	"github.com/krisarmstrong/niac-go/internal/storage"
 )
@@ -279,6 +280,10 @@ type Server struct {
 	bgStopOnce        sync.Once
 	library           *library.Library
 	tlsFingerprint    tlsFingerprintCache
+	// license is the offline license manager. Populated lazily in
+	// NewServer; may be nil in tests / dev builds that don't exercise
+	// license-gated endpoints.
+	license *license.Manager
 	// tokens is the active bearer-token store. Seeded from
 	// ServerConfig.TokenFile (preferred) or ServerConfig.Token at
 	// construction time, then rotated by Server.ReloadTokensFromFile or
@@ -311,7 +316,7 @@ func NewServer(cfg ServerConfig) *Server {
 		slog.Info("[API] Content library opened", "root", lib.Root())
 	}
 
-	return &Server{
+	srv := &Server{
 		cfg:           cfg,
 		logger:        slog.Default(),
 		startTime:     time.Now(),
@@ -326,6 +331,17 @@ func NewServer(cfg ServerConfig) *Server {
 		library:       lib,
 		tokens:        initialTokenStore(cfg),
 	}
+	// License manager is best-effort: failure to initialise leaves
+	// srv.license == nil, which the requireFeature middleware treats as
+	// "license disabled" so dev / test builds keep working without
+	// forcing a license setup.
+	if lm, lmErr := license.NewManager(); lmErr == nil {
+		srv.license = lm
+	} else {
+		slog.Warn("[API] license manager init failed; feature gates will allow all",
+			"error", lmErr)
+	}
+	return srv
 }
 
 // initialTokenStore seeds the bearer-token store at construction time.

--- a/internal/license/activation.go
+++ b/internal/license/activation.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 )
@@ -128,6 +129,23 @@ func (m *Manager) IsActivated() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.isActivatedLocked()
+}
+
+// HasFeature reports whether the active license includes the named
+// feature. Returns false unless the license is activated AND the
+// feature is in the active feature set. Active trials grant Pro-
+// equivalent features. Canonical feature names come from keygen's
+// productCatalog (e.g. "bgp", "ospf", "snmpv3", "pcap_ingest").
+//
+// Per-feature gates in HTTP handlers call this on every request, so
+// the lookup must stay cheap: single slice scan under RLock.
+func (m *Manager) HasFeature(feature string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.isActivatedLocked() || m.state == nil {
+		return false
+	}
+	return slices.Contains(m.state.Features, feature)
 }
 
 func (m *Manager) isActivatedLocked() bool {


### PR DESCRIPTION
## Summary

Mirrors the seed gating framework (seed PR #1153) for NIAC.

Adds the building blocks that PR-C2 (device-cap), PR-C3 (protocol gates: BGP/OSPF/SNMPv3/NetBIOS/FTP/STP) and PR-C4 (other Pro features: error_injection, traffic_shaping, config_templates, multi_ip, pcap_ingest) will use to gate paid functionality.

**No routes are gated yet** — that's the follow-up PRs.

## Changes

- `internal/license/activation.go`:
  - New `Manager.HasFeature(name string) bool` — single slice scan under `RLock`. Returns false unless the license is activated AND the feature is in the active feature set. Active trials grant Pro-equivalent features.

- `internal/api/middleware_license.go` (new):
  - `Server.requireFeature(feature, next) http.HandlerFunc` — wraps a handler so it only runs when the active license includes `feature`. Otherwise returns 402 Payment Required with a structured `FeatureGateResponse` JSON body (\`error\`, \`code\`, \`requiredFeature\`, \`currentTier\`, \`upgradeMessage\`).
  - Nil license manager = pass-through (dev / test builds). Code on the wire: \`TIER_TOO_LOW\`.

- `internal/api/server.go`:
  - New \`license *license.Manager\` field. Best-effort init in \`NewServer\` — failure leaves the field nil and the middleware permits all features so local workflows keep working.

- `internal/api/middleware_license_internal_test.go` (new):
  - Four cases: license-disabled allows, feature-present allows, feature-absent → 402, no-license → Free tier in the response.

## Test plan

- [x] \`go test -race -count=1 ./internal/api/ ./internal/license/\` — pass
- [x] \`golangci-lint run\` — clean (0 issues)
- [x] Pre-commit hook — pass
- [ ] CI green