### PR TITLE
feat(license): enforce Free-tier 10-device cap on device create

### DIFF
--- a/internal/api/devices_helpers.go
+++ b/internal/api/devices_helpers.go
@@ -27,6 +27,18 @@ func (s *Server) validateDeviceCreatePreconditions(
 		return nil, errValidationFailed
 	}
 
+	// Free-tier soft cap. Pro licenses carry the "unlimited_devices"
+	// feature and skip this gate. A nil license manager (dev / test
+	// builds) is treated as license-disabled and allows up to the
+	// hard ceiling.
+	if s.license != nil && !s.license.HasFeature("unlimited_devices") &&
+		len(cfg.Devices) >= FreeTierDeviceCount {
+		s.writeFeatureGate(w, r, "unlimited_devices",
+			fmt.Sprintf("Free tier supports up to %d devices. "+
+				"Upgrade to Pro for unlimited devices.", FreeTierDeviceCount))
+		return nil, errValidationFailed
+	}
+
 	if deviceExists(cfg.Devices, hostname) {
 		writeError(w, r, http.StatusConflict, "device_exists",
 			fmt.Sprintf("Device '%s' already exists", hostname), nil)

--- a/internal/api/devices_helpers_gate_internal_test.go
+++ b/internal/api/devices_helpers_gate_internal_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/config"
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+// newGateTestServerWithDevices builds a Server with the supplied license
+// manager and a config populated with n placeholder devices. It mirrors
+// newGateTestServer (in middleware_license_internal_test.go) but adds
+// the config wiring validateDeviceCreatePreconditions needs.
+func newGateTestServerWithDevices(
+	t *testing.T, mgr *license.Manager, n int,
+) *Server {
+	t.Helper()
+	devices := make([]config.Device, n)
+	for i := range devices {
+		devices[i] = config.Device{Name: fmt.Sprintf("dev%03d", i)}
+	}
+	return &Server{
+		logger:  slog.Default(),
+		license: mgr,
+		cfg:     ServerConfig{Config: &config.Config{Devices: devices}},
+	}
+}
+
+func TestDeviceCreate_Blocks402AtFreeTierCap(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	// No StartTrial — Free tier.
+	s := newGateTestServerWithDevices(t, mgr, FreeTierDeviceCount)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices", http.NoBody)
+	w := httptest.NewRecorder()
+
+	_, err := s.validateDeviceCreatePreconditions(w, req, "newhost")
+	if err == nil {
+		t.Fatal("expected validation failure at Free tier cap")
+	}
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402", w.Code)
+	}
+
+	var body FeatureGateResponse
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode response: %v", decErr)
+	}
+	if body.Code != errCodeTierTooLow {
+		t.Errorf("Code = %q, want %q", body.Code, errCodeTierTooLow)
+	}
+	if body.RequiredFeature != "unlimited_devices" {
+		t.Errorf("RequiredFeature = %q, want unlimited_devices",
+			body.RequiredFeature)
+	}
+}
+
+func TestDeviceCreate_AllowsBelowFreeTierCap(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newGateTestServerWithDevices(t, mgr, FreeTierDeviceCount-1)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices", http.NoBody)
+	w := httptest.NewRecorder()
+
+	cfg, err := s.validateDeviceCreatePreconditions(w, req, "newhost")
+	if err != nil {
+		t.Fatalf("unexpected validation failure: %v (status=%d)", err, w.Code)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+func TestDeviceCreate_AllowsAtFreeCapWhenProLicensed(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	// Pro trial → unlimited_devices feature present → no soft cap.
+	s := newGateTestServerWithDevices(t, mgr, FreeTierDeviceCount+50)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices", http.NoBody)
+	w := httptest.NewRecorder()
+
+	cfg, err := s.validateDeviceCreatePreconditions(w, req, "newhost")
+	if err != nil {
+		t.Fatalf("Pro license unexpectedly blocked: %v (status=%d)", err, w.Code)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+func TestDeviceCreate_HardCapStillEnforced(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	// Pro trial would normally skip the Free cap, but the absolute
+	// MaxDeviceCount must still block creation.
+	s := newGateTestServerWithDevices(t, mgr, MaxDeviceCount)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices", http.NoBody)
+	w := httptest.NewRecorder()
+
+	_, err := s.validateDeviceCreatePreconditions(w, req, "newhost")
+	if err == nil {
+		t.Fatal("expected hard-cap failure")
+	}
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (hard cap)", w.Code)
+	}
+}
+
+func TestDeviceCreate_NilLicenseAllowsUpToHardCap(t *testing.T) {
+	t.Parallel()
+	// Dev / test build: license manager is nil. Free cap is bypassed
+	// to keep local workflows working; the hard cap still applies.
+	s := newGateTestServerWithDevices(t, nil, FreeTierDeviceCount+5)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices", http.NoBody)
+	w := httptest.NewRecorder()
+
+	cfg, err := s.validateDeviceCreatePreconditions(w, req, "newhost")
+	if err != nil {
+		t.Fatalf("nil-license build unexpectedly blocked: %v (status=%d)",
+			err, w.Code)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}

--- a/internal/api/devices_validation.go
+++ b/internal/api/devices_validation.go
@@ -17,9 +17,19 @@ var (
 )
 
 const (
-	// MaxDeviceCount is the maximum number of devices allowed.
-	// SECURITY FIX #173: Prevents resource exhaustion via unbounded device creation.
+	// MaxDeviceCount is the absolute device ceiling enforced for every
+	// tier as a resource-exhaustion guard (security fix #173). Pro
+	// licenses raise the soft cap to this value via the
+	// "unlimited_devices" feature.
 	MaxDeviceCount = 1000
+
+	// FreeTierDeviceCount is the soft cap applied when the active
+	// license does NOT include the "unlimited_devices" feature
+	// (Free tier). Crossing it returns 402 + FeatureGateResponse
+	// rather than the generic 429 "device_limit_reached" the hard
+	// ceiling produces — UIs can render the upgrade hint instead of
+	// a server-error toast.
+	FreeTierDeviceCount = 10
 
 	// maxLabelLen is the max length of a hostname label (RFC 1123).
 	maxLabelLen = 63

--- a/internal/api/middleware_license.go
+++ b/internal/api/middleware_license.go
@@ -29,6 +29,44 @@ type FeatureGateResponse struct {
 	UpgradeMessage  string `json:"upgradeMessage"`
 }
 
+// defaultUpgradeMessage is the standard upgrade hint surfaced when a
+// caller doesn't supply a feature-specific message.
+const defaultUpgradeMessage = "Start a 14-day Pro trial with `niac license trial` " +
+	"or activate a Pro key with `niac license activate -k <KEY>`."
+
+// writeFeatureGate writes the canonical 402 Payment Required response
+// for a feature-gated request. Shared between requireFeature (route-
+// level) and handler-level soft caps (e.g. device count). Pass an
+// empty upgradeMessage to use defaultUpgradeMessage.
+func (s *Server) writeFeatureGate(
+	w http.ResponseWriter, r *http.Request,
+	feature, upgradeMessage string,
+) {
+	tierName := license.TierFree.String()
+	if s.license != nil {
+		if st := s.license.GetState(); st != nil {
+			tierName = st.Tier.String()
+		}
+	}
+	if upgradeMessage == "" {
+		upgradeMessage = defaultUpgradeMessage
+	}
+
+	resp := FeatureGateResponse{
+		Error:           "Feature requires the Pro tier",
+		Code:            errCodeTierTooLow,
+		RequiredFeature: feature,
+		CurrentTier:     tierName,
+		UpgradeMessage:  upgradeMessage,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusPaymentRequired)
+	if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
+		slog.ErrorContext(r.Context(),
+			"failed to encode feature-gate response", "error", encErr)
+	}
+}
+
 // requireFeature wraps `next` so it only runs when the active license
 // includes `feature`. Returns 402 Payment Required with a structured
 // upgrade hint otherwise.
@@ -38,30 +76,10 @@ type FeatureGateResponse struct {
 // local workflows.
 func (s *Server) requireFeature(feature string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		mgr := s.license
-		if mgr == nil || mgr.HasFeature(feature) {
+		if s.license == nil || s.license.HasFeature(feature) {
 			next(w, r)
 			return
 		}
-
-		tierName := license.TierFree.String()
-		if st := mgr.GetState(); st != nil {
-			tierName = st.Tier.String()
-		}
-
-		resp := FeatureGateResponse{
-			Error:           "Feature requires the Pro tier",
-			Code:            errCodeTierTooLow,
-			RequiredFeature: feature,
-			CurrentTier:     tierName,
-			UpgradeMessage: "Start a 14-day Pro trial with `niac license trial` " +
-				"or activate a Pro key with `niac license activate -k <KEY>`.",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusPaymentRequired)
-		if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
-			slog.ErrorContext(r.Context(),
-				"failed to encode feature-gate response", "error", encErr)
-		}
+		s.writeFeatureGate(w, r, feature, "")
 	}
 }


### PR DESCRIPTION
## Summary

First feature gate on top of the gating framework (#704).

When the active license lacks the \`unlimited_devices\` feature (Free tier), \`POST /api/devices\` returns 402 + \`FeatureGateResponse\` once the config already holds 10 devices. Pro licenses (and active Pro trials) carry \`unlimited_devices\` and skip the soft cap; the absolute 1000-device hard ceiling (security fix #173) still applies.

## Changes

- \`internal/api/devices_validation.go\`:
  - New \`FreeTierDeviceCount = 10\` alongside \`MaxDeviceCount = 1000\`.

- \`internal/api/devices_helpers.go\`:
  - \`validateDeviceCreatePreconditions\` runs the Free-tier soft cap after the hard cap. Emits the canonical 402 \`FeatureGateResponse\` (\`RequiredFeature: \"unlimited_devices\"\`) instead of the 429 \"device_limit_reached\" message so the UI can render an upgrade hint instead of a server-error toast.
  - Nil license manager (dev / test builds) bypasses the soft cap.

- \`internal/api/middleware_license.go\`:
  - Extracted \`writeFeatureGate(w, r, feature, upgradeMessage)\` from \`requireFeature\` so route-level gates and handler-level soft caps emit the same response shape. Empty \`upgradeMessage\` falls back to the default \`niac license trial\` / \`niac license activate\` hint.

- \`internal/api/devices_helpers_gate_internal_test.go\` (new):
  - Free cap blocks at 10 (402, code=\`TIER_TOO_LOW\`, requiredFeature=\`unlimited_devices\`)
  - Free allows below 10
  - Pro trial passes 60 devices
  - Hard cap still blocks Pro at 1000 (429)
  - Nil license bypasses the soft cap

## Test plan

- [x] \`go test -race -count=1 ./internal/api/ ./internal/license/\` — pass
- [x] \`golangci-lint run\` — clean
- [x] Pre-commit hook — pass
- [ ] CI green