### PR TITLE
feat(license): model bgp/ospf/snmpv3 on device, gate bgp+ospf

### DIFF
--- a/docs/schemas/niac.schema.json
+++ b/docs/schemas/niac.schema.json
@@ -35,6 +35,52 @@
         "value"
       ]
     },
+    "BgpConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "asn": {
+          "type": "integer"
+        },
+        "router_id": {
+          "type": "string"
+        },
+        "hold_time": {
+          "type": "integer"
+        },
+        "keep_alive": {
+          "type": "integer"
+        },
+        "neighbors": {
+          "items": {
+            "$ref": "#/$defs/BgpNeighbor"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "BgpNeighbor": {
+      "properties": {
+        "ip": {
+          "type": "string"
+        },
+        "remote_as": {
+          "type": "integer"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ip",
+        "remote_as"
+      ]
+    },
     "CapturePlayback": {
       "properties": {
         "file_name": {
@@ -227,6 +273,15 @@
         },
         "netbios": {
           "$ref": "#/$defs/NetbiosConfig"
+        },
+        "bgp": {
+          "$ref": "#/$defs/BgpConfig"
+        },
+        "ospf": {
+          "$ref": "#/$defs/OspfConfig"
+        },
+        "snmpv3": {
+          "$ref": "#/$defs/Snmpv3Config"
         },
         "icmp": {
           "$ref": "#/$defs/IcmpConfig"
@@ -880,6 +935,51 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "OspfArea": {
+      "properties": {
+        "area_id": {
+          "type": "string"
+        },
+        "networks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "stub": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "area_id"
+      ]
+    },
+    "OspfConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "router_id": {
+          "type": "string"
+        },
+        "hello_time": {
+          "type": "integer"
+        },
+        "dead_time": {
+          "type": "integer"
+        },
+        "areas": {
+          "items": {
+            "$ref": "#/$defs/OspfArea"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "PeriodicPingConfig": {
       "properties": {
         "enabled": {
@@ -996,6 +1096,48 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "Snmpv3Config": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "engine_id": {
+          "type": "string"
+        },
+        "users": {
+          "items": {
+            "$ref": "#/$defs/Snmpv3User"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Snmpv3User": {
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "auth_protocol": {
+          "type": "string"
+        },
+        "auth_password": {
+          "type": "string"
+        },
+        "priv_protocol": {
+          "type": "string"
+        },
+        "priv_password": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "username"
+      ]
     },
     "StpConfig": {
       "properties": {

--- a/internal/api/devices_protocol_gates.go
+++ b/internal/api/devices_protocol_gates.go
@@ -24,9 +24,11 @@ type protocolFeatureCheck struct {
 }
 
 // gatedDeviceProtocolChecks enumerates the device-config fields that
-// map to a licensed Pro feature. BGP, OSPF, SNMPv3, and
-// error_injection are in the keygen catalog but not yet modeled on
-// Device — tracked separately for follow-up.
+// map to a licensed Pro feature. SNMPv3 is deliberately NOT gated:
+// it's the only safe SNMP version (v1/v2c send credentials in
+// cleartext) so gating it would push users toward the insecure
+// variants. error_injection is in the keygen catalog but routed
+// through a separate flag, not a device-config field.
 //
 // Returned by a function rather than held in a package-level slice so
 // gochecknoglobals stays clean; the closures aren't worth caching.
@@ -43,6 +45,14 @@ func gatedDeviceProtocolChecks() []protocolFeatureCheck {
 		{
 			feature: "netbios",
 			present: func(d *config.Device) bool { return d != nil && d.NetBIOSConfig != nil },
+		},
+		{
+			feature: "bgp",
+			present: func(d *config.Device) bool { return d != nil && d.BGPConfig != nil },
+		},
+		{
+			feature: "ospf",
+			present: func(d *config.Device) bool { return d != nil && d.OSPFConfig != nil },
 		},
 		{
 			// traffic_shaping: any device-level traffic pattern config

--- a/internal/api/devices_protocol_gates_test.go
+++ b/internal/api/devices_protocol_gates_test.go
@@ -132,12 +132,78 @@ func TestRequireDeviceProtocolFeatures_AllowsProTrial(t *testing.T) {
 		FTPConfig:     &config.FTPConfig{},
 		STPConfig:     &config.STPConfig{},
 		NetBIOSConfig: &config.NetBIOSConfig{},
+		BGPConfig:     &config.BGPConfig{},
+		OSPFConfig:    &config.OSPFConfig{},
+		SNMPv3Config:  &config.SNMPv3Config{},
 	}
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 
 	if !s.requireDeviceProtocolFeatures(w, req, dev) {
 		t.Fatalf("Pro trial should allow gated protocols; status=%d body=%s",
+			w.Code, w.Body.String())
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_BlocksFreeOnBGP(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{Name: "withbgp", BGPConfig: &config.BGPConfig{}}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on BGP")
+	}
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402", w.Code)
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "bgp" {
+		t.Errorf("RequiredFeature = %q, want bgp", body.RequiredFeature)
+	}
+}
+
+func TestRequireDeviceProtocolFeatures_BlocksFreeOnOSPF(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{Name: "withospf", OSPFConfig: &config.OSPFConfig{}}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatal("expected Free tier to be blocked on OSPF")
+	}
+	var body FeatureGateResponse
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body.RequiredFeature != "ospf" {
+		t.Errorf("RequiredFeature = %q, want ospf", body.RequiredFeature)
+	}
+}
+
+// SNMPv3 is deliberately free for all tiers — gating it would push
+// users toward the cleartext v1/v2c variants. Locking that behavior
+// in with a test so a future "add snmpv3 to Pro" change has to also
+// delete this test (paper trail).
+func TestRequireDeviceProtocolFeatures_AllowsSNMPv3OnFree(t *testing.T) {
+	t.Parallel()
+	mgr := freshManager(t)
+	s := newProtoGateServer(t, mgr)
+
+	dev := &config.Device{
+		Name:         "withv3",
+		SNMPv3Config: &config.SNMPv3Config{Enabled: true},
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+
+	if !s.requireDeviceProtocolFeatures(w, req, dev) {
+		t.Fatalf("SNMPv3 must be free for all tiers; got status=%d body=%s",
 			w.Code, w.Body.String())
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -163,6 +163,9 @@ type Device struct {
 	HTTPConfig          *HTTPConfig          // HTTP server configuration
 	FTPConfig           *FTPConfig           // FTP server configuration
 	NetBIOSConfig       *NetBIOSConfig       // NetBIOS service configuration
+	BGPConfig           *BGPConfig           // BGP speaker configuration (v0.86.0 — Pro)
+	OSPFConfig          *OSPFConfig          // OSPF speaker configuration (v0.86.0 — Pro)
+	SNMPv3Config        *SNMPv3Config        // SNMPv3 USM users (v0.86.0 — free, safe SNMP variant)
 	ICMPConfig          *ICMPConfig          // ICMP/ICMPv4 configuration
 	ICMPv6Config        *ICMPv6Config        // ICMPv6 configuration
 	DHCPv6Config        *DHCPv6Config        // DHCPv6 server configuration
@@ -406,6 +409,71 @@ type NetBIOSName struct {
 	Name   string
 	Suffix uint8
 	Group  bool
+}
+
+// BGPConfig holds BGP (Border Gateway Protocol) speaker configuration.
+//
+// Added 2026-05-27 — Pro tier feature. Presence on a Device trips the
+// `bgp` gate at create/update time. The protocol speaker itself is a
+// separate, larger workstream (RFC 4271); this struct exists today
+// purely so the license-gate has something concrete to test against
+// instead of "TODO: not yet modeled."
+type BGPConfig struct {
+	Enabled   bool
+	ASN       uint32
+	RouterID  net.IP
+	HoldTime  uint16 // seconds (default 180)
+	KeepAlive uint16 // seconds (default 60)
+	Neighbors []BGPNeighbor
+}
+
+// BGPNeighbor represents a single BGP peer entry.
+type BGPNeighbor struct {
+	IP       net.IP
+	RemoteAS uint32
+	Password string // MD5/TCP-AO shared secret (optional)
+}
+
+// OSPFConfig holds OSPF (Open Shortest Path First) speaker configuration.
+//
+// Added 2026-05-27 — Pro tier feature. Same shape and reasoning as
+// BGPConfig: schema-only stub so the gate has a concrete handle.
+// Speaker implementation tracked separately (RFC 2328).
+type OSPFConfig struct {
+	Enabled   bool
+	RouterID  net.IP
+	HelloTime uint16 // seconds (default 10)
+	DeadTime  uint16 // seconds (default 40)
+	Areas     []OSPFArea
+}
+
+// OSPFArea represents an OSPF area declaration.
+type OSPFArea struct {
+	AreaID   string
+	Networks []string
+	Stub     bool
+}
+
+// SNMPv3Config holds SNMPv3 USM (User-based Security Model)
+// configuration: engine ID + users with auth/priv credentials.
+//
+// Added 2026-05-27 — NOT license-gated. SNMPv3 is the only safe SNMP
+// version (v1/v2c send credentials in cleartext) and so stays free
+// for every NIAC tier. The actual SNMP packet handling lives in
+// internal/protocols/snmp/.
+type SNMPv3Config struct {
+	Enabled  bool
+	EngineID string
+	Users    []SNMPv3User
+}
+
+// SNMPv3User represents one SNMPv3 USM user record.
+type SNMPv3User struct {
+	Username     string
+	AuthProtocol string // "none" | "md5" | "sha" | "sha256" | "sha512"
+	AuthPassword string
+	PrivProtocol string // "none" | "des" | "aes" | "aes192" | "aes256"
+	PrivPassword string
 }
 
 // ICMPConfig holds ICMP/ICMPv4 configuration.

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -380,6 +380,11 @@ func parseDeviceProtocolConfigs(device *Device, yamlDevice *converter.Device) er
 	device.FTPConfig = parseFTPConfig(yamlDevice.Ftp, device.Name)
 	device.NetBIOSConfig = parseNetBIOSConfig(yamlDevice.Netbios, device.Name)
 
+	// Handle routing + manageability protocols (v0.86.0)
+	device.BGPConfig = parseBGPConfig(yamlDevice.Bgp)
+	device.OSPFConfig = parseOSPFConfig(yamlDevice.Ospf)
+	device.SNMPv3Config = parseSNMPv3Config(yamlDevice.Snmpv3)
+
 	// Handle ICMP protocols
 	device.ICMPConfig = parseICMPConfig(yamlDevice.Icmp)
 	device.ICMPv6Config = parseICMPv6Config(yamlDevice.Icmpv6)

--- a/internal/config/yaml_protocols.go
+++ b/internal/config/yaml_protocols.go
@@ -882,4 +882,103 @@ func parseFTPConfig(yamlFtp *converter.FtpConfig, deviceName string) *FTPConfig 
 	return ftpCfg
 }
 
+// parseBGPConfig parses BGP configuration from YAML. Returns nil for
+// absent input - gating logic treats nil as "BGP not configured".
+func parseBGPConfig(yamlBgp *converter.BgpConfig) *BGPConfig {
+	if yamlBgp == nil {
+		return nil
+	}
+
+	cfg := &BGPConfig{
+		Enabled:   yamlBgp.Enabled,
+		ASN:       yamlBgp.ASN,
+		HoldTime:  yamlBgp.HoldTime,
+		KeepAlive: yamlBgp.KeepAlive,
+		Neighbors: make([]BGPNeighbor, 0, len(yamlBgp.Neighbors)),
+	}
+	if yamlBgp.RouterID != "" {
+		cfg.RouterID = net.ParseIP(yamlBgp.RouterID)
+	}
+
+	if cfg.HoldTime == 0 {
+		cfg.HoldTime = 180
+	}
+
+	if cfg.KeepAlive == 0 {
+		cfg.KeepAlive = 60
+	}
+
+	for _, n := range yamlBgp.Neighbors {
+		cfg.Neighbors = append(cfg.Neighbors, BGPNeighbor{
+			IP:       net.ParseIP(n.IP),
+			RemoteAS: n.RemoteAS,
+			Password: n.Password,
+		})
+	}
+
+	return cfg
+}
+
+// parseOSPFConfig parses OSPF configuration from YAML. Returns nil
+// for absent input.
+func parseOSPFConfig(yamlOspf *converter.OspfConfig) *OSPFConfig {
+	if yamlOspf == nil {
+		return nil
+	}
+
+	cfg := &OSPFConfig{
+		Enabled:   yamlOspf.Enabled,
+		HelloTime: yamlOspf.HelloTime,
+		DeadTime:  yamlOspf.DeadTime,
+		Areas:     make([]OSPFArea, 0, len(yamlOspf.Areas)),
+	}
+	if yamlOspf.RouterID != "" {
+		cfg.RouterID = net.ParseIP(yamlOspf.RouterID)
+	}
+
+	if cfg.HelloTime == 0 {
+		cfg.HelloTime = 10
+	}
+
+	if cfg.DeadTime == 0 {
+		cfg.DeadTime = 40
+	}
+
+	for _, a := range yamlOspf.Areas {
+		cfg.Areas = append(cfg.Areas, OSPFArea{
+			AreaID:   a.AreaID,
+			Networks: append([]string(nil), a.Networks...),
+			Stub:     a.Stub,
+		})
+	}
+
+	return cfg
+}
+
+// parseSNMPv3Config parses SNMPv3 USM user configuration from YAML.
+// Returns nil for absent input. NOT license-gated — SNMPv3 is free
+// for all tiers (the only safe SNMP version).
+func parseSNMPv3Config(yamlV3 *converter.Snmpv3Config) *SNMPv3Config {
+	if yamlV3 == nil {
+		return nil
+	}
+
+	cfg := &SNMPv3Config{
+		Enabled:  yamlV3.Enabled,
+		EngineID: yamlV3.EngineID,
+		Users:    make([]SNMPv3User, 0, len(yamlV3.Users)),
+	}
+	for _, u := range yamlV3.Users {
+		cfg.Users = append(cfg.Users, SNMPv3User{
+			Username:     u.Username,
+			AuthProtocol: u.AuthProtocol,
+			AuthPassword: u.AuthPassword,
+			PrivProtocol: u.PrivProtocol,
+			PrivPassword: u.PrivPassword,
+		})
+	}
+
+	return cfg
+}
+
 // ParseSimpleConfig parses a simple device configuration format

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -77,6 +77,9 @@ type Device struct {
 	HTTP          *HTTPConfig          `yaml:"http,omitempty"`
 	Ftp           *FtpConfig           `yaml:"ftp,omitempty"`
 	Netbios       *NetbiosConfig       `yaml:"netbios,omitempty"`
+	Bgp           *BgpConfig           `yaml:"bgp,omitempty"`    // v0.86.0 — Pro
+	Ospf          *OspfConfig          `yaml:"ospf,omitempty"`   // v0.86.0 — Pro
+	Snmpv3        *Snmpv3Config        `yaml:"snmpv3,omitempty"` // v0.86.0 — free (safe SNMP variant)
 	Icmp          *IcmpConfig          `yaml:"icmp,omitempty"`
 	Icmpv6        *Icmpv6Config        `yaml:"icmpv6,omitempty"`
 	Dhcpv6        *Dhcpv6Config        `yaml:"dhcpv6,omitempty"`
@@ -322,6 +325,68 @@ type NetbiosName struct {
 	Name   string `yaml:"name,omitempty"`
 	Suffix string `yaml:"suffix,omitempty"`
 	Group  bool   `yaml:"group,omitempty"`
+}
+
+// BgpConfig represents BGP (Border Gateway Protocol) speaker configuration.
+//
+// Added 2026-05-27 for license-gating purposes. Presence on a device
+// activates the bgp Pro feature gate; the protocol speaker itself is
+// a separate workstream (RFC 4271).
+type BgpConfig struct {
+	Enabled   bool          `yaml:"enabled,omitempty"`
+	ASN       uint32        `yaml:"asn,omitempty"        validate:"omitempty,gte=1,lte=4294967295"`
+	RouterID  string        `yaml:"router_id,omitempty"  validate:"omitempty,ip"`
+	HoldTime  uint16        `yaml:"hold_time,omitempty"`  // seconds (default 180)
+	KeepAlive uint16        `yaml:"keep_alive,omitempty"` // seconds (default 60)
+	Neighbors []BgpNeighbor `yaml:"neighbors,omitempty"`
+}
+
+// BgpNeighbor represents one BGP peer entry.
+type BgpNeighbor struct {
+	IP       string `yaml:"ip"                 validate:"required,ip"`
+	RemoteAS uint32 `yaml:"remote_as"          validate:"required,gte=1"`
+	Password string `yaml:"password,omitempty"`
+}
+
+// OspfConfig represents OSPF (Open Shortest Path First) configuration.
+//
+// Added 2026-05-27 for license-gating purposes. Presence on a device
+// activates the ospf Pro feature gate; the protocol speaker itself is
+// a separate workstream (RFC 2328).
+type OspfConfig struct {
+	Enabled   bool       `yaml:"enabled,omitempty"`
+	RouterID  string     `yaml:"router_id,omitempty"  validate:"omitempty,ip"`
+	HelloTime uint16     `yaml:"hello_time,omitempty"` // seconds (default 10)
+	DeadTime  uint16     `yaml:"dead_time,omitempty"`  // seconds (default 40)
+	Areas     []OspfArea `yaml:"areas,omitempty"`
+}
+
+// OspfArea represents an OSPF area declaration.
+type OspfArea struct {
+	AreaID   string   `yaml:"area_id"            validate:"required"`
+	Networks []string `yaml:"networks,omitempty"`
+	Stub     bool     `yaml:"stub,omitempty"`
+}
+
+// Snmpv3Config represents SNMPv3 user / auth / priv configuration.
+//
+// Added 2026-05-27. NOT license-gated — SNMPv3 is the only safe SNMP
+// version (v1/v2c send credentials in cleartext) and is free for all
+// NIAC tiers. The actual SNMPv3 packet path lives in
+// internal/protocols/snmp/.
+type Snmpv3Config struct {
+	Enabled  bool         `yaml:"enabled,omitempty"`
+	EngineID string       `yaml:"engine_id,omitempty"`
+	Users    []Snmpv3User `yaml:"users,omitempty"`
+}
+
+// Snmpv3User represents one SNMPv3 USM user record.
+type Snmpv3User struct {
+	Username     string `yaml:"username"                validate:"required"`
+	AuthProtocol string `yaml:"auth_protocol,omitempty" validate:"omitempty,oneof=none md5 sha sha256 sha512"`
+	AuthPassword string `yaml:"auth_password,omitempty"`
+	PrivProtocol string `yaml:"priv_protocol,omitempty" validate:"omitempty,oneof=none des aes aes192 aes256"`
+	PrivPassword string `yaml:"priv_password,omitempty"`
 }
 
 // IcmpConfig represents ICMP/ICMPv4 configuration.

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -76,7 +76,9 @@ func TestValidateRejectsBadInputs(t *testing.T) {
 // seed locked theirs in seed PR #1095 — this is NIAC's contribution
 // to the same shared spec.
 //
-// Anchored to keygen v2.0.0 (2026-05-21).
+// Anchored to keygen v2.2.0 (2026-05-27) — snmpv3 dropped from Pro
+// (free for all tiers; SNMPv3 is the only safe SNMP version, so
+// gating it would push users toward the cleartext v1/v2c variants).
 func TestKeygenContract(t *testing.T) {
 	t.Parallel()
 	vector := keygenVector{
@@ -87,7 +89,7 @@ func TestKeygenContract(t *testing.T) {
 		serial:  "NIACPRO",
 		features: []string{
 			"unlimited_devices",
-			"bgp", "ospf", "snmpv3", "netbios", "ftp", "stp",
+			"bgp", "ospf", "netbios", "ftp", "stp",
 			"ipv6_advanced", "error_injection", "traffic_shaping",
 			"config_templates", "multi_ip", "pcap_ingest", "rest_api",
 		},

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -216,10 +216,16 @@ func (li *Info) CanRunPro() bool {
 
 // proFeatures returns the feature list granted to NIAC Pro (product
 // code 5001). Mirrors keygen's productCatalog.
+//
+// snmpv3 was removed from Pro on 2026-05-27: SNMPv3 is the only safe
+// SNMP version (v1/v2c send credentials in cleartext), so gating it
+// would push customers toward the insecure variants. BGP + OSPF stay
+// on Pro because they're large protocol implementations, not a
+// safety floor.
 func proFeatures() []string {
 	return []string{
 		"unlimited_devices",
-		"bgp", "ospf", "snmpv3", "netbios", "ftp", "stp",
+		"bgp", "ospf", "netbios", "ftp", "stp",
 		"ipv6_advanced", "error_injection", "traffic_shaping",
 		"config_templates", "multi_ip", "pcap_ingest", "rest_api",
 	}


### PR DESCRIPTION
## Summary

- Adds `BGPConfig`, `OSPFConfig`, `SNMPv3Config` structs to the YAML schema (`internal/converter/types.go`) and domain config (`internal/config/types.go`) so the per-device protocol gate has concrete fields to detect.
- Wires `bgp` and `ospf` into `gatedDeviceProtocolChecks` (parity with `stp`/`ftp`/`netbios`).
- **`snmpv3` is deliberately NOT gated.** SNMPv3 is the only safe SNMP version (v1/v2c send credentials in cleartext), so gating it would push customers toward the insecure variants. Stays free for all NIAC tiers. A test (`TestRequireDeviceProtocolFeatures_AllowsSNMPv3OnFree`) pins this so any future "add snmpv3 to Pro" change has to delete it.
- Mirrors the keygen catalog change (msn-internal-tools/keygen PR #4) in `internal/license/validator.go` and updates `TestKeygenContract` to the new shape.
- Regenerates `docs/schemas/niac.schema.json` (drift-checked in CI).

Protocol speakers themselves (RFC 4271 BGP, RFC 2328 OSPF) remain a separate workstream — this PR only models config + gating.

Closes #129.

## Test plan

- [x] `make lint-backend` — 0 issues
- [x] `go test ./...` — all packages green
- [x] `TestRequireDeviceProtocolFeatures_BlocksFreeOnBGP` — blocks Free
- [x] `TestRequireDeviceProtocolFeatures_BlocksFreeOnOSPF` — blocks Free
- [x] `TestRequireDeviceProtocolFeatures_AllowsSNMPv3OnFree` — passes Free
- [x] `TestRequireDeviceProtocolFeatures_AllowsProTrial` — kitchen sink passes Pro
- [x] `TestKeygenContract` — pinned to keygen v2.2.0 catalog (snmpv3 removed)
- [x] `make schema` — 142 new lines (bgp/ospf/snmpv3 schemas), drift check passes