### PR TITLE
fix(ci): unblock NIAC main — duplicate heading + Lighthouse cert

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -4,9 +4,9 @@
       "url": ["https://localhost:8445/"],
       "numberOfRuns": 3,
       "settings": {
-        "preset": "desktop"
-      },
-      "chromeFlags": "--ignore-certificate-errors --no-sandbox"
+        "preset": "desktop",
+        "chromeFlags": "--ignore-certificate-errors --allow-insecure-localhost --no-sandbox"
+      }
     },
     "assert": {
       "preset": "lighthouse:recommended",

--- a/ui/src/pages/ConfigDiffPage.tsx
+++ b/ui/src/pages/ConfigDiffPage.tsx
@@ -153,24 +153,20 @@ export const ConfigDiffPage: FC = () => {
       {/* Header section */}
       <Card className="border-surface-border bg-bg-surface/70">
         <CardContent className="stack-lg">
-          <div className="flex flex-wrap items-center justify-between gap-comfortable">
-            <div>
-              <H2 className="flex items-center gap-compact">
-                <GitCompare className={`${iconSizes.lg} text-brand-accent`} />
-                Compare & Merge
-              </H2>
-              <P className="text-text-muted mt-tight">
-                Compare two YAML network configs side-by-side and merge changes between them.
-              </P>
+          {/* Page-level "Compare & Merge" title + description live in
+           * PageHeader (rendered by App.tsx via pageRegistry.title /
+           * .description). Duplicating them inside the Card creates a
+           * strict-mode heading conflict (PageHeader h1 + Card h2 both
+           * matched getByRole('heading', { name: /compare & merge/i })).
+           * The Card now opens straight into its actions; the changes
+           * counter remains on the right when files are present. */}
+          {hasFiles && (
+            <div className="flex items-center justify-end gap-compact">
+              <Tag colorScheme="purple">
+                {diffBlocks.filter((b) => b.type !== 'unchanged').length} changes
+              </Tag>
             </div>
-            {hasFiles && (
-              <div className="flex items-center gap-compact">
-                <Tag colorScheme="purple">
-                  {diffBlocks.filter((b) => b.type !== 'unchanged').length} changes
-                </Tag>
-              </div>
-            )}
-          </div>
+          )}
 
           {/* Status message */}
           {message && (


### PR DESCRIPTION
## Summary

Two failures on NIAC main are blocking release-please from refreshing the release PR. Real fixes (not threshold relaxations).

## E2E — duplicate heading

\`config-diff-page.spec.ts:18\` uses \`getByRole('heading', { name: /^compare & merge$/i })\` which matched **two** elements in strict mode:
1. The page-level \`<h1>\` rendered by \`PageHeader\` (via \`pageRegistry.title\`)
2. A card-level \`<h2>\` inside \`ConfigDiffPage\` that duplicated the same title

**Fix**: removed the redundant H2+P block. The Card now opens straight into its actions; the diff-block counter remains on the right when files are present. \`PageHeader\` continues to provide the page-level h1, breadcrumbs, and description — this is the correct division per our Phase 1 PageHeader contract.

## Lighthouse — self-signed cert blocked navigation

Run logs showed \`INSECURE_DOCUMENT_REQUEST\` at \`https://localhost:8445/\` — Chrome bailed on the self-signed dev cert.

The config had \`chromeFlags\` at the wrong nesting level (sibling of \`settings\` instead of inside it). Lighthouse CI silently ignored the flags so the navigation failed.

**Fix**: moved \`chromeFlags\` into \`settings\` (per Lighthouse CI's schema) and added \`--allow-insecure-localhost\` to match stem's config:
\`\`\`json
"settings": {
  "preset": "desktop",
  "chromeFlags": "--ignore-certificate-errors --allow-insecure-localhost --no-sandbox"
}
\`\`\`

## Test plan

- [x] \`npm run build\` — PASS
- [ ] CI E2E (config-diff-page heading test) — should pass on this PR
- [ ] CI Lighthouse — should at least navigate now; some perf assertions may still need attention
🤖 Generated with [Claude Code](https://claude.com/claude-code)