### PR TITLE
feat(api): unify authz-denial event name with seed (#1257)

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -254,9 +254,16 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 		if scope < required {
 			writeError(w, r, http.StatusForbidden, "forbidden",
 				"token lacks required scope", nil)
+			// #1257 (Wave 5): unified `event=auth.forbidden` across
+			// seed/niac/stem so SIEM rules can filter authz denials
+			// with one expression regardless of which repo emitted
+			// the record. The `reason` field distinguishes niac's
+			// scope-based denial from seed's role-based denial so
+			// detections can still split on mechanism when needed.
 			s.logger.WarnContext(r.Context(),
 				"[API] Forbidden request: token scope insufficient",
-				"event", "auth.forbidden_scope",
+				"event", "auth.forbidden",
+				"reason", "scope",
 				"requestID", requestID,
 				"clientIP", clientIP,
 				"userAgent", r.UserAgent(),


### PR DESCRIPTION
Refs seed#1257 · Wave 5 cross-repo sub-item 1 (niac half)

## Why

Renames the scope-denial log event from \`auth.forbidden_scope\` to \`auth.forbidden\` so SIEM pipelines across seed/niac/stem can filter authorization failures with one rule. The seed half (rolerequireRole emissions) landed in seed#1271 using the same event name.

## What

The mechanism-specific detail is preserved on a new \`reason\` field — \`reason=scope\` here vs \`reason=role\` on seed — so detections that want to split on the underlying authz model can still do so without losing the unified parent event.

All other record fields (requestID, clientIP, userAgent, path, method, tokenScope, requiredScope) are unchanged. The 403 HTTP response, \`writeError\` call, and scope comparison are untouched. This is a pure log-shape rename.

## Operator note

SIEM rules that filtered on \`event=auth.forbidden_scope\` need to switch to \`event=auth.forbidden\` (optionally further filtered by \`reason=scope\` for the niac-specific subset).

## Test plan
- [x] \`go test ./internal/api/ -count=1\` — passes
- [x] \`golangci-lint run ./internal/api/...\` — 0 issues