### PR TITLE
feat(ui): add LicenseProvider/useLicense + TierGate/RequireFeature primitives

### DIFF
--- a/ui/src/components/ui/RequireFeature.tsx
+++ b/ui/src/components/ui/RequireFeature.tsx
@@ -1,0 +1,37 @@
+/**
+ * RequireFeature — render children only if the active license
+ * includes the feature.
+ *
+ * This is the "hide" variant of feature gating. Use it for entire
+ * pages, drawer sections, or nav items that should simply not
+ * exist for users on a lower tier.
+ *
+ * For interactive controls that should stay *visible but disabled*
+ * with an upgrade hint, prefer <TierGate>.
+ *
+ * While the initial license fetch is in flight, the component
+ * renders `fallback` (default: null) — this avoids a flash of
+ * paid content disappearing once the fetch resolves.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { useLicense } from '../../contexts/LicenseContext';
+
+interface RequireFeatureProps {
+  feature: string;
+  children: ReactNode;
+  /** Rendered when the feature is absent or license is still loading. */
+  fallback?: ReactNode;
+}
+
+export function RequireFeature({
+  feature,
+  children,
+  fallback = null,
+}: RequireFeatureProps): ReactElement {
+  const { hasFeature, loading } = useLicense();
+  if (loading || !hasFeature(feature)) {
+    return <>{fallback}</>;
+  }
+  return <>{children}</>;
+}

--- a/ui/src/components/ui/TierGate.tsx
+++ b/ui/src/components/ui/TierGate.tsx
@@ -1,0 +1,74 @@
+/**
+ * TierGate — render children regardless, but visually mark them
+ * as locked + show an upgrade hint when the active license doesn't
+ * include the feature.
+ *
+ * This is the "disable" variant of feature gating. Use it for
+ * settings panels, individual buttons, or any UI where the user
+ * should still see the feature exists (so they know what they're
+ * missing) but cannot interact with it without upgrading.
+ *
+ * For surfaces that should simply not exist on lower tiers, prefer
+ * <RequireFeature>.
+ *
+ * Interactive children don't need to know they're inside a
+ * <TierGate> — the wrapper covers them with a transparent overlay
+ * that intercepts clicks and shows the upgrade tooltip on hover.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { useLicense } from '../../contexts/LicenseContext';
+
+interface TierGateProps {
+  feature: string;
+  children: ReactNode;
+  /** Tier name shown in the tooltip (e.g. "Pro"). */
+  requiredTier?: string;
+  /**
+   * Custom tooltip. Defaults to a hard-coded English string today;
+   * once NIAC's UI wires up react-i18next, switch the default to
+   * `t('errors:license.tierGateTooltip', { tier })` (the locale
+   * keys are already in `internal/i18n/locales/{en,es}/errors.json`).
+   */
+  message?: string;
+}
+
+export function TierGate({
+  feature,
+  children,
+  requiredTier = 'Pro',
+  message,
+}: TierGateProps): ReactElement {
+  const { hasFeature, loading } = useLicense();
+
+  // Always render children while loading so layouts don't shift;
+  // gate visually only after we know they lack the feature.
+  if (loading || hasFeature(feature)) {
+    return <>{children}</>;
+  }
+
+  const hint = message ?? `Requires the ${requiredTier} tier`;
+
+  // CSS-only hover (`group` + `group-hover:`) keeps the tooltip tied
+  // to the wrapper without JS event handlers — that lets the outer
+  // span stay presentation-only and dodges the a11y rule against
+  // static elements with interaction handlers.
+  return (
+    <span
+      data-testid="tier-gate-locked"
+      data-feature={feature}
+      className="relative inline-block group"
+    >
+      <span aria-disabled="true" className="pointer-events-none opacity-60">
+        {children}
+      </span>
+      <span aria-hidden="true" className="absolute inset-0 cursor-not-allowed" title={hint} />
+      <span
+        role="tooltip"
+        className="invisible group-hover:visible group-focus-within:visible absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 rounded bg-surface-raised border border-surface-border text-xs text-text-primary whitespace-nowrap shadow-lg"
+      >
+        {hint}
+      </span>
+    </span>
+  );
+}

--- a/ui/src/contexts/LicenseContext.tsx
+++ b/ui/src/contexts/LicenseContext.tsx
@@ -1,0 +1,122 @@
+/**
+ * LicenseContext — active license tier + feature flags.
+ *
+ * Fetches GET /api/v1/license once at app boot, caches the result,
+ * and exposes it via `useLicense()`. UI components use this to
+ * decide whether to render a feature (`<RequireFeature>`) or
+ * disable it with an upgrade hint (`<TierGate>`).
+ *
+ * No license is a valid state — unlicensed Free is the default.
+ * Components that read the hook before fetch completes get
+ * `loading=true` and should render placeholder content rather than
+ * flashing paid features.
+ *
+ * On a 402 response from a gated API call, call `refresh()` so the
+ * UI picks up any tier change made via the `niac license` CLI
+ * without forcing a page reload.
+ */
+
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { deduplicatedGet } from '../api/requestCore';
+
+/** Shape of GET /api/v1/license — mirrors LicenseStatusResponse on the server. */
+export interface LicenseStatus {
+  tier: string;
+  isActivated: boolean;
+  isTrialMode: boolean;
+  trialDaysRemaining: number;
+  features: string[];
+  /**
+   * False on dev / test builds where no license manager is wired
+   * in. UIs should treat this as "all features available, hide
+   * upgrade hints" so local development isn't cluttered with
+   * paid-tier prompts.
+   */
+  licenseEnforced: boolean;
+}
+
+interface LicenseContextValue {
+  /** Latest fetch, or null while loading / on fetch error. */
+  status: LicenseStatus | null;
+  /** True while the initial fetch is in flight. */
+  loading: boolean;
+  /** Last fetch error message, or null. */
+  error: string | null;
+  /** Re-fetch the license state — call after CLI activation. */
+  refresh: () => Promise<void>;
+  /**
+   * True iff the active license includes the named feature.
+   * - When the server reports `licenseEnforced=false` (dev / test),
+   *   all features are reported as present so local UI works.
+   * - During loading, returns false so gated UI hides rather than
+   *   flashing on boot.
+   */
+  hasFeature: (feature: string) => boolean;
+}
+
+const LicenseContext = createContext<LicenseContextValue | null>(null);
+
+interface LicenseProviderProps {
+  children: ReactNode;
+}
+
+export function LicenseProvider({ children }: LicenseProviderProps): ReactElement {
+  const [status, setStatus] = useState<LicenseStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const fresh = await deduplicatedGet<LicenseStatus>('/api/v1/license');
+      setStatus(fresh);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load license');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const hasFeature = useCallback(
+    (feature: string): boolean => {
+      if (!status) {
+        return false;
+      }
+      if (!status.licenseEnforced) {
+        return true;
+      }
+      return status.features.includes(feature);
+    },
+    [status],
+  );
+
+  return (
+    <LicenseContext.Provider value={{ status, loading, error, refresh, hasFeature }}>
+      {children}
+    </LicenseContext.Provider>
+  );
+}
+
+/**
+ * useLicense returns the active license state. Throws if called
+ * outside `<LicenseProvider>` — that always indicates a wiring bug.
+ */
+export function useLicense(): LicenseContextValue {
+  const ctx = useContext(LicenseContext);
+  if (!ctx) {
+    throw new Error('useLicense() must be called inside <LicenseProvider>');
+  }
+  return ctx;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
+import { LicenseProvider } from './contexts/LicenseContext';
 import { initThemeFromStorage } from './hooks/useTheme';
 import './index.css';
 
@@ -20,7 +21,9 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <LicenseProvider>
+        <App />
+      </LicenseProvider>
     </BrowserRouter>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary

Closes out PR-E1 with the React side — mirrors seed PR-A4 so any future Pro-tier UI surface in NIAC can be gated with two drop-in primitives instead of bespoke 402 parsing.

Builds on PR #710 (\`GET /api/v1/license\` read endpoint) which just landed.

## Changes

- \`ui/src/contexts/LicenseContext.tsx\` (new):
  - \`LicenseProvider\` fetches \`/api/v1/license\` once at boot.
  - \`useLicense()\` returns \`{ status, loading, error, refresh, hasFeature(feature) }\`.
  - \`licenseEnforced=false\` (dev / test builds) makes \`hasFeature\` return true for every feature so local UI works without a license setup.

- \`ui/src/components/ui/RequireFeature.tsx\` (new):
  - Hide variant — render children only when the feature is present.

- \`ui/src/components/ui/TierGate.tsx\` (new):
  - Disable variant — render children covered by a click-blocking transparent overlay + CSS-only hover tooltip.
  - Tooltip default is a hard-coded English string for now; once NIAC wires up react-i18next, switch to \`t('errors:license.tierGateTooltip', { tier })\` — the locale keys are already in \`errors.json\` (#709).

- \`ui/src/main.tsx\`: wrap \`<App>\` in \`<LicenseProvider>\` above the router so the hook is available everywhere.

## Out of scope

- No call sites of \`TierGate\` / \`RequireFeature\` are added in this PR. The primitives stand alone and are dead code until callers adopt them; that's a deliberate split so each adoption is its own reviewable change.
- react-i18next integration follow-up tracked separately.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vite build\` — clean
- [x] Pre-commit hook — pass
- [ ] CI green