### PR TITLE
feat(license): gate STP/FTP/NetBIOS protocols on device create+update

### DIFF
--- a/internal/api/devices.go
+++ b/internal/api/devices.go
@@ -175,6 +175,10 @@ func (s *Server) handleDeviceUpdate(w http.ResponseWriter, r *http.Request, host
 			return
 		}
 
+		if !s.requireDeviceProtocolFeatures(w, r, updatedDevice) {
+			return
+		}
+
 		newCfg.Devices[deviceIdx] = *updatedDevice
 	} else {
 		if err := applyPartialDeviceUpdate(&newCfg.Devices[deviceIdx], req); err != nil {

--- a/internal/api/devices_helpers.go
+++ b/internal/api/devices_helpers.go
@@ -133,6 +133,10 @@ func (s *Server) createAndSaveDevice(
 		return nil, err
 	}
 
+	if !s.requireDeviceProtocolFeatures(w, r, newDevice) {
+		return nil, errValidationFailed
+	}
+
 	newCfg := *deepCopyConfig(cfg)
 	newCfg.Devices = append(newCfg.Devices, *newDevice)
 

--- a/internal/api/devices_protocol_gates.go
+++ b/internal/api/devices_protocol_gates.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+// devices_protocol_gates.go enforces per-protocol license features on
+// device create and update. The gating runs after the device has been
+// parsed (so we know which protocols it actually configures) but
+// before save, returning 402 + FeatureGateResponse rather than the
+// usual 400 validation error so UIs can render an upgrade hint.
+
+import (
+	"net/http"
+
+	"github.com/krisarmstrong/niac-go/internal/config"
+)
+
+// protocolFeatureCheck pairs a per-device protocol detector with its
+// canonical license feature name from the keygen productCatalog.
+type protocolFeatureCheck struct {
+	// feature is the keygen feature key (e.g. "stp", "ftp").
+	feature string
+	// present reports whether the device configures the protocol.
+	present func(*config.Device) bool
+}
+
+// gatedDeviceProtocolChecks enumerates the protocols that exist in the
+// current Device struct and have a matching license feature. BGP,
+// OSPF, and SNMPv3 are in the licensed feature catalog but not yet
+// modeled on Device — tracked separately for follow-up.
+//
+// Returned by a function rather than held in a package-level slice so
+// gochecknoglobals stays clean; the closures aren't worth caching.
+func gatedDeviceProtocolChecks() []protocolFeatureCheck {
+	return []protocolFeatureCheck{
+		{
+			feature: "stp",
+			present: func(d *config.Device) bool { return d != nil && d.STPConfig != nil },
+		},
+		{
+			feature: "ftp",
+			present: func(d *config.Device) bool { return d != nil && d.FTPConfig != nil },
+		},
+		{
+			feature: "netbios",
+			present: func(d *config.Device) bool { return d != nil && d.NetBIOSConfig != nil },
+		},
+	}
+}
+
+// requireDeviceProtocolFeatures returns false (and writes a 402
+// FeatureGateResponse) when the device's protocol set includes a
+// protocol the active license doesn't cover. Nil license manager
+// = pass (dev / test builds).
+func (s *Server) requireDeviceProtocolFeatures(
+	w http.ResponseWriter, r *http.Request, dev *config.Device,
+) bool {
+	if s.license == nil || dev == nil {
+		return true
+	}
+	for _, chk := range gatedDeviceProtocolChecks() {
+		if !chk.present(dev) {
+			continue
+		}
+		if !s.license.HasFeature(chk.feature) {
+			s.writeFeatureGate(w, r, chk.feature,
+				"This device uses "+chk.feature+
+					", which requires the Pro tier. "+
+					"Start a 14-day Pro trial with `niac license trial`.")
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/devices_protocol_gates_test.go
+++ b/internal/api/devices_protocol_gates_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/config"
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+// newProtoGateServer wires a Server with just enough state to exercise
+// requireDeviceProtocolFeatures.
+func newProtoGateServer(t *testing.T, mgr *license.Manager) *Server {
+	t.Helper()
+	return &Server{
+		logger:  slog.Default(),
+		license: mgr,
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_AllowsPlainDevice(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{Name: "plain"}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if !s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatalf("plain device should pass; status=%d body=%s",
+			w.Code, w.Body.String())
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_NilLicenseAllowsAll(t *testing.T) {
+	t.Parallel()
+	s := newProtoGateServer(t, nil)
+
+	dev := &config.Device{
+		Name:          "withftp",
+		FTPConfig:     &config.FTPConfig{},
+		STPConfig:     &config.STPConfig{},
+		NetBIOSConfig: &config.NetBIOSConfig{},
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if !s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatalf("nil license should allow all; status=%d", w.Code)
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_BlocksFreeOnFTP(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{Name: "withftp", FTPConfig: &config.FTPConfig{}}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on FTP")
+	}
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402", w.Code)
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "ftp" {
+		t.Errorf("RequiredFeature = %q, want ftp", body.RequiredFeature)
+	}
+	if body.Code != errCodeTierTooLow {
+		t.Errorf("Code = %q, want %q", body.Code, errCodeTierTooLow)
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_BlocksFreeOnSTP(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{Name: "withstp", STPConfig: &config.STPConfig{}}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on STP")
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "stp" {
+		t.Errorf("RequiredFeature = %q, want stp", body.RequiredFeature)
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_BlocksFreeOnNetBIOS(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{Name: "withnb", NetBIOSConfig: &config.NetBIOSConfig{}}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on NetBIOS")
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "netbios" {
+		t.Errorf("RequiredFeature = %q, want netbios", body.RequiredFeature)
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_AllowsProTrial(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{
+		Name:          "kitchensink",
+		FTPConfig:     &config.FTPConfig{},
+		STPConfig:     &config.STPConfig{},
+		NetBIOSConfig: &config.NetBIOSConfig{},
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if !s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatalf("Pro trial should allow gated protocols; status=%d body=%s",
+			w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

First protocol-level gates on top of the framework (#704) and device-cap (#706) PRs.

When a device's parsed config includes a gated protocol (\`STPConfig\`, \`FTPConfig\`, \`NetBIOSConfig\`) and the active license doesn't carry the matching feature, the create/update returns 402 + \`FeatureGateResponse\` rather than silently dropping the protocol.

## Scope decision

The keygen feature catalog also names \`bgp\`, \`ospf\`, and \`snmpv3\`. None of those are currently modeled on \`config.Device\`, so a gate would be a no-op. They'll be wired in when the underlying capability lands. Tracked as a follow-up so the gating layer doesn't drift behind the implementation.

## Changes

- \`internal/api/devices_protocol_gates.go\` (new):
  - \`requireDeviceProtocolFeatures(w, r, dev) bool\` — single scan over the gate list, writes the canonical 402 \`FeatureGateResponse\` and returns false on the first violation. Nil license manager = pass (dev/test).
  - \`gatedDeviceProtocolChecks()\` returns the \`{feature, present}\` pairs. Function rather than package-level slice to keep \`gochecknoglobals\` clean.

- \`internal/api/devices_helpers.go\`:
  - \`createAndSaveDevice\` runs the gate immediately after parsing the device, before save.

- \`internal/api/devices.go\`:
  - \`handleDeviceUpdate\` runs the gate after YAML-driven updates, before save. Partial JSON updates don't touch protocol configs, so they skip the gate.

- \`internal/api/devices_protocol_gates_test.go\` (new):
  - Plain device passes, nil-license bypass, FTP/STP/NetBIOS each block Free with the right \`RequiredFeature\`, Pro trial allows the kitchen sink.

## Test plan

- [x] \`go test -race -count=1 ./internal/api/\` — pass
- [x] \`golangci-lint run\` — clean
- [x] Pre-commit hook — pass
- [ ] CI green