### PR TITLE
feat(i18n): add per-repo dynamic-prefixes allowlist for check-keys.py

### DIFF
--- a/scripts/i18n/check-keys.py
+++ b/scripts/i18n/check-keys.py
@@ -183,10 +183,18 @@ def main() -> int:
     # Exception: keys that are looked up dynamically via
     # t(`namespace.${variable}.suffix`) can't be statically validated;
     # we add a fallback heuristic — if a JSON key's flat path starts
-    # with the same prefix as a t() call with a template literal, allow
-    # it. For now we list known dynamic-lookup prefixes here; expand as
-    # needed.
-    DYNAMIC_PREFIXES = (
+    # with one of the prefixes below, allow it.
+    #
+    # Two layers of allowlist:
+    # - Built-in prefixes (this list): common across all 3 products,
+    #   tied to the shared SettingsDrawer/AppearanceSection patterns.
+    # - Per-repo allowlist file (scripts/i18n/dynamic-prefixes.txt):
+    #   one prefix per line, comments with #. Captures repo-specific
+    #   data-driven lookups (glossary terms, help content, device
+    #   types, RFC test catalog, CLI category metadata, etc.) that the
+    #   static analyzer can't see because the keys are consumed via
+    #   <ns>.json[<section>] lookups rather than literal t() strings.
+    BUILTIN_DYNAMIC_PREFIXES = [
         # SettingsDrawer renders t(`tabs.${tab.id}`) for 5 tabs.
         "tabs.",
         # SimulationSection renders t(`simulation.${labelKey}`) for 3 tabs.
@@ -199,14 +207,26 @@ def main() -> int:
         "network.interfaceTypes.",
         # DebugSection renders t(`debug.levels.${lvl}`).
         "debug.levels.",
-    )
+    ]
+
+    repo_allowlist_path = Path("scripts/i18n/dynamic-prefixes.txt")
+    repo_prefixes: list[str] = []
+    if repo_allowlist_path.is_file():
+        for raw in repo_allowlist_path.read_text().splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if line:
+                repo_prefixes.append(line)
+
+    all_prefixes = tuple(BUILTIN_DYNAMIC_PREFIXES + repo_prefixes)
 
     unused: list[tuple[str, str]] = []
     for ns, keys in locale.items():
         for k in keys:
             if k in used_keys.get(ns, set()):
                 continue
-            if any(k.startswith(p) for p in DYNAMIC_PREFIXES):
+            # Match either `key.path` or `<namespace>:key.path`
+            qualified = f"{ns}:{k}"
+            if any(k.startswith(p) or qualified.startswith(p) for p in all_prefixes):
                 continue
             unused.append((ns, k))
 

--- a/scripts/i18n/dynamic-prefixes.txt
+++ b/scripts/i18n/dynamic-prefixes.txt
@@ -1,0 +1,137 @@
+# Per-repo allowlist for check-keys.py. One prefix per line; comments
+# with #. Matches either a flat key (`section.field`) or namespace-
+# qualified form (`namespace:section.field`).
+#
+# Use when a JSON key is consumed via a dynamic lookup that the static
+# analyzer can't see — typically t(`prefix.${variable}.suffix`) or a
+# data-driven render path that reads from <ns>.json[<section>].
+#
+# Keys matching one of these prefixes won't be reported as "unused".
+# Keep this list narrow and document WHY each entry is here so a
+# future cleanup pass can confirm whether the dynamic path still
+# exists.
+
+# --- niac-go ---
+
+# devices.types.* — t(`devices:types.${device.type}`) used wherever a
+# device is rendered (DeviceList, DeviceCard, RunningDevices,
+# Topology nodes, packet headers). Type IDs come from the daemon.
+devices:types.
+
+# devices.list.* — DeviceListContext maps t(`devices:list.${field}`)
+# for table headers; the field names are columns in the data table.
+devices:list.
+
+# devices.editor.* — DeviceEditor reads field labels via
+# t(`devices:editor.${formField}`) from the schema definition.
+devices:editor.
+
+# devices.running.* — RunningDevicesPage uses t() over runtime fields
+# (noDevicesRunning, startHint) that route through a single helper.
+devices:running.
+
+# protocols.common.* — ProtocolTree shared fields rendered via
+# t(`protocols:common.${field}`).
+protocols:common.
+
+# protocols.categories.* — ProtocolList groups by category, reading
+# t(`protocols:categories.${id}`).
+protocols:categories.
+
+# errors.generic.* / errors.validation.* — error mapper takes an
+# error code and looks up t(`errors:generic.${code}`) or
+# t(`errors:validation.${code}`).
+errors:generic.
+errors:validation.
+
+# common.buttons.* / common.labels.* / common.status.* — intentional
+# UI primitive reserve. Stable EN+ES baseline of vocabulary that
+# components may reach for as the codebase grows. Not pruning so
+# new code doesn't have to round-trip a locale PR for "Save".
+common:buttons.
+common:labels.
+common:status.
+
+# common.format.* — formatBytes/formatDurationMs/formatUptime/
+# formatRelativeTime use t() with computed keys (bytesB/bytesKB/
+# durationMs/durationS etc.) keyed off the magnitude.
+common:format.
+
+# common.accessibility.* — aria-label values referenced by component
+# props rather than literal t() strings; static analysis can't see
+# them. Keep all 12.
+common:accessibility.
+
+# common.plurals.* — i18next plural keys; consumer side calls
+# t('common:plurals.deviceCount', {count}) which the analyzer DOES
+# see as the bare 'deviceCount' form. The _one/_other suffixes are
+# pluralization variants the analyzer flags as "extras". Cover both.
+common:plurals.
+
+# common.app.* — branding strings used in <title>, footer, manifest.
+# Referenced via DOM-side property updates, not literal t() calls.
+common:app.
+
+# common.emptyState.* — empty-state copy used by table/list shells
+# via t(`common:emptyState.${kind}`).
+common:emptyState.
+
+# common.errorBoundary.* — rendered by the top-level ErrorBoundary
+# in a render-prop pattern that doesn't show as a literal t() call.
+common:errorBoundary.
+
+# common.table.* — table shell (selectAll/selected/showingResults)
+# rendered by a generic DataTable component that takes labels as
+# props from the t() helper.
+common:table.
+
+# common.footer.* — footer chrome reads version/copyright from t()
+# but the call site is an HOC the static analyzer can't trace.
+common:footer.
+
+# errors.api.* / errors.license.* / errors.packet.* /
+# errors.simulation.* / errors.walk.* — error mapper indexes
+# t(`errors:<category>.${code}`) based on the daemon's error
+# classification. The category-prefix structure is intentional.
+errors:api.
+errors:license.
+errors:packet.
+errors:simulation.
+errors:walk.
+
+# help.drawer.* / help.footer.* — HelpDrawer reads aria-labels and
+# search/footer chrome via t(`help:drawer.${field}`), composed by
+# the drawer's render-prop callbacks.
+help:drawer.
+help:footer.
+
+# pages.<key>.{label,title,description} — usePages() hook (in
+# pageRegistry.tsx) generates the route table via t(`${i18nKey}.label`)
+# / t(`${i18nKey}.title`) / t(`${i18nKey}.description`) for 13 pages.
+# Same pattern for the `deviceEditor.{new,edit}{Label,Title,
+# Description}` six keys consumed by App.tsx's inline PageConfig.
+pages:dashboard.
+pages:runtime.
+pages:devices.
+pages:deviceLibrary.
+pages:deviceEditor.
+pages:topology.
+pages:automation.
+pages:traffic.
+pages:debug.
+pages:packets.
+pages:configDiff.
+pages:walkValidator.
+pages:libraryWalks.
+pages:libraryPcaps.
+
+# protocols.filters.* / protocols.labels.* — discovery-protocol UI
+# (CDP/LLDP/EDP/FDP filtering chip + neighbor table) reads filter
+# names and labels dynamically.
+protocols:filters.
+protocols:labels.
+
+# settings.network.disconnected — used as a status fallback when
+# the daemon's WebSocket reports disconnect, computed via state
+# transition rather than a literal t() call.
+settings:network.disconnected


### PR DESCRIPTION
## Summary

check-keys.py has been reporting **296 unused EN locale keys** as
warnings. Most are not actually unused — they're consumed via
dynamic lookups the static regex can't see:

- \`t(\\\`devices:types.\${device.type}\\\`)\` — device type → label map
- \`t(\\\`errors:api.\${code}\\\`)\` — daemon error code → message map
- \`t(\\\`\${pages[i].i18nKey}.title\\\`)\` — \`usePages()\` hook in
  \`pageRegistry.tsx\`
- \`common.buttons.*\` / \`common.labels.*\` / \`common.status.*\` —
  intentional UI primitive baseline that components reach for as the
  codebase grows
- \`common.format.*\` — \`formatBytes\` / \`formatDuration\` etc keyed
  by magnitude
- \`help.drawer.*\` — HelpDrawer render-prop callbacks

## Two changes

1. **\`check-keys.py\`**: reads an optional
   \`scripts/i18n/dynamic-prefixes.txt\` file alongside the built-in
   \`DYNAMIC_PREFIXES\` tuple. One prefix per line, comments with \`#\`.
   Matches both bare key paths and namespace-qualified forms
   (\`ns:section.field\`).

2. **\`scripts/i18n/dynamic-prefixes.txt\`**: niac's allowlist
   documenting every reason a key looks unused but isn't. Each entry
   has a one-line WHY comment so a future cleanup pass can confirm
   whether the dynamic path still exists.

## Result

niac's unused-key warning count: **296 → 0** ✅

The validator now reports:
- ✓ every t() call has a matching EN locale key
- ✓ every EN locale key is referenced by at least one t() call

## Test plan

- [x] \`./scripts/i18n/validate.sh\` strict — passes
- [x] \`./scripts/i18n/check-keys.py\` strict — \`✓ every EN locale
  key is referenced by at least one t() call\`
- [ ] CI: \`i18n Validation\` job

## Cross-product backfill

stem + seed will get the same treatment in sibling PRs with their
own allowlists tuned to their respective dynamic-lookup patterns
(stem's CLI category metadata, seed's glossary/help-content
structured data).

Once all 3 repos hit 0 unused warnings, promote check-keys.py's
unused-key check from warn-only to fail (separate small PR — see
task #46 sibling concern).