### PR TITLE
fix(ui): restore missing spacing classes + dual-aside e2e selector

### DIFF
--- a/ui/e2e/language-switch.spec.ts
+++ b/ui/e2e/language-switch.spec.ts
@@ -42,7 +42,12 @@ test.describe('Language switching', () => {
     // Two stable EN markers: the Dashboard nav label (sidebar) and the
     // page-header h1. Both come from pages.dashboard.{label,title} —
     // changing them should require updating this test AND the TM.
-    await expect(page.getByText(/^Dashboard$/).first()).toBeVisible();
+    //
+    // The canonical Sidebar renders its body in both a mobile aside
+    // (`lg:hidden`) and a desktop aside (`hidden lg:flex`). At the default
+    // 1280px viewport the mobile aside is display:none, so `.first()`
+    // matches a hidden node. Use `.last()` for the visible desktop aside.
+    await expect(page.getByText(/^Dashboard$/).last()).toBeVisible();
   });
 
   test('flips to Spanish when localStorage is set to es', async ({ page }) => {
@@ -64,7 +69,8 @@ test.describe('Language switching', () => {
     // ES marker: Dashboard's translated label is "Panel" per
     // pages.dashboard.label in es/pages.json + the TM. The sidebar
     // shows this label, and so does the page header title.
-    await expect(page.getByText(/Panel/).first()).toBeVisible();
+    // See above for why `.last()` rather than `.first()`.
+    await expect(page.getByText(/Panel/).last()).toBeVisible();
   });
 
   test('honors pluralization for device count', async ({ page }) => {

--- a/ui/public/robots.txt
+++ b/ui/public/robots.txt
@@ -1,0 +1,4 @@
+# NIAC is an authenticated network device simulator — there is no public
+# content to index. Block all crawlers from the entire app.
+User-agent: *
+Disallow: /

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -376,6 +376,303 @@ body {
   .code {
     @apply font-mono text-sm bg-surface-hover px-1.5 py-0.5 rounded;
   }
+
+  /* ========================================================================
+     SPACING SCALE — harmonized with seed/stem (Phase 0 follow-up).
+     ========================================================================
+     NIAC previously used raw Tailwind spacing utilities directly. The Phase 0
+     tokenization migrated components to these semantic classes, but NIAC's
+     index.css never defined them (seed/stem did), so the migrated classes
+     were no-ops — all padding/gap/margin silently dropped. These definitions
+     restore them. Values match seed/stem exactly.
+     ======================================================================== */
+
+  /* Vertical stacking (space-y equivalents with semantic names) */
+  .stack-xs {
+    @apply space-y-1;
+  }
+  .stack-sm {
+    @apply space-y-2;
+  }
+  .stack {
+    @apply space-y-3;
+  }
+  .stack-lg {
+    @apply space-y-4;
+  }
+  .stack-xl {
+    @apply space-y-6;
+  }
+
+  /* Section separators */
+  .section-gap {
+    @apply space-y-6;
+  }
+  .section-gap-lg {
+    @apply space-y-8;
+  }
+
+  /* Component gaps (for flex/grid) */
+  .gap-tight {
+    @apply gap-1;
+  }
+  .gap-compact {
+    @apply gap-2;
+  }
+  .gap-default {
+    @apply gap-3;
+  }
+  .gap-comfortable {
+    @apply gap-4;
+  }
+  .gap-spacious {
+    @apply gap-6;
+  }
+
+  /* Card/container padding */
+  .pad-xs {
+    @apply p-2;
+  }
+  .pad-sm {
+    @apply p-3;
+  }
+  .pad {
+    @apply p-4;
+  }
+  .pad-lg {
+    @apply p-6;
+  }
+  .pad-xl {
+    @apply p-8;
+  }
+
+  /* Chip/pill padding */
+  .chip-pad {
+    @apply px-3 py-1;
+  }
+  .chip-pad-md {
+    @apply px-3 py-1.5;
+  }
+  .chip-pad-lg {
+    @apply px-3 py-2;
+  }
+
+  /* Tab button padding */
+  .tab-pad {
+    @apply py-2.5 px-3;
+  }
+
+  /* Inline spacing */
+  .inline-gap-xs {
+    @apply gap-1;
+  }
+  .inline-gap-sm {
+    @apply gap-1.5;
+  }
+  .inline-gap {
+    @apply gap-2;
+  }
+  .inline-gap-lg {
+    @apply gap-3;
+  }
+
+  /* Layout utilities */
+  .content-max {
+    @apply max-w-7xl mx-auto px-4;
+  }
+  .content-grid {
+    @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4;
+  }
+  .flex-center {
+    @apply flex items-center justify-center;
+  }
+  .flex-between {
+    @apply flex items-center justify-between;
+  }
+
+  /* ========================================================================
+     MARGIN UTILITIES — harmonized with seed/stem.
+     ======================================================================== */
+
+  /* Bottom margins */
+  .mb-section {
+    @apply mb-6;
+  }
+  .mb-section-lg {
+    @apply mb-8;
+  }
+  .mb-heading {
+    @apply mb-3;
+  }
+  .mb-content {
+    @apply mb-4;
+  }
+  .mb-tight {
+    @apply mb-1;
+  }
+
+  /* Top margins */
+  .mt-section {
+    @apply mt-8;
+  }
+  .mt-content {
+    @apply mt-4;
+  }
+  .mt-heading {
+    @apply mt-3;
+  }
+  .mt-inline {
+    @apply mt-2;
+  }
+  .mt-tight {
+    @apply mt-1;
+  }
+
+  /* Top/bottom padding for dividers/sections */
+  .pt-heading {
+    @apply pt-3;
+  }
+  .pt-section {
+    @apply pt-4;
+  }
+  .pt-tight {
+    @apply pt-1;
+  }
+  .pb-inline {
+    @apply pb-2;
+  }
+  .pb-tight {
+    @apply pb-1;
+  }
+
+  /* Centered content padding */
+  .py-centered {
+    @apply py-12;
+  }
+
+  /* Left margins */
+  .ml-tight {
+    @apply ml-1;
+  }
+  .ml-inline {
+    @apply ml-2;
+  }
+  .ml-content {
+    @apply ml-4;
+  }
+  .ml-spacious {
+    @apply ml-6;
+  }
+
+  /* Right padding (inputs with icons) */
+  .pr-icon {
+    @apply pr-10;
+  }
+  .pr-tight {
+    @apply pr-8;
+  }
+
+  /* Compact action button padding */
+  .action-btn-pad {
+    @apply px-1;
+  }
+
+  /* Micro spacing */
+  .gap-micro {
+    @apply gap-0.5;
+  }
+  .mt-micro {
+    @apply mt-0.5;
+  }
+  .pb-micro {
+    @apply pb-0.5;
+  }
+  .pb-compact {
+    @apply pb-1;
+  }
+  .pb-compact-md {
+    @apply pb-1.5;
+  }
+  .mt-compact-md {
+    @apply mt-1.5;
+  }
+  .-mt-tight {
+    @apply -mt-1;
+  }
+
+  /* Badge/status indicator padding */
+  .p-badge-xs {
+    @apply p-0.5;
+  }
+  .p-badge-sm {
+    @apply p-1;
+  }
+  .badge-pad-xs {
+    @apply px-2 py-0.5;
+  }
+  .kbd-pad {
+    @apply px-1 py-0.5;
+  }
+
+  /* Left padding for indentation */
+  .pl-indent {
+    @apply pl-5;
+  }
+
+  /* Compact vertical padding */
+  .py-compact {
+    @apply py-1;
+  }
+  .py-compact-md {
+    @apply py-1.5;
+  }
+  .py-row {
+    @apply py-2;
+  }
+  .py-row-lg {
+    @apply py-3;
+  }
+
+  /* Compact horizontal padding */
+  .px-cell {
+    @apply px-2;
+  }
+
+  /* Icon button padding */
+  .p-icon-btn {
+    @apply p-1;
+  }
+  .p-icon-btn-md {
+    @apply p-1.5;
+  }
+
+  /* Main content padding (responsive) */
+  .main-padding-y {
+    @apply py-4 sm:py-6;
+  }
+  .content-padding-x {
+    @apply px-4 sm:px-6 lg:px-8;
+  }
+
+  /* Header padding (responsive) */
+  .header-padding-y {
+    @apply py-2 sm:py-3;
+  }
+
+  /* Drawer/Panel content padding */
+  .drawer-content-pad {
+    @apply px-4 sm:px-5 pb-10 pt-4;
+  }
+
+  /* Table cell padding */
+  .table-cell-empty {
+    @apply px-2 py-4;
+  }
+
+  /* Custom max-width for main container */
+  .max-w-8xl {
+    max-width: 88rem;
+  }
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary

Root-cause fix for niac's E2E failures **and** a silent visual regression: niac's entire UI has been rendering with **no padding/gap/margin** since Phase 0 merged.

## The big one: spacing utilities were never defined in niac

Phase 0 tokenization migrated niac components from raw Tailwind (`p-4`, `gap-3`, `space-y-3`, `flex items-center justify-between`) to semantic classes (`pad`, `gap-default`, `stack`, `flex-between`). **Unlike seed/stem, niac's `index.css` never defined those classes** — so every migrated class was a silent no-op. All spacing dropped across the app.

Why it slipped through:
- Tailwind v4 doesn't error on unknown utility classes
- The token-discipline gate bans *raw* palette/spacing — it doesn't verify the *semantic target* exists
- So CI built green while the UI rendered unstyled

**Fix**: added the full `SPACING SCALE` + `MARGIN UTILITIES` block to niac's `@layer components`, values identical to seed/stem. CSS bundle grew to ~101 kB confirming the classes now generate.

This directly explains two CI failures:
- **Responsive touch-target E2E** (20px < 32px): the HeaderBar theme toggle's `pad-xs` resolved to nothing → 20px button. With `pad-xs = p-2` restored it's 36px.
- **CLS** (Lighthouse): content reflowed as layout settled without reserved spacing.

## Also fixed

- **language-switch E2E**: `getByText(...).first()` matched the hidden mobile sidebar (display:none at 1280px). Switched to `.last()` for the visible desktop aside (same as stem).
- **robots.txt**: corrected stale "The Stem" copy-paste to NIAC.

## Follow-up (not in this PR)

Lighthouse may still flag `errors-in-console`, `unused-css-rules` (maxLength:0 is unrealistic for Tailwind), `bf-cache`, `network-dependency-tree`. Those need a separate audit-config + console-error pass — tracked.

## Test plan

- [x] `npm run build` — PASS, CSS bundle grew (classes generate)
- [x] `./scripts/check-token-discipline.sh` — clean
- [ ] CI E2E (responsive touch-targets + language-switch) — should pass
- [ ] Visual: niac should have its spacing back

🤖 Generated with [Claude Code](https://claude.com/claude-code)