### PR TITLE
feat(ui): add canonical help-drawer testids (Phase 3b)

### DIFF
--- a/ui/src/components/HelpDrawer.tsx
+++ b/ui/src/components/HelpDrawer.tsx
@@ -86,6 +86,7 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
         {/* Drawer */}
         <div
           ref={drawerRef}
+          data-testid="help-drawer"
           role="dialog"
           aria-modal="true"
           aria-label="Help"
@@ -100,6 +101,7 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
               </div>
               <button
                 type="button"
+                data-testid="help-drawer-close"
                 onClick={onClose}
                 className={cn(
                   'pad-xs hover:bg-surface-hover rounded-lg transition-colors',


### PR DESCRIPTION
Phase 3b (bounded) — add the canonical `help-drawer` / `help-drawer-close` testid pair to niac's help drawer (the reference drawer architecture) so help is consistently testable across products. `help-drawer-close` is the header X (distinct from the backdrop button). Testids only; ESC-close + `role=dialog`/`aria-modal` already present. tsc + biome clean.