### PR TITLE
feat(i18n): migrate 8 long-tail components to t() (Phase 3 NIAC tail)

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -112,12 +112,28 @@
       "headerMgmtAddr": "Mgmt Addr",
       "headerTtl": "TTL",
       "headerLastSeen": "Last Seen"
+    },
+    "page": {
+      "networkTopologyTitle": "Network Topology",
+      "noTopologyData": "No topology data available"
+    },
+    "legend": {
+      "deviceTypesHeading": "Device Types",
+      "linkSpeedsHeading": "Link Speeds"
+    },
+    "actionsMenu": {
+      "exportPng": "Export as PNG",
+      "exportJson": "Export topology JSON"
     }
   },
   "automation": {
     "label": "Alerts",
     "title": "Alerts",
-    "description": "Configure alert thresholds and webhook targets for the running daemon."
+    "description": "Configure alert thresholds and webhook targets for the running daemon.",
+    "page": {
+      "packetThresholdLabel": "Packet threshold",
+      "webhookUrlLabel": "Webhook URL"
+    }
   },
   "traffic": {
     "label": "Traffic",
@@ -177,6 +193,16 @@
       "headerProtocol": "Protocol",
       "headerLength": "Length",
       "headerInfo": "Info"
+    },
+    "inspector": {
+      "standaloneCapture": "Standalone packet capture",
+      "noInterfaces": "No interfaces detected",
+      "followStreamTitle": "Follow Stream",
+      "noPayload": "No payload data available for this stream",
+      "selectPacketForProtocol": "Select a packet to view protocol layers",
+      "noProtocolLayers": "No protocol layers available",
+      "protocolHeaders": "Protocol Headers",
+      "selectPacketForDetails": "Select a packet to view details"
     }
   },
   "configDiff": {

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -112,12 +112,28 @@
       "headerMgmtAddr": "Dir. gestión",
       "headerTtl": "TTL",
       "headerLastSeen": "Visto por última vez"
+    },
+    "page": {
+      "networkTopologyTitle": "Topología de red",
+      "noTopologyData": "Sin datos de topología disponibles"
+    },
+    "legend": {
+      "deviceTypesHeading": "Tipos de dispositivo",
+      "linkSpeedsHeading": "Velocidades de enlace"
+    },
+    "actionsMenu": {
+      "exportPng": "Exportar como PNG",
+      "exportJson": "Exportar topología JSON"
     }
   },
   "automation": {
     "label": "Alertas",
     "title": "Alertas",
-    "description": "Configure los umbrales de alerta y los destinos de webhook para el daemon en ejecución."
+    "description": "Configure los umbrales de alerta y los destinos de webhook para el daemon en ejecución.",
+    "page": {
+      "packetThresholdLabel": "Umbral de paquetes",
+      "webhookUrlLabel": "URL del webhook"
+    }
   },
   "traffic": {
     "label": "Tráfico",
@@ -177,6 +193,16 @@
       "headerProtocol": "Protocolo",
       "headerLength": "Longitud",
       "headerInfo": "Información"
+    },
+    "inspector": {
+      "standaloneCapture": "Captura de paquetes independiente",
+      "noInterfaces": "No se detectaron interfaces",
+      "followStreamTitle": "Seguir flujo",
+      "noPayload": "No hay datos de carga útil disponibles para este flujo",
+      "selectPacketForProtocol": "Seleccione un paquete para ver las capas de protocolo",
+      "noProtocolLayers": "No hay capas de protocolo disponibles",
+      "protocolHeaders": "Encabezados de protocolo",
+      "selectPacketForDetails": "Seleccione un paquete para ver los detalles"
     }
   },
   "configDiff": {

--- a/ui/src/components/PacketDetails.tsx
+++ b/ui/src/components/PacketDetails.tsx
@@ -1,4 +1,5 @@
 import { type FC, memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Tag } from '../ui/Tag';
 import { SmallText } from '../ui/Typography';
 import { formatBytes } from '../utils/format';
@@ -43,13 +44,16 @@ DetailRow.displayName = 'DetailRow';
  * Headers section for parsed protocol headers
  */
 const HeadersSection = memo(({ headers }: { headers: Record<string, unknown> | undefined }) => {
+  const { t } = useTranslation('pages');
   if (!headers || Object.keys(headers).length === 0) {
     return null;
   }
 
   return (
     <div className="mt-4">
-      <h4 className="text-sm font-semibold text-text-secondary mb-2">Protocol Headers</h4>
+      <h4 className="text-sm font-semibold text-text-secondary mb-2">
+        {t('packets.inspector.protocolHeaders')}
+      </h4>
       <div className="rounded-lg bg-bg-base/50 p-3 border border-surface-border">
         {Object.entries(headers).map(([key, value]) => (
           <DetailRow
@@ -75,10 +79,11 @@ HeadersSection.displayName = 'HeadersSection';
  * - Protocol-specific headers when available
  */
 export const PacketDetails: FC<PacketDetailsProps> = memo(({ packet, onFieldSelect }) => {
+  const { t } = useTranslation('pages');
   if (!packet) {
     return (
       <div className="h-full flex items-center justify-center text-text-muted">
-        <p className="text-sm">Select a packet to view details</p>
+        <p className="text-sm">{t('packets.inspector.selectPacketForDetails')}</p>
       </div>
     );
   }

--- a/ui/src/components/ProtocolTree.tsx
+++ b/ui/src/components/ProtocolTree.tsx
@@ -1,4 +1,5 @@
 import { type FC, memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { PcapPacket } from '../api/types';
 import { buildProtocolLayers } from '../utils/protocol-layers';
 import type { Packet } from './PacketList';
@@ -14,6 +15,7 @@ interface ProtocolTreeProps {
  * layered protocol inspection. Clicking fields with byte offsets highlights the hex dump.
  */
 export const ProtocolTree: FC<ProtocolTreeProps> = memo(({ packet, onFieldSelect }) => {
+  const { t } = useTranslation('pages');
   const layers = useMemo(() => {
     if (!packet) return [];
 
@@ -35,7 +37,7 @@ export const ProtocolTree: FC<ProtocolTreeProps> = memo(({ packet, onFieldSelect
   if (!packet) {
     return (
       <div className="h-full flex items-center justify-center text-text-muted">
-        <p className="text-sm">Select a packet to view protocol layers</p>
+        <p className="text-sm">{t('packets.inspector.selectPacketForProtocol')}</p>
       </div>
     );
   }
@@ -43,7 +45,7 @@ export const ProtocolTree: FC<ProtocolTreeProps> = memo(({ packet, onFieldSelect
   if (layers.length === 0) {
     return (
       <div className="h-full flex items-center justify-center text-text-muted">
-        <p className="text-sm">No protocol layers available</p>
+        <p className="text-sm">{t('packets.inspector.noProtocolLayers')}</p>
       </div>
     );
   }

--- a/ui/src/components/StreamView.tsx
+++ b/ui/src/components/StreamView.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react';
 import { type FC, memo, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { PcapPacket } from '../api/types';
 import { Button } from '../ui/Button';
 import { SmallText } from '../ui/Typography';
@@ -67,6 +68,7 @@ interface StreamSegment {
  * - Packet-by-packet segmentation
  */
 export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, onClose }) => {
+  const { t } = useTranslation('pages');
   const [displayMode, setDisplayMode] = useState<DisplayMode>('ascii');
 
   const segments = useMemo<StreamSegment[]>(() => {
@@ -95,7 +97,9 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-surface-border">
           <div>
-            <h3 className="text-lg font-semibold text-text-primary">Follow Stream</h3>
+            <h3 className="text-lg font-semibold text-text-primary">
+              {t('packets.inspector.followStreamTitle')}
+            </h3>
             <SmallText className="text-text-muted">
               {packets.length} packets |{' '}
               <span className="text-status-info">{totalClientBytes} B client</span> /{' '}
@@ -143,7 +147,7 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
         <div className="flex-1 overflow-y-auto px-5 py-4">
           {segments.length === 0 ? (
             <div className="text-center py-8 text-text-muted">
-              <p>No payload data available for this stream</p>
+              <p>{t('packets.inspector.noPayload')}</p>
             </div>
           ) : (
             <div className="space-y-1 font-mono text-xs">

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -1,5 +1,6 @@
 import { BellRing } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { fetchAlerts, fetchStats, updateAlerts } from '../api/client';
 import type { AlertConfig } from '../api/types';
 import { iconSizes } from '../constants/sizes';
@@ -29,6 +30,7 @@ export const AutomationPage: FC = () => {
  * Alert Config Card - Configure alert thresholds and webhooks
  */
 const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
+  const { t } = useTranslation('pages');
   const { data, loading, error } = useApiResource(fetchAlerts, [], {
     intervalMs: 15000,
   });
@@ -112,7 +114,9 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
           <>
             <div className="grid gap-4 md:grid-cols-2">
               <div>
-                <SmallText className="text-text-muted">Packet threshold</SmallText>
+                <SmallText className="text-text-muted">
+                  {t('automation.page.packetThresholdLabel')}
+                </SmallText>
                 <input
                   className="mt-1 w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
                   type="number"
@@ -128,7 +132,9 @@ const AlertConfigCard: FC<{ recentErrors: number }> = ({ recentErrors }) => {
                 />
               </div>
               <div>
-                <SmallText className="text-text-muted">Webhook URL</SmallText>
+                <SmallText className="text-text-muted">
+                  {t('automation.page.webhookUrlLabel')}
+                </SmallText>
                 <input
                   className="mt-1 w-full rounded-lg border border-surface-border bg-bg-base/60 p-2 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
                   placeholder="https://hooks.example.com/niac"

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -12,6 +12,7 @@ import {
   WifiOff,
 } from 'lucide-react';
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
   fetchCaptureStatus,
@@ -547,6 +548,7 @@ const StandaloneCaptureStarter: FC<{
   onStarted: () => void;
   navigateToSim: () => void;
 }> = ({ onStarted, navigateToSim }) => {
+  const { t } = useTranslation('pages');
   const { data: interfacesResp } = useApiResource(fetchUsableInterfaces, []);
   const interfaces = interfacesResp?.interfaces ?? [];
   const [selectedIface, setSelectedIface] = useState('');
@@ -585,7 +587,9 @@ const StandaloneCaptureStarter: FC<{
         <div className="flex items-start gap-3">
           <Activity className={`mt-1 ${iconSizes.lg} text-brand-accent`} />
           <div className="flex-1">
-            <p className="font-semibold text-text-primary">Standalone packet capture</p>
+            <p className="font-semibold text-text-primary">
+              {t('packets.inspector.standaloneCapture')}
+            </p>
             <SmallText className="text-text-muted">
               Sniff an interface without starting a simulation. Frames stream into the viewer below
               as soon as they hit the wire. Or{' '}
@@ -610,7 +614,7 @@ const StandaloneCaptureStarter: FC<{
               className="rounded-lg border border-surface-border bg-bg-base/60 px-3 py-2 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
             >
               {interfaces.length === 0 ? (
-                <option value="">No interfaces detected</option>
+                <option value="">{t('packets.inspector.noInterfaces')}</option>
               ) : (
                 interfaces.map((iface) => (
                   <option key={iface.name} value={iface.name}>

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -13,6 +13,7 @@ import {
   useNodesState,
 } from '@xyflow/react';
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import '@xyflow/react/dist/style.css';
 import { Network, Radar, RefreshCw } from 'lucide-react';
@@ -70,6 +71,7 @@ const edgeTypes: EdgeTypes = {
  * legend / minimap / selected device, and the export action.
  */
 export const TopologyPage: FC = () => {
+  const { t } = useTranslation('pages');
   const navigate = useNavigate();
 
   // Fetch topology data from the API with periodic polling
@@ -555,7 +557,7 @@ export const TopologyPage: FC = () => {
                 <Network className="w-6 h-6 text-status-info" />
               </div>
               <div>
-                <H2>Network Topology</H2>
+                <H2>{t('topology.page.networkTopologyTitle')}</H2>
                 <SmallText className="text-text-muted">
                   {devices?.length || 0} {devices?.length === 1 ? 'device' : 'devices'} |{' '}
                   {topology?.links?.length || 0}{' '}
@@ -753,7 +755,7 @@ export const TopologyPage: FC = () => {
               <div className="absolute inset-0 flex items-center justify-center">
                 <div className="text-center">
                   <Network className="w-16 h-16 text-text-disabled mx-auto mb-4" />
-                  <p className="text-text-muted mb-2">No topology data available</p>
+                  <p className="text-text-muted mb-2">{t('topology.page.noTopologyData')}</p>
                   <SmallText className="text-text-muted">
                     Configure devices with trunk ports or port-channels to visualize connections
                   </SmallText>

--- a/ui/src/pages/topology/ActionsMenu.tsx
+++ b/ui/src/pages/topology/ActionsMenu.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, Download } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '../../ui/Button';
 
 /**
@@ -20,6 +21,7 @@ export const ActionsMenu: FC<{
   onExportPNG: () => void;
   onExportJSON: () => void;
 }> = ({ disabled, onExportPNG, onExportJSON }) => {
+  const { t } = useTranslation('pages');
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -69,7 +71,7 @@ export const ActionsMenu: FC<{
             onClick={handle(onExportPNG)}
             className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-surface-hover hover:text-text-primary"
           >
-            <span>Export as PNG</span>
+            <span>{t('topology.actionsMenu.exportPng')}</span>
             <span className="text-[10px] text-text-muted">image</span>
           </button>
           <button
@@ -78,7 +80,7 @@ export const ActionsMenu: FC<{
             onClick={handle(onExportJSON)}
             className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-surface-hover hover:text-text-primary"
           >
-            <span>Export topology JSON</span>
+            <span>{t('topology.actionsMenu.exportJson')}</span>
             <span className="text-[10px] text-text-muted">data</span>
           </button>
         </div>

--- a/ui/src/pages/topology/TopologyLegend.tsx
+++ b/ui/src/pages/topology/TopologyLegend.tsx
@@ -7,6 +7,7 @@
 
 import { Eye, EyeOff, Network } from 'lucide-react';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   topologyDeviceColors as deviceColors,
   topologyDeviceIcons as deviceIcons,
@@ -22,6 +23,7 @@ interface TopologyLegendProps {
  * Can be collapsed to save space on the canvas.
  */
 export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
+  const { t } = useTranslation('pages');
   if (!show) {
     return (
       <button
@@ -51,7 +53,9 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
       <div className="space-y-4">
         {/* Device Types */}
         <div>
-          <div className="text-xs text-text-muted uppercase tracking-wide mb-2">Device Types</div>
+          <div className="text-xs text-text-muted uppercase tracking-wide mb-2">
+            {t('topology.legend.deviceTypesHeading')}
+          </div>
           <div className="space-y-1.5">
             {[
               { type: 'router', label: 'Router' },
@@ -81,7 +85,9 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
 
         {/* Link Speeds */}
         <div>
-          <div className="text-xs text-text-muted uppercase tracking-wide mb-2">Link Speeds</div>
+          <div className="text-xs text-text-muted uppercase tracking-wide mb-2">
+            {t('topology.legend.linkSpeedsHeading')}
+          </div>
           <div className="space-y-1.5">
             {[
               { label: '100M', color: 'var(--color-link-100m)' },


### PR DESCRIPTION
## Summary

Phase 3 NIAC long-tail (task #43). 8 components each had 1-2
hardcoded JSX strings flagged by the validator's warn-only
heuristic; bundled into one PR since they all extend the existing
\`pages.*\` namespace.

## New keys

Under \`pages.{topology,packets,automation}.*\`:
- \`topology.page.{networkTopologyTitle, noTopologyData}\`
- \`topology.legend.{deviceTypesHeading, linkSpeedsHeading}\`
- \`topology.actionsMenu.{exportPng, exportJson}\`
- \`packets.inspector.{standaloneCapture, noInterfaces,
  followStreamTitle, noPayload, selectPacketForProtocol,
  noProtocolLayers, protocolHeaders, selectPacketForDetails}\`
- \`automation.page.{packetThresholdLabel, webhookUrlLabel}\`

## Migrated

| File | Strings |
|------|---------|
| TopologyPage.tsx | 2 (H2 + empty state) |
| TopologyLegend.tsx | 2 (Device Types / Link Speeds headings) |
| ActionsMenu.tsx | 2 (Export PNG / JSON menu items) |
| PacketInspectorPage.tsx / StandaloneCaptureStarter | 2 (standalone capture intro + no-interfaces option) |
| AutomationPage.tsx / AlertConfigCard | 2 (packet threshold + webhook URL field labels) |
| StreamView.tsx | 2 (Follow Stream header + no-payload empty state) |
| ProtocolTree.tsx | 2 (packet-select prompt + no-layers empty state) |
| PacketDetails.tsx / HeadersSection | 2 (Protocol Headers heading + packet-select prompt) |

## Test plan

- [x] \`npx tsc -b --noEmit\` — clean
- [x] \`npx biome check --write\` — auto-fixed 5 files (formatting)
- [x] \`./scripts/i18n/validate.sh\` strict passes; JSX heuristic
  count drops by 16
- [ ] Manual smoke: open Topology page, toggle legend, use Export
  menu; open Packets page, start standalone capture, select a
  packet to see details/protocol tree; open Alerts page to see
  field labels. Confirm ES rendering for all when language switched.

## Remaining heuristic flags

The 15 \`help:\` JSX prose blocks inside \`pageRegistry.tsx\` are
deliberately left for Phase 7 follow-up work (they need their own
\`help.pages.*\` namespace structure to handle the multi-paragraph
prose with \`<strong>\`/\`<code>\`/\`<ul>\` markup via i18next \`<Trans>\`
component). Tracked separately.