### PR TITLE
refactor(ui): a11y fill text + tokenize inset shadow + guard rgb/hsl

### DIFF
--- a/scripts/check-token-discipline.sh
+++ b/scripts/check-token-discipline.sh
@@ -89,6 +89,9 @@ block ARBITRARY_COLOR_VAR \
 block RAW_HEX_COLOR \
   '#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?\b' \
   'Use a CSS theme variable; SVG/inline styles can use var(--color-*) directly'
+block RGB_HSL_COLOR \
+  '\b(rgba?|hsla?)\([0-9]' \
+  'Use a CSS theme variable; for white/black overlays use color-mix(var(--color-knob|scrim))'
 
 # ── ADVISORY: spacing / typography / flex (warn-only) ───────────────────────
 advise RAW_SPACE_Y '(?<![-\w])space-y-(1|2|3|4|6)(?![-\w])' 'Use stack-xs/sm/[default]/lg/xl'

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -713,6 +713,13 @@ body {
 /* ========================================
  * Utility Classes
  * ======================================== */
+
+/* Subtle top-edge highlight for active nav items (replaces a raw
+ * rgba(255,255,255,0.1) inline shadow — white at 10% via the knob token). */
+.shadow-edge-highlight {
+  box-shadow: inset 0 1px 0 color-mix(in oklab, var(--color-knob) 10%, transparent);
+}
+
 .focus-ring:focus {
   outline: none;
   box-shadow:

--- a/ui/src/ui/Button.tsx
+++ b/ui/src/ui/Button.tsx
@@ -31,11 +31,11 @@ const sizeStyles: Record<ButtonSize, string> = {
 const variantStyles: Record<ButtonVariant, Record<ButtonTone, string>> = {
   solid: {
     violet:
-      'bg-brand-primary hover:bg-brand-accent text-text-inverse shadow-lg shadow-brand-primary/25 focus:ring-brand-primary',
-    red: 'bg-status-error hover:bg-status-error/85 text-text-inverse shadow-lg shadow-status-error/25 focus:ring-status-error',
+      'bg-brand-primary hover:bg-brand-accent text-on-brand shadow-lg shadow-brand-primary/25 focus:ring-brand-primary',
+    red: 'bg-status-error hover:bg-status-error/85 text-on-danger shadow-lg shadow-status-error/25 focus:ring-status-error',
     green:
       'bg-status-success hover:bg-status-success/85 text-text-inverse shadow-lg shadow-status-success/25 focus:ring-status-success',
-    blue: 'bg-status-info hover:bg-status-info/85 text-text-inverse shadow-lg shadow-status-info/25 focus:ring-status-info',
+    blue: 'bg-status-info hover:bg-status-info/85 text-on-info shadow-lg shadow-status-info/25 focus:ring-status-info',
     gray: 'bg-surface-hover hover:bg-surface-sunken text-text-primary shadow-lg shadow-surface-border/25 focus:ring-border-muted',
   },
   outline: {

--- a/ui/src/ui/Layout.tsx
+++ b/ui/src/ui/Layout.tsx
@@ -122,7 +122,7 @@ export const PrimaryNav: FC<PrimaryNavProps> = ({
         }}
         className={`flex items-center gap-compact px-3 py-row rounded-lg text-sm font-medium transition-all duration-200 whitespace-nowrap ${
           isActive
-            ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary border-l-2 border-brand-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
+            ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary border-l-2 border-brand-primary shadow-edge-highlight'
             : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
         } ${isGrouped ? 'w-full justify-start' : ''}`}
       >

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -80,7 +80,7 @@ const NavItemButton: FC<NavItemButtonProps> = ({ item, active, collapsed, onNavi
     onMouseEnter={() => prefetchRoute(item.path)}
     className={`group flex items-center gap-default w-full px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 ${
       active
-        ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
+        ? 'bg-gradient-to-r from-brand-primary/30 to-brand-primary/20 text-text-primary shadow-edge-highlight'
         : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
     }`}
     title={collapsed ? item.label : undefined}
@@ -418,7 +418,7 @@ export const SidebarLayout: FC<SidebarLayoutProps> = ({
     <div className="min-h-screen text-text-primary bg-gradient-to-br from-surface-base via-surface-raised to-surface-deep">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-row focus:rounded-lg focus:bg-brand-primary focus:text-text-inverse focus:outline-none"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-row focus:rounded-lg focus:bg-brand-primary focus:text-on-brand focus:outline-none"
       >
         Skip to main content
       </a>


### PR DESCRIPTION
Re-audit polish (niac): brand/status fill `text-text-inverse` → `text-on-brand`/`on-danger`/`on-info` (indigo brand → near-zero visual; fixes dark mode); inset-highlight shadow → `.shadow-edge-highlight`; guard gains a blocking rgb()/hsl() rule (topology/editor domain files already allowlisted). guard CLEAN, biome/tsc clean, 76 tests pass. Deferred: Button green tone (needs on-success).