### PR TITLE
feat(i18n): add errors.license.* keys for tier-gating UI

### DIFF
--- a/internal/i18n/locales/en/errors.json
+++ b/internal/i18n/locales/en/errors.json
@@ -8,6 +8,14 @@
     "serverError": "Server error — please try again",
     "invalidRequest": "Invalid request"
   },
+  "license": {
+    "tierTooLow": "This feature requires the {{tier}} tier",
+    "upgradeHint": "Start a 14-day {{tier}} trial with `niac license trial`, or activate a {{tier}} key with `niac license activate -k <KEY>`.",
+    "tierGateTooltip": "Requires the {{tier}} tier",
+    "featureUnavailable": "{{feature}} is not available on your current tier",
+    "currentTier": "Current tier: {{tier}}",
+    "loading": "Checking license…"
+  },
   "validation": {
     "required": "This field is required",
     "tooShort": "Must be at least {{min}} characters",

--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -8,6 +8,14 @@
     "serverError": "Error del servidor — intente nuevamente",
     "invalidRequest": "Solicitud inválida"
   },
+  "license": {
+    "tierTooLow": "Esta función requiere el nivel {{tier}}",
+    "upgradeHint": "Inicia una prueba gratuita de {{tier}} de 14 días con `niac license trial`, o activa una clave {{tier}} con `niac license activate -k <CLAVE>`.",
+    "tierGateTooltip": "Requiere el nivel {{tier}}",
+    "featureUnavailable": "{{feature}} no está disponible en tu nivel actual",
+    "currentTier": "Nivel actual: {{tier}}",
+    "loading": "Verificando licencia…"
+  },
   "validation": {
     "required": "Este campo es obligatorio",
     "tooShort": "Debe tener al menos {{min}} caracteres",


### PR DESCRIPTION
## Summary

Mirrors seed PR #1160 and stem PR #313 — adds the gating-specific i18n keys so NIAC's locale layer covers the upgrade hints surfaced by the Tier-3 gates (#704 framework, #706 device cap, #707 STP/FTP/NetBIOS, #708 pcap/templates/traffic/multi-IP).

## Changes

- \`internal/i18n/locales/{en,es}/errors.json\`: new \`errors.license\` group with \`tierTooLow\`, \`upgradeHint\`, \`tierGateTooltip\`, \`featureUnavailable\`, \`currentTier\`, \`loading\`.

NIAC's React UI doesn't yet ship a \`TierGate\` primitive — Pro-tier device-feature flags currently land server-side only. The keys land first so the UI follow-up doesn't need its own i18n PR.

## Test plan

- [x] Pre-commit hook — pass
- [ ] CI green