### PR TITLE
chore(security): add output-escaping/XSS regression gate (#742)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
           fi
           echo "Schema is up to date."
 
+      - name: Output-escaping / XSS gate (#742)
+        run: ./scripts/check-output-escaping.sh
+
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/scripts/check-output-escaping.sh
+++ b/scripts/check-output-escaping.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# check-output-escaping.sh — output-escaping / XSS regression gate (#742).
+#
+# Audited 2026-05-28: classified all fmt.Fprintf(w, ...) sites.
+#   - internal/converter (PrintSummary -> *bufio.Writer): CLI/file output.
+#   - internal/protocols/snmp/synth/format.go (io.Writer): SNMP walk-file
+#     generation, CLI/file output.
+#   - internal/api/handlers_metrics.go: Prometheus exposition format,
+#     Content-Type text/plain, metric names are server constants.
+#   - internal/api/sse_serve.go: SSE frame interpolating a fixed
+#     SSEStream enum ("packets"/"logs"/"stats"), never user input.
+# No site renders user-supplied data as HTML. This gate prevents
+# regressions.
+#
+# Two checks:
+#   1. No raw innerHTML injection in ui/src (React XSS vector).
+#   2. No NEW value-interpolating fmt.Fprintf(w, "...%s...") in
+#      internal/api outside the audited allow-list. HTTP responses
+#      should use writeJSON / json.Encode, never raw format strings.
+#
+# Run locally: scripts/check-output-escaping.sh
+
+set -uo pipefail
+
+FAIL=0
+INNER_HTML_RE='dangerously[S]etInnerHTML'
+
+# Files in internal/api whose Fprintf(w,...) sites were audited safe.
+# handlers_metrics.go: Prometheus text/plain, server-constant names.
+# sse_serve.go: SSE frame with a fixed server-side enum, not user input.
+ALLOWLIST_RE='internal/api/(handlers_metrics|sse_serve)\.go'
+
+UI_DIR=""
+if [ -d "ui/src" ]; then
+  UI_DIR="ui/src"
+elif [ -d "src" ] && [ -f "package.json" ]; then
+  UI_DIR="src"
+fi
+
+if [ -n "$UI_DIR" ]; then
+  DANGER=$(grep -rEn "$INNER_HTML_RE" "$UI_DIR" \
+    --include='*.tsx' --include='*.ts' 2>/dev/null \
+    | grep -vE '\.(test|spec|stories)\.(ts|tsx):' || true)
+  if [ -n "$DANGER" ]; then
+    echo "============================================================"
+    echo "[XSS] raw innerHTML injection found in UI app code:"
+    echo "$DANGER"
+    echo "Use plain text/JSX, or sanitize with DOMPurify and justify in review."
+    echo ""
+    FAIL=1
+  fi
+fi
+
+if [ -d "internal/api" ]; then
+  HTTP_FMT=$(grep -rEn 'fmt\.Fprintf\(w,[^)]*%[svqd]' internal/api 2>/dev/null \
+    | grep -v '_test.go' \
+    | grep -vE "$ALLOWLIST_RE" || true)
+  if [ -n "$HTTP_FMT" ]; then
+    echo "============================================================"
+    echo "[XSS] value-interpolating fmt.Fprintf(w, ...) in internal/api —"
+    echo "HTTP responses must use writeJSON / json.NewEncoder, not raw"
+    echo "format strings:"
+    echo "$HTTP_FMT"
+    echo ""
+    echo "If a new site is deliberately safe (text/plain or a"
+    echo "server-controlled enum), add it to ALLOWLIST_RE with a note."
+    echo ""
+    FAIL=1
+  fi
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAIL: output-escaping gate (#742)."
+  exit 1
+fi
+
+echo "OK: no raw innerHTML injection; internal/api Fprintf sites are within the audited allow-list."


### PR DESCRIPTION
Audit (2026-05-28): classified all 21 fmt.Fprintf(w, ...) sites.
- internal/converter PrintSummary (*bufio.Writer): CLI/file output
- internal/protocols/snmp/synth/format.go (io.Writer): SNMP walk-file
- internal/api/handlers_metrics.go: Prometheus text/plain, server-const names
- internal/api/sse_serve.go: SSE frame with a fixed SSEStream enum
  ("packets"/"logs"/"stats"), never user input
Zero sites render user data as HTML. No code fix needed.

Adds scripts/check-output-escaping.sh + CI wiring:
- fails on raw innerHTML injection in ui/src
- fails on NEW value-interpolating fmt.Fprintf(w, "...%s...") in
  internal/api outside the audited allow-list (handlers_metrics,
  sse_serve)

Closes #742.
