### PR TITLE
feat(api): ScopeAdmin tier gates whole-config replacement (#743)

### DIFF
--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -278,10 +278,10 @@ func handleSIGHUP(hupChan <-chan os.Signal, done <-chan struct{}, d *daemon.Daem
 				)
 				continue
 			}
-			ro, rw := d.TokenScopeCounts()
+			ro, rw, admin := d.TokenScopeCounts()
 			logging.Infof(
-				"SIGHUP: token set rotated (%d total: read-only=%d, read-write=%d)",
-				count, ro, rw,
+				"SIGHUP: token set rotated (%d total: read-only=%d, read-write=%d, admin=%d)",
+				count, ro, rw, admin,
 			)
 		}
 	}

--- a/internal/api/admin_scope_test.go
+++ b/internal/api/admin_scope_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestParseScope_Admin proves the admin scope round-trips through the
+// JSON parser. The hyphen / underscore / case variants exercised by the
+// read-only and read-write cases don't apply here — there's only one
+// canonical spelling for the admin tier.
+func TestParseScope_Admin(t *testing.T) {
+	t.Parallel()
+	scope, err := parseScope("admin")
+	if err != nil {
+		t.Fatalf("parseScope(admin): %v", err)
+	}
+	if scope != ScopeAdmin {
+		t.Errorf("parseScope(admin) = %v, want ScopeAdmin", scope)
+	}
+	if got := ScopeAdmin.String(); got != "admin" {
+		t.Errorf("ScopeAdmin.String() = %q, want %q", got, "admin")
+	}
+}
+
+// TestScopeOrdering pins viewer<readwrite<admin so a future refactor
+// can't silently reorder the comparisons that adminProtect relies on.
+func TestScopeOrdering(t *testing.T) {
+	t.Parallel()
+	if ScopeReadOnly >= ScopeReadWrite || ScopeReadWrite >= ScopeAdmin {
+		t.Errorf("scope ordering broken: %d %d %d, want strictly ascending",
+			ScopeReadOnly, ScopeReadWrite, ScopeAdmin)
+	}
+}
+
+// TestAdminProtect_Matrix covers the gate's three relevant inputs:
+// missing scope (treated as forbidden — defense in depth for routes
+// that wire adminProtect without auth upstream), under-privileged
+// scope (read-only and read-write both 403), admin scope (passes).
+func TestAdminProtect_Matrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		setup      func(r *http.Request) *http.Request
+		wantStatus int
+		wantCalled bool
+	}{
+		{
+			name:       "no scope on context => forbidden",
+			setup:      func(r *http.Request) *http.Request { return r },
+			wantStatus: http.StatusForbidden,
+			wantCalled: false,
+		},
+		{
+			name: "read-only token => forbidden",
+			setup: func(r *http.Request) *http.Request {
+				return r.WithContext(withScope(r.Context(), ScopeReadOnly))
+			},
+			wantStatus: http.StatusForbidden,
+			wantCalled: false,
+		},
+		{
+			name: "read-write token => forbidden (write != admin)",
+			setup: func(r *http.Request) *http.Request {
+				return r.WithContext(withScope(r.Context(), ScopeReadWrite))
+			},
+			wantStatus: http.StatusForbidden,
+			wantCalled: false,
+		},
+		{
+			name: "admin token => passes through",
+			setup: func(r *http.Request) *http.Request {
+				return r.WithContext(withScope(r.Context(), ScopeAdmin))
+			},
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+	}
+	// Each subtest owns its own probe + called flag so the cases can
+	// run in parallel without racing on shared closure state.
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			server := createTestServerForMiddleware(t)
+
+			called := false
+			probe := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+			gated := server.adminProtect(probe)
+
+			req := c.setup(httptest.NewRequest(http.MethodPost, "/api/v1/config/import", nil))
+			w := httptest.NewRecorder()
+			gated(w, req)
+			if w.Code != c.wantStatus {
+				t.Errorf("status = %d, want %d; body=%s", w.Code, c.wantStatus, w.Body.String())
+			}
+			if called != c.wantCalled {
+				t.Errorf("handler called = %v, want %v", called, c.wantCalled)
+			}
+		})
+	}
+}
+
+// TestAuth_StashesScopeOnContext proves that downstream middleware can
+// read the scope auth() resolved. Without this stash, adminProtect
+// would have to re-lookup the token (duplication + perf hit) or fall
+// open (security bug).
+func TestAuth_StashesScopeOnContext(t *testing.T) {
+	t.Parallel()
+	server := createTestServerForMiddleware(t)
+
+	// Configure a single admin-scoped token so the success path runs.
+	server.tokens = NewTokenStore([]ScopedToken{{Value: "admin-token", Scope: ScopeAdmin}})
+
+	var captured TokenScope
+	var capturedOK bool
+	tail := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured, capturedOK = scopeFromContext(r.Context())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/something", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	server.auth(tail)(w, req)
+
+	if !capturedOK {
+		t.Fatal("auth() did not stash scope on context")
+	}
+	if captured != ScopeAdmin {
+		t.Errorf("stashed scope = %v, want ScopeAdmin", captured)
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
@@ -10,6 +11,29 @@ import (
 	"runtime/debug"
 	"strings"
 )
+
+// scopeContextKey is the request-context key under which the auth()
+// middleware stashes the resolved TokenScope for the request. The
+// downstream adminProtect middleware reads it via scopeFromContext so
+// the gate stays a single concern rather than re-doing token lookup.
+// Bypass paths (loopback no-token, NIAC_AUTH_DISABLED=true) stash
+// ScopeAdmin so dev workflows aren't suddenly locked out of admin
+// operations they could perform pre-#743.
+type scopeContextKey struct{}
+
+func withScope(ctx context.Context, scope TokenScope) context.Context {
+	return context.WithValue(ctx, scopeContextKey{}, scope)
+}
+
+// scopeFromContext returns the scope stashed by auth(). The second
+// return reports whether a value was actually stashed — false means
+// either the request never went through auth() (which would itself be
+// a configuration bug) or it pre-dates #743. In the false case the
+// caller should fail closed.
+func scopeFromContext(ctx context.Context) (TokenScope, bool) {
+	v, ok := ctx.Value(scopeContextKey{}).(TokenScope)
+	return v, ok
+}
 
 // generateCSRFToken generates a cryptographically secure random token
 // SECURITY FIX LOW-1: CSRF protection.
@@ -191,14 +215,17 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 		// NIAC_AUTH_DISABLED=true.
 		if s.tokens == nil || s.tokens.Len() == 0 {
 			if os.Getenv("NIAC_AUTH_DISABLED") == "true" {
-				next(w, r)
+				// #743: dev-only bypass — treat as admin so dev
+				// workflows can still exercise admin-gated routes.
+				next(w, r.WithContext(withScope(r.Context(), ScopeAdmin)))
 
 				return
 			}
 			nonLoopback, _ := addrIsNonLoopback(s.cfg.Addr)
 			if !nonLoopback {
 				// Loopback-only, no token: the documented local-dev path.
-				next(w, r)
+				// #743: stash admin so local-dev keeps full access.
+				next(w, r.WithContext(withScope(r.Context(), ScopeAdmin)))
 
 				return
 			}
@@ -272,6 +299,42 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 				"tokenScope", scope.String(),
 				"requiredScope", required.String(),
 			)
+			return
+		}
+
+		// #743: stash the resolved scope on the context so adminProtect
+		// (and any future scope-aware middleware) can read it without
+		// re-doing token lookup.
+		next(w, r.WithContext(withScope(r.Context(), scope)))
+	}
+}
+
+// adminProtect wraps handlers that require ScopeAdmin (typically
+// destructive whole-config operations like /api/v1/config/import).
+// The auth() middleware must run upstream — adminProtect reads the
+// scope stashed there; an unstashed context is treated as a 403 so
+// missing wiring fails closed rather than silently bypassing the gate.
+//
+// #743 (Wave 4). New admin-only routes go through this wrapper rather
+// than re-implementing the gate inline.
+func (s *Server) adminProtect(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		scope, ok := scopeFromContext(r.Context())
+		if !ok || scope < ScopeAdmin {
+			writeError(w, r, http.StatusForbidden, "forbidden",
+				"this operation requires an admin-scoped token", nil)
+			s.logger.WarnContext(r.Context(),
+				"[API] Forbidden request: admin scope required",
+				"event", "auth.forbidden",
+				"reason", "scope",
+				"requestID", r.Header.Get("X-Request-ID"),
+				"clientIP", getClientIP(r),
+				"userAgent", r.UserAgent(),
+				"path", r.URL.Path,
+				"method", r.Method,
+				"requiredScope", ScopeAdmin.String(),
+			)
+
 			return
 		}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -51,8 +51,13 @@ func (s *Server) registerWriteProtectedRoutes(mux *http.ServeMux) {
 		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleConfigMerge)))),
 	)
 	mux.HandleFunc(
+		// #743: full topology replacement is admin-class (an
+		// admin-scoped token in addition to read-write). Routine
+		// per-device edits / configs CRUD stay at ScopeReadWrite
+		// because they're normal operator actions, not whole-topology
+		// events.
 		"/api/v1/config/import",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleConfigImport)))),
+		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.adminProtect(s.handleConfigImport))))),
 	)
 	mux.HandleFunc(
 		"/api/v1/replay",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -422,9 +422,10 @@ func (s *Server) AuthConfigured() bool {
 
 // TokenScopeCounts exposes the active token-store breakdown for the
 // SIGHUP audit log line. Returns zeros when no store is attached.
-func (s *Server) TokenScopeCounts() (int, int) {
+// Third return is the admin-token count (#743).
+func (s *Server) TokenScopeCounts() (int, int, int) {
 	if s.tokens == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
 	return s.tokens.ScopeCounts()
 }

--- a/internal/api/token_store.go
+++ b/internal/api/token_store.go
@@ -30,6 +30,13 @@ const (
 	// ScopeReadWrite grants full read + write privileges. Wave 1's single
 	// NIAC_API_TOKEN env var maps to this scope for back-compat.
 	ScopeReadWrite
+	// ScopeAdmin grants ScopeReadWrite plus the right to perform
+	// destructive whole-config operations like /api/v1/config/import
+	// which replaces the entire device topology in one shot (#743).
+	// Existing /api/v1/devices/{host} edits, configs/templates CRUD,
+	// etc. stay at ScopeReadWrite because they're routine operator
+	// actions, not topology-replacement events.
+	ScopeAdmin
 )
 
 // String renders the scope in the canonical hyphenated form used in the
@@ -40,6 +47,8 @@ func (s TokenScope) String() string {
 		return "read-only"
 	case ScopeReadWrite:
 		return "read-write"
+	case ScopeAdmin:
+		return "admin"
 	default:
 		return "unknown"
 	}
@@ -165,23 +174,32 @@ func (s *TokenStore) Len() int {
 }
 
 // ScopeCounts returns a breakdown of the active tokens by scope, used
+//
+// Returns (readOnly, readWrite, admin) counts. Admin tier (#743) is
+// returned separately so dashboards can surface high-privilege token
+// counts at a glance.
+//
+// Deprecated naming kept on the function returning three ints; callers
+// should treat the third return as admin-token count.
 // by the SIGHUP reload log line so operators see "rotated to N tokens
 // (RO=X RW=Y)" without ever logging the values themselves.
-func (s *TokenStore) ScopeCounts() (int, int) {
+func (s *TokenStore) ScopeCounts() (int, int, int) {
 	snap := s.cur.Load()
 	if snap == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
-	var readOnly, readWrite int
+	var readOnly, readWrite, admin int
 	for _, scope := range snap.byHash {
 		switch scope {
 		case ScopeReadOnly:
 			readOnly++
 		case ScopeReadWrite:
 			readWrite++
+		case ScopeAdmin:
+			admin++
 		}
 	}
-	return readOnly, readWrite
+	return readOnly, readWrite, admin
 }
 
 // Replace atomically swaps the active token set. In-flight requests
@@ -274,6 +292,8 @@ func parseScope(s string) (TokenScope, error) {
 		// forgets the scope key should get the safer, Wave-1-equivalent
 		// behaviour rather than a load failure.
 		return ScopeReadWrite, nil
+	case "admin":
+		return ScopeAdmin, nil
 	default:
 		return 0, fmt.Errorf("%w: %q", ErrInvalidTokenScope, s)
 	}

--- a/internal/api/token_store_test.go
+++ b/internal/api/token_store_test.go
@@ -107,9 +107,9 @@ func TestTokenStore_LookupAndReplace(t *testing.T) {
 	if got := store.Len(); got != 1 {
 		t.Errorf("store size after Replace = %d, want 1", got)
 	}
-	ro, rw := store.ScopeCounts()
-	if ro != 0 || rw != 1 {
-		t.Errorf("ScopeCounts after Replace = (ro=%d, rw=%d), want (0, 1)", ro, rw)
+	ro, rw, admin := store.ScopeCounts()
+	if ro != 0 || rw != 1 || admin != 0 {
+		t.Errorf("ScopeCounts after Replace = (ro=%d, rw=%d, admin=%d), want (0, 1, 0)", ro, rw, admin)
 	}
 }
 
@@ -220,7 +220,9 @@ func TestTokenStore_LoadTokenFile_RejectsInvalidScope(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "tokens.json")
 
-	body := `{"tokens":[{"value":"x","scope":"admin"}]}`
+	// "admin" became a valid scope in #743; "superuser" remains
+	// unknown and exercises the reject path.
+	body := `{"tokens":[{"value":"x","scope":"superuser"}]}`
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("write token file: %v", err)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -220,12 +220,12 @@ func (d *Daemon) ReloadTokens() (int, error) {
 }
 
 // TokenScopeCounts returns the number of active (read-only,
-// read-write) tokens in the API server's token store. Used by the
-// SIGHUP handler to surface a useful audit line without leaking token
-// values.
-func (d *Daemon) TokenScopeCounts() (int, int) {
+// read-write, admin) tokens in the API server's token store. Used by
+// the SIGHUP handler to surface a useful audit line without leaking
+// token values. Third return is the admin-token count (#743).
+func (d *Daemon) TokenScopeCounts() (int, int, int) {
 	if d.apiServer == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
 	return d.apiServer.TokenScopeCounts()
 }


### PR DESCRIPTION
Closes #743 (re-scoped — see #1257 comment for the original deferral analysis)

## Why

Per-device edits / configs+templates CRUD are routine operator actions. Replacing the entire device topology in one shot (\`/api/v1/config/import\`) is materially more destructive — it's the "rip and replace the running simulation" path, not the "edit one device" path. This PR adds a third token scope tier above read-write so the topology-replacement path can be locked behind a higher-privilege token while normal operator work stays at read-write.

Existing read-write tokens are unaffected on every existing route. The new tier is opt-in.

## What

- \`TokenScope\` iota gains \`ScopeAdmin\` above \`ScopeReadWrite\` (ordering pinned by \`TestScopeOrdering\` so a refactor can't silently reorder).
- \`TokenScope.String()\` and \`parseScope()\` round-trip \`"admin"\`.
- \`auth()\` stashes the resolved scope on the request context via \`withScope\` / \`scopeFromContext\`. Bypass paths (loopback no-token, \`NIAC_AUTH_DISABLED=true\`) stash \`ScopeAdmin\` so dev workflows aren't suddenly locked out of admin routes they could perform pre-#743.
- New \`adminProtect(next)\` middleware reads the stashed scope and requires \`>= ScopeAdmin\`. An unstashed context is treated as forbidden so the gate fails closed if a future route forgets to wire \`auth()\` upstream.
- \`/api/v1/config/import\` rewrapped: \`recover -> auth -> writeRateLimit -> csrfProtect -> adminProtect -> handleConfigImport\`.
- \`ScopeCounts()\` / \`TokenScopeCounts()\` return a third \"admin\" count; SIGHUP audit log line propagates.

## Tests
- \`TestParseScope_Admin\` / \`TestScopeOrdering\`
- \`TestAdminProtect_Matrix\` — full no-scope / RO / RW / admin matrix (subtests parallel; each owns its probe)
- \`TestAuth_StashesScopeOnContext\` — proves the auth→adminProtect contract
- Updated \`TestTokenStore_LoadTokenFile_RejectsInvalidScope\` (uses \`\"superuser\"\` now that \`\"admin\"\` is valid)
- Updated \`TestTokenStore_Replace\` for the 3-int ScopeCounts return

## Operator note

Existing tokens continue to work unchanged. To use the new tier:

\`\`\`json
{\"value\": \"...\", \"scope\": \"admin\"}
\`\`\`

Then point your config-import automation at the admin-scoped token.

## Test plan
- [x] \`go test ./...\` — passes (api + daemon + cmd)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go build ./...\` — clean