### PR TITLE
fix(ui): repair token-discipline guard + close last leaks (NIAC 3/3)

### DIFF
--- a/scripts/check-token-discipline.sh
+++ b/scripts/check-token-discipline.sh
@@ -1,36 +1,38 @@
 #!/usr/bin/env bash
-# check-token-discipline.sh — full design-token discipline gate (Phase 0).
+# check-token-discipline.sh — design-token discipline gate.
 #
-# Enforces that UI application code uses semantic theme tokens instead of
-# raw Tailwind utilities. Run by CI on every PR.
+# Enforces that UI application code uses the semantic theme tokens defined in
+# ui/src/index.css instead of raw values. Run by CI on every PR.
 #
-# Scope: *.tsx and *.ts files under ui/src/ EXCEPT styles/, constants/, and
-# test files (.test.tsx, .spec.tsx, .stories.tsx, .mock.tsx).
+# TWO TIERS:
+#   BLOCKING (fails CI) — COLOR discipline. The codebase is fully migrated, so
+#     these must stay at zero:
+#       - raw Tailwind palette colors (gray-N, blue-N, amber-N, …)
+#       - bare bg/text/border-white|black
+#       - text-[var(--color-X)] indirection (use text-X directly)
+#       - raw 6/8-digit hex colors in .ts/.tsx
+#   ADVISORY (warns, never fails) — spacing / typography / flex shortcuts that
+#     have semantic replacements. Pre-existing debt; surfaced for burn-down.
 #
-# What's banned:
-#   - Raw Tailwind palette colors (gray-N, slate-N, red-N, blue-N, etc.)
-#   - Bare bg-white / bg-black / text-white / text-black / etc.
-#   - Raw spacing utilities that have semantic replacements
-#       (space-y-N, gap-N (numeric), p-N (standalone), mb-N, mt-N, etc.)
-#   - text-[var(--color-X)] arbitrary-value indirection — use text-X directly
+# Scope: *.tsx / *.ts under ui/src/, EXCEPT test files (.test/.spec/.stories/
+# .mock), token definition sites (styles/, constants/), and the documented
+# domain-rendering palettes (intentional, not theme colors):
+#   components/config/YamlEditor.tsx       CodeMirror One Dark editor theme
+#   utils/coloring-rules.ts                topology color-rule preset swatches
+#   components/ColoringRulesPanel.tsx      coloring-rule default swatches
+#   pages/topology/layout.ts               topology graph edge colors
+#   pages/TopologyPage.tsx                 topology graph canvas background
 #
-# What's allowed:
-#   - Tokens defined in ui/src/index.css (@theme + @layer components)
-#   - Tokens defined in ui/src/styles/ (theme.ts, themeSpacing.ts, etc.)
-#   - Raw Tailwind for layout/sizing that has no semantic replacement
-#       (w-full, h-screen, fixed, relative, absolute, flex, grid, etc.)
-#   - Raw text-N / font-N (these ARE the canonical tokens per
-#       typography.size.* / typography.weight.* in stem/seed/niac)
+# Portability: BLOCKING rules use POSIX ERE (GNU + BSD/macOS grep). ADVISORY
+# rules use PCRE lookbehind (-P, GNU grep); on BSD grep they report nothing,
+# which is fine because they never fail the build.
 #
-# Run locally: scripts/check-token-discipline.sh
-# To see what would be flagged, pass --report (continues past first failure).
+# Run locally: scripts/check-token-discipline.sh   (--report = never fail)
 
 set -uo pipefail
 
 REPORT_MODE=0
-if [ "${1:-}" = "--report" ]; then
-  REPORT_MODE=1
-fi
+[ "${1:-}" = "--report" ] && REPORT_MODE=1
 
 if [ -d "ui/src" ]; then
   TARGET="ui/src"
@@ -41,77 +43,70 @@ else
   exit 2
 fi
 
-# Files we never check (definition sites, tests).
-EXCLUDE_RE='\.(test|spec|stories|mock)\.(ts|tsx):|/styles/|/constants/'
+# Definition sites, tests, and documented domain-rendering palettes.
+EXCLUDE_RE='\.(test|spec|stories|mock)\.(ts|tsx):|/styles/|/constants/|/YamlEditor\.tsx:|/coloring-rules\.ts:|/ColoringRulesPanel\.tsx:|topology/layout\.ts:|/TopologyPage\.tsx:'
 
-# Pattern groups. Each group has a label + regex + remediation hint.
-declare -a GROUPS=(
-  # Colors — never use raw palette in app code.
-  "RAW_PALETTE|(-(gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[0-9]+)|Use brand-*/surface-*/text-*/status-*/log-* tokens instead"
-  "BARE_WHITE_BLACK|(\\b(bg|text|border|from|via|to|ring|fill|stroke|placeholder|shadow|outline|divide|accent|caret|decoration)-(white|black)\\b)|Use bg-knob (constant white) / bg-scrim/N (constant black) / text-text-inverse / etc."
+FAIL_COUNT=0
 
-  # Arbitrary-value color indirection — text-[var(--color-status-error)] is the same as text-status-error.
-  "ARBITRARY_COLOR_VAR|(text|bg|border|ring|fill|stroke|placeholder|shadow|from|via|to|outline|divide|accent|caret|decoration)-\\[var\\(--color-[a-z0-9-]+\\)\\]|Drop the var() indirection: text-[var(--color-status-error)] → text-status-error"
-
-  # Spacing — raw must be replaced by semantic. Word boundaries prevent matching px-/py-/pt- etc.
-  "RAW_SPACE_Y|(?<![-\\w])space-y-(1|2|3|4|6)(?![-\\w])|Use stack-xs/sm/[default]/lg/xl"
-  "RAW_GAP|(?<![-\\w])gap-(1|2|3|4|6)(?![-\\w])|Use gap-tight/compact/default/comfortable/spacious"
-  "RAW_P|(?<![-\\w])p-(2|3|4|6|8)(?![-\\w])|Use pad-xs/sm/[default]/lg/xl"
-  "RAW_MB|(?<![-\\w])mb-(1|3|4|6|8)(?![-\\w])|Use mb-tight/heading/content/section/section-lg"
-  "RAW_MT|(?<![-\\w])mt-(1|2|3|4|8)(?![-\\w])|Use mt-tight/inline/heading/content/section"
-  "RAW_ML|(?<![-\\w])ml-(1|2|4|6)(?![-\\w])|Use ml-tight/inline/content/spacious"
-  "RAW_PT|(?<![-\\w])pt-(1|3|4)(?![-\\w])|Use pt-tight/heading/section"
-  "RAW_PB|(?<![-\\w])pb-(1|2)(?![-\\w])|Use pb-tight/inline"
-  "RAW_PX_2|(?<![-\\w])px-2(?![-\\w])|Use px-cell"
-  "RAW_PR|(?<![-\\w])pr-(8|10)(?![-\\w])|Use pr-tight/icon"
-  "RAW_PL_5|(?<![-\\w])pl-5(?![-\\w])|Use pl-indent"
-  "RAW_PY_12|(?<![-\\w])py-12(?![-\\w])|Use py-centered"
-
-  # Typography compounds — paired text+font should use heading-N or body-N etc.
-  "RAW_HEADING_PAIR|(text-2xl[^\"\\\`]*font-bold|font-bold[^\"\\\`]*text-2xl|text-xl[^\"\\\`]*font-semibold|font-semibold[^\"\\\`]*text-xl|text-lg[^\"\\\`]*font-semibold|font-semibold[^\"\\\`]*text-lg)|Use heading-1/2/3 (or heading-4 for text-base font-medium)"
-
-  # Flex shortcuts
-  "RAW_FLEX_BETWEEN|flex items-center justify-between|Use flex-between"
-  "RAW_FLEX_CENTER|flex items-center justify-center|Use flex-center"
-)
-
-TOTAL_VIOLATIONS=0
-FAILED_GROUPS=()
-
-for GROUP in "${GROUPS[@]}"; do
-  LABEL="${GROUP%%|*}"
-  REST="${GROUP#*|}"
-  REGEX="${REST%%|*}"
-  HINT="${REST#*|}"
-
-  HITS=$(grep -rEn --include='*.tsx' --include='*.ts' -P -- "$REGEX" "$TARGET" 2>/dev/null \
+# block LABEL REGEX HINT — POSIX ERE, fails the build on any hit.
+block() {
+  local label="$1" rx="$2" hint="$3" hits count
+  hits=$(grep -rEn --include='*.tsx' --include='*.ts' -- "$rx" "$TARGET" 2>/dev/null \
     | grep -vE "$EXCLUDE_RE" || true)
-
-  if [ -n "$HITS" ]; then
-    COUNT=$(echo "$HITS" | wc -l | tr -d ' ')
-    TOTAL_VIOLATIONS=$((TOTAL_VIOLATIONS + COUNT))
-    FAILED_GROUPS+=("$LABEL ($COUNT)")
-    echo "============================================================"
-    echo "[$LABEL] $COUNT violation(s)"
-    echo "Hint: $HINT"
-    echo "------------------------------------------------------------"
-    echo "$HITS" | head -10
-    HIDDEN=$((COUNT - 10))
-    if [ "$HIDDEN" -gt 0 ]; then
-      echo "... and $HIDDEN more"
-    fi
-    echo ""
-    if [ "$REPORT_MODE" -eq 0 ]; then
-      echo "FAIL: token discipline violated (see above). Run scripts/migrate-tokens.py to auto-fix many cases."
-      exit 1
-    fi
-  fi
-done
-
-if [ "$TOTAL_VIOLATIONS" -gt 0 ]; then
+  [ -z "$hits" ] && return 0
+  count=$(printf '%s\n' "$hits" | grep -c .)
+  FAIL_COUNT=$((FAIL_COUNT + count))
   echo "============================================================"
-  echo "TOTAL: $TOTAL_VIOLATIONS violation(s) across groups: ${FAILED_GROUPS[*]}"
+  echo "[BLOCK: $label] $count violation(s)"
+  echo "  fix: $hint"
+  echo "------------------------------------------------------------"
+  printf '%s\n' "$hits" | head -10
+  local hidden=$((count - 10))
+  [ "$hidden" -gt 0 ] && echo "  … and $hidden more"
+  echo ""
+}
+
+# advise LABEL REGEX HINT — PCRE; warns only, never fails.
+advise() {
+  local label="$1" rx="$2" hint="$3" hits count
+  hits=$(grep -rn --include='*.tsx' --include='*.ts' -P -- "$rx" "$TARGET" 2>/dev/null \
+    | grep -vE "$EXCLUDE_RE" || true)
+  [ -z "$hits" ] && return 0
+  count=$(printf '%s\n' "$hits" | grep -c .)
+  echo "[warn: $label] $count occurrence(s) — $hint"
+}
+
+# ── BLOCKING: color discipline ──────────────────────────────────────────────
+block RAW_PALETTE \
+  '-(gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[0-9]+' \
+  'Use surface-*/text-*/border-*/status-*/module-*/device-*/link-*/proto-*/chart-* tokens'
+block BARE_WHITE_BLACK \
+  '\b(bg|text|border|from|via|to|ring|fill|stroke|placeholder|shadow|outline|divide|accent|caret|decoration)-(white|black)\b' \
+  'Use bg-knob (white) / bg-scrim (black) / text-on-* / text-text-inverse'
+block ARBITRARY_COLOR_VAR \
+  '(text|bg|border|ring|fill|stroke|placeholder|shadow|from|via|to|outline|divide|accent|caret|decoration)-\[var\(--color-[a-z0-9-]+\)\]' \
+  'Drop the var() indirection: text-[var(--color-status-error)] -> text-status-error'
+block RAW_HEX_COLOR \
+  '#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?\b' \
+  'Use a CSS theme variable; SVG/inline styles can use var(--color-*) directly'
+
+# ── ADVISORY: spacing / typography / flex (warn-only) ───────────────────────
+advise RAW_SPACE_Y '(?<![-\w])space-y-(1|2|3|4|6)(?![-\w])' 'Use stack-xs/sm/[default]/lg/xl'
+advise RAW_GAP '(?<![-\w])gap-(1|2|3|4|6)(?![-\w])' 'Use gap-tight/compact/default/comfortable/spacious'
+advise RAW_P '(?<![-\w])p-(2|3|4|6|8)(?![-\w])' 'Use pad-xs/sm/[default]/lg/xl'
+advise RAW_MB '(?<![-\w])mb-(1|3|4|6|8)(?![-\w])' 'Use mb-tight/heading/content/section/section-lg'
+advise RAW_MT '(?<![-\w])mt-(1|2|3|4|8)(?![-\w])' 'Use mt-tight/inline/heading/content/section'
+advise RAW_PX_2 '(?<![-\w])px-2(?![-\w])' 'Use px-cell'
+advise RAW_HEADING_PAIR \
+  '(text-2xl[^"`]*font-bold|font-bold[^"`]*text-2xl|text-xl[^"`]*font-semibold|font-semibold[^"`]*text-xl|text-lg[^"`]*font-semibold|font-semibold[^"`]*text-lg)' \
+  'Use heading-1/2/3 (or heading-4 for text-base font-medium)'
+advise RAW_FLEX_BETWEEN 'flex items-center justify-between' 'Use flex-between'
+advise RAW_FLEX_CENTER 'flex items-center justify-center' 'Use flex-center'
+
+if [ "$FAIL_COUNT" -gt 0 ] && [ "$REPORT_MODE" -eq 0 ]; then
+  echo "============================================================"
+  echo "FAIL: $FAIL_COUNT blocking color-token violation(s) above."
   exit 1
 fi
 
-echo "OK: ui/src is token-clean across all categories."
+echo "OK: blocking color-token discipline is clean (advisory warnings, if any, are non-blocking)."

--- a/ui/src/components/ColoringRulesPanel.tsx
+++ b/ui/src/components/ColoringRulesPanel.tsx
@@ -35,7 +35,7 @@ const RuleRow: FC<{
         type="checkbox"
         checked={rule.enabled}
         onChange={(e) => onChange({ ...rule, enabled: e.target.checked })}
-        className="rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-accent focus:ring-offset-gray-900 flex-shrink-0"
+        className="rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-accent focus:ring-offset-surface-base flex-shrink-0"
       />
 
       {/* Color preview */}

--- a/ui/src/components/LogFilters.tsx
+++ b/ui/src/components/LogFilters.tsx
@@ -147,7 +147,7 @@ export const LogFilters: FC<LogFiltersProps> = memo(
                 type="checkbox"
                 checked={autoScroll}
                 onChange={handleAutoScrollChange}
-                className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary focus:ring-offset-gray-900"
+                className="h-4 w-4 rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-primary focus:ring-offset-surface-base"
               />
               <span className="text-sm text-text-secondary">Auto-scroll</span>
             </label>

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -385,7 +385,7 @@ export const LogViewer: FC<LogViewerProps> = memo(({ logs, searchQuery, autoScro
       {/* Log Container */}
       <div
         ref={containerRef}
-        className="h-[500px] overflow-y-auto rounded-lg border border-surface-border bg-bg-base/70 scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-gray-700"
+        className="h-[500px] overflow-y-auto rounded-lg border border-surface-border bg-bg-base/70 scrollbar-thin scrollbar-track-surface-base scrollbar-thumb-surface-border"
         role="log"
         aria-label="Debug console log output"
         aria-live="polite"

--- a/ui/src/components/device-list/DeviceCardView.tsx
+++ b/ui/src/components/device-list/DeviceCardView.tsx
@@ -63,7 +63,7 @@ export const DeviceCardView: FC = () => {
                 <button
                   type="button"
                   onClick={() => onEdit(device.hostname)}
-                  className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2 focus:ring-offset-gray-900"
+                  className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2 focus:ring-offset-surface-base"
                   aria-label={`Edit device ${device.hostname}`}
                 >
                   {/* Device name and IP */}

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -43,7 +43,9 @@ export const DashboardPage: FC = () => {
   return (
     <div className="stack-xl animate-fade-in">
       {/* Status banner */}
-      <Card className={`border-l-4 ${isRunning ? 'border-l-emerald-500' : 'border-l-gray-500'}`}>
+      <Card
+        className={`border-l-4 ${isRunning ? 'border-l-status-success' : 'border-l-surface-border'}`}
+      >
         <CardContent className="py-4">
           <div className="flex flex-wrap items-center justify-between gap-comfortable">
             <div className="flex items-center gap-comfortable">

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -425,7 +425,7 @@ export const PacketInspectorPage: FC = () => {
                     type="checkbox"
                     checked={autoScroll}
                     onChange={(e) => setAutoScroll(e.target.checked)}
-                    className="rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-accent focus:ring-offset-gray-900"
+                    className="rounded border-border-muted bg-bg-elevated text-brand-primary focus:ring-brand-accent focus:ring-offset-surface-base"
                   />
                   <SmallText className="text-text-muted">Auto-scroll</SmallText>
                 </label>

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -35,8 +35,8 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
       type="button"
       className={`
         relative px-4 py-row-lg rounded-xl border-2 transition-all duration-200 text-left
-        ${selected ? 'ring-2 ring-brand-primary ring-offset-2 ring-offset-gray-900' : ''}
-        hover:shadow-lg hover:shadow-black/30
+        ${selected ? 'ring-2 ring-brand-primary ring-offset-2 ring-offset-surface-base' : ''}
+        hover:shadow-lg hover:shadow-scrim/30
       `}
       style={{
         backgroundColor: 'var(--color-bg-elevated)',

--- a/ui/src/styles/themeComponents.ts
+++ b/ui/src/styles/themeComponents.ts
@@ -61,7 +61,7 @@ export const card = {
 
   variant: {
     default: 'bg-bg-elevated border-border-default',
-    elevated: 'bg-bg-elevated border-border-default shadow-xl shadow-black/20',
+    elevated: 'bg-bg-elevated border-border-default shadow-xl shadow-scrim/20',
     interactive:
       'bg-bg-elevated border-border-default hover:border-brand-primary/50 cursor-pointer transition-colors',
     glass: 'bg-bg-elevated/40 backdrop-blur-2xl border-border-default shadow-2xl',

--- a/ui/src/ui/Card.tsx
+++ b/ui/src/ui/Card.tsx
@@ -39,9 +39,9 @@ type CardVariant = 'default' | 'elevated' | 'outlined' | 'ghost';
 
 const variantStyles: Record<CardVariant, string> = {
   default:
-    'backdrop-blur-xl bg-gradient-to-br from-bg-surface/90 to-bg-surface/70 border border-surface-border shadow-xl shadow-black/20',
+    'backdrop-blur-xl bg-gradient-to-br from-bg-surface/90 to-bg-surface/70 border border-surface-border shadow-xl shadow-scrim/20',
   elevated:
-    'backdrop-blur-xl bg-gradient-to-br from-bg-elevated/90 to-bg-surface/80 border border-surface-border shadow-2xl shadow-black/30',
+    'backdrop-blur-xl bg-gradient-to-br from-bg-elevated/90 to-bg-surface/80 border border-surface-border shadow-2xl shadow-scrim/30',
   outlined: 'bg-transparent border border-surface-border',
   ghost: 'bg-surface-hover border border-transparent',
 };
@@ -164,7 +164,7 @@ export const StatusCard: FC<StatusCardProps> = ({
     <div
       className={`rounded-xl ${variantStyles[variant]} pad sm:pad-lg
         transition-all hover:border-surface-border touch-manipulation
-        focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 outline-none
+        focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base outline-none
         ${isInteractive ? 'cursor-pointer active:scale-[0.98]' : ''}
         ${className}`}
       onClick={onClick}

--- a/ui/src/ui/Input.tsx
+++ b/ui/src/ui/Input.tsx
@@ -278,7 +278,7 @@ export const Toggle: FC<ToggleProps> = ({
         }}
         className={`
           relative inline-flex h-6 w-11 items-center rounded-full transition-colors
-          focus:outline-none focus:ring-2 focus:ring-brand-primary/50 focus:ring-offset-2 focus:ring-offset-gray-900
+          focus:outline-none focus:ring-2 focus:ring-brand-primary/50 focus:ring-offset-2 focus:ring-offset-surface-base
           ${checked ? 'bg-brand-primary' : 'bg-bg-elevated'}
           ${className}
         `}


### PR DESCRIPTION
## Summary

Makes NIAC's single-source-of-truth **self-enforcing** — the finale, parallel to seed/stem.

**The guard was a silent no-op** (same bugs as seed/stem: `grep -E`+`-P` errored; `|`-delimited rules truncated alternations). **Rewrite** as function-based rules, two tiers:
- **BLOCKING (fails CI)**, POSIX-ERE: raw palette, bare white/black, `text-[var(--color-*)]`, raw 6/8-digit hex — all clean.
- **ADVISORY (warn-only)**, PCRE: pre-existing spacing/typography debt.

**Allowlists the documented domain-rendering palettes** (intentional fixed colors, like seed's FloorPlanCanvas/cableWire): `YamlEditor` (CodeMirror One Dark theme), `coloring-rules.ts` + `ColoringRulesPanel` (topology color-rule swatches), `topology/layout.ts` + `TopologyPage` (graph edge/canvas colors).

**Closed the leaks the now-working guard catches** (PR 2's prefix-anchored scan had missed these — the guard's regex is unanchored): `ring-offset-gray-900`→`ring-offset-surface-base` (×6), LogViewer scrollbar grays→surface tokens, DashboardPage status border→`status-success`/`surface-border`, `shadow-black/N`→`shadow-scrim/N`.

## Test plan
- [x] guard exits 0 (blocking tier clean) + regex matches known positives (not a no-op)
- [x] `biome` clean, `tsc -b --noEmit` passes, `vitest` 76/76, `vite build` succeeds

This completes the NIAC token consolidation. All three products (seed/stem/niac) now flow color from `index.css`, lint-enforced, with documented allowlisted domain exceptions — same approach, each repo independent (no shared modules).