### PR TITLE
fix(security): harden empty-store auth bypass + close CSRF gaps (#739, #740)

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"strings"
 )
@@ -180,13 +181,40 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 
 		// Wave 2: auth is keyed off the TokenStore, not the legacy
 		// single-token field on ServerConfig. An empty / unset store
-		// preserves Wave 1's "loopback-only, no auth configured"
-		// behaviour: the non-loopback gate in server.go has already
-		// refused to start in that case if the listener wasn't bound
-		// to loopback, so reaching this branch with an empty store
-		// implies the operator deliberately opted out.
+		// means "no auth configured". The startup gate
+		// (enforceNonLoopbackAuthGate) already refuses to bind a
+		// non-loopback address without a token — but #739 hardens this
+		// at request time too, so a refactor that weakens or relocates
+		// the startup gate can never silently expose a non-loopback
+		// listener. The bypass is allowed only when the bind is
+		// loopback-only OR the operator explicitly opted out via
+		// NIAC_AUTH_DISABLED=true.
 		if s.tokens == nil || s.tokens.Len() == 0 {
-			next(w, r)
+			if os.Getenv("NIAC_AUTH_DISABLED") == "true" {
+				next(w, r)
+
+				return
+			}
+			nonLoopback, _ := addrIsNonLoopback(s.cfg.Addr)
+			if !nonLoopback {
+				// Loopback-only, no token: the documented local-dev path.
+				next(w, r)
+
+				return
+			}
+			// Non-loopback + no token + no explicit opt-out. The startup
+			// gate should have prevented this; failing closed here is the
+			// defense-in-depth backstop.
+			s.logger.ErrorContext(r.Context(),
+				"[API] Refusing request: non-loopback bind has no tokens and NIAC_AUTH_DISABLED is not set",
+				"event", "auth.misconfigured",
+				"requestID", requestID,
+				"addr", s.cfg.Addr,
+				"path", r.URL.Path)
+			writeError(w, r, http.StatusUnauthorized, "auth_not_configured",
+				"Server is bound to a non-loopback address without authentication tokens. "+
+					"Set NIAC_API_TOKEN, or NIAC_AUTH_DISABLED=true to explicitly disable auth (development only).",
+				nil)
 
 			return
 		}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -33,6 +33,9 @@ devices:
 			Config: cfg,
 		},
 		logger: slog.Default(),
+		// auth() applies per-IP rate limiting before the token check, so
+		// any test that exercises auth() needs a non-nil limiter.
+		rateLimiter: NewRateLimiter(DefaultRateLimit, DefaultBurst),
 	}
 }
 
@@ -385,5 +388,79 @@ func TestAuthMiddleware_BackCompat_SingleNIACAPIToken(t *testing.T) {
 	}
 	if scope != ScopeReadWrite {
 		t.Errorf("Wave 1 single-token seed: scope = %v, want ScopeReadWrite", scope)
+	}
+}
+
+// TestAuth_EmptyStore_LoopbackBypasses confirms the documented local-dev
+// path: an empty token store on a loopback (or unbound) listener lets
+// requests through without auth (#739).
+func TestAuth_EmptyStore_LoopbackBypasses(t *testing.T) {
+	server := createTestServerForMiddleware(t)
+	server.tokens = NewTokenStore(nil) // empty store
+	server.cfg.Addr = "127.0.0.1:8445"
+
+	called := false
+	wrapped := server.auth(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if !called || rec.Code != http.StatusOK {
+		t.Errorf("loopback + empty store should bypass auth: called=%v code=%d", called, rec.Code)
+	}
+}
+
+// TestAuth_EmptyStore_NonLoopbackFailsClosed is the #739 regression test:
+// an empty token store on a NON-loopback listener, without an explicit
+// opt-out, must fail closed (401) instead of silently bypassing auth —
+// even though the startup gate should have prevented this bind.
+func TestAuth_EmptyStore_NonLoopbackFailsClosed(t *testing.T) {
+	server := createTestServerForMiddleware(t)
+	server.tokens = NewTokenStore(nil) // empty store
+	server.cfg.Addr = "0.0.0.0:8445"   // non-loopback
+
+	called := false
+	wrapped := server.auth(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if called {
+		t.Error("non-loopback + empty store must NOT reach the handler (silent auth bypass)")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for non-loopback unauth bind, got %d", rec.Code)
+	}
+}
+
+// TestAuth_EmptyStore_NonLoopbackExplicitOptOut verifies the operator can
+// still run unauthenticated on a non-loopback bind, but only by setting
+// NIAC_AUTH_DISABLED=true explicitly (#739).
+func TestAuth_EmptyStore_NonLoopbackExplicitOptOut(t *testing.T) {
+	t.Setenv("NIAC_AUTH_DISABLED", "true")
+	server := createTestServerForMiddleware(t)
+	server.tokens = NewTokenStore(nil)
+	server.cfg.Addr = "0.0.0.0:8445"
+
+	called := false
+	wrapped := server.auth(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if !called || rec.Code != http.StatusOK {
+		t.Errorf("explicit NIAC_AUTH_DISABLED=true should bypass: called=%v code=%d", called, rec.Code)
 	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -81,13 +81,21 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 	// SECURITY FIX #171: Apply file-specific rate limiting
 	mux.HandleFunc("/api/v1/files", s.recoverMiddleware(s.auth(s.fileRateLimit(s.handleFiles))))
 
-	// Templates API
-	mux.HandleFunc("/api/v1/templates", s.recoverMiddleware(s.auth(s.handleTemplates)))
-	mux.HandleFunc("/api/v1/templates/", s.recoverMiddleware(s.auth(s.handleTemplateByName)))
+	// Templates API. POST (upload), DELETE, and the "use" subpath all
+	// mutate state, so these go through csrfProtect like the other
+	// mutating routes (#740). csrfProtect internally skips GET, so reads
+	// still pass through untouched.
+	mux.HandleFunc("/api/v1/templates",
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleTemplates)))))
+	mux.HandleFunc("/api/v1/templates/",
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleTemplateByName)))))
 
-	// User Configs API - GET is read-only, POST/DELETE handled separately
-	mux.HandleFunc("/api/v1/configs", s.recoverMiddleware(s.auth(s.handleUserConfigs)))
-	mux.HandleFunc("/api/v1/configs/", s.recoverMiddleware(s.auth(s.handleUserConfigByName)))
+	// User Configs API. POST (upload) on /configs and DELETE on
+	// /configs/ mutate state — gate with csrfProtect (#740).
+	mux.HandleFunc("/api/v1/configs",
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleUserConfigs)))))
+	mux.HandleFunc("/api/v1/configs/",
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleUserConfigByName)))))
 
 	// Unified Library API (#548). Networks landed in PR 1 with full
 	// CRUD; walks/pcaps land in PR 3 as read-only browser endpoints —

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -695,4 +696,53 @@ func generateTestToken() string {
 	_, _ = rand.Read(b)
 
 	return base64.URLEncoding.EncodeToString(b)
+}
+
+// TestCSRFWiring_TemplatesAndConfigs is the #740 regression test: it
+// drives requests through the real mux (registerAPIRoutes) to prove the
+// templates + configs mutating endpoints actually have csrfProtect in
+// their middleware chain. A POST without the X-Csrf-Token header must be
+// rejected with 403 — if someone removes csrfProtect from routes.go,
+// this fails.
+func TestCSRFWiring_TemplatesAndConfigs(t *testing.T) {
+	server, _, token := newTestServerWithAuth(t)
+	// The templates/configs routes chain through writeRateLimit, whose
+	// limiter newTestServerWithAuth doesn't initialize — set it so the
+	// full mux chain doesn't nil-panic before reaching csrfProtect.
+	server.writeLimiter = NewRateLimiter(WriteRateLimit, WriteBurst)
+	mux := http.NewServeMux()
+	server.registerAPIRoutes(mux)
+
+	for _, path := range []string{"/api/v1/templates", "/api/v1/configs"} {
+		t.Run("POST "+path+" without CSRF -> 403", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path,
+				bytes.NewReader([]byte(`{"name":"x","content":"y"}`)))
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			// Deliberately NO X-Csrf-Token.
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("%s without CSRF: status = %d, want 403 (csrfProtect missing from route?)",
+					path, rec.Code)
+			}
+		})
+
+		t.Run("POST "+path+" with CSRF -> not 403", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path,
+				bytes.NewReader([]byte(`{"name":"x","content":"y"}`)))
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Csrf-Token", server.csrfToken)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			// We don't assert 200 (the body may be rejected by handler
+			// validation) — only that CSRF did not block it.
+			if rec.Code == http.StatusForbidden {
+				t.Errorf("%s with valid CSRF still 403: %s", path, rec.Body.String())
+			}
+		})
+	}
 }


### PR DESCRIPTION
## #739 — fail closed on non-loopback empty-store binds

The auth middleware bypassed authentication whenever the token store
was empty, trusting that the startup gate (enforceNonLoopbackAuthGate)
had already refused a non-loopback bind without a token. Those two
checks live in different files and can drift — a refactor that weakens
the startup gate would silently expose a non-loopback listener.

Now the request-time bypass is explicit:
- loopback (or unbound) + empty store → bypass (documented local-dev path)
- NIAC_AUTH_DISABLED=true → bypass (explicit operator opt-out)
- non-loopback + empty store + no opt-out → 401 fail-closed + ERROR log

## #740 — apply existing csrfProtect to templates + configs routes

Correction to the original issue: niac already HAS csrfProtect on most
mutating routes. The real gap was four endpoints that skipped it:
- /api/v1/templates       (POST upload — where UploadTemplateModal posts)
- /api/v1/templates/      (DELETE + the "use" POST subpath)
- /api/v1/configs         (POST upload)
- /api/v1/configs/        (DELETE)

All four now go through auth(writeRateLimit(csrfProtect(...))) matching
the 14 sibling mutating routes. csrfProtect skips GET internally so
reads are unaffected.

## Tests

- TestAuth_EmptyStore_LoopbackBypasses / _NonLoopbackFailsClosed /
  _NonLoopbackExplicitOptOut — lock the three #739 branches.
- TestCSRFWiring_TemplatesAndConfigs — drives requests through the real
  mux to prove csrfProtect is in the chain for templates + configs
  (POST without X-Csrf-Token → 403; with token → not blocked). Catches
  anyone removing csrfProtect from routes.go.
- Added rateLimiter to createTestServerForMiddleware (auth() rate-limits
  before the token check, so any auth() test needs a non-nil limiter).

Refs #739, #740.
