### PR TITLE
refactor(ui): topology grid color rgba() -> hex

### DIFF
--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -815,7 +815,7 @@ export const TopologyPage: FC = () => {
                     variant={BackgroundVariant.Dots}
                     gap={20}
                     size={1}
-                    color="rgba(255, 255, 255, 0.05)"
+                    color="#ffffff0d"
                   />
                   <Controls showZoom={true} showFitView={true} showInteractive={false} />
 


### PR DESCRIPTION
Harmonize on hex: the lone non-canvas rgba() (topology faint grid line) -> 8-digit hex #ffffff0d (white@5%, same value). guard CLEAN, lint/tsc clean. CodeMirror editor keeps rgba (idiomatic).