### PR TITLE
feat(forms): migrate UploadTemplateModal + ErrorInjectionPanel (#730)

### DIFF
--- a/ui/src/components/ErrorInjectionPanel.tsx
+++ b/ui/src/components/ErrorInjectionPanel.tsx
@@ -1,4 +1,6 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { type FC, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import {
   clearAllErrors,
@@ -9,6 +11,7 @@ import {
 } from '../api/client';
 import type { ErrorType } from '../api/types';
 import { useApiResource } from '../hooks/useApiResource';
+import { type ErrorInjectionFormFields, ErrorInjectionSchema } from '../schemas/forms';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { ConfirmModal } from '../ui/ConfirmModal';
@@ -23,11 +26,25 @@ export const ErrorInjectionPanel: FC = () => {
     intervalMs: 5000,
   });
 
-  const [selectedDevice, setSelectedDevice] = useState('');
-  const [selectedInterface, setSelectedInterface] = useState('');
-  const [selectedErrorType, setSelectedErrorType] = useState('');
-  const [errorValue, setErrorValue] = useState(50);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<ErrorInjectionFormFields>({
+    resolver: zodResolver(ErrorInjectionSchema),
+    defaultValues: {
+      selectedDevice: '',
+      selectedInterface: '',
+      selectedErrorType: '',
+      errorValue: 50,
+    },
+    mode: 'onBlur',
+  });
+  const selectedErrorType = watch('selectedErrorType');
+  const errorValue = watch('errorValue');
+
+  const [clearingBusy, setClearingBusy] = useState(false);
   const [message, setMessage] = useState<{
     type: 'success' | 'error';
     text: string;
@@ -39,24 +56,14 @@ export const ErrorInjectionPanel: FC = () => {
     Record<string, Record<string, number>>,
   ][];
 
-  const handleInject = async () => {
-    if (!(selectedDevice && selectedInterface && selectedErrorType)) {
-      setMessage({
-        type: 'error',
-        text: t('injection.selectMissing'),
-      });
-      return;
-    }
-
-    setIsSubmitting(true);
+  const onInject: SubmitHandler<ErrorInjectionFormFields> = async (values) => {
     setMessage(null);
-
     try {
       await injectError({
-        deviceIp: selectedDevice,
-        interface: selectedInterface,
-        errorType: selectedErrorType,
-        value: errorValue,
+        deviceIp: values.selectedDevice,
+        interface: values.selectedInterface,
+        errorType: values.selectedErrorType,
+        value: values.errorValue,
       });
       setMessage({ type: 'success', text: t('injection.injectSuccess') });
       refetchErrors();
@@ -65,14 +72,12 @@ export const ErrorInjectionPanel: FC = () => {
         type: 'error',
         text: getErrorMessage(err) || t('injection.injectFailed'),
       });
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
   const handleClearAllConfirm = async () => {
     setShowClearAllConfirm(false);
-    setIsSubmitting(true);
+    setClearingBusy(true);
     try {
       await clearAllErrors();
       setMessage({ type: 'success', text: t('injection.clearAllSuccess') });
@@ -83,12 +88,12 @@ export const ErrorInjectionPanel: FC = () => {
         text: getErrorMessage(err) || t('injection.clearAllFailed'),
       });
     } finally {
-      setIsSubmitting(false);
+      setClearingBusy(false);
     }
   };
 
   const handleClearSpecific = async (deviceIp: string, iface: string) => {
-    setIsSubmitting(true);
+    setClearingBusy(true);
     try {
       await clearError(deviceIp, iface);
       setMessage({
@@ -102,123 +107,141 @@ export const ErrorInjectionPanel: FC = () => {
         text: getErrorMessage(err) || t('injection.clearSpecificFailed'),
       });
     } finally {
-      setIsSubmitting(false);
+      setClearingBusy(false);
     }
   };
+
+  const busy = isSubmitting || clearingBusy;
 
   return (
     <div className="space-y-4">
       {/* Injection Form */}
       <Card>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Device Selector */}
-            <div>
-              <label htmlFor="error-device" className="block text-sm font-medium mb-2">
-                {t('injection.deviceLabel')}
-              </label>
-              <select
-                id="error-device"
-                value={selectedDevice}
-                onChange={(e) => setSelectedDevice(e.target.value)}
-                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
+        <CardContent>
+          <form onSubmit={handleSubmit(onInject)} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {/* Device Selector */}
+              <div>
+                <label htmlFor="error-device" className="block text-sm font-medium mb-2">
+                  {t('injection.deviceLabel')}
+                </label>
+                <select
+                  id="error-device"
+                  {...register('selectedDevice')}
+                  className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
+                >
+                  <option value="">{t('injection.deviceSelectPlaceholder')}</option>
+                  {devices?.map((dev) => (
+                    <option key={dev.name} value={dev.ips?.[0]}>
+                      {dev.name} ({dev.ips?.[0]})
+                    </option>
+                  ))}
+                </select>
+                {errors.selectedDevice ? (
+                  <p className="text-xs text-status-error mt-1">{errors.selectedDevice.message}</p>
+                ) : null}
+              </div>
+
+              {/* Interface Input */}
+              <div>
+                <label htmlFor="error-interface" className="block text-sm font-medium mb-2">
+                  {t('injection.interfaceLabel')}
+                </label>
+                <input
+                  id="error-interface"
+                  type="text"
+                  {...register('selectedInterface')}
+                  placeholder={t('injection.interfacePlaceholder')}
+                  className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
+                />
+                {errors.selectedInterface ? (
+                  <p className="text-xs text-status-error mt-1">
+                    {errors.selectedInterface.message}
+                  </p>
+                ) : null}
+              </div>
+
+              {/* Error Type Selector */}
+              <div>
+                <label htmlFor="error-type" className="block text-sm font-medium mb-2">
+                  {t('injection.errorTypeLabel')}
+                </label>
+                <select
+                  id="error-type"
+                  {...register('selectedErrorType')}
+                  className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
+                >
+                  <option value="">{t('injection.errorTypeSelectPlaceholder')}</option>
+                  {errorInfo?.availableTypes?.map((type: ErrorType) => (
+                    <option key={type.type} value={type.type}>
+                      {type.type}
+                    </option>
+                  ))}
+                </select>
+                {selectedErrorType && errorInfo?.availableTypes && (
+                  <SmallText className="text-text-muted mt-1">
+                    {
+                      errorInfo.availableTypes.find(
+                        (et: ErrorType) => et.type === selectedErrorType,
+                      )?.description
+                    }
+                  </SmallText>
+                )}
+                {errors.selectedErrorType ? (
+                  <p className="text-xs text-status-error mt-1">
+                    {errors.selectedErrorType.message}
+                  </p>
+                ) : null}
+              </div>
+
+              {/* Value Slider */}
+              <div>
+                <label htmlFor="error-value" className="block text-sm font-medium mb-2">
+                  {t('injection.valueLabel', { value: errorValue })}
+                </label>
+                <input
+                  id="error-value"
+                  type="range"
+                  min="0"
+                  max="100"
+                  {...register('errorValue', { valueAsNumber: true })}
+                  className="w-full h-2 bg-bg-elevated rounded-lg appearance-none cursor-pointer"
+                />
+                <SmallText className="text-text-muted">{t('injection.valueHelper')}</SmallText>
+                {errors.errorValue ? (
+                  <p className="text-xs text-status-error mt-1">{errors.errorValue.message}</p>
+                ) : null}
+              </div>
+            </div>
+
+            {/* Message Display */}
+            {message && (
+              <div
+                className={`p-3 rounded ${
+                  message.type === 'success'
+                    ? 'bg-status-success/10 text-status-success border border-status-success/20'
+                    : 'bg-status-error/10 text-status-error border border-status-error/20'
+                }`}
               >
-                <option value="">{t('injection.deviceSelectPlaceholder')}</option>
-                {devices?.map((dev) => (
-                  <option key={dev.name} value={dev.ips?.[0]}>
-                    {dev.name} ({dev.ips?.[0]})
-                  </option>
-                ))}
-              </select>
-            </div>
+                {message.text}
+              </div>
+            )}
 
-            {/* Interface Input */}
-            <div>
-              <label htmlFor="error-interface" className="block text-sm font-medium mb-2">
-                {t('injection.interfaceLabel')}
-              </label>
-              <input
-                id="error-interface"
-                type="text"
-                value={selectedInterface}
-                onChange={(e) => setSelectedInterface(e.target.value)}
-                placeholder={t('injection.interfacePlaceholder')}
-                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
-              />
-            </div>
-
-            {/* Error Type Selector */}
-            <div>
-              <label htmlFor="error-type" className="block text-sm font-medium mb-2">
-                {t('injection.errorTypeLabel')}
-              </label>
-              <select
-                id="error-type"
-                value={selectedErrorType}
-                onChange={(e) => setSelectedErrorType(e.target.value)}
-                className="w-full px-3 py-2 bg-bg-elevated border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-status-info"
+            {/* Action Buttons */}
+            <div className="flex gap-3">
+              <Button type="submit" disabled={busy}>
+                {isSubmitting ? t('injection.injectingButton') : t('injection.injectButton')}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => setShowClearAllConfirm(true)}
+                disabled={busy}
+                variant="secondary"
               >
-                <option value="">{t('injection.errorTypeSelectPlaceholder')}</option>
-                {errorInfo?.availableTypes?.map((type: ErrorType) => (
-                  <option key={type.type} value={type.type}>
-                    {type.type}
-                  </option>
-                ))}
-              </select>
-              {selectedErrorType && errorInfo?.availableTypes && (
-                <SmallText className="text-text-muted mt-1">
-                  {
-                    errorInfo.availableTypes.find((et: ErrorType) => et.type === selectedErrorType)
-                      ?.description
-                  }
-                </SmallText>
-              )}
+                {t('injection.clearAllButton')}
+              </Button>
             </div>
-
-            {/* Value Slider */}
-            <div>
-              <label htmlFor="error-value" className="block text-sm font-medium mb-2">
-                {t('injection.valueLabel', { value: errorValue })}
-              </label>
-              <input
-                id="error-value"
-                type="range"
-                min="0"
-                max="100"
-                value={errorValue}
-                onChange={(e) => setErrorValue(Number.parseInt(e.target.value, 10))}
-                className="w-full h-2 bg-bg-elevated rounded-lg appearance-none cursor-pointer"
-              />
-              <SmallText className="text-text-muted">{t('injection.valueHelper')}</SmallText>
-            </div>
-          </div>
-
-          {/* Message Display */}
-          {message && (
-            <div
-              className={`p-3 rounded ${
-                message.type === 'success'
-                  ? 'bg-status-success/10 text-status-success border border-status-success/20'
-                  : 'bg-status-error/10 text-status-error border border-status-error/20'
-              }`}
-            >
-              {message.text}
-            </div>
-          )}
-
-          {/* Action Buttons */}
-          <div className="flex gap-3">
-            <Button onClick={handleInject} disabled={isSubmitting}>
-              {isSubmitting ? t('injection.injectingButton') : t('injection.injectButton')}
-            </Button>
-            <Button
-              onClick={() => setShowClearAllConfirm(true)}
-              disabled={isSubmitting}
-              variant="secondary"
-            >
-              {t('injection.clearAllButton')}
-            </Button>
-          </div>
+          </form>
         </CardContent>
       </Card>
 
@@ -256,7 +279,7 @@ export const ErrorInjectionPanel: FC = () => {
                             <button
                               type="button"
                               onClick={() => handleClearSpecific(deviceIp, iface)}
-                              disabled={isSubmitting}
+                              disabled={busy}
                               className="text-status-info hover:text-status-info text-sm"
                               aria-label={t('injection.clearOneAriaLabel', { deviceIp, iface })}
                             >

--- a/ui/src/pages/templates/UploadTemplateModal.tsx
+++ b/ui/src/pages/templates/UploadTemplateModal.tsx
@@ -1,9 +1,11 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Upload, X } from 'lucide-react';
 import { type FC, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { uploadTemplate } from '../../api/client';
-import type { Template } from '../../api/types';
 import { iconSizes } from '../../constants/sizes';
+import { type UploadTemplateFormFields, UploadTemplateSchema } from '../../schemas/forms';
 import { Button } from '../../ui/Button';
 import { SmallText } from '../../ui/Typography';
 
@@ -19,12 +21,21 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
   onError,
 }) => {
   const { t } = useTranslation('pages');
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [content, setContent] = useState('');
-  const [type, setType] = useState<Template['type']>('custom');
-  const [uploading, setUploading] = useState(false);
   const [uploadFile, setUploadFile] = useState<File | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<UploadTemplateFormFields>({
+    resolver: zodResolver(UploadTemplateSchema),
+    defaultValues: { name: '', description: '', content: '', type: 'custom' },
+    mode: 'onBlur',
+  });
+
+  const name = watch('name');
 
   const handleFileChange = async (file: File | null) => {
     if (!file) {
@@ -39,7 +50,6 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
       return;
     }
 
-    // Validate file type
     if (!file.name.match(/\.(yaml|yml)$/i)) {
       onError(new Error(t('templates.uploadModal.errorInvalidFile')));
       return;
@@ -47,44 +57,35 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
 
     setUploadFile(file);
 
-    // Read file content
     try {
       const text = await file.text();
-      setContent(text);
-
+      setValue('content', text, { shouldValidate: true, shouldDirty: true });
       // Auto-fill name from filename if empty
       if (!name) {
-        setName(file.name.replace(/\.(yaml|yml)$/i, ''));
+        setValue('name', file.name.replace(/\.(yaml|yml)$/i, ''), {
+          shouldValidate: true,
+          shouldDirty: true,
+        });
       }
     } catch {
       onError(new Error(t('templates.uploadModal.errorReadFailed')));
     }
   };
 
-  const handleSubmit = async () => {
-    if (!(name.trim() && content.trim())) {
-      onError(new Error(t('templates.uploadModal.errorRequired')));
-      return;
-    }
-
-    setUploading(true);
-
+  const onSubmit: SubmitHandler<UploadTemplateFormFields> = async (values) => {
     try {
       await uploadTemplate({
-        name: name.trim(),
-        description: description.trim(),
-        content,
-        type,
+        name: values.name,
+        description: values.description,
+        content: values.content,
+        type: values.type,
       });
       onSuccess();
     } catch (err) {
       onError(err as Error);
-    } finally {
-      setUploading(false);
     }
   };
 
-  // TODO: Refactor to use shared Modal component from ui/Modal.tsx
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <button
@@ -124,125 +125,130 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
           </button>
         </div>
 
-        {/* Modal Content */}
-        <div className="space-y-4 p-6">
-          {/* File upload */}
-          <div>
-            <label
-              htmlFor="template-upload"
-              className="mb-2 block text-sm font-medium text-text-secondary"
-            >
-              {t('templates.uploadModal.fileLabel')}
-            </label>
-            <input
-              id="template-upload"
-              type="file"
-              accept=".yaml,.yml"
-              onChange={(e) => handleFileChange(e.target.files?.[0] || null)}
-              className="w-full cursor-pointer rounded-lg border border-dashed border-surface-border bg-bg-base/40 p-3 text-sm text-text-primary file:mr-3 file:rounded-md file:border-0 file:bg-brand-primary file:px-3 file:py-1 file:text-sm file:font-medium"
-            />
-            {uploadFile && (
-              <SmallText className="mt-1 text-status-success">
-                {t('templates.uploadModal.fileSelected', { filename: uploadFile.name })}
-              </SmallText>
-            )}
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {/* Modal Content */}
+          <div className="space-y-4 p-6">
+            {/* File upload */}
+            <div>
+              <label
+                htmlFor="template-upload"
+                className="mb-2 block text-sm font-medium text-text-secondary"
+              >
+                {t('templates.uploadModal.fileLabel')}
+              </label>
+              <input
+                id="template-upload"
+                type="file"
+                accept=".yaml,.yml"
+                onChange={(e) => handleFileChange(e.target.files?.[0] || null)}
+                className="w-full cursor-pointer rounded-lg border border-dashed border-surface-border bg-bg-base/40 p-3 text-sm text-text-primary file:mr-3 file:rounded-md file:border-0 file:bg-brand-primary file:px-3 file:py-1 file:text-sm file:font-medium"
+              />
+              {uploadFile && (
+                <SmallText className="mt-1 text-status-success">
+                  {t('templates.uploadModal.fileSelected', { filename: uploadFile.name })}
+                </SmallText>
+              )}
+            </div>
+
+            {/* Name input */}
+            <div>
+              <label
+                htmlFor="template-name"
+                className="mb-2 block text-sm font-medium text-text-secondary"
+              >
+                {t('templates.uploadModal.nameLabel')}
+              </label>
+              <input
+                id="template-name"
+                type="text"
+                {...register('name')}
+                placeholder={t('templates.uploadModal.namePlaceholder')}
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+              />
+              {errors.name ? (
+                <p className="mt-1 text-xs text-status-error">{errors.name.message}</p>
+              ) : null}
+            </div>
+
+            {/* Description input */}
+            <div>
+              <label
+                htmlFor="template-description"
+                className="mb-2 block text-sm font-medium text-text-secondary"
+              >
+                {t('templates.uploadModal.descriptionLabel')}
+              </label>
+              <textarea
+                id="template-description"
+                {...register('description')}
+                placeholder={t('templates.uploadModal.descriptionPlaceholder')}
+                rows={2}
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
+              />
+              {errors.description ? (
+                <p className="mt-1 text-xs text-status-error">{errors.description.message}</p>
+              ) : null}
+            </div>
+
+            {/* Type selector */}
+            <div>
+              <label
+                htmlFor="template-type"
+                className="mb-2 block text-sm font-medium text-text-secondary"
+              >
+                {t('templates.uploadModal.typeLabel')}
+              </label>
+              <select
+                id="template-type"
+                {...register('type')}
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
+              >
+                <option value="basic">{t('templates.uploadModal.categoryBasic')}</option>
+                <option value="router">{t('templates.uploadModal.categoryRouter')}</option>
+                <option value="switch">{t('templates.uploadModal.categorySwitch')}</option>
+                <option value="access-point">
+                  {t('templates.uploadModal.categoryAccessPoint')}
+                </option>
+                <option value="server">{t('templates.uploadModal.categoryServer')}</option>
+                <option value="complete">{t('templates.uploadModal.categoryComplete')}</option>
+                <option value="custom">{t('templates.uploadModal.categoryCustom')}</option>
+              </select>
+            </div>
+
+            {/* Content textarea */}
+            <div>
+              <label
+                htmlFor="template-content"
+                className="mb-2 block text-sm font-medium text-text-secondary"
+              >
+                {t('templates.uploadModal.contentLabel')}
+              </label>
+              <textarea
+                id="template-content"
+                {...register('content')}
+                placeholder={t('templates.uploadModal.contentPlaceholder')}
+                rows={10}
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 font-mono text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
+                spellCheck={false}
+              />
+              {errors.content ? (
+                <p className="mt-1 text-xs text-status-error">{errors.content.message}</p>
+              ) : null}
+            </div>
           </div>
 
-          {/* Name input */}
-          <div>
-            <label
-              htmlFor="template-name"
-              className="mb-2 block text-sm font-medium text-text-secondary"
-            >
-              {t('templates.uploadModal.nameLabel')}
-            </label>
-            <input
-              id="template-name"
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t('templates.uploadModal.namePlaceholder')}
-              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
-            />
+          {/* Modal Footer */}
+          <div className="flex justify-end gap-3 border-t border-surface-border px-6 py-4 bg-bg-base/50">
+            <Button variant="outline" type="button" onClick={onClose} disabled={isSubmitting}>
+              {t('templates.uploadModal.cancel')}
+            </Button>
+            <Button tone="violet" type="submit" disabled={isSubmitting}>
+              {isSubmitting
+                ? t('templates.uploadModal.uploading')
+                : t('templates.uploadModal.uploadButton')}
+            </Button>
           </div>
-
-          {/* Description input */}
-          <div>
-            <label
-              htmlFor="template-description"
-              className="mb-2 block text-sm font-medium text-text-secondary"
-            >
-              {t('templates.uploadModal.descriptionLabel')}
-            </label>
-            <textarea
-              id="template-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder={t('templates.uploadModal.descriptionPlaceholder')}
-              rows={2}
-              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
-            />
-          </div>
-
-          {/* Type selector */}
-          <div>
-            <label
-              htmlFor="template-type"
-              className="mb-2 block text-sm font-medium text-text-secondary"
-            >
-              {t('templates.uploadModal.typeLabel')}
-            </label>
-            <select
-              id="template-type"
-              value={type}
-              onChange={(e) => setType(e.target.value as Template['type'])}
-              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 text-sm text-text-primary focus:border-brand-accent focus:outline-none"
-            >
-              <option value="basic">{t('templates.uploadModal.categoryBasic')}</option>
-              <option value="router">{t('templates.uploadModal.categoryRouter')}</option>
-              <option value="switch">{t('templates.uploadModal.categorySwitch')}</option>
-              <option value="access-point">{t('templates.uploadModal.categoryAccessPoint')}</option>
-              <option value="server">{t('templates.uploadModal.categoryServer')}</option>
-              <option value="complete">{t('templates.uploadModal.categoryComplete')}</option>
-              <option value="custom">{t('templates.uploadModal.categoryCustom')}</option>
-            </select>
-          </div>
-
-          {/* Content textarea */}
-          <div>
-            <label
-              htmlFor="template-content"
-              className="mb-2 block text-sm font-medium text-text-secondary"
-            >
-              {t('templates.uploadModal.contentLabel')}
-            </label>
-            <textarea
-              id="template-content"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder={t('templates.uploadModal.contentPlaceholder')}
-              rows={10}
-              className="w-full rounded-lg border border-surface-border bg-bg-base/60 p-3 font-mono text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
-              spellCheck={false}
-            />
-          </div>
-        </div>
-
-        {/* Modal Footer */}
-        <div className="flex justify-end gap-3 border-t border-surface-border px-6 py-4 bg-bg-base/50">
-          <Button variant="outline" onClick={onClose} disabled={uploading}>
-            {t('templates.uploadModal.cancel')}
-          </Button>
-          <Button
-            tone="violet"
-            onClick={handleSubmit}
-            disabled={uploading || !name.trim() || !content.trim()}
-          >
-            {uploading
-              ? t('templates.uploadModal.uploading')
-              : t('templates.uploadModal.uploadButton')}
-          </Button>
-        </div>
+        </form>
       </div>
     </div>
   );

--- a/ui/src/schemas/forms.ts
+++ b/ui/src/schemas/forms.ts
@@ -28,3 +28,43 @@ export const CloneDeviceSchema = z.object({
 });
 
 export type CloneDeviceFormFields = z.infer<typeof CloneDeviceSchema>;
+
+/**
+ * Upload-template modal: name + description + YAML content + category.
+ * The Go side does YAML parsing; this layer just blocks empty
+ * submissions and overly long names.
+ */
+export const UploadTemplateSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Template name is required')
+    .max(64, 'Name is too long (max 64 chars)'),
+  description: z.string().max(256, 'Description is too long (max 256 chars)'),
+  content: z.string().min(1, 'Template content is required'),
+  type: z.enum(['basic', 'router', 'switch', 'access-point', 'server', 'complete', 'custom']),
+});
+
+export type UploadTemplateFormFields = z.infer<typeof UploadTemplateSchema>;
+
+/**
+ * Error injection form: device + interface + error type + percentage value.
+ * Used by ErrorInjectionPanel. The Go side validates the (deviceIp,
+ * interface, errorType) tuple against the simulation registry.
+ */
+export const ErrorInjectionSchema = z.object({
+  selectedDevice: z.string().min(1, 'Device is required'),
+  selectedInterface: z
+    .string()
+    .trim()
+    .min(1, 'Interface is required')
+    .max(15, 'Interface name is too long (max 15 chars)'),
+  selectedErrorType: z.string().min(1, 'Error type is required'),
+  errorValue: z
+    .number()
+    .int('Value must be an integer')
+    .min(0, 'Value must be 0 or more')
+    .max(100, 'Value must be 100 or less'),
+});
+
+export type ErrorInjectionFormFields = z.infer<typeof ErrorInjectionSchema>;


### PR DESCRIPTION
Extends the react-hook-form + zod pattern from #729's
CloneDeviceModal pilot to two more form-like surfaces. Both moved
from useState + onClick into useForm + handleSubmit, which:
- wraps the JSX in an actual <form> (Enter-key submit works)
- replaces hand-rolled trim-checks with schema validation
- shows inline per-field errors instead of a single shared message

Schema additions in src/schemas/forms.ts:
- UploadTemplateSchema: name/description length checks, content
  required, type as enum of the known template categories
- ErrorInjectionSchema: device + interface (max 15 chars) +
  errorType + integer percentage (0-100)

ErrorInjectionPanel split its single `isSubmitting` state into
`isSubmitting` (the inject form's react-hook-form state) plus
`clearingBusy` (the inline table's clear-all / clear-one
operations). They combine into a `busy` flag for the table buttons
so they share the same disable behavior as before.

Out of scope (still in #730): ConfigPicker, device-editor,
packet-inspector filters, settings panels.
