### PR TITLE
fix(ui): re-sync shell — sidebar shows "NIAC" not "The Stem"

### DIFF
--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "title": "NIAC",
     "name": "NIAC",
     "fullName": "Network In A Can",
     "tagline": "Network protocol simulator and packet inspector"

--- a/internal/i18n/locales/es/common.json
+++ b/internal/i18n/locales/es/common.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "title": "NIAC",
     "name": "NIAC",
     "fullName": "Network In A Can",
     "tagline": "Simulador de protocolos de red e inspector de paquetes"

--- a/ui/src/ui/.shell-sync.lock
+++ b/ui/src/ui/.shell-sync.lock
@@ -1,3 +1,3 @@
-# SOURCE_SHA: 2b6604246970750e83e6fee5b5d0b3d3c1b6d48c  (chore/phase1-canonical-shell-modernize)
-781da6243dcbff582cfd446c401b8672d4142712dad203806b72b3072e606e74  ui/src/ui/Sidebar.tsx
-77dedb9669e2970233ab5d2fbc0ba40ebef78c16b314c0b49245eacd177fd470  ui/src/ui/PageHeader.tsx
+# SOURCE_SHA: 446b6390f4353378d0b8b55c2d6721a39d1807b2  (main)
+97305633aafc625cf225c5ec13eb2a16b89e185865f486087612b2d4911d8fa3  ui/src/ui/Sidebar.tsx
+8117cbffb0ab32f90880415d4dea586ec299e68139049ceb0f574e22193dfb48  ui/src/ui/PageHeader.tsx

--- a/ui/src/ui/PageHeader.tsx
+++ b/ui/src/ui/PageHeader.tsx
@@ -1,4 +1,4 @@
-// SYNCED FROM stem@2b6604246970 — DO NOT EDIT.
+// SYNCED FROM stem@446b6390f435 — DO NOT EDIT.
 // Edits in this repo will be overwritten on next `make sync-shell`.
 // To change this file, send a PR to stem then re-sync.
 /**
@@ -142,7 +142,9 @@ export const PageHeader: FC<PageHeaderProps> = ({
         <div className="flex items-center gap-default">
           {icon ? createElement(icon, { className: `h-8 w-8 ${iconColorClass}` }) : null}
           <div>
-            <h1 className="heading-1 font-display">{title}</h1>
+            <h1 className="heading-1 font-display" data-testid="page-header-title">
+              {title}
+            </h1>
             {description ? <p className="body-small mt-tight max-w-2xl">{description}</p> : null}
           </div>
         </div>

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -1,4 +1,4 @@
-// SYNCED FROM stem@2b6604246970 — DO NOT EDIT.
+// SYNCED FROM stem@446b6390f435 — DO NOT EDIT.
 // Edits in this repo will be overwritten on next `make sync-shell`.
 // To change this file, send a PR to stem then re-sync.
 /**
@@ -26,6 +26,7 @@ import {
   X,
 } from 'lucide-react';
 import { createElement, type FC, type ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { iconSizes } from '../constants/sizes';
 import { prefetchRoute } from '../utils/prefetch';
@@ -139,38 +140,41 @@ interface SidebarHeaderProps {
   onCollapse: () => void;
 }
 
-const SidebarHeader: FC<SidebarHeaderProps> = ({ collapsed, onCollapse }) => (
-  <div
-    className={`flex items-center ${
-      collapsed ? 'justify-center' : 'justify-between'
-    } px-3 py-4 border-b border-surface-border`}
-  >
-    <div className={`flex items-center gap-compact ${collapsed ? 'justify-center' : ''}`}>
-      <div className="relative flex-shrink-0">
-        <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center shadow-lg">
-          <Activity className={`${iconSizes.lg} text-text-inverse`} />
+const SidebarHeader: FC<SidebarHeaderProps> = ({ collapsed, onCollapse }) => {
+  const { t } = useTranslation();
+  return (
+    <div
+      className={`flex items-center ${
+        collapsed ? 'justify-center' : 'justify-between'
+      } px-3 py-4 border-b border-surface-border`}
+    >
+      <div className={`flex items-center gap-compact ${collapsed ? 'justify-center' : ''}`}>
+        <div className="relative flex-shrink-0">
+          <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center shadow-lg">
+            <Activity className={`${iconSizes.lg} text-text-inverse`} />
+          </div>
+          <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-status-success border-2 border-surface-raised" />
         </div>
-        <div className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-status-success border-2 border-surface-raised" />
+        {!collapsed ? (
+          <span className="font-display font-bold text-lg text-text-primary tracking-tight">
+            {t('app.title')}
+          </span>
+        ) : null}
       </div>
       {!collapsed ? (
-        <span className="font-display font-bold text-lg text-text-primary tracking-tight">
-          The Stem
-        </span>
+        <button
+          type="button"
+          onClick={onCollapse}
+          className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors lg:flex hidden"
+          title="Collapse sidebar"
+          aria-label="Collapse sidebar"
+        >
+          <ChevronLeft className={iconSizes.md} />
+        </button>
       ) : null}
     </div>
-    {!collapsed ? (
-      <button
-        type="button"
-        onClick={onCollapse}
-        className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors lg:flex hidden"
-        title="Collapse sidebar"
-        aria-label="Collapse sidebar"
-      >
-        <ChevronLeft className={iconSizes.md} />
-      </button>
-    ) : null}
-  </div>
-);
+  );
+};
 
 interface SidebarFooterProps {
   collapsed: boolean;
@@ -297,68 +301,79 @@ const SidebarBody: FC<SidebarBodyProps> = ({
   onOpenSettings,
   onOpenHistory,
   onOpenProfiles,
-}) => (
-  <>
-    <SidebarHeader collapsed={collapsed} onCollapse={onCollapse} />
-    <nav className="flex-1 overflow-y-auto py-4 px-cell stack-xl">
-      {groups.map((group, groupIndex) => (
-        <div key={group.label || `nav-group-${String(groupIndex)}`}>
-          {!collapsed && group.label ? (
-            <h3 className="px-3 mb-2 text-xs font-semibold text-text-muted uppercase tracking-wider">
-              {group.label}
-            </h3>
-          ) : null}
-          {collapsed ? <div className="h-px bg-surface-border mx-2 mb-2" /> : null}
-          <div className="stack-xs">
-            {group.items.map((item) => (
-              <NavItemButton
-                key={item.path}
-                item={item}
-                active={isActive(item.path)}
-                collapsed={collapsed}
-                onNavigate={onNavigate}
-              />
-            ))}
+}) => {
+  const { t } = useTranslation();
+  // group.label is either a plain display string ("Account") or an
+  // i18n key ("common:sections.modules"). t() returns the translation
+  // if the key resolves; otherwise the defaultValue (label itself).
+  const translateLabel = (label: string): string =>
+    label ? t(label, { defaultValue: label }) : '';
+  return (
+    <>
+      <SidebarHeader collapsed={collapsed} onCollapse={onCollapse} />
+      <nav className="flex-1 overflow-y-auto py-4 px-cell stack-xl">
+        {groups.map((group, groupIndex) => (
+          <div key={group.label || `nav-group-${String(groupIndex)}`}>
+            {!collapsed && group.label ? (
+              <h3 className="px-3 mb-2 text-xs font-semibold text-text-muted uppercase tracking-wider">
+                {translateLabel(group.label)}
+              </h3>
+            ) : null}
+            {collapsed ? <div className="h-px bg-surface-border mx-2 mb-2" /> : null}
+            <div className="stack-xs">
+              {group.items.map((item) => (
+                <NavItemButton
+                  key={item.path}
+                  item={item}
+                  active={isActive(item.path)}
+                  collapsed={collapsed}
+                  onNavigate={onNavigate}
+                />
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
-    </nav>
-    <SidebarFooter
-      collapsed={collapsed}
-      version={version}
-      onOpenHelp={onOpenHelp}
-      onOpenSettings={onOpenSettings}
-      onOpenHistory={onOpenHistory}
-      onOpenProfiles={onOpenProfiles}
-      onExpand={onExpand}
-    />
-  </>
-);
+        ))}
+      </nav>
+      <SidebarFooter
+        collapsed={collapsed}
+        version={version}
+        onOpenHelp={onOpenHelp}
+        onOpenSettings={onOpenSettings}
+        onOpenHistory={onOpenHistory}
+        onOpenProfiles={onOpenProfiles}
+        onExpand={onExpand}
+      />
+    </>
+  );
+};
 
 interface MobileTopBarProps {
   mobileOpen: boolean;
   toggleMobile: () => void;
 }
 
-const MobileTopBar: FC<MobileTopBarProps> = ({ mobileOpen, toggleMobile }) => (
-  <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex-between px-4 py-row-lg bg-surface-raised/95 backdrop-blur-xl border-b border-surface-border">
-    <div className="flex items-center gap-compact">
-      <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center">
-        <Activity className={`${iconSizes.md} text-text-inverse`} />
+const MobileTopBar: FC<MobileTopBarProps> = ({ mobileOpen, toggleMobile }) => {
+  const { t } = useTranslation();
+  return (
+    <header className="lg:hidden fixed top-0 left-0 right-0 z-50 flex-between px-4 py-row-lg bg-surface-raised/95 backdrop-blur-xl border-b border-surface-border">
+      <div className="flex items-center gap-compact">
+        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-brand-primary to-brand-accent flex-center">
+          <Activity className={`${iconSizes.md} text-text-inverse`} />
+        </div>
+        <span className="font-display font-bold text-text-primary">{t('app.title')}</span>
       </div>
-      <span className="font-display font-bold text-text-primary">The Stem</span>
-    </div>
-    <button
-      type="button"
-      onClick={toggleMobile}
-      className="pad-xs rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors"
-      title={mobileOpen ? 'Close menu' : 'Open menu'}
-      aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
-    >
-      {mobileOpen ? <X className={iconSizes.lg} /> : <Menu className={iconSizes.lg} />}
-    </button>
-  </header>
-);
+      <button
+        type="button"
+        onClick={toggleMobile}
+        className="pad-xs rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors"
+        title={mobileOpen ? 'Close menu' : 'Open menu'}
+        aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+      >
+        {mobileOpen ? <X className={iconSizes.lg} /> : <Menu className={iconSizes.lg} />}
+      </button>
+    </header>
+  );
+};
 
 export const SidebarLayout: FC<SidebarLayoutProps> = ({
   groups,


### PR DESCRIPTION
## Summary
Re-syncs the canonical shell from **stem@446b639** (PR stem#350), which renders the sidebar product name from `t('app.title')` rather than a hardcoded "The Stem". niac only defined `app.name`, so add **`app.title`="NIAC"** to the `en` and `es` locales; the sidebar header + mobile top bar now show "NIAC" instead of leaking "The Stem".

- `Sidebar.tsx`: synced (now uses `t('app.title')`).
- `PageHeader.tsx`: banner SHA bump only.
- `en`/`es` `common.json`: add `app.title`.
- `.shell-sync.lock`: updated checksums.

## Test plan
- [x] `sync-shell.sh` clean; `tsc --noEmit` clean; both locales have `app.title`
- [x] no "The Stem" hardcode remains
- [ ] CI green (incl. `sync-shell.sh --verify` + i18n validation)