### PR TITLE
feat(i18n): Phase 5 — pluralization + Intl APIs + locale-aware formatters

### DIFF
--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -170,5 +170,42 @@
     "actionsHeading": "Actions",
     "openSettings": "Open Settings",
     "openHelp": "Open Help"
+  },
+  "plurals": {
+    "deviceCount_one": "{{count}} device",
+    "deviceCount_other": "{{count}} devices",
+    "deviceCountSelected_one": "{{count}} device selected",
+    "deviceCountSelected_other": "{{count}} devices selected",
+    "logCount_one": "{{count}} log buffered",
+    "logCount_other": "{{count}} logs buffered",
+    "conversationCount_one": "{{count}} conversation",
+    "conversationCount_other": "{{count}} conversations",
+    "packetCount_one": "{{count}} packet",
+    "packetCount_other": "{{count}} packets",
+    "itemCount_one": "{{count}} item",
+    "itemCount_other": "{{count}} items"
+  },
+  "format": {
+    "bytesB": "{{value}} B",
+    "bytesKB": "{{value}} KB",
+    "bytesMB": "{{value}} MB",
+    "bytesGB": "{{value}} GB",
+    "durationLessThanMs": "<1ms",
+    "durationMs": "{{value}} ms",
+    "durationS": "{{value}} s",
+    "durationMin": "{{value}} min",
+    "durationHr": "{{value}} hr",
+    "durationMinSec": "{{min}}m {{sec}}s",
+    "uptimeS": "{{value}}s",
+    "uptimeMS": "{{min}}m {{sec}}s",
+    "uptimeHM": "{{hr}}h {{min}}m",
+    "uptimeDH": "{{day}}d {{hr}}h",
+    "relativeJustNow": "just now",
+    "relativeSecAgo": "{{value}}s ago",
+    "relativeMinAgo": "{{value}}m ago",
+    "relativeHourAgo": "{{value}}h ago",
+    "relativeDayAgo": "{{value}}d ago",
+    "dash": "—",
+    "unexpectedError": "An unexpected error occurred"
   }
 }

--- a/internal/i18n/locales/en/devices.json
+++ b/internal/i18n/locales/en/devices.json
@@ -37,6 +37,14 @@
       "noMatchTitle": "No Matching Devices",
       "noMatchDescription": "No devices match your current filters. Try adjusting your search.",
       "clearFilters": "Clear Filters"
+    },
+    "bulkActions": {
+      "deleteSelectedButton": "Delete Selected",
+      "clearSelectionButton": "Clear Selection",
+      "confirmDeleteTitle": "Delete Selected Devices",
+      "confirmDeleteMessage_one": "Are you sure you want to delete {{count}} device? This action cannot be undone.",
+      "confirmDeleteMessage_other": "Are you sure you want to delete {{count}} devices? This action cannot be undone.",
+      "confirmDeleteLabel": "Delete All"
     }
   },
   "editor": {

--- a/internal/i18n/locales/es/common.json
+++ b/internal/i18n/locales/es/common.json
@@ -170,5 +170,42 @@
     "actionsHeading": "Acciones",
     "openSettings": "Abrir configuración",
     "openHelp": "Abrir ayuda"
+  },
+  "plurals": {
+    "deviceCount_one": "{{count}} dispositivo",
+    "deviceCount_other": "{{count}} dispositivos",
+    "deviceCountSelected_one": "{{count}} dispositivo seleccionado",
+    "deviceCountSelected_other": "{{count}} dispositivos seleccionados",
+    "logCount_one": "{{count}} registro almacenado",
+    "logCount_other": "{{count}} registros almacenados",
+    "conversationCount_one": "{{count}} conversación",
+    "conversationCount_other": "{{count}} conversaciones",
+    "packetCount_one": "{{count}} paquete",
+    "packetCount_other": "{{count}} paquetes",
+    "itemCount_one": "{{count}} elemento",
+    "itemCount_other": "{{count}} elementos"
+  },
+  "format": {
+    "bytesB": "{{value}} B",
+    "bytesKB": "{{value}} KB",
+    "bytesMB": "{{value}} MB",
+    "bytesGB": "{{value}} GB",
+    "durationLessThanMs": "<1ms",
+    "durationMs": "{{value}} ms",
+    "durationS": "{{value}} s",
+    "durationMin": "{{value}} min",
+    "durationHr": "{{value}} h",
+    "durationMinSec": "{{min}}m {{sec}}s",
+    "uptimeS": "{{value}}s",
+    "uptimeMS": "{{min}}m {{sec}}s",
+    "uptimeHM": "{{hr}}h {{min}}m",
+    "uptimeDH": "{{day}}d {{hr}}h",
+    "relativeJustNow": "ahora mismo",
+    "relativeSecAgo": "hace {{value}}s",
+    "relativeMinAgo": "hace {{value}}m",
+    "relativeHourAgo": "hace {{value}}h",
+    "relativeDayAgo": "hace {{value}}d",
+    "dash": "—",
+    "unexpectedError": "Ocurrió un error inesperado"
   }
 }

--- a/internal/i18n/locales/es/devices.json
+++ b/internal/i18n/locales/es/devices.json
@@ -37,6 +37,14 @@
       "noMatchTitle": "Sin dispositivos coincidentes",
       "noMatchDescription": "Ningún dispositivo coincide con sus filtros actuales. Pruebe a ajustar la búsqueda.",
       "clearFilters": "Borrar filtros"
+    },
+    "bulkActions": {
+      "deleteSelectedButton": "Eliminar seleccionados",
+      "clearSelectionButton": "Borrar selección",
+      "confirmDeleteTitle": "Eliminar dispositivos seleccionados",
+      "confirmDeleteMessage_one": "¿Está seguro de que desea eliminar {{count}} dispositivo? Esta acción no se puede deshacer.",
+      "confirmDeleteMessage_other": "¿Está seguro de que desea eliminar {{count}} dispositivos? Esta acción no se puede deshacer.",
+      "confirmDeleteLabel": "Eliminar todos"
     }
   },
   "editor": {

--- a/ui/src/components/ConversationList.tsx
+++ b/ui/src/components/ConversationList.tsx
@@ -1,4 +1,5 @@
 import { type FC, memo, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { PcapPacket } from '../api/types';
 import { Card, CardContent } from '../ui/Card';
 import { Tag } from '../ui/Tag';
@@ -28,6 +29,7 @@ interface ConversationListProps {
  */
 export const ConversationList: FC<ConversationListProps> = memo(
   ({ packets, onSelectConversation }) => {
+    const { t } = useTranslation('common');
     const [sortField, setSortField] = useState<SortField>('packets');
     const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
@@ -94,7 +96,7 @@ export const ConversationList: FC<ConversationListProps> = memo(
         <CardContent>
           <div className="mb-3 flex items-center justify-between">
             <SmallText className="text-text-muted">
-              {conversations.length} conversation{conversations.length !== 1 ? 's' : ''}
+              {t('plurals.conversationCount', { count: conversations.length })}
             </SmallText>
             <SmallText className="text-text-muted">Click a row to filter packets</SmallText>
           </div>

--- a/ui/src/components/LogFilters.tsx
+++ b/ui/src/components/LogFilters.tsx
@@ -1,5 +1,6 @@
 import { Download, Pause, Play, Search, Trash2 } from 'lucide-react';
 import { type ChangeEvent, type FC, memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { LogLevel, Protocol } from '../api/types';
 import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
@@ -56,6 +57,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
     onExport,
     onClear,
   }) => {
+    const { t } = useTranslation('common');
     const handleLevelChange = (e: ChangeEvent<HTMLSelectElement>) => {
       onLevelChange(e.target.value as LogLevel | 'All');
     };
@@ -152,7 +154,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
 
             {/* Log Count */}
             <SmallText className="text-text-muted">
-              {logCount} log{logCount !== 1 ? 's' : ''} buffered
+              {t('plurals.logCount', { count: logCount })}
             </SmallText>
           </div>
 

--- a/ui/src/components/device-list/DeviceBulkActions.tsx
+++ b/ui/src/components/device-list/DeviceBulkActions.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from 'lucide-react';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '../../ui/Button';
 
 interface DeviceBulkActionsProps {
@@ -13,6 +14,8 @@ export const DeviceBulkActions: FC<DeviceBulkActionsProps> = ({
   onDeleteSelected,
   onClearSelection,
 }) => {
+  const { t: tCommon } = useTranslation('common');
+  const { t: tDevices } = useTranslation('devices');
   if (selectedCount === 0) {
     return null;
   }
@@ -20,8 +23,7 @@ export const DeviceBulkActions: FC<DeviceBulkActionsProps> = ({
   return (
     <div className="flex items-center gap-4 p-3 rounded-lg bg-brand-primary/10 border border-brand-primary/30">
       <span className="text-sm text-brand-accent">
-        {selectedCount} device
-        {selectedCount !== 1 ? 's' : ''} selected
+        {tCommon('plurals.deviceCountSelected', { count: selectedCount })}
       </span>
       <Button
         variant="ghost"
@@ -30,10 +32,10 @@ export const DeviceBulkActions: FC<DeviceBulkActionsProps> = ({
         onClick={onDeleteSelected}
         className="text-status-error hover:text-status-error hover:bg-status-error/20"
       >
-        Delete Selected
+        {tDevices('list.bulkActions.deleteSelectedButton')}
       </Button>
       <Button variant="ghost" size="sm" onClick={onClearSelection}>
-        Clear Selection
+        {tDevices('list.bulkActions.clearSelectionButton')}
       </Button>
     </div>
   );

--- a/ui/src/components/pcap/PcapStats.tsx
+++ b/ui/src/components/pcap/PcapStats.tsx
@@ -6,32 +6,13 @@ import { iconSizes } from '../../constants/sizes';
 import { Card, CardContent } from '../../ui/Card';
 import { Tag } from '../../ui/Tag';
 import { H2, SmallText } from '../../ui/Typography';
-import { formatBytes, formatDurationMs } from '../../utils/format';
+import { formatBytes, formatDurationMs, useFormatTime } from '../../utils/format';
 import { getProtocolColor } from '../../utils/protocol-colors';
 
 interface PcapStatsProps {
   stats: PcapStatsType | null;
   filename: string | null;
   fileSize: number | null;
-}
-
-/**
- * Format timestamp to readable string
- */
-function formatTimestamp(timestamp: string): string {
-  try {
-    const date = new Date(timestamp);
-    return date.toLocaleString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: false,
-    });
-  } catch {
-    return timestamp;
-  }
 }
 
 /**
@@ -190,6 +171,7 @@ TopEndpoints.displayName = 'TopEndpoints';
  */
 export const PcapStats: FC<PcapStatsProps> = memo(({ stats, filename, fileSize }) => {
   const { t } = useTranslation('pages');
+  const formatTimestamp = useFormatTime();
 
   if (!stats) {
     return (

--- a/ui/src/hooks/useLocale.ts
+++ b/ui/src/hooks/useLocale.ts
@@ -1,0 +1,29 @@
+/**
+ * useLocale — single source for the active i18next language code.
+ *
+ * Returns a BCP-47 tag suitable for `Intl.*` constructors. i18next
+ * gives us the short code ('en' / 'es'); we normalise to the regional
+ * tags 'en-US' / 'es-ES' so number/date formatters get a sensible
+ * default (decimal separators, weekday names) without each call site
+ * having to pick.
+ *
+ * Use this whenever you'd otherwise call `Intl.NumberFormat(undefined,
+ * …)` or hardcode `'en-US'`. The hook re-renders consumers when the
+ * user switches language, so date strings flip automatically.
+ *
+ * Lower-level (non-React) code that needs the same value can call
+ * `i18n.language` directly — but prefer the hook in components so
+ * language changes trigger re-renders.
+ */
+
+import { useTranslation } from 'react-i18next';
+
+const REGION_BY_LANGUAGE: Record<string, string> = {
+  en: 'en-US',
+  es: 'es-ES',
+};
+
+export function useLocale(): string {
+  const { i18n } = useTranslation();
+  return REGION_BY_LANGUAGE[i18n.language] ?? i18n.language ?? 'en-US';
+}

--- a/ui/src/pages/DeviceListPage.tsx
+++ b/ui/src/pages/DeviceListPage.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { CloneDeviceModal } from '../components/device-list/CloneDeviceModal';
 import { ConfirmDeleteModal } from '../components/device-list/ConfirmDeleteModal';
@@ -20,6 +21,7 @@ import { Card, CardContent } from '../ui/Card';
 import { ConfirmModal } from '../ui/ConfirmModal';
 
 export const DeviceListPage: FC = () => {
+  const { t } = useTranslation('devices');
   const navigate = useNavigate();
 
   const {
@@ -147,18 +149,9 @@ export const DeviceListPage: FC = () => {
         isOpen={showBulkDeleteConfirm}
         onConfirm={handleBulkDeleteConfirm}
         onCancel={() => setShowBulkDeleteConfirm(false)}
-        title="Delete Selected Devices"
-        message={
-          <>
-            Are you sure you want to delete{' '}
-            <strong>
-              {selectedDevices.size} device
-              {selectedDevices.size !== 1 ? 's' : ''}
-            </strong>
-            ? This action cannot be undone.
-          </>
-        }
-        confirmLabel="Delete All"
+        title={t('list.bulkActions.confirmDeleteTitle')}
+        message={t('list.bulkActions.confirmDeleteMessage', { count: selectedDevices.size })}
+        confirmLabel={t('list.bulkActions.confirmDeleteLabel')}
         confirmTone="red"
       />
     </div>

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -1,41 +1,75 @@
 /**
- * Formatting utility functions
+ * Formatting utilities.
+ *
+ * Two layers:
+ *
+ *   1. Pure functions (formatBytes, formatDurationMs, formatUptime,
+ *      formatRelativeTime, getErrorMessage) — fall back to English
+ *      and the browser-default locale. Safe to call from non-React
+ *      code (utilities, error boundaries, console logs).
+ *
+ *   2. React hooks (useFormatBytes, useFormatNumber, useFormatTime,
+ *      useFormatRelativeTime) — return locale-aware formatters bound
+ *      to the active i18next language and pulling unit suffixes
+ *      from the common.format.* locale keys.
+ *
+ * Prefer the hooks inside components so number/date strings flip
+ * between English and Spanish (and re-render) on language change.
+ * Call sites that need a one-shot format outside a component (e.g.
+ * inside a Zustand store callback) can use the pure functions.
  */
 
-export function formatNumber(value: number): string {
-  return value.toLocaleString();
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocale } from '../hooks/useLocale';
+
+// ---------------------------------------------------------------------------
+// Pure formatters (English fallback)
+// ---------------------------------------------------------------------------
+
+export function formatNumber(value: number, locale?: string): string {
+  return value.toLocaleString(locale);
 }
 
-export function formatTime(value: string): string {
-  return new Date(value).toLocaleString();
+export function formatTime(value: string, locale?: string): string {
+  return new Date(value).toLocaleString(locale);
 }
 
 export function formatDuration(value: string): string {
   return value || '—';
 }
 
-export function formatRelativeTime(timestamp: string): string {
+/**
+ * Relative-time formatter. Uses Intl.RelativeTimeFormat when a locale
+ * is provided so output is fully translated; without a locale, falls
+ * back to terse English (`5s ago`, `2m ago`, …).
+ */
+export function formatRelativeTime(timestamp: string, locale?: string): string {
   if (!timestamp) {
     return '—';
   }
   const diff = Date.now() - new Date(timestamp).getTime();
   if (diff < 0) {
-    return 'just now';
+    return locale
+      ? new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }).format(0, 'second')
+      : 'just now';
   }
   const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) {
-    return `${seconds}s ago`;
+  if (locale && typeof Intl?.RelativeTimeFormat === 'function') {
+    const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+    if (seconds < 60) return rtf.format(-seconds, 'second');
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return rtf.format(-minutes, 'minute');
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return rtf.format(-hours, 'hour');
+    return rtf.format(-Math.floor(hours / 24), 'day');
   }
+  if (seconds < 60) return `${seconds}s ago`;
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) {
-    return `${minutes}m ago`;
-  }
+  if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) {
-    return `${hours}h ago`;
-  }
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
 }
 
 export function formatDurationSeconds(seconds: number): string {
@@ -85,14 +119,101 @@ export function formatUptime(seconds: number): string {
 }
 
 /**
- * Helper function to safely extract error messages
+ * Extract a human-readable error message. Returns translated default
+ * when caller provides one; otherwise English fallback.
  */
-export function getErrorMessage(err: unknown): string {
+export function getErrorMessage(err: unknown, fallback?: string): string {
   if (err instanceof Error) {
     return err.message;
   }
   if (typeof err === 'string') {
     return err;
   }
-  return 'An unexpected error occurred';
+  return fallback ?? 'An unexpected error occurred';
+}
+
+// ---------------------------------------------------------------------------
+// Locale-aware hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * useFormatNumber — Intl.NumberFormat bound to the active locale.
+ * Use for any count/value rendered in JSX so 1,234.56 (en) becomes
+ * 1.234,56 (es) automatically.
+ */
+export function useFormatNumber(): (value: number, options?: Intl.NumberFormatOptions) => string {
+  const locale = useLocale();
+  return useCallback(
+    (value, options) => new Intl.NumberFormat(locale, options).format(value),
+    [locale],
+  );
+}
+
+/**
+ * useFormatTime — Intl.DateTimeFormat bound to the active locale.
+ * Defaults to the long localized form. Pass options to override.
+ */
+export function useFormatTime(
+  defaultOptions: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  },
+): (timestamp: string | number | Date, options?: Intl.DateTimeFormatOptions) => string {
+  const locale = useLocale();
+  return useCallback(
+    (timestamp, options) => {
+      try {
+        const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+        return new Intl.DateTimeFormat(locale, options ?? defaultOptions).format(date);
+      } catch {
+        return String(timestamp);
+      }
+    },
+    [locale, defaultOptions],
+  );
+}
+
+/**
+ * useFormatRelativeTime — Intl.RelativeTimeFormat for "5 minutes ago"
+ * style output keyed off the active locale. ES output uses the proper
+ * "hace 5 min" form.
+ */
+export function useFormatRelativeTime(): (timestamp: string) => string {
+  const locale = useLocale();
+  return useCallback((timestamp) => formatRelativeTime(timestamp, locale), [locale]);
+}
+
+/**
+ * useFormatBytes — locale-aware byte-size formatter.
+ * The number part flips between 1,024 (en) and 1.024 (es) decimal
+ * conventions; the unit suffix (B/KB/MB/GB) is pulled from the
+ * common.format.bytes* locale keys to allow translators to localize
+ * the unit if needed (most ES locales keep B/KB/MB/GB verbatim).
+ */
+export function useFormatBytes(): (size: number) => string {
+  const locale = useLocale();
+  const { t } = useTranslation('common');
+  return useCallback(
+    (size) => {
+      if (!Number.isFinite(size) || size <= 0) {
+        return t('format.bytesB', { value: '0' });
+      }
+      const units = ['bytesB', 'bytesKB', 'bytesMB', 'bytesGB'] as const;
+      let idx = 0;
+      let value = size;
+      while (value >= 1024 && idx < units.length - 1) {
+        value /= 1024;
+        idx++;
+      }
+      const formatted = new Intl.NumberFormat(locale, {
+        maximumFractionDigits: value >= 10 ? 0 : 1,
+      }).format(value);
+      return t(`format.${units[idx]}`, { value: formatted });
+    },
+    [locale, t],
+  );
 }


### PR DESCRIPTION
## Summary

Phase 5 of the cross-repo i18n initiative. Replaces hand-rolled
English pluralization (\`\${n}\${n!==1?'s':''}\`) and hardcoded
\`'en-US'\` formatting with i18next plural keys and Intl.* APIs keyed
off the active language.

**Stacked on PR #717** (Phase 3 NIAC bootstrap + migration). Merge
#717 first.

## What's new

**New utilities:**
- \`hooks/useLocale.ts\` — single source for the active BCP-47 tag.
  Normalises i18next's short codes ('en'/'es') to regional tags
  ('en-US'/'es-ES') so \`Intl.*\` constructors get a sensible default.
- \`utils/format.ts\` — refactored into two layers:
  - Pure functions (\`formatBytes\`, \`formatDurationMs\`,
    \`formatRelativeTime\`, \`getErrorMessage\`) retained for non-React
    call sites.
  - New hooks (\`useFormatNumber\`, \`useFormatTime\`,
    \`useFormatRelativeTime\`, \`useFormatBytes\`) bind to the active
    locale.
  - \`formatRelativeTime\` now uses \`Intl.RelativeTimeFormat\` when a
    locale is passed (proper \"hace 5 min\" in ES vs just \"5m ago\").

**New plural keys** (\`common.plurals.*\`):
- \`deviceCount_one/_other\`, \`deviceCountSelected_one/_other\`
- \`logCount_one/_other\`
- \`conversationCount_one/_other\`
- \`packetCount_one/_other\`
- \`itemCount_one/_other\`

**New format keys** (\`common.format.*\`) — byte/duration/uptime/
relative-time strings, with ES translations of \"ago\" → \"hace …\".

**New \`devices.list.bulkActions.*\` sub-namespace** for the
bulk-delete confirm modal (with \`confirmDeleteMessage_one/_other\`).

## Migrated call sites

4 sites doing manual \`\${n}\${n!==1?'s':''}\`:
- ConversationList.tsx: conversation count
- LogFilters.tsx: log buffer count
- DeviceBulkActions.tsx: selected device count + button labels
- DeviceListPage.tsx: bulk delete confirm modal

1 site with hardcoded \`'en-US'\`:
- PcapStats.tsx — replaced inline \`toLocaleString('en-US', …)\` with
  \`useFormatTime()\` so PCAP timestamps render in active locale.

## Test plan

- [x] \`npx tsc -b --noEmit\` — clean
- [x] \`npx biome check src/\` — clean (7 files touched)
- [x] \`npx vite build\` — succeeds
- [x] \`./scripts/i18n/validate.sh\` strict passes (plural completeness
  check green for all new pairs)
- [ ] Manual smoke (ES):
  \`localStorage.setItem('niac-language','es'); location.reload()\`
  - Dashboard \"5 devices\" → \"5 dispositivos\" (vs \"5 device\" /
    \"1 dispositivo\")
  - Device-list bulk select shows \"3 dispositivos seleccionados\"
  - Bulk-delete confirm shows \"¿Está seguro de que desea eliminar 3
    dispositivos?\" (pluralized)
  - PCAP timestamp shows ES short month/day format
  - Log buffer shows \"127 registros almacenados\"

## Follow-up (not in this PR)

- Migrate seed + stem to the same pattern (Phase 7 cross-repo
  backfill)
- Add i18next-parser as a CI gate to catch unused/missing keys
  (deferred — also Phase 5 work but separate PR; see task #40)