### PR TITLE
chore(i18n): sync check_key_usage ratchet + bash 3.2 fix with stem/seed

### DIFF
--- a/scripts/i18n/check-keys.py
+++ b/scripts/i18n/check-keys.py
@@ -211,14 +211,17 @@ def main() -> int:
             unused.append((ns, k))
 
     # Report.
+    ratchet = "--ratchet" in sys.argv
     code = 0
     if missing:
-        print(f"::error::{len(missing)} t() call(s) reference keys missing from EN locale:")
+        level = "warning" if ratchet else "error"
+        print(f"::{level}::{len(missing)} t() call(s) reference keys missing from EN locale:")
         for ns, key, line, file in sorted(missing)[:30]:
             print(f"  {file}:{line}: t('{ns}:{key}') — not in {ns}.json")
         if len(missing) > 30:
             print(f"  … and {len(missing) - 30} more")
-        code = 1
+        if not ratchet:
+            code = 1
     else:
         print("✓ every t() call has a matching EN locale key")
 

--- a/scripts/i18n/validate.sh
+++ b/scripts/i18n/validate.sh
@@ -389,15 +389,21 @@ check_key_usage() {
   section "t() call ↔ EN locale key cross-reference"
   local script="scripts/i18n/check-keys.py"
   if [ ! -f "$script" ]; then
-    warn "$script not found; skipping (only NIAC ships check-keys.py today)"
+    warn "$script not found; skipping (run on repos that ship check-keys.py)"
     return
   fi
   if ! command -v python3 >/dev/null 2>&1; then
     warn "python3 not found; skipping check-keys.py"
     return
   fi
+  # Propagate --ratchet so newly-added repos can absorb check-keys.py
+  # without an immediate cleanup burden. Use a plain string instead of
+  # an array because bash 3.2 (macOS default) errors on `${empty[@]}`
+  # under `set -u`.
+  local extra=""
+  [ "$RATCHET" -eq 1 ] && extra="--ratchet"
   local out
-  if ! out=$(python3 "$script" 2>&1); then
+  if ! out=$(python3 "$script" $extra 2>&1); then
     fail "check-keys.py found t() calls referencing missing keys:"
     echo "$out" | head -40 | sed 's/^/      /'
     return
@@ -409,7 +415,7 @@ check_key_usage() {
     wcount=$(echo "$out" | grep -c "^  [^✓]" || echo 0)
     warn "$wcount unused EN locale key(s) (informational; not failing — too noisy until catch-up)"
   fi
-  ok "every t() call resolves to an EN locale key"
+  ok "every t() call resolves to an EN locale key (or all errors demoted under --ratchet)"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Brings niac's validator into symmetry with the patterns landed in
stem#327 and seed#1203. Two changes:

1. **check-keys.py**: add \`--ratchet\` flag that demotes the
   missing-keys error to a warning. Useful when porting to a new
   repo with a backlog of pre-existing t() typos. Niac has 0 missing
   keys today, so \`--ratchet\` is a no-op here — added for
   cross-repo symmetry only.

2. **validate.sh \`check_key_usage\`**: propagate \`--ratchet\` from
   validate.sh to check-keys.py via \`local extra=""\` instead of
   \`local args=()\`. Bash 3.2 (macOS default) errors on
   \`\\\${empty[@]}\` under \`set -u\`; the plain-string form works on
   both bash 3.2 and 5.x.

Also updates the "only NIAC ships check-keys.py today" comment
that's no longer accurate — both stem (#327) and seed (#1203) ship
it now.

## Behavior change

- CI: none (Linux bash 5.x handles either form).
- Local dev on macOS: \`./scripts/i18n/validate.sh --ratchet\` now
  works correctly instead of silently passing \`--ratchet\`
  incorrectly through the broken array expansion.

## Test plan

- [x] \`./scripts/i18n/validate.sh\` (strict) — OK with 2 warnings
- [x] \`./scripts/i18n/validate.sh --ratchet\` — OK with 2 warnings