### PR TITLE
feat(license): gate pcap, templates, traffic_shaping, multi_ip

### DIFF
--- a/internal/api/devices_pro_features_test.go
+++ b/internal/api/devices_pro_features_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/config"
+)
+
+func TestDeviceFeature_BlocksFreeOnMultiIP(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{
+		Name:        "multi",
+		IPAddresses: []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2")},
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on multi-IP device")
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "multi_ip" {
+		t.Errorf("RequiredFeature = %q, want multi_ip", body.RequiredFeature)
+	}
+}
+
+func TestDeviceFeature_BlocksFreeOnMapToIP(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{
+		Name:        "mapto",
+		IPAddresses: []net.IP{net.ParseIP("10.0.0.1")}, // single IP
+		MapToIP:     net.ParseIP("203.0.113.5"),
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on MapToIP")
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "multi_ip" {
+		t.Errorf("RequiredFeature = %q, want multi_ip", body.RequiredFeature)
+	}
+}
+
+func TestDeviceFeature_AllowsFreeOnSingleIP(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{
+		Name:        "single",
+		IPAddresses: []net.IP{net.ParseIP("10.0.0.1")},
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if !s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatalf("single-IP should pass Free; status=%d", w.Code)
+	}
+}
+
+func TestDeviceFeature_BlocksFreeOnTrafficShaping(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{
+		Name:          "shaped",
+		TrafficConfig: &config.TrafficConfig{Enabled: true},
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on TrafficConfig")
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "traffic_shaping" {
+		t.Errorf("RequiredFeature = %q, want traffic_shaping",
+			body.RequiredFeature)
+	}
+}
+
+func TestDeviceFeature_AllowsProTrialOnTrafficAndMultiIP(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{
+		Name: "kitchensink2",
+		IPAddresses: []net.IP{
+			net.ParseIP("10.0.0.1"),
+			net.ParseIP("10.0.0.2"),
+		},
+		MapToIP:       net.ParseIP("203.0.113.5"),
+		TrafficConfig: &config.TrafficConfig{Enabled: true},
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if !s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatalf("Pro trial should allow gated features; status=%d body=%s",
+			w.Code, w.Body.String())
+	}
+}

--- a/internal/api/devices_protocol_gates.go
+++ b/internal/api/devices_protocol_gates.go
@@ -23,10 +23,10 @@ type protocolFeatureCheck struct {
 	present func(*config.Device) bool
 }
 
-// gatedDeviceProtocolChecks enumerates the protocols that exist in the
-// current Device struct and have a matching license feature. BGP,
-// OSPF, and SNMPv3 are in the licensed feature catalog but not yet
-// modeled on Device — tracked separately for follow-up.
+// gatedDeviceProtocolChecks enumerates the device-config fields that
+// map to a licensed Pro feature. BGP, OSPF, SNMPv3, and
+// error_injection are in the keygen catalog but not yet modeled on
+// Device — tracked separately for follow-up.
 //
 // Returned by a function rather than held in a package-level slice so
 // gochecknoglobals stays clean; the closures aren't worth caching.
@@ -43,6 +43,25 @@ func gatedDeviceProtocolChecks() []protocolFeatureCheck {
 		{
 			feature: "netbios",
 			present: func(d *config.Device) bool { return d != nil && d.NetBIOSConfig != nil },
+		},
+		{
+			// traffic_shaping: any device-level traffic pattern config
+			// (ARP announcements, periodic pings, random background
+			// traffic) requires Pro.
+			feature: "traffic_shaping",
+			present: func(d *config.Device) bool { return d != nil && d.TrafficConfig != nil },
+		},
+		{
+			// multi_ip: a device with more than one IP address, or
+			// with MapToIP set (UDP-mapping to an external IP), is a
+			// Pro feature. Single-IP devices stay Free.
+			feature: "multi_ip",
+			present: func(d *config.Device) bool {
+				if d == nil {
+					return false
+				}
+				return len(d.IPAddresses) > 1 || d.MapToIP != nil
+			},
 		},
 	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -161,9 +161,12 @@ func (s *Server) registerPcapRoutes(mux *http.ServeMux) {
 	// SECURITY FIX #156: Apply upload-specific rate limiting for uploads
 	mux.HandleFunc(
 		"/api/v1/pcap/upload",
-		s.recoverMiddleware(s.auth(s.uploadRateLimit(s.csrfProtect(s.handlePcapUpload)))),
+		s.recoverMiddleware(s.auth(s.uploadRateLimit(s.csrfProtect(
+			s.requireFeature("pcap_ingest", s.handlePcapUpload))))),
 	)
-	mux.HandleFunc("/api/v1/pcap/", s.recoverMiddleware(s.auth(s.handlePcapAnalysis)))
+	mux.HandleFunc("/api/v1/pcap/",
+		s.recoverMiddleware(s.auth(
+			s.requireFeature("pcap_ingest", s.handlePcapAnalysis))))
 }
 
 // registerSSERoutes registers Server-Sent Events endpoints for real-time streaming.

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -106,8 +106,16 @@ func (s *Server) handleTemplateByName(w http.ResponseWriter, r *http.Request) {
 	// Extract template name from path: /api/v1/templates/{name}
 	name := strings.TrimPrefix(r.URL.Path, "/api/v1/templates/")
 
-	// Handle /api/v1/templates/use separately
+	// Handle /api/v1/templates/use separately. Applying a template is
+	// gated behind the config_templates feature; listing / reading /
+	// deleting templates stays open.
 	if name == "use" {
+		if s.license != nil && !s.license.HasFeature("config_templates") {
+			s.writeFeatureGate(w, r, "config_templates",
+				"Applying a config template requires the Pro tier. "+
+					"Start a 14-day Pro trial with `niac license trial`.")
+			return
+		}
 		s.handleTemplateUse(w, r)
 		return
 	}


### PR DESCRIPTION
## Summary

Closes out the Tier-3 NIAC gating sweep — wires the remaining Pro features named in the keygen catalog into the gating framework.

## Changes

Route-level (via \`requireFeature\`):
- \`POST /api/v1/pcap/upload\` → \`pcap_ingest\`
- \`GET /api/v1/pcap/{id}\` → \`pcap_ingest\` (reading back an already-uploaded pcap is part of the same Pro feature)
- \`POST /api/v1/templates/use\` → \`config_templates\` (inline check inside \`handleTemplateByName\`'s \"use\" dispatch, since list / read / delete templates share the same route prefix and stay open)

Device-level (extends \`gatedDeviceProtocolChecks()\`):
- \`TrafficConfig != nil\` → \`traffic_shaping\`
- \`len(IPAddresses) > 1 || MapToIP != nil\` → \`multi_ip\`

## Out of scope

\`error_injection\` is in the keygen catalog but not yet modeled on \`config.Device\` — tracked as follow-up #129 alongside BGP/OSPF/SNMPv3.

## Test plan

- [x] \`go test -race -count=1 ./internal/api/\` — pass (five new tests for multi-IP / MapToIP / single-IP / TrafficConfig / Pro-trial kitchen sink)
- [x] \`golangci-lint run\` — clean
- [x] Pre-commit hook — pass
- [ ] CI green