### PR TITLE
refactor(ui): migrate raw palette leaks to tokens (NIAC 2/3)

### DIFF
--- a/ui/src/components/BpfFilterBar.tsx
+++ b/ui/src/components/BpfFilterBar.tsx
@@ -127,11 +127,11 @@ export const BpfFilterBar: FC = memo(() => {
           }}
           onKeyDown={handleKeyDown}
           placeholder="BPF filter (e.g. tcp port 80)"
-          className={`flex-1 bg-bg-base/70 border rounded-lg px-3 py-compact-md text-sm font-mono text-text-primary placeholder-gray-500 focus:outline-none focus:ring-1 ${
+          className={`flex-1 bg-bg-base/70 border rounded-lg px-3 py-compact-md text-sm font-mono text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 ${
             error
               ? 'border-status-error/60 focus:ring-status-error/40'
               : isActive
-                ? 'border-status-success/40 focus:ring-green-500/40'
+                ? 'border-status-success/40 focus:ring-status-success/40'
                 : 'border-surface-border focus:ring-brand-primary/40'
           }`}
           disabled={isLoading}

--- a/ui/src/components/FilterBar.tsx
+++ b/ui/src/components/FilterBar.tsx
@@ -112,7 +112,7 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
             onBlur={() => setTimeout(() => setIsFocused(false), 200)}
             onKeyDown={handleKeyDown}
             placeholder={placeholder ?? 'Display filter (e.g., ip.src == 10.0.0.1 && tcp)'}
-            className={`w-full rounded-lg border ${borderColor} bg-bg-base/60 px-3 py-row text-sm text-text-primary placeholder-gray-500 focus:outline-none font-mono transition-colors`}
+            className={`w-full rounded-lg border ${borderColor} bg-bg-base/60 px-3 py-row text-sm text-text-primary placeholder:text-text-muted focus:outline-none font-mono transition-colors`}
           />
           {validationError && isFocused && (
             <div className="absolute top-full left-0 mt-tight px-cell py-compact bg-status-error/90 border border-status-error/50 rounded text-xs text-status-error z-20 max-w-md">

--- a/ui/src/components/LogFilters.tsx
+++ b/ui/src/components/LogFilters.tsx
@@ -131,7 +131,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
                 value={searchQuery}
                 onChange={handleSearchChange}
                 placeholder="Filter logs..."
-                className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-compact-md pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-compact-md pl-9 pr-3 text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                 aria-label="Search logs"
               />
             </div>

--- a/ui/src/components/TemplateCard.tsx
+++ b/ui/src/components/TemplateCard.tsx
@@ -32,7 +32,7 @@ const typeColors: Record<Template['type'], string> = {
   server: 'bg-status-info/20 text-status-info border-status-info/30',
   firewall: 'bg-status-error/20 text-status-error border-status-error/30',
   complete: 'bg-status-warning/20 text-status-warning border-status-warning/30',
-  custom: 'bg-pink-500/20 text-pink-300 border-pink-500/30',
+  custom: 'bg-chart-7/20 text-chart-7 border-chart-7/30',
 };
 
 export const TemplateCard: FC<TemplateCardProps> = memo(({ template, onView, onUse }) => {

--- a/ui/src/components/debug/ProtocolDebugLevels.tsx
+++ b/ui/src/components/debug/ProtocolDebugLevels.tsx
@@ -37,7 +37,7 @@ const CATEGORY_COLORS: Record<ProtocolCategory, string> = {
   routing: 'border-status-info/30',
   redundancy: 'border-status-warning/30',
   multicast: 'border-brand-primary/30',
-  monitoring: 'border-pink-500/30',
+  monitoring: 'border-chart-7/30',
 };
 
 const CATEGORY_HEADER_COLORS: Record<ProtocolCategory, string> = {
@@ -46,7 +46,7 @@ const CATEGORY_HEADER_COLORS: Record<ProtocolCategory, string> = {
   routing: 'text-status-info',
   redundancy: 'text-status-warning',
   multicast: 'text-brand-accent',
-  monitoring: 'text-pink-400',
+  monitoring: 'text-chart-7',
 };
 
 /**
@@ -93,7 +93,7 @@ const ProtocolSlider: FC<ProtocolSliderProps> = memo(({ config, onChange, disabl
 
       <div className="relative">
         {/* Slider track background with gradient */}
-        <div className="absolute top-1/2 left-0 right-0 h-2 -translate-y-1/2 rounded-full bg-gradient-to-r from-gray-700 via-yellow-600 to-purple-600 opacity-30" />
+        <div className="absolute top-1/2 left-0 right-0 h-2 -translate-y-1/2 rounded-full bg-gradient-to-r from-surface-border via-status-warning to-chart-5 opacity-30" />
 
         {/* Active track */}
         <div

--- a/ui/src/components/device-editor/DNSSection.tsx
+++ b/ui/src/components/device-editor/DNSSection.tsx
@@ -73,7 +73,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
                   }}
                   placeholder="IP Address"
-                  className="w-40 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
+                  className="w-40 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none font-mono"
                 />
                 <input
                   type="number"
@@ -87,7 +87,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
                   }}
                   placeholder="TTL"
-                  className="w-24 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                  className="w-24 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                 />
                 <Button
                   variant="ghost"
@@ -140,7 +140,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                     updateDns({ ...getDnsConfig(), reverseRecords: records });
                   }}
                   placeholder="IP Address"
-                  className="w-40 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
+                  className="w-40 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none font-mono"
                 />
                 <input
                   type="text"

--- a/ui/src/components/device-editor/FTPSection.tsx
+++ b/ui/src/components/device-editor/FTPSection.tsx
@@ -110,7 +110,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Username"
-                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                 />
                 <input
                   type="text"
@@ -124,7 +124,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Password"
-                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                 />
                 <input
                   type="text"
@@ -135,7 +135,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder="Home Directory"
-                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
+                  className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none font-mono"
                 />
                 <Button
                   variant="ghost"

--- a/ui/src/components/device-editor/HTTPSection.tsx
+++ b/ui/src/components/device-editor/HTTPSection.tsx
@@ -89,7 +89,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="/api/status"
-                    className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono"
+                    className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none font-mono"
                   />
                   <input
                     type="number"
@@ -103,7 +103,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Status"
-                    className="w-20 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                    className="w-20 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                   />
                   <Button
                     variant="ghost"
@@ -132,7 +132,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Content-Type (e.g., application/json)"
-                    className="w-64 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                    className="w-64 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                   />
                   <input
                     type="text"
@@ -146,7 +146,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                       updateHttp({ ...getHttpConfig(), endpoints });
                     }}
                     placeholder="Response body"
-                    className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                    className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                   />
                 </div>
               </div>

--- a/ui/src/components/device-editor/TrafficSection.tsx
+++ b/ui/src/components/device-editor/TrafficSection.tsx
@@ -93,7 +93,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                     });
                   }}
                   min={1}
-                  className="w-32 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                  className="w-32 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                 />
               </FormField>
             )}
@@ -147,7 +147,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                       });
                     }}
                     min={1}
-                    className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                    className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                   />
                 </FormField>
                 <FormField label="Payload Size (bytes)" helpText="Size of ICMP payload">
@@ -167,7 +167,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                     }}
                     min={0}
                     max={65507}
-                    className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                    className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                   />
                 </FormField>
               </div>
@@ -224,7 +224,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                         });
                       }}
                       min={1}
-                      className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                      className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                     />
                   </FormField>
                   <FormField label="Packet Count" helpText="Packets per burst">
@@ -245,7 +245,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                       }}
                       min={1}
                       max={100}
-                      className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                      className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                     />
                   </FormField>
                 </div>

--- a/ui/src/components/device-editor/types.ts
+++ b/ui/src/components/device-editor/types.ts
@@ -27,10 +27,10 @@ export interface SNMPSectionProps extends ProtocolSectionProps {
  * Common input class names for device editor forms
  */
 export const inputClassName =
-  'w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none';
+  'w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none';
 
 export const monoInputClassName =
-  'w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono';
+  'w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none font-mono';
 
 export const selectClassName =
   'w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary focus:border-brand-accent focus:outline-none';
@@ -39,4 +39,4 @@ export const checkboxClassName =
   'w-4 h-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary';
 
 export const smallInputClassName =
-  'flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none font-mono';
+  'flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none font-mono';

--- a/ui/src/components/device-list/CloneDeviceModal.tsx
+++ b/ui/src/components/device-list/CloneDeviceModal.tsx
@@ -59,7 +59,7 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
               id="new-hostname"
               type="text"
               {...register('newHostname')}
-              className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+              className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
             />
             {errors.newHostname ? (
               <p className="mt-inline text-xs text-status-error">{errors.newHostname.message}</p>

--- a/ui/src/components/device-list/DeviceSearchFilters.tsx
+++ b/ui/src/components/device-list/DeviceSearchFilters.tsx
@@ -38,7 +38,7 @@ export const DeviceSearchFilters: FC<DeviceSearchFiltersProps> = ({
           placeholder="Search by hostname, MAC, or IP..."
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
-          className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-2.5 pl-10 pr-icon text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+          className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-2.5 pl-10 pr-icon text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
         />
         {searchQuery && (
           <button

--- a/ui/src/components/help-drawer/HelpItemCard.tsx
+++ b/ui/src/components/help-drawer/HelpItemCard.tsx
@@ -142,11 +142,11 @@ export function HelpItemCard({ item, defaultOpen = false }: HelpItemCardProps): 
                       <span className="text-xs text-text-muted">{m.unit}</span>
                     </div>
                     <p className="text-xs text-text-muted mt-0.5">
-                      <span className="text-emerald-400">{t('itemCard.metricGoodLabel')}</span>{' '}
+                      <span className="text-status-success">{t('itemCard.metricGoodLabel')}</span>{' '}
                       {m.goodRange}
                     </p>
                     <p className="text-xs text-text-muted">
-                      <span className="text-amber-400">{t('itemCard.metricBadLabel')}</span>{' '}
+                      <span className="text-status-warning">{t('itemCard.metricBadLabel')}</span>{' '}
                       {m.badMeaning}
                     </p>
                   </div>

--- a/ui/src/components/simulation/ConfigPicker.tsx
+++ b/ui/src/components/simulation/ConfigPicker.tsx
@@ -281,7 +281,7 @@ export const ConfigPicker: FC<ConfigPickerProps> = ({
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search configs…"
-            className="w-full rounded border border-surface-border bg-bg-surface/60 py-row pl-9 pr-3 text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+            className="w-full rounded border border-surface-border bg-bg-surface/60 py-row pl-9 pr-3 text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
           />
         </div>
         <fieldset

--- a/ui/src/components/simulation/ConfigPicker.types.ts
+++ b/ui/src/components/simulation/ConfigPicker.types.ts
@@ -35,7 +35,7 @@ export const TEMPLATE_TYPE_TINT: Record<Template['type'], string> = {
   server: 'bg-status-info/15 text-status-info border-status-info/30',
   firewall: 'bg-status-error/15 text-status-error border-status-error/30',
   complete: 'bg-status-warning/15 text-status-warning border-status-warning/30',
-  custom: 'bg-pink-500/15 text-pink-200 border-pink-400/30',
+  custom: 'bg-chart-7/15 text-chart-7 border-chart-7/30',
 };
 
 /**

--- a/ui/src/components/templates/JavaDslImportCard.tsx
+++ b/ui/src/components/templates/JavaDslImportCard.tsx
@@ -87,7 +87,7 @@ export const JavaDslImportCard: FC = () => {
           }}
           placeholder="device my-router {&#10;  type = router&#10;  ip = 192.168.1.1&#10;  ...&#10;}"
           rows={10}
-          className="w-full rounded border border-surface-border bg-bg-base/60 pad-sm font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-success focus:outline-none"
+          className="w-full rounded border border-surface-border bg-bg-base/60 pad-sm font-mono text-xs text-text-primary placeholder:text-text-muted focus:border-status-success focus:outline-none"
           aria-label="Legacy Java DSL config content"
         />
 

--- a/ui/src/pages/LibraryFilesPage.tsx
+++ b/ui/src/pages/LibraryFilesPage.tsx
@@ -70,7 +70,7 @@ function LibraryFilesView({ kind }: Props) {
                   onChange={(e) => setSearch(e.target.value)}
                   placeholder="Search by name…"
                   aria-label="Filter library entries by name"
-                  className="w-64 rounded-md border border-surface-border bg-bg-base/40 pl-7 pr-3 py-compact-md text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+                  className="w-64 rounded-md border border-surface-border bg-bg-base/40 pl-7 pr-3 py-compact-md text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-status-info/30"
                 />
               </div>
               <Button

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -692,7 +692,7 @@ export const TopologyPage: FC = () => {
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search devices by name…"
                 aria-label="Filter devices by name"
-                className="w-full sm:w-64 rounded-md border border-surface-border bg-bg-base/40 px-3 py-compact-md text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-cyan-500/30"
+                className="w-full sm:w-64 rounded-md border border-surface-border bg-bg-base/40 px-3 py-compact-md text-xs text-text-primary placeholder:text-text-muted focus:border-status-info/40 focus:outline-none focus:ring-1 focus:ring-status-info/30"
               />
               {availableTypes.length > 0 && (
                 <div className="flex flex-wrap items-center gap-1.5">

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -9,7 +9,7 @@ type Severity = 'error' | 'warning' | 'info';
 const SEVERITY_BADGE: Record<Severity, string> = {
   error: 'bg-status-error/20 text-status-error ring-status-error/40',
   warning: 'bg-status-warning/20 text-status-warning ring-status-warning/40',
-  info: 'bg-sky-500/20 text-sky-200 ring-sky-400/40',
+  info: 'bg-status-info/20 text-status-info ring-status-info/40',
 };
 
 const SEVERITY_ORDER: Severity[] = ['error', 'warning', 'info'];
@@ -139,7 +139,7 @@ export const WalkValidatorPage: FC = () => {
                 onChange={(e) => setCustomPath(e.target.value)}
                 placeholder="/srv/niac/walks/cisco-c9300.walk"
                 title="Absolute path to a walk file. Takes precedence over the dropdown selection. The path is bounded server-side; ../ traversal is rejected."
-                className="mt-tight w-full rounded border border-surface-border bg-bg-base/60 px-3 py-row font-mono text-xs text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
+                className="mt-tight w-full rounded border border-surface-border bg-bg-base/60 px-3 py-row font-mono text-xs text-text-primary placeholder:text-text-muted focus:border-status-info focus:outline-none"
               />
             </label>
           </div>
@@ -150,7 +150,7 @@ export const WalkValidatorPage: FC = () => {
               onClick={() => void run('validating')}
               disabled={busy !== 'idle' || !targetPath}
               title="Read-only validation: parses the walk and returns per-line issues. Doesn't modify the file."
-              className="rounded bg-status-info/20 px-3 py-compact-md text-sm font-medium text-status-info ring-1 ring-cyan-400/40 hover:bg-status-info/30 disabled:opacity-50"
+              className="rounded bg-status-info/20 px-3 py-compact-md text-sm font-medium text-status-info ring-1 ring-status-info/40 hover:bg-status-info/30 disabled:opacity-50"
             >
               {busy === 'validating' ? 'Validating…' : 'Validate'}
             </button>

--- a/ui/src/pages/runtime/RunningSimulationCard.tsx
+++ b/ui/src/pages/runtime/RunningSimulationCard.tsx
@@ -54,7 +54,7 @@ export const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
   };
 
   return (
-    <Card className="border-status-success/30 bg-gradient-to-br from-green-900/30 to-bg-surface/70">
+    <Card className="border-status-success/30 bg-gradient-to-br from-status-success/20 to-bg-surface/70">
       <CardContent className="space-y-5">
         <div className="flex-between">
           <div className="flex items-center gap-default">

--- a/ui/src/pages/templates/TemplatesHeader.tsx
+++ b/ui/src/pages/templates/TemplatesHeader.tsx
@@ -53,7 +53,7 @@ export const TemplatesHeader: FC<TemplatesHeaderProps> = ({
             placeholder="Search templates by name, description, or type..."
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
-            className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-row-lg pl-10 pr-icon text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+            className="w-full rounded-lg border border-surface-border bg-bg-base/60 py-row-lg pl-10 pr-icon text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
           />
           {searchQuery && (
             <button

--- a/ui/src/pages/templates/UploadTemplateModal.tsx
+++ b/ui/src/pages/templates/UploadTemplateModal.tsx
@@ -163,7 +163,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
                 type="text"
                 {...register('name')}
                 placeholder={t('templates.uploadModal.namePlaceholder')}
-                className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
               />
               {errors.name ? (
                 <p className="mt-tight text-xs text-status-error">{errors.name.message}</p>
@@ -183,7 +183,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
                 {...register('description')}
                 placeholder={t('templates.uploadModal.descriptionPlaceholder')}
                 rows={2}
-                className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none resize-none"
               />
               {errors.description ? (
                 <p className="mt-tight text-xs text-status-error">{errors.description.message}</p>
@@ -228,7 +228,7 @@ export const UploadTemplateModal: FC<UploadTemplateModalProps> = ({
                 {...register('content')}
                 placeholder={t('templates.uploadModal.contentPlaceholder')}
                 rows={10}
-                className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm font-mono text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none resize-none"
+                className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm font-mono text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none resize-none"
                 spellCheck={false}
               />
               {errors.content ? (

--- a/ui/src/pages/topology/NeighborsView.tsx
+++ b/ui/src/pages/topology/NeighborsView.tsx
@@ -151,7 +151,7 @@ export const NeighborsView: FC = () => {
                     }
                     className={`rounded px-3 py-compact text-xs font-medium ${
                       active
-                        ? 'bg-status-info/20 text-status-info ring-1 ring-cyan-400/40'
+                        ? 'bg-status-info/20 text-status-info ring-1 ring-status-info/40'
                         : 'bg-bg-elevated/60 text-text-secondary hover:bg-bg-elevated'
                     }`}
                   >
@@ -167,7 +167,7 @@ export const NeighborsView: FC = () => {
               onChange={(e) => setSearch(e.target.value)}
               placeholder={t('topology.neighbors.searchPlaceholder')}
               title={t('topology.neighbors.searchTitle')}
-              className="ml-auto w-64 rounded border border-surface-border bg-bg-base/60 px-3 py-compact-md text-sm text-text-primary placeholder-gray-500 focus:border-status-info focus:outline-none"
+              className="ml-auto w-64 rounded border border-surface-border bg-bg-base/60 px-3 py-compact-md text-sm text-text-primary placeholder:text-text-muted focus:border-status-info focus:outline-none"
               aria-label={t('topology.neighbors.searchAriaLabel')}
             />
             <span className="text-xs text-text-muted">

--- a/ui/src/ui/InputModal.tsx
+++ b/ui/src/ui/InputModal.tsx
@@ -67,7 +67,7 @@ export const InputModal: FC<InputModalProps> = ({
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder-gray-500 focus:border-brand-accent focus:outline-none"
+          className="w-full rounded-lg border border-surface-border bg-bg-base/60 pad-sm text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
         />
         <div className="flex justify-end gap-default pt-2">
           <Button variant="outline" onClick={onCancel}>

--- a/ui/src/ui/Layout.tsx
+++ b/ui/src/ui/Layout.tsx
@@ -31,7 +31,7 @@ interface PageShellProps {
 
 export const PageShell: FC<PageShellProps> = ({ children, className = '' }) => (
   <div
-    className={`min-h-screen bg-gradient-to-br from-bg-base via-bg-surface to-gray-950 ${className}`}
+    className={`min-h-screen bg-gradient-to-br from-bg-base via-bg-surface to-surface-deep ${className}`}
   >
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6">{children}</div>
   </div>


### PR DESCRIPTION
## Summary

Wires the remaining **~47 raw Tailwind palette** usages to NIAC's **existing** token ramps — no new tokens needed (NIAC already defines `status-*`/`chart-1..10`/`surface-*`).

- **`placeholder-gray-500` → `placeholder:text-text-muted`** (×32 form inputs; also fixes the v4 syntax — `placeholder-{color}` is the old API and may not render).
- **Status semantics:** `emerald`→`status-success`, `amber`→`status-warning`, BPF filter green focus-ring→`status-success`; `cyan`/`sky` rings+badges that pair with `status-info` elements → `status-info`.
- **Categorical:** the `custom` template/config type and `monitoring` debug level (pink) → `chart-7` (data-viz pink token); the debug-slider spectrum gradient → `surface-border`/`status-warning`/`chart-5`.
- **Gradients:** Layout page-bg `to-gray-950` → `to-surface-deep` (identical value); `RunningSimulationCard` `from-green-900/30` → `from-status-success/20`.

## Visible shifts (minor, to eyeball)
A few hues shift to canonical: cyan/sky→info-blue, emerald→success-green, the pink `custom`/`monitoring` chips → the data-viz pink (`chart-7`), and the decorative debug-slider track. All status/structural colors unchanged.

## Test plan
- [x] `biome` clean, `tsc -b --noEmit` passes, `vitest` 76/76, `vite build` succeeds
- [x] grep: component tree palette-free (excl `/styles/` definitions)
- [ ] Reviewer: form placeholders, template/config "custom" chips, debug levels, BPF filter, topology/library search rings, walk-validator badges

Next (3/3): wire `YamlEditor` syntax hex → existing `--color-syntax-*`, formalize `coloring-rules` swatches, repair the broken `check-token-discipline.sh` + allowlist.