### PR TITLE
ci: block undefined design tokens in token-discipline guard

### DIFF
--- a/scripts/check-token-discipline.sh
+++ b/scripts/check-token-discipline.sh
@@ -11,6 +11,9 @@
 #       - bare bg/text/border-white|black
 #       - text-[var(--color-X)] indirection (use text-X directly)
 #       - raw 6/8-digit hex colors in .ts/.tsx
+#       - undefined tokens: bg-/text-/… utilities whose --color-* is not in
+#         index.css (compiles to nothing, renders no color) — see
+#         resolve-token-refs.py
 #   ADVISORY (warns, never fails) — spacing / typography / flex shortcuts that
 #     have semantic replacements. Pre-existing debt; surfaced for burn-down.
 #
@@ -92,6 +95,25 @@ block RAW_HEX_COLOR \
 block RGB_HSL_COLOR \
   '\b(rgba?|hsla?)\([0-9]' \
   'Use a CSS theme variable; for white/black overlays use color-mix(var(--color-knob|scrim))'
+
+# UNDEFINED_TOKEN — every referenced color token must resolve to a --color-*
+# defined in index.css. Catches typos / renamed tokens that compile to nothing
+# and silently render no color (invisible to the palette/hex rules above).
+if command -v python3 >/dev/null 2>&1; then
+  resolve_out=$(python3 "$(dirname "$0")/resolve-token-refs.py" "$TARGET" 2>/dev/null)
+  if [ -n "$resolve_out" ]; then
+    rc_count=$(printf '%s\n' "$resolve_out" | grep -c 'undefined token:')
+    FAIL_COUNT=$((FAIL_COUNT + rc_count))
+    echo "============================================================"
+    echo "[BLOCK: UNDEFINED_TOKEN] $rc_count token(s) referenced but not defined in index.css"
+    echo "  fix: define the --color-* in index.css, or use the correct token name"
+    echo "------------------------------------------------------------"
+    printf '%s\n' "$resolve_out"
+    echo ""
+  fi
+else
+  echo "[warn: UNDEFINED_TOKEN] python3 not found — skipping undefined-token resolve check"
+fi
 
 # ── ADVISORY: spacing / typography / flex (warn-only) ───────────────────────
 advise RAW_SPACE_Y '(?<![-\w])space-y-(1|2|3|4|6)(?![-\w])' 'Use stack-xs/sm/[default]/lg/xl'

--- a/scripts/resolve-token-refs.py
+++ b/scripts/resolve-token-refs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""resolve-token-refs.py — undefined design-token gate.
+
+Every semantic color token referenced as a Tailwind utility (bg-/text-/
+border-/ring-/...) MUST resolve to a --color-* defined in index.css. An
+undefined token (e.g. bg-status-danger when only --color-status-error exists)
+compiles to nothing and silently renders no color, so the palette/hex guard in
+check-token-discipline.sh cannot see it. This check closes that gap.
+
+Usage: resolve-token-refs.py <target-dir>
+  <target-dir> contains index.css and the *.ts/*.tsx tree (e.g. "src" when run
+  from ui/, or "ui/src" from the repo root). Exits non-zero on any undefined
+  token; prints file:line for each.
+"""
+import re
+import sys
+from pathlib import Path
+
+target = Path(sys.argv[1] if len(sys.argv) > 1 else "ui/src")
+css = (target / "index.css").read_text()
+
+# Defined --color-* names from :root / .dark / @theme — the source of truth.
+defined = set(re.findall(r"--color-([a-z0-9-]+)\s*:", css))
+# Known semantic roots = first segment of each defined token. Only utilities
+# whose name starts with one of these roots are treated as token references;
+# this excludes built-ins (text-sm, border-2, shadow-lg, bg-transparent, ...).
+roots = {name.split("-")[0] for name in defined}
+
+PREFIXES = (
+    "bg|text|border|ring|fill|stroke|from|via|to|shadow|outline|"
+    "divide|placeholder|caret|decoration|accent"
+)
+util = re.compile(rf"\b(?:{PREFIXES})-([a-z][a-z0-9]*(?:-[a-z0-9]+)*)")
+SKIP = re.compile(r"\.(test|spec|stories|mock)\.(ts|tsx)$|/styles/|/constants/")
+
+undefined: dict[str, list[str]] = {}
+for path in target.rglob("*.ts*"):
+    if path.suffix not in (".ts", ".tsx") or SKIP.search(str(path)):
+        continue
+    for i, line in enumerate(path.read_text().splitlines(), 1):
+        for name in util.findall(line):
+            if name.split("-")[0] in roots and name not in defined:
+                undefined.setdefault(name, []).append(f"{path}:{i}")
+
+if not undefined:
+    sys.exit(0)
+
+for tok in sorted(undefined):
+    locs = undefined[tok]
+    print(f"  undefined token: {tok}  ({len(locs)}x)  e.g. {locs[0]}")
+    for loc in locs[1:6]:
+        print(f"      {loc}")
+sys.exit(1)


### PR DESCRIPTION
The color/hex rules miss tokens like bg-status-danger that reference a
--color-* not defined in index.css: they compile to nothing and render no
color. Add resolve-token-refs.py (every bg-/text-/border-/… utility whose
name uses a known semantic root must resolve to a defined --color-*) and
wire it as a blocking tier in check-token-discipline.sh.
