### PR TITLE
feat(ui): add slim HeaderBar (Phase 2)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,17 +1,16 @@
-import { Moon, Sun, Wrench } from 'lucide-react';
-import { memo, type ReactElement, type ReactNode, Suspense, useState } from 'react';
+import { Wrench } from 'lucide-react';
+import { memo, type ReactNode, Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { ErrorBoundary, PageErrorBoundary } from './components/ErrorBoundary';
+import { HeaderBar } from './components/HeaderBar';
 import { HelpDrawer } from './components/HelpDrawer';
 import { SettingsDrawer } from './components/SettingsDrawer';
 import { AppProvider, useAppState } from './contexts/AppContext';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
-import { useTheme } from './hooks/useTheme';
 import { useNavGroups } from './navGroups';
 import { DeviceEditorPageRef, type PageConfig, usePages } from './pageRegistry';
 import { Breadcrumbs } from './ui/Breadcrumbs';
-import { ConnectionStatus } from './ui/ConnectionStatus';
 import { PageHeader } from './ui/PageHeader';
 import { PageLoader } from './ui/PageLoader';
 import { SidebarLayout } from './ui/Sidebar';
@@ -38,41 +37,6 @@ export default function App() {
   );
 }
 
-/**
- * TopBar renders the sticky upper-right control cluster: connection
- * indicator + theme toggle. Mirrors stem's UI shell so cross-product
- * navigation has consistent affordances.
- */
-function TopBar(): ReactElement {
-  const { t } = useTranslation('common');
-  const { isDark, toggleTheme } = useTheme();
-  const themeToggleLabel = isDark
-    ? t('accessibility.switchToLightMode')
-    : t('accessibility.switchToDarkMode');
-  return (
-    <>
-      {/* Left side reserved for future breadcrumbs / page-level chrome. */}
-      <div className="flex items-center" />
-      <div className="flex items-center gap-compact">
-        <ConnectionStatus />
-        <button
-          type="button"
-          onClick={toggleTheme}
-          className="pad-xs rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-hover"
-          title={themeToggleLabel}
-          aria-label={themeToggleLabel}
-        >
-          {isDark ? (
-            <Sun className="h-5 w-5" aria-hidden="true" />
-          ) : (
-            <Moon className="h-5 w-5" aria-hidden="true" />
-          )}
-        </button>
-      </div>
-    </>
-  );
-}
-
 function AppShell() {
   const { t } = useTranslation('pages');
   const { data: version } = useAppState('version');
@@ -89,7 +53,7 @@ function AppShell() {
     <SidebarLayout
       groups={navGroups}
       version={version?.version}
-      topBar={<TopBar />}
+      topBar={<HeaderBar />}
       onOpenHelp={() => setHelpOpen(true)}
       onOpenSettings={() => setSettingsOpen(true)}
     >

--- a/ui/src/components/HeaderBar.tsx
+++ b/ui/src/components/HeaderBar.tsx
@@ -1,0 +1,56 @@
+/**
+ * HeaderBar — NIAC's slim three-slot header.
+ *
+ * Per the canonical convention (stem/ui/SHELL.md): per-product, not synced.
+ * NIAC has no profile system and no interface picker, so the right slot
+ * carries only the theme toggle. Settings + Help live in the sidebar
+ * footer; there is no logout (NIAC is single-user).
+ *
+ *   ┌──────────────────────────────────────────────────────────────┐
+ *   │ [logo] NIAC  [ConnectionStatus]    …    [theme toggle]       │
+ *   └──────────────────────────────────────────────────────────────┘
+ */
+import { Moon, Network, Sun } from 'lucide-react';
+import type { FC, ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../hooks/useTheme';
+import { ConnectionStatus } from '../ui/ConnectionStatus';
+
+export const HeaderBar: FC = (): ReactElement => {
+  const { t } = useTranslation('common');
+  const { isDark, toggleTheme } = useTheme();
+  const themeToggleLabel = isDark
+    ? t('accessibility.switchToLightMode')
+    : t('accessibility.switchToDarkMode');
+
+  return (
+    <>
+      {/* Left slot: logo + product name + connection status */}
+      <div className="flex items-center gap-default min-w-0">
+        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center shrink-0">
+          <Network className="h-5 w-5 text-text-inverse" aria-hidden="true" />
+        </div>
+        <span className="font-display font-bold text-text-primary truncate">NIAC</span>
+        <ConnectionStatus />
+      </div>
+
+      {/* Right slot: theme toggle only (no profiles / interfaces in NIAC).
+       * Settings + Help live in the sidebar footer; see stem/ui/SHELL.md. */}
+      <div className="flex items-center gap-tight">
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="pad-xs rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-hover"
+          title={themeToggleLabel}
+          aria-label={themeToggleLabel}
+        >
+          {isDark ? (
+            <Sun className="h-5 w-5" aria-hidden="true" />
+          ) : (
+            <Moon className="h-5 w-5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

NIAC's first proper HeaderBar. Follows the canonical three-slot shape documented in `stem/ui/SHELL.md` (added in stem #342). Replaces the inline `TopBar` function in `App.tsx`.

**Stacked on #738** (Phase 1). Will rebase onto main once that lands.

## Layout

```
┌──────────────────────────────────────────────────────────────┐
│ [logo] NIAC  [ConnectionStatus]    …    [theme toggle]       │
└──────────────────────────────────────────────────────────────┘
   ◄────── LEFT ──────►   ◄ CENTER ►   ◄──── RIGHT ────►
```

## Per-product slot fills

| Slot | Contents |
|---|---|
| **LEFT** | Network-icon logo on brand gradient + "NIAC" wordmark + `ConnectionStatus` (polls `/api/v1/version`) |
| **CENTER** | empty (reserved for breadcrumbs / page chrome) |
| **RIGHT** | theme toggle only |

NIAC has no profiles or interfaces → no Profile/Interface dropdowns. Help + Settings live in the sidebar footer (Phase 1). No Logout button (NIAC is single-user).

## File location + convention

`ui/src/components/HeaderBar.tsx` — same path stem and seed use. **Per-product, not synced** — the SHAPE is shared via `SHELL.md`; the implementation is local. NIAC's stays minimal until it grows interface / session concepts.

## App.tsx cleanup

- Replaces inline `TopBar` with `<HeaderBar />`.
- Drops now-unused imports: `Moon`, `Sun`, `ConnectionStatus`, `useTheme`, `useTranslation('common')` — all encapsulated in HeaderBar.

## Test plan

- [x] `./scripts/check-token-discipline.sh` — PASS
- [x] `./scripts/sync-shell.sh --verify` — PASS
- [x] `npm run build` — PASS
- [x] `npm run lint` — PASS
- [ ] Visual smoke: NIAC-indigo logo gradient, connection-status pill on the left, theme toggle on the right; sidebar's help/settings buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)