### PR TITLE
feat(api): add GET /api/v1/license read endpoint

### DIFF
--- a/internal/api/handlers_license.go
+++ b/internal/api/handlers_license.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+// handlers_license.go exposes the active license state to the UI so
+// the React layer can render TierGate / RequireFeature primitives
+// without needing to hit a gated endpoint and parse a 402.
+
+import (
+	"net/http"
+
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+// LicenseStatusResponse is the JSON shape returned by
+// GET /api/v1/license. It is intentionally read-only — activation,
+// trial start, and deactivation go through the `niac license` CLI,
+// not the HTTP API, so the only thing the UI needs is the current
+// state.
+type LicenseStatusResponse struct {
+	// Tier is the human-readable tier name ("Free" / "Pro" /
+	// "Invalid"). When the license manager is disabled (dev / test
+	// builds), this is "Free" so the UI degrades gracefully.
+	Tier string `json:"tier"`
+	// IsActivated is true when either an activated key OR a valid
+	// trial is in effect.
+	IsActivated bool `json:"isActivated"`
+	// IsTrialMode reports whether the active license is a trial.
+	IsTrialMode bool `json:"isTrialMode"`
+	// TrialDaysRemaining is the days left in the current trial; 0
+	// when no trial is active.
+	TrialDaysRemaining int `json:"trialDaysRemaining"`
+	// Features is the active feature set keyed by the keygen
+	// productCatalog feature names. Empty slice (not nil) when the
+	// license is not activated, so the UI can iterate without a nil
+	// check.
+	Features []string `json:"features"`
+	// LicenseEnforced is false when the server is running without a
+	// license manager (dev / test builds). The UI should treat
+	// LicenseEnforced=false as "all features available, hide upgrade
+	// hints" so local development isn't cluttered with paid-tier
+	// prompts.
+	LicenseEnforced bool `json:"licenseEnforced"`
+}
+
+// handleLicenseStatus serves GET /api/v1/license. No auth gate beyond
+// the shared session auth that the route is already wrapped in — the
+// UI needs to know the tier on every page, including the login-
+// adjacent ones, so this stays on the cheapest path.
+func (s *Server) handleLicenseStatus(w http.ResponseWriter, _ *http.Request) {
+	resp := LicenseStatusResponse{
+		Tier:            license.TierFree.String(),
+		Features:        []string{},
+		LicenseEnforced: s.license != nil,
+	}
+
+	if s.license != nil {
+		resp.IsActivated = s.license.IsActivated()
+		if st := s.license.GetState(); st != nil {
+			resp.Tier = st.Tier.String()
+			resp.IsTrialMode = st.IsTrialMode
+			if st.Features != nil {
+				resp.Features = st.Features
+			}
+		}
+		resp.TrialDaysRemaining = s.license.TrialDaysRemaining()
+	}
+
+	s.writeJSON(w, resp)
+}

--- a/internal/api/handlers_license_test.go
+++ b/internal/api/handlers_license_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krisarmstrong/niac-go/internal/license"
+)
+
+func newLicenseHandlerServer(t *testing.T, mgr *license.Manager) *Server {
+	t.Helper()
+	return &Server{
+		logger:  slog.Default(),
+		license: mgr,
+	}
+}
+
+func TestLicenseStatus_NilManagerReportsUnenforced(t *testing.T) {
+	t.Parallel()
+	s := newLicenseHandlerServer(t, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/license", http.NoBody)
+	s.handleLicenseStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body LicenseStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.LicenseEnforced {
+		t.Error("LicenseEnforced should be false when manager is nil")
+	}
+	if body.Tier != license.TierFree.String() {
+		t.Errorf("Tier = %q, want Free", body.Tier)
+	}
+	if body.Features == nil {
+		t.Error("Features should be non-nil empty slice, not nil")
+	}
+}
+
+func TestLicenseStatus_FreshManagerReportsFree(t *testing.T) {
+	t.Parallel()
+	mgr, err := license.NewManagerWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManagerWithDir: %v", err)
+	}
+	s := newLicenseHandlerServer(t, mgr)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/license", http.NoBody)
+	s.handleLicenseStatus(w, req)
+
+	var body LicenseStatusResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if !body.LicenseEnforced {
+		t.Error("LicenseEnforced should be true with a real manager")
+	}
+	if body.IsActivated {
+		t.Error("fresh manager should not be activated")
+	}
+	if body.Tier != license.TierFree.String() {
+		t.Errorf("Tier = %q, want Free", body.Tier)
+	}
+}
+
+func TestLicenseStatus_ProTrialReportsFeatures(t *testing.T) {
+	t.Parallel()
+	mgr, err := license.NewManagerWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManagerWithDir: %v", err)
+	}
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	s := newLicenseHandlerServer(t, mgr)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/license", http.NoBody)
+	s.handleLicenseStatus(w, req)
+
+	var body LicenseStatusResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if !body.IsActivated {
+		t.Error("expected activated trial")
+	}
+	if !body.IsTrialMode {
+		t.Error("expected trial mode")
+	}
+	if body.Tier != license.TierPro.String() {
+		t.Errorf("Tier = %q, want Pro", body.Tier)
+	}
+	if body.TrialDaysRemaining <= 0 {
+		t.Errorf("TrialDaysRemaining = %d, want > 0", body.TrialDaysRemaining)
+	}
+	if len(body.Features) == 0 {
+		t.Error("expected non-empty Features in Pro trial")
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -17,6 +17,7 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/stats", s.recoverMiddleware(s.auth(s.handleStats)))
 	mux.HandleFunc("/api/v1/devices", s.recoverMiddleware(s.auth(s.handleDevices)))
 	mux.HandleFunc("/api/v1/history", s.recoverMiddleware(s.auth(s.handleHistory)))
+	mux.HandleFunc("/api/v1/license", s.recoverMiddleware(s.auth(s.handleLicenseStatus)))
 
 	// SECURITY FIX LOW-1: Protect state-changing endpoints with CSRF
 	// SECURITY FIX #156: Apply write rate limiting to state-changing endpoints


### PR DESCRIPTION
## Summary

Exposes the active license state to the UI so a React TierGate / RequireFeature primitive can render the right copy without first having to hit a gated endpoint and parse a 402. Mirrors seed's \`/api/v1/license\` pattern.

## Changes

- \`internal/api/handlers_license.go\` (new):
  - \`LicenseStatusResponse\`: \`{ tier, isActivated, isTrialMode, trialDaysRemaining, features, licenseEnforced }\`.
  - \`handleLicenseStatus\` reads through \`Manager.GetState()\` / \`IsActivated()\` / \`TrialDaysRemaining()\`. Nil license manager (dev / test) reports \`licenseEnforced=false\` so the UI hides upgrade hints in local development.
  - \`Features\` is always non-nil (empty slice when no features) so the UI iterates without a nil check.

- \`internal/api/routes.go\`:
  - Register \`GET /api/v1/license\` alongside the other read routes. Same auth middleware as \`/api/v1/stats\`.

- \`internal/api/handlers_license_test.go\`:
  - Three cases: nil manager (unenforced), fresh manager (Free, not activated), active Pro trial.

This is the server piece. The React \`LicenseProvider\` / \`useLicense\` / \`TierGate\` primitives mirroring seed PR-A4 will follow in a separate UI PR.

## Test plan

- [x] \`go test -race -count=1 ./internal/api/\` — pass
- [x] Pre-commit hook — pass
- [ ] CI green