### PR TITLE
feat(api): add strict JSON decode helpers + sweep handlers (#718)

### DIFF
--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -17,31 +16,8 @@ func (s *Server) handleAlerts(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		s.writeJSON(w, s.getAlertConfig())
 	case http.MethodPut, http.MethodPost:
-		// SECURITY FIX MEDIUM-3: Add request body size limit
-		r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 		var req AlertConfig
-		err := json.NewDecoder(r.Body).Decode(&req)
-		if err != nil {
-			if err.Error() == ErrMsgRequestBodyTooLarge {
-				writeError(
-					w,
-					r,
-					http.StatusRequestEntityTooLarge,
-					"request_too_large",
-					fmt.Sprintf(
-						"Request body exceeds maximum size of %d bytes",
-						MaxRequestBodySize,
-					),
-					nil,
-				)
-
-				return
-			}
-
-			writeError(w, r, http.StatusBadRequest, "invalid_request",
-				"Failed to parse request body", nil)
-
+		if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 			return
 		}
 

--- a/internal/api/capture_filter.go
+++ b/internal/api/capture_filter.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 )
 
@@ -56,13 +55,8 @@ func (s *Server) handleCaptureFilterSet(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req CaptureFilterRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request",
-			"Failed to parse request body", nil)
-
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 

--- a/internal/api/config_ops.go
+++ b/internal/api/config_ops.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -60,11 +59,8 @@ func (s *Server) handleConfigMerge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
 	var req MergeConfigsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request",
-			fmt.Sprintf("Invalid request body: %v", err), nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 	if strings.TrimSpace(req.Base) == "" {
@@ -140,11 +136,8 @@ func (s *Server) handleConfigImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
 	var req ConfigImportRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request",
-			fmt.Sprintf("Invalid request body: %v", err), nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 	if strings.TrimSpace(req.Content) == "" {

--- a/internal/api/configs.go
+++ b/internal/api/configs.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -222,17 +221,8 @@ func findUserConfig(name string) string {
 
 // handleUserConfigUpload handles POST /api/v1/configs (upload new config).
 func (s *Server) handleUserConfigUpload(w http.ResponseWriter, r *http.Request) {
-	// Enforce request body size limit
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req UploadConfigRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		if err.Error() == ErrMsgRequestBodyTooLarge {
-			writeError(w, r, http.StatusRequestEntityTooLarge, "request_too_large",
-				"Config file too large", nil)
-			return
-		}
-		writeError(w, r, http.StatusBadRequest, "invalid_request", "Invalid JSON body", nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 

--- a/internal/api/decode.go
+++ b/internal/api/decode.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+)
+
+// decodeJSONStrict reads and validates JSON from r.Body into dst. It applies
+// [http.MaxBytesReader] to cap memory, DisallowUnknownFields to reject typoed
+// keys, and rejects trailing data after the JSON object.
+//
+// On any decode failure it writes a structured error response via writeError
+// (413 for oversized bodies, 400 for everything else) and returns false; the
+// caller should return immediately. On success it returns true and dst is
+// populated.
+//
+// Pass maxSize as a per-call-site limit. Most handlers should pass
+// MaxRequestBodySize; specialized endpoints (e.g., bulk-import) may want a
+// larger cap. Never pass a magic number.
+//
+// Mirrors the pattern in seed/internal/api/decode.go and
+// stem/internal/api/decode.go (Zod-replacement parity issue #718).
+func decodeJSONStrict(w http.ResponseWriter, r *http.Request, dst any, maxSize int64) bool {
+	return decodeJSONStrictWith(w, r, dst, maxSize)
+}
+
+// decodeJSONStrictWith is the variant of decodeJSONStrict that carries extra
+// structured log fields into the WARN line on decode failure. Use for handlers
+// where preserving an audit-log breadcrumb matters (e.g., client_ip, device_id,
+// session_id).
+func decodeJSONStrictWith(
+	w http.ResponseWriter,
+	r *http.Request,
+	dst any,
+	maxSize int64,
+	extraAttrs ...any,
+) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	logger := slog.Default()
+
+	if err := decoder.Decode(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			attrs := append([]any{"max_size", maxSize}, extraAttrs...)
+			logger.WarnContext(r.Context(), "Request body too large", attrs...)
+			writeError(w, r, http.StatusRequestEntityTooLarge,
+				"request_too_large", "Request body exceeds size limit", nil)
+			return false
+		}
+		attrs := append([]any{"error", err}, extraAttrs...)
+		logger.WarnContext(r.Context(), "Invalid request body", attrs...)
+		// Don't leak json parser internals to clients.
+		writeError(w, r, http.StatusBadRequest,
+			"invalid_request", "Invalid JSON in request body", nil)
+		return false
+	}
+
+	// Reject "smuggled" data after the top-level JSON object — multiple
+	// concatenated payloads, trailing garbage, etc.
+	if decoder.More() {
+		logger.WarnContext(r.Context(), "Unexpected trailing data after JSON object", extraAttrs...)
+		writeError(w, r, http.StatusBadRequest,
+			"invalid_request", "Unexpected trailing data after JSON object", nil)
+		return false
+	}
+
+	return true
+}

--- a/internal/api/decode_internal_test.go
+++ b/internal/api/decode_internal_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type decodeFixture struct {
+	Name string `json:"name"`
+	Port int    `json:"port"`
+}
+
+func newDecodeRequest(body string) *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+}
+
+func TestDecodeJSONStrict_ValidJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"alpha","port":8080}`)
+	var dst decodeFixture
+
+	if !decodeJSONStrict(w, r, &dst, MaxRequestBodySize) {
+		t.Fatalf("expected success, got %d: %s", w.Code, w.Body.String())
+	}
+	if dst.Name != "alpha" || dst.Port != 8080 {
+		t.Errorf("unexpected decode: %+v", dst)
+	}
+}
+
+func TestDecodeJSONStrict_RejectsUnknownField(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"alpha","port":8080,"extra":"oops"}`)
+	var dst decodeFixture
+
+	if decodeJSONStrict(w, r, &dst, MaxRequestBodySize) {
+		t.Fatal("expected failure for unknown field")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDecodeJSONStrict_RejectsMalformedJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":}`)
+	var dst decodeFixture
+
+	if decodeJSONStrict(w, r, &dst, MaxRequestBodySize) {
+		t.Fatal("expected failure for malformed JSON")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDecodeJSONStrict_RejectsOversizedBody(t *testing.T) {
+	big := strings.Repeat("x", 100)
+	body := `{"name":"` + big + `","port":1}`
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(body)
+	var dst decodeFixture
+
+	if decodeJSONStrict(w, r, &dst, 50) {
+		t.Fatal("expected failure for oversized body")
+	}
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413, got %d", w.Code)
+	}
+}
+
+func TestDecodeJSONStrict_RejectsTrailingData(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"a","port":1}{"name":"b","port":2}`)
+	var dst decodeFixture
+
+	if decodeJSONStrict(w, r, &dst, MaxRequestBodySize) {
+		t.Fatal("expected failure for trailing data")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "trailing") {
+		t.Errorf("response should mention trailing data: %s", w.Body.String())
+	}
+}
+
+func TestDecodeJSONStrict_RejectsEmptyBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(``)
+	var dst decodeFixture
+
+	if decodeJSONStrict(w, r, &dst, MaxRequestBodySize) {
+		t.Fatal("expected failure for empty body")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDecodeJSONStrict_ResponseIsValidJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`not json`)
+	var dst decodeFixture
+
+	_ = decodeJSONStrict(w, r, &dst, MaxRequestBodySize)
+	var envelope map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("error response is not valid JSON: %v\n  body: %s", err, w.Body.String())
+	}
+	if envelope["error"] != "invalid_request" {
+		t.Errorf("expected error=invalid_request, got %v", envelope["error"])
+	}
+}
+
+func TestDecodeJSONStrictWith_ExtraAttrsCarried(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := newDecodeRequest(`{"name":"alpha","port":8080}`)
+	var dst decodeFixture
+
+	if !decodeJSONStrictWith(w, r, &dst, MaxRequestBodySize, "client_ip", "127.0.0.1") {
+		t.Fatalf("expected success, got %d: %s", w.Code, w.Body.String())
+	}
+	if dst.Name != "alpha" {
+		t.Errorf("unexpected decode: %+v", dst)
+	}
+}

--- a/internal/api/devices.go
+++ b/internal/api/devices.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -111,11 +110,8 @@ func (s *Server) handleDeviceGet(w http.ResponseWriter, r *http.Request, hostnam
 
 // handleDeviceCreate creates a new device.
 func (s *Server) handleDeviceCreate(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req DeviceCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request", "Failed to parse request", nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 
@@ -145,11 +141,8 @@ func (s *Server) handleDeviceCreate(w http.ResponseWriter, r *http.Request) {
 // validateDeviceCreatePreconditions checks config and device limits.
 
 func (s *Server) handleDeviceUpdate(w http.ResponseWriter, r *http.Request, hostname string) {
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req DeviceUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request", "Failed to parse request", nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 
@@ -264,13 +257,8 @@ func (s *Server) handleDeviceDelete(w http.ResponseWriter, r *http.Request, host
 
 // handleDeviceClone clones an existing device.
 func (s *Server) handleDeviceClone(w http.ResponseWriter, r *http.Request, hostname string) {
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req DeviceCloneRequest
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request", "Failed to parse request", nil)
-
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 
@@ -333,8 +321,7 @@ func (s *Server) handleDeviceClone(w http.ResponseWriter, r *http.Request, hostn
 	newCfg := *deepCopyConfig(cfg)
 	newCfg.Devices = append(newCfg.Devices, *clonedDevice)
 
-	err = s.saveConfig(&newCfg)
-	if err != nil {
+	if err := s.saveConfig(&newCfg); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "save_failed", "Failed to save configuration", nil)
 
 		return

--- a/internal/api/handlers_capture.go
+++ b/internal/api/handlers_capture.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 )
@@ -71,12 +70,8 @@ func (s *Server) handleStandaloneCapture(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleStandaloneCaptureStart(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req CaptureRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request",
-			"Failed to parse capture request body", nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 

--- a/internal/api/handlers_errors.go
+++ b/internal/api/handlers_errors.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 
 	apperr "github.com/krisarmstrong/niac-go/internal/apperr"
@@ -101,20 +100,8 @@ func (s *Server) handleErrorInjection(
 	r *http.Request,
 	errorMgr *apperr.StateManager,
 ) {
-	// SECURITY FIX #111: Enforce request body size limit
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req errorInjectionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		// SECURITY FIX MEDIUM-6: Don't expose internal error details
-		writeError(
-			w,
-			r,
-			http.StatusBadRequest,
-			"invalid_request",
-			"Failed to parse request body",
-			nil,
-		)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 

--- a/internal/api/handlers_library.go
+++ b/internal/api/handlers_library.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"io"
 	"io/fs"
@@ -100,10 +99,8 @@ type libraryNetworkUploadRequest struct {
 }
 
 func (s *Server) handleLibraryNetworkUpload(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
 	var req libraryNetworkUploadRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request", "Invalid JSON body", nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 	if err := s.library.WriteNetwork(req.Name, req.Content); err != nil {

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -229,13 +228,7 @@ func (s *Server) parseConfigUpdateRequest(w http.ResponseWriter, r *http.Request
 	var req struct {
 		Content string `json:"content"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		if err.Error() == ErrMsgRequestBodyTooLarge {
-			writeError(w, r, http.StatusRequestEntityTooLarge, "request_too_large",
-				fmt.Sprintf("Request body exceeds maximum size of %d bytes", MaxRequestBodySize), nil)
-		} else {
-			writeError(w, r, http.StatusBadRequest, "invalid_request", "Failed to parse request body", nil)
-		}
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return "", false
 	}
 	if strings.TrimSpace(req.Content) == "" {
@@ -303,20 +296,8 @@ func (s *Server) handleReplay(w http.ResponseWriter, r *http.Request) {
 		s.writeJSON(w, s.cfg.Replay.Status())
 	case http.MethodPost:
 		// SECURITY FIX #97: Enforce request body size limit for PCAP uploads
-		r.Body = http.MaxBytesReader(w, r.Body, MaxPCAPUploadSize)
-
 		var req ReplayRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			if err.Error() == ErrMsgRequestBodyTooLarge {
-				writeError(w, r, http.StatusRequestEntityTooLarge, "request_too_large",
-					"PCAP file too large (max 100MB)", nil)
-
-				return
-			}
-
-			writeError(w, r, http.StatusBadRequest, "invalid_request",
-				"Failed to parse request body", nil)
-
+		if !decodeJSONStrict(w, r, &req, MaxPCAPUploadSize) {
 			return
 		}
 

--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -31,17 +29,8 @@ func (s *Server) handleSimulation(w http.ResponseWriter, r *http.Request) {
 
 // handleSimulationStart processes POST requests to start a simulation.
 func (s *Server) handleSimulationStart(w http.ResponseWriter, r *http.Request) {
-	// SECURITY FIX MEDIUM-3: Request body size limit
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-
 	var req SimulationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		if err.Error() == ErrMsgRequestBodyTooLarge {
-			writeError(w, r, http.StatusRequestEntityTooLarge, "request_too_large",
-				fmt.Sprintf("Request body exceeds maximum size of %d bytes", MaxRequestBodySize), nil)
-			return
-		}
-		writeError(w, r, http.StatusBadRequest, "invalid_request", "Failed to parse request body", nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 

--- a/internal/api/handlers_synthesize_walk.go
+++ b/internal/api/handlers_synthesize_walk.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -111,10 +110,8 @@ func (s *Server) handleSynthesizeWalk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
 	var req SynthesizeWalkRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request", "Invalid JSON body", nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 

--- a/internal/api/pcap.go
+++ b/internal/api/pcap.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -264,14 +263,7 @@ func (c *pcapCache) EntryCount() int {
 // Returns the raw PCAP bytes, the parsed request, and true on success.
 func decodePcapUpload(w http.ResponseWriter, r *http.Request) ([]byte, PcapUploadRequest, bool) {
 	var req PcapUploadRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		if err.Error() == ErrMsgRequestBodyTooLarge {
-			writeError(w, r, http.StatusRequestEntityTooLarge, "request_too_large",
-				"PCAP file too large (max 100MB)", nil)
-			return nil, req, false
-		}
-		writeError(w, r, http.StatusBadRequest, "invalid_request",
-			"Invalid JSON request body", nil)
+	if !decodeJSONStrict(w, r, &req, MaxPCAPUploadSize) {
 		return nil, req, false
 	}
 
@@ -318,9 +310,6 @@ func (s *Server) handlePcapUpload(w http.ResponseWriter, r *http.Request) {
 			"Only POST method is allowed", nil)
 		return
 	}
-
-	// Limit request size
-	r.Body = http.MaxBytesReader(w, r.Body, MaxPCAPUploadSize)
 
 	pcapData, req, ok := decodePcapUpload(w, r)
 	if !ok {

--- a/internal/api/walk.go
+++ b/internal/api/walk.go
@@ -232,11 +232,9 @@ func (s *Server) handleWalkValidation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	isAutoFix := strings.HasSuffix(r.URL.Path, "/fix")
-	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
 
 	var req WalkValidationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_request", fmt.Sprintf("Invalid request body: %v", err), nil)
+	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
 


### PR DESCRIPTION
Closes the non-library portion of the Zod-replacement parity gap with
seed/stem. The frontend-library choice (zod vs valibot) is being tracked
separately in seed#1199 — niac stays on zod 4.4.3 for now.

Add internal/api/decode.go with:

- decodeJSONStrict(w, r, dst, maxSize) bool — strict JSON decode with
  http.MaxBytesReader caps memory, DisallowUnknownFields rejects typoed
  keys, decoder.More() rejects trailing data (anti-smuggling).
- decodeJSONStrictWith(..., extraAttrs...) — variant carrying extra
  structured log fields into the WARN line on decode failure. Mirrors
  seed's decodeJSONStrictLocalizedWith pattern; niac's API layer
  doesn't carry a localizer, so the localized variants don't apply.

Sweep 13 ad-hoc decode call sites across the api package:

  alerts.go, capture_filter.go, config_ops.go (x2), configs.go,
  devices.go (x3), handlers_capture.go, handlers_errors.go,
  handlers_library.go, handlers_read.go (x2), handlers_simulation.go,
  handlers_synthesize_walk.go, pcap.go, walk.go

All previously did some combination of (sometimes) MaxBytesReader +
json.NewDecoder + string-match against ErrMsgRequestBodyTooLarge to
detect oversize. None applied DisallowUnknownFields, none checked
decoder.More() — both real gaps the helper now closes uniformly.

decode_internal_test.go covers: valid JSON, unknown fields, malformed
JSON, oversized body, trailing data, empty body, JSON-valid error
envelope shape, and the With() variant.

Intentionally not converted:
- templates.go parseUseTemplateRequest returns (req, error) rather
  than writing to w — different contract; leave for a follow-up.

Refs #718, refs seed#1199
