### PR TITLE
test(i18n): add ES layout sanity e2e for overflow detection

### DIFF
--- a/ui/e2e/language-layout-sanity.spec.ts
+++ b/ui/e2e/language-layout-sanity.spec.ts
@@ -1,0 +1,94 @@
+import { type Page, expect, test } from '@playwright/test';
+
+/**
+ * Language layout sanity (ES overflow detection)
+ *
+ * Spanish UI strings run on average ~30% longer than English. The
+ * unit tests, key-resolution tests, and language-switch.spec only
+ * verify that ES text RENDERS — they don't catch when "Inyección de
+ * errores" overflows a button sized for "Error Injection", or when
+ * "Verificaciones de salud" clips the column header.
+ *
+ * This spec exercises a small fixed set of high-traffic views in ES
+ * and asserts that key text containers don't overflow their parents
+ * (causing clipping, mid-word wrap, or horizontal scrollbars). It's
+ * an alternative to full visual-regression snapshots — much lighter
+ * to maintain (no per-route PNG baselines that bit-rot on CSS
+ * tweaks) and catches the specific class of bug that ES introduces.
+ *
+ * For full pixel-diff regression we'd need:
+ * - `expect(page).toHaveScreenshot()` calls + per-route .png
+ *   baselines committed to the repo
+ * - `playwright test --update-snapshots` workflow in CI
+ * - Snapshot storage for the inevitable churn as components evolve
+ *
+ * That's queued for a separate workstream when the UI shape settles
+ * past the current rapid-iteration phase.
+ */
+
+const LOCAL_STORAGE_KEY = 'niac-language';
+
+const setLanguage = async (page: Page, lang: 'en' | 'es'): Promise<void> => {
+  await page.addInitScript(
+    ({ key, value }) => {
+      localStorage.setItem(key, value);
+    },
+    { key: LOCAL_STORAGE_KEY, value: lang },
+  );
+};
+
+const noHorizontalScroll = async (page: Page): Promise<void> => {
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  // Allow 1px tolerance for subpixel rendering. Anything more is a
+  // real overflow that produces a horizontal scrollbar.
+  expect(scrollWidth - clientWidth).toBeLessThan(2);
+};
+
+const noClippedText = async (page: Page, selector: string): Promise<void> => {
+  // For each matching element, compare scroll width to client width.
+  // If scrollWidth > clientWidth, the text is wider than its container
+  // and is being clipped (typically by `text-overflow: ellipsis` or
+  // `overflow: hidden`).
+  const clipped = await page.locator(selector).evaluateAll((els: Element[]) =>
+    els
+      .filter((el) => {
+        const e = el as HTMLElement;
+        // Only count elements that actually have visible text.
+        return e.scrollWidth > e.clientWidth && e.innerText.trim().length > 0;
+      })
+      .map((el) => (el as HTMLElement).innerText.trim().slice(0, 80)),
+  );
+  expect(clipped, `${selector} elements with clipped text:\n  ${clipped.join('\n  ')}`).toEqual(
+    [],
+  );
+};
+
+test.describe('Language layout sanity', () => {
+  for (const lang of ['en', 'es'] as const) {
+    test.describe(`${lang.toUpperCase()} dashboard`, () => {
+      test.beforeEach(async ({ page }) => {
+        await setLanguage(page, lang);
+        await page.goto('/');
+        await page.waitForLoadState('domcontentloaded');
+      });
+
+      test('no horizontal scrollbar on dashboard', async ({ page }) => {
+        await noHorizontalScroll(page);
+      });
+
+      test("sidebar nav labels don't get clipped", async ({ page }) => {
+        // Nav labels are the highest-risk surface for ES overflow:
+        // "Compare & Merge" → "Comparar y fusionar" (~30% wider),
+        // "Walks" → "Recorridos" (~70% wider).
+        await noClippedText(page, 'nav a, aside a, [role="navigation"] a');
+      });
+
+      test("page header h1/h2 don't get clipped", async ({ page }) => {
+        await noClippedText(page, 'h1, h2');
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Catches a class of i18n bug the existing tests miss: when ES text
overflows containers sized for shorter EN text.

Spanish UI strings run **~30% longer** than English on average.
Unit tests, key-resolution tests, and the language-switch spec only
verify that ES text RENDERS — they don't catch when \"Inyección de
errores\" overflows a button sized for \"Error Injection\", or when
\"Verificaciones de salud\" clips a column header.

## What this spec does

Four tests (2 assertions × 2 locales on the dashboard):

- **No horizontal scrollbar** — would cause a double-scroll UX bug
  if ES content pushes content >viewport width
- **Sidebar nav labels not clipped** — highest-risk surface
  (\"Walks\" → \"Recorridos\" is ~70% wider; \"Compare & Merge\" →
  \"Comparar y fusionar\" ~30% wider)
- **h1/h2 headers not clipped** — page-header chrome typically
  sized for EN headline length

Uses \`scrollWidth > clientWidth\` as the clipped-text signal — runs
inside the browser via \`evaluateAll\`, no pixel-diff snapshot
needed.

## Why not full visual regression?

Pixel-diff with \`toHaveScreenshot()\` + per-route \`.png\` baselines
is much heavier to maintain:
- CSS tweaks invalidate every snapshot
- New components require manual baseline generation
- Snapshot storage and CI cost
- macOS dev / Linux CI rendering differences (the visual project was
  deleted from niac in 2026q2 for exactly this reason)

The layout-overflow checks here catch the actual ES bug pattern
with no baseline maintenance burden. Full visual regression queued
for when the UI shape settles past current rapid-iteration phase.

## Test plan

- [x] biome clean
- [ ] CI: \`E2E Browser Tests\` exercises the new spec across
  Chromium + WebKit
- [ ] Manual: temporarily wrap a sidebar nav item's label in a too-
  narrow container; spec should fail with the clipped text reported

## Cross-product backfill

| Repo | PR |
|---|---|
| niac-go | this PR |
| stem | sibling PR queued |
| seed | sibling PR queued |