### PR TITLE
refactor(ui): on-color tokens + migrate white/black to tokens (NIAC 1/3)

### DIFF
--- a/ui/src/components/ColoringRulesPanel.tsx
+++ b/ui/src/components/ColoringRulesPanel.tsx
@@ -186,7 +186,7 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
     }, [onReset, onClose]);
 
     return (
-      <div className="fixed inset-0 z-50 flex-center bg-black/60">
+      <div className="fixed inset-0 z-50 flex-center bg-scrim/60">
         <div className="w-full max-w-3xl mx-4 bg-bg-surface border border-surface-border rounded-xl shadow-2xl max-h-[80vh] flex flex-col">
           {/* Header */}
           <div className="flex-between px-5 py-4 border-b border-surface-border">

--- a/ui/src/components/ConversationList.tsx
+++ b/ui/src/components/ConversationList.tsx
@@ -102,7 +102,7 @@ export const ConversationList: FC<ConversationListProps> = memo(
           </div>
 
           <div className="overflow-auto rounded-lg border border-surface-border max-h-[500px]">
-            <table className="min-w-full divide-y divide-white/5">
+            <table className="min-w-full divide-y divide-knob/5">
               <thead className="bg-bg-surface/80 sticky top-0 z-10">
                 <tr>
                   <th className="px-3 py-row text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
@@ -137,7 +137,7 @@ export const ConversationList: FC<ConversationListProps> = memo(
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-white/5">
+              <tbody className="divide-y divide-knob/5">
                 {sorted.map((conv) => (
                   <ConversationRow
                     key={conv.id}

--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -123,7 +123,7 @@ export class ErrorBoundary extends Component<Props, State> {
               <button
                 type="button"
                 onClick={this.handleReload}
-                className="inline-flex items-center gap-compact rounded-lg border border-border-muted bg-white px-4 py-row text-sm font-medium text-text-disabled transition-colors hover:bg-bg-muted focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2 dark:border-border-muted dark:bg-bg-elevated dark:text-text-secondary dark:hover:bg-bg-elevated"
+                className="inline-flex items-center gap-compact rounded-lg border border-border-muted bg-knob px-4 py-row text-sm font-medium text-text-disabled transition-colors hover:bg-bg-muted focus:outline-none focus:ring-2 focus:ring-status-info focus:ring-offset-2 dark:border-border-muted dark:bg-bg-elevated dark:text-text-secondary dark:hover:bg-bg-elevated"
               >
                 Reload Page
               </button>

--- a/ui/src/components/StreamView.tsx
+++ b/ui/src/components/StreamView.tsx
@@ -92,7 +92,7 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
   );
 
   return (
-    <div className="fixed inset-0 z-50 flex-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex-center bg-scrim/60">
       <div className="w-full max-w-4xl mx-4 bg-bg-surface border border-surface-border rounded-xl shadow-2xl max-h-[85vh] flex flex-col">
         {/* Header */}
         <div className="flex-between px-5 py-4 border-b border-surface-border">

--- a/ui/src/components/TemplatePreviewModal.tsx
+++ b/ui/src/components/TemplatePreviewModal.tsx
@@ -103,7 +103,7 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
     <div className="fixed inset-0 z-50 flex-center">
       <button
         type="button"
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
         onClick={onClose}
         aria-label="Close modal"
       />

--- a/ui/src/components/config/MergeControls.tsx
+++ b/ui/src/components/config/MergeControls.tsx
@@ -322,7 +322,7 @@ export const MergePreviewModal: FC<MergePreviewModalProps> = ({ content, onClose
     <div className="fixed inset-0 z-50 flex-center">
       <button
         type="button"
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
         onClick={onClose}
         aria-label="Close modal"
       />

--- a/ui/src/components/config/diff-viewer/DiffBlock.tsx
+++ b/ui/src/components/config/diff-viewer/DiffBlock.tsx
@@ -94,7 +94,7 @@ export const DiffBlockComponent: FC<DiffBlockComponentProps> = memo(
         )}
 
         {/* Side-by-side diff display */}
-        <div className="grid grid-cols-2 divide-x divide-white/10">
+        <div className="grid grid-cols-2 divide-x divide-knob/10">
           {/* Left panel */}
           <div className="overflow-x-auto">
             {paddedLeftLines.map((line, idx) => (

--- a/ui/src/components/debug/ProtocolDebugLevels.tsx
+++ b/ui/src/components/debug/ProtocolDebugLevels.tsx
@@ -118,7 +118,7 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
             [&::-webkit-slider-thumb]:h-5
             [&::-webkit-slider-thumb]:w-5
             [&::-webkit-slider-thumb]:rounded-full
-            [&::-webkit-slider-thumb]:bg-white
+            [&::-webkit-slider-thumb]:bg-knob
             [&::-webkit-slider-thumb]:shadow-md
             [&::-webkit-slider-thumb]:border-2
             [&::-webkit-slider-thumb]:border-brand-accent
@@ -127,7 +127,7 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
             [&::-moz-range-thumb]:h-5
             [&::-moz-range-thumb]:w-5
             [&::-moz-range-thumb]:rounded-full
-            [&::-moz-range-thumb]:bg-white
+            [&::-moz-range-thumb]:bg-knob
             [&::-moz-range-thumb]:shadow-md
             [&::-moz-range-thumb]:border-2
             [&::-moz-range-thumb]:border-brand-accent"

--- a/ui/src/components/device-editor/DeleteConfirmModal.tsx
+++ b/ui/src/components/device-editor/DeleteConfirmModal.tsx
@@ -20,7 +20,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
     <div className="fixed inset-0 z-50 flex-center">
       <button
         type="button"
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
         onClick={onCancel}
         aria-label="Close delete confirmation"
       />

--- a/ui/src/components/device-editor/FTPSection.tsx
+++ b/ui/src/components/device-editor/FTPSection.tsx
@@ -77,7 +77,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                 />
                 <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
-                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.ftp.allowAnonymous ? 'translate-x-4' : ''}`}
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${device.ftp.allowAnonymous ? 'translate-x-4' : ''}`}
                   />
                 </div>
                 <span className="ml-3 text-sm text-text-secondary">

--- a/ui/src/components/device-editor/TrafficSection.tsx
+++ b/ui/src/components/device-editor/TrafficSection.tsx
@@ -72,7 +72,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                 />
                 <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
-                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.arpAnnouncements?.enabled ? 'translate-x-4' : ''}`}
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${device.traffic.arpAnnouncements?.enabled ? 'translate-x-4' : ''}`}
                   />
                 </div>
               </label>
@@ -124,7 +124,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                 />
                 <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
-                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.periodicPings?.enabled ? 'translate-x-4' : ''}`}
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${device.traffic.periodicPings?.enabled ? 'translate-x-4' : ''}`}
                   />
                 </div>
               </label>
@@ -199,7 +199,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                 />
                 <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                   <div
-                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${device.traffic.randomTraffic?.enabled ? 'translate-x-4' : ''}`}
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${device.traffic.randomTraffic?.enabled ? 'translate-x-4' : ''}`}
                   />
                 </div>
               </label>

--- a/ui/src/components/device-list/CloneDeviceModal.tsx
+++ b/ui/src/components/device-list/CloneDeviceModal.tsx
@@ -31,7 +31,7 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
     <div className="fixed inset-0 z-50 flex-center">
       <button
         type="button"
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
         onClick={onCancel}
         aria-label="Close clone device modal"
       />

--- a/ui/src/components/device-list/ConfirmDeleteModal.tsx
+++ b/ui/src/components/device-list/ConfirmDeleteModal.tsx
@@ -16,7 +16,7 @@ export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
   <div className="fixed inset-0 z-50 flex-center">
     <button
       type="button"
-      className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+      className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
       onClick={onCancel}
       aria-label="Close delete confirmation"
     />

--- a/ui/src/components/device-list/DeviceTableView.tsx
+++ b/ui/src/components/device-list/DeviceTableView.tsx
@@ -41,7 +41,7 @@ export const DeviceTableView: FC = () => {
         </div>
 
         {/* Device rows */}
-        <div className="divide-y divide-white/5">
+        <div className="divide-y divide-knob/5">
           {devices.map((device) => {
             // Defensive: wild device types like "ap" / "access-point" aren't
             // in the DeviceType union; fall back to 'unknown' so the lookup

--- a/ui/src/components/form/CollapsibleSection.tsx
+++ b/ui/src/components/form/CollapsibleSection.tsx
@@ -56,7 +56,7 @@ export const CollapsibleSection: FC<CollapsibleSectionProps> = ({
               />
               <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
                 <div
-                  className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${enabled ? 'translate-x-4' : ''}`}
+                  className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${enabled ? 'translate-x-4' : ''}`}
                 />
               </div>
             </label>

--- a/ui/src/components/pcap/PcapPacketList.tsx
+++ b/ui/src/components/pcap/PcapPacketList.tsx
@@ -108,7 +108,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
                 </div>
               </div>
             ) : (
-              <table className="min-w-full divide-y divide-white/5">
+              <table className="min-w-full divide-y divide-knob/5">
                 <thead className="bg-bg-surface/80 sticky top-0 z-10">
                   <tr>
                     <th className="px-3 py-row text-left text-xs font-semibold uppercase tracking-wide text-text-muted">
@@ -138,7 +138,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-white/5">
+                <tbody className="divide-y divide-knob/5">
                   {packets.map((packet, idx) => (
                     <PacketRow
                       key={packet.id}

--- a/ui/src/components/simulation/ConfigPickerList.tsx
+++ b/ui/src/components/simulation/ConfigPickerList.tsx
@@ -97,7 +97,7 @@ export const ConfigsList: FC<{
             ))}
           </div>
         ) : (
-          <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-surface-border bg-bg-base/40">
+          <ul className="divide-y divide-knob/5 overflow-hidden rounded-lg border border-surface-border bg-bg-base/40">
             {items.map((item) => (
               <ConfigRow
                 key={item.key}

--- a/ui/src/components/templates/JavaDslImportCard.tsx
+++ b/ui/src/components/templates/JavaDslImportCard.tsx
@@ -70,7 +70,7 @@ export const JavaDslImportCard: FC = () => {
         </P>
 
         <div className="flex flex-wrap items-center gap-default">
-          <label className="cursor-pointer rounded bg-bg-elevated/60 px-3 py-compact-md text-xs font-medium text-text-primary ring-1 ring-white/10 hover:bg-bg-elevated">
+          <label className="cursor-pointer rounded bg-bg-elevated/60 px-3 py-compact-md text-xs font-medium text-text-primary ring-1 ring-knob/10 hover:bg-bg-elevated">
             Choose .cfg file…
             <input type="file" accept=".cfg,.conf,.txt" onChange={onPickFile} className="hidden" />
           </label>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -234,6 +234,13 @@
   --color-surface-deep: #020617;
   --color-scrim: #000000;
   --color-knob: #ffffff;
+
+  /* On-color foregrounds — AA text/icon on a filled brand/status surface.
+   * NIAC's brand (indigo) and status-error/info fills are saturated, so these
+   * are white. Constant across modes. Replaces bare text-white on buttons. */
+  --color-on-brand: #ffffff;
+  --color-on-danger: #ffffff;
+  --color-on-info: #ffffff;
 }
 
 /* ==========================================================================

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -83,7 +83,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
   if (!useVirtualization) {
     return (
       <div className="overflow-x-auto rounded-xl border border-surface-border">
-        <table className="min-w-full divide-y divide-white/10 text-sm">
+        <table className="min-w-full divide-y divide-knob/10 text-sm">
           <thead className="bg-bg-surface/60 text-xs uppercase tracking-wide text-text-muted">
             <tr>
               <th className="px-4 py-row-lg text-left">Device</th>
@@ -92,7 +92,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
               <th className="px-4 py-row-lg text-left">Protocols</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-white/5 text-text-secondary">
+          <tbody className="divide-y divide-knob/5 text-text-secondary">
             {devices.map((device) => (
               <DeviceRow key={device.name} device={device} />
             ))}
@@ -111,7 +111,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
       <div {...virtualScroll.containerProps} className="overflow-auto">
         <div {...virtualScroll.spacerProps}>
           <div {...virtualScroll.contentProps}>
-            <table className="min-w-full divide-y divide-white/10 text-sm">
+            <table className="min-w-full divide-y divide-knob/10 text-sm">
               <thead className="bg-bg-surface/60 text-xs uppercase tracking-wide text-text-muted">
                 <tr>
                   <th className="px-4 py-row-lg text-left">Device</th>
@@ -120,7 +120,7 @@ const DeviceTable = memo(({ devices }: { devices: DeviceSummary[] }) => {
                   <th className="px-4 py-row-lg text-left">Protocols</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-white/5 text-text-secondary">
+              <tbody className="divide-y divide-knob/5 text-text-secondary">
                 {virtualScroll.visibleItems.map(({ item: device }) => (
                   <DeviceRow key={device.name} device={device} />
                 ))}

--- a/ui/src/pages/RuntimeControlPage.tsx
+++ b/ui/src/pages/RuntimeControlPage.tsx
@@ -231,7 +231,7 @@ export const RuntimeControlPage: FC = () => {
                 <SmallText className="text-status-warning/90">
                   To use simulation controls, start NIAC in daemon mode:
                 </SmallText>
-                <code className="mt-inline block rounded bg-black/40 pad-sm font-mono text-sm text-status-warning">
+                <code className="mt-inline block rounded bg-scrim/40 pad-sm font-mono text-sm text-status-warning">
                   niac daemon --listen :8080 --token yourtoken
                 </code>
               </div>

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -216,7 +216,7 @@ export const WalkValidatorPage: FC = () => {
                     <th className="px-3 py-row">Original</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-white/5">
+                <tbody className="divide-y divide-knob/5">
                   {issues.slice(0, 200).map((issue, idx) => (
                     <tr
                       key={`${issue.line}-${idx}`}

--- a/ui/src/pages/templates/UploadTemplateModal.tsx
+++ b/ui/src/pages/templates/UploadTemplateModal.tsx
@@ -90,7 +90,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
     <div className="fixed inset-0 z-50 flex-center">
       <button
         type="button"
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
         onClick={onClose}
         aria-label={t('templates.uploadModal.backdropAriaLabel')}
       />

--- a/ui/src/pages/topology/NeighborsView.tsx
+++ b/ui/src/pages/topology/NeighborsView.tsx
@@ -211,7 +211,7 @@ export const NeighborsView: FC = () => {
                   <th className="px-4 py-row">{t('topology.neighbors.headerLastSeen')}</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-white/5">
+              <tbody className="divide-y divide-knob/5">
                 {filtered.map((n) => (
                   <tr
                     key={`${n.localDevice}-${n.remoteDevice}-${n.remotePort}`}

--- a/ui/src/styles/DESIGN_SYSTEM.md
+++ b/ui/src/styles/DESIGN_SYSTEM.md
@@ -1,0 +1,43 @@
+# NIAC Design System
+
+Keeps styling consistent and theme-aware. Use the centralized tokens instead of
+raw values.
+
+## Token Architecture (read first)
+
+Three tiers, **one** source of truth for values, **one** derivation direction:
+
+```
+Primitive   Tailwind's built-in palette (indigo-600 = #4f46e5)   ← never referenced directly in app code
+   ↓ alias
+Semantic    index.css @theme + :root/.dark                       ← THE source of truth for VALUES
+            brand-*, status-*, surface-*, text-*, module-*,
+            device-*, link-*, proto-*, syntax-*, chart-1..10,
+            log-*, scrim, knob, on-brand/on-danger/on-info
+   ↓ alias
+Component   index.css @layer components + the TS class-token
+            objects in styles/                                   ← consume semantic tokens
+```
+
+**Two invariants (enforced by `scripts/check-token-discipline.sh`):**
+
+1. **Values flow one direction** — defined once in `index.css`, everything else
+   references them. Never hand-copy a hex sideways into a `.ts`/`.tsx` file.
+2. **App code names only semantic / component tokens** — never a primitive
+   palette utility (`bg-gray-500`, `text-pink-400`) and never a raw hex.
+
+**Picking the right token:**
+- Neutral chrome (backgrounds, borders, muted text) → `surface-*` / `border-*` / `text-*`.
+- Meaning (ok / warn / error / info) → `status-*`.
+- Filled-surface foreground → `on-brand` / `on-danger` / `on-info`; black/white → `scrim` / `knob`.
+- Domain categoricals → the dedicated ramps: `device-*` (topology nodes),
+  `link-*` (speeds), `proto-*` (protocols), `chart-1..10` (generic categorical),
+  `module-*` (the 5 feature modules), `syntax-*` (YAML/code editor).
+
+**Charts / SVG / inline styles / CodeMirror:** consume the CSS variables directly —
+`fill="var(--color-device-router)"`, `color: 'var(--color-syntax-keyword)'`. They
+flip light↔dark via the cascade. NIAC has no `<canvas>` drawing, so (unlike seed)
+it needs no JS token-reader; the topology graph is SVG.
+
+**Brand:** NIAC's anchor is **indigo** `#4f46e5` (niac-500). The five feature
+modules have their own accents (`--color-module-{topology,protocols,analyze,inject,templates}`).

--- a/ui/src/styles/themeComponents.ts
+++ b/ui/src/styles/themeComponents.ts
@@ -12,12 +12,12 @@ export const button = {
   base: 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-primary/50 disabled:opacity-50 disabled:cursor-not-allowed',
 
   variant: {
-    // text-white (not text-text-inverse) — text-inverse flips to dark in dark
+    // text-on-brand (not text-text-inverse) — text-inverse flips to dark in dark
     // mode and would fail WCAG AA against the constant indigo brand bg.
     // hover:bg-brand-primary/90 avoids the color-shift trap of using the
     // lighter brand-accent (which fails contrast against white text).
     primary:
-      'bg-brand-primary text-white shadow-lg shadow-brand-primary/30 hover:bg-brand-primary/90 active:scale-[0.98]',
+      'bg-brand-primary text-on-brand shadow-lg shadow-brand-primary/30 hover:bg-brand-primary/90 active:scale-[0.98]',
     secondary: 'bg-bg-elevated text-text-primary hover:bg-bg-overlay border border-border-default',
     ghost: 'text-text-muted hover:text-text-primary hover:bg-bg-elevated',
     outline:
@@ -109,7 +109,7 @@ export const alert = {
 
 export const modal = {
   overlay: 'fixed inset-0 z-50 flex items-center justify-center p-4',
-  backdrop: 'absolute inset-0 bg-black/60 backdrop-blur-sm',
+  backdrop: 'absolute inset-0 bg-scrim/60 backdrop-blur-sm',
   content:
     'relative bg-bg-surface border border-border-default rounded-xl shadow-2xl max-h-[85vh] overflow-y-auto',
 
@@ -124,7 +124,7 @@ export const modal = {
 
 export const drawer = {
   overlay: 'fixed inset-0 z-50',
-  backdrop: 'absolute inset-0 bg-black/50 backdrop-blur-sm',
+  backdrop: 'absolute inset-0 bg-scrim/50 backdrop-blur-sm',
   content:
     'absolute right-0 top-0 h-full bg-bg-surface border-l border-border-default shadow-2xl overflow-y-auto',
 

--- a/ui/src/ui/Card.tsx
+++ b/ui/src/ui/Card.tsx
@@ -234,7 +234,7 @@ interface CardFooterProps {
 }
 
 export const CardFooter: FC<CardFooterProps> = ({ children, className = '' }) => (
-  <div className={`px-6 py-4 border-t border-surface-border bg-black/20 rounded-b-xl ${className}`}>
+  <div className={`px-6 py-4 border-t border-surface-border bg-scrim/20 rounded-b-xl ${className}`}>
     {children}
   </div>
 );

--- a/ui/src/ui/CommandPalette.tsx
+++ b/ui/src/ui/CommandPalette.tsx
@@ -78,7 +78,7 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
         onClick={() => onOpenChange(false)}
         aria-label={t('commandPalette.closeAriaLabel')}
       />

--- a/ui/src/ui/Input.tsx
+++ b/ui/src/ui/Input.tsx
@@ -285,7 +285,7 @@ export const Toggle: FC<ToggleProps> = ({
       >
         <span
           className={`
-            inline-block h-4 w-4 transform rounded-full bg-white shadow-lg transition-transform
+            inline-block h-4 w-4 transform rounded-full bg-knob shadow-lg transition-transform
             ${checked ? 'translate-x-6' : 'translate-x-1'}
           `}
         />

--- a/ui/src/ui/Layout.tsx
+++ b/ui/src/ui/Layout.tsx
@@ -317,7 +317,7 @@ const HelpPanel: FC<{ title: string; children: ReactNode; onClose: () => void }>
 
   return (
     <div
-      className="fixed inset-0 z-50 flex justify-end bg-black/40 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex justify-end bg-scrim/40 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-label={`Help: ${title}`}

--- a/ui/src/ui/Modal.tsx
+++ b/ui/src/ui/Modal.tsx
@@ -68,12 +68,12 @@ export const Modal: FC<ModalProps> = ({
       {closeOnBackdropClick ? (
         <button
           type="button"
-          className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+          className="absolute inset-0 bg-scrim/70 backdrop-blur-sm"
           onClick={onClose}
           aria-label="Close modal"
         />
       ) : (
-        <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+        <div className="absolute inset-0 bg-scrim/70 backdrop-blur-sm" />
       )}
       <div
         ref={containerRef}

--- a/ui/src/ui/Skeleton.tsx
+++ b/ui/src/ui/Skeleton.tsx
@@ -16,7 +16,7 @@ export const Skeleton: FC<SkeletonProps> = ({
   lines = 1,
 }) => {
   const baseClass =
-    'skeleton bg-gradient-to-r from-white/5 via-white/10 to-white/5 bg-[length:200%_100%] animate-shimmer';
+    'skeleton bg-gradient-to-r from-knob/5 via-knob/10 to-knob/5 bg-[length:200%_100%] animate-shimmer';
 
   const variantClasses = {
     text: 'h-4 rounded',

--- a/ui/src/ui/Tooltip.tsx
+++ b/ui/src/ui/Tooltip.tsx
@@ -55,7 +55,7 @@ export const Tooltip: FC<TooltipProps> = ({ text, side = 'top', children, classN
       <span
         id={id}
         role="tooltip"
-        className={`pointer-events-none absolute z-50 max-w-xs whitespace-normal rounded-md bg-bg-base/95 px-cell py-compact text-xs text-text-primary ring-1 ring-white/10 transition-opacity duration-100 ${sideClass[side]} ${open ? 'opacity-100' : 'opacity-0'}`}
+        className={`pointer-events-none absolute z-50 max-w-xs whitespace-normal rounded-md bg-bg-base/95 px-cell py-compact text-xs text-text-primary ring-1 ring-knob/10 transition-opacity duration-100 ${sideClass[side]} ${open ? 'opacity-100' : 'opacity-0'}`}
       >
         {text}
       </span>


### PR DESCRIPTION
## Summary

Applies the seed/stem design-token consolidation to NIAC (the third product). NIAC has the **most complete** token system of the three (`device-*`/`link-*`/`proto-*`/`syntax-*`/`chart-1..10`/`module-*`), so most of the work is *wiring components to existing tokens*. No canvas (topology is SVG → reads `var()` directly), so no `tokens.ts` needed.

This PR (1 of 3) = **foundation + white/black**:
- Add `--color-on-brand`/`on-danger`/`on-info` (white — NIAC's indigo brand + saturated status fills need white foregrounds), in the `@theme` harmonization block alongside `scrim`/`knob`.
- Migrate **~44 bare white/black** across 31 components to tokens — **all zero-visual** (tokens carry identical values): `bg-black/N`→`bg-scrim/N`, `bg-white`→`bg-knob`, `divide-white/`→`divide-knob/`, shimmer `via/from/to-white`→`*-knob`, `ring-white/`→`ring-knob/`, brand-button `text-white`→`text-on-brand`.
- Add `styles/DESIGN_SYSTEM.md` (three-tier architecture + NIAC's domain ramps).

Brand is already correct indigo `#4f46e5`.

## Test plan
- [x] `biome` clean, `tsc -b --noEmit` passes, `vitest` 76/76, `vite build` succeeds
- [x] built CSS emits `--color-on-brand` + `.text-on-brand` (token now consumed)
- [ ] Reviewer: modal/drawer backdrops, toggle knobs, table dividers, skeleton shimmer in both themes (should be unchanged)

Bulk rename done via a scoped, verified `perl` (44 identical mechanical swaps across 31 files; verified by build + biome). Next: NIAC 2/3 migrates the ~47 raw-palette leaks (gray→surface/text, categorical→chart/module); 3/3 wires the domain palettes (YamlEditor→syntax tokens) + repairs the guard.