### PR TITLE
feat(api,ui): scope-discovery endpoint + UI gating primitives (#762)

### DIFF
--- a/internal/api/handlers_auth_scope.go
+++ b/internal/api/handlers_auth_scope.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import "net/http"
+
+// AuthScopeResponse is the body of GET /api/v1/auth/scope. It tells
+// the UI which scope the caller's bearer token resolves to so the
+// frontend can hide controls that would 403 anyway (#762, companion
+// to #743).
+//
+// The scope string matches the canonical form returned by
+// TokenScope.String(): "read-only" / "read-write" / "admin". A
+// missing or unauthenticated path returns the bypass scope ("admin")
+// because the auth() middleware stashes admin on those paths so they
+// continue to function — the UI gates would otherwise lock loopback
+// dev sessions out of admin controls they'd previously had access to.
+type AuthScopeResponse struct {
+	Scope string `json:"scope"`
+}
+
+// handleAuthScope reports the caller's resolved bearer-token scope so
+// the UI can render scope-aware controls. Wrapped by auth() upstream
+// so the scopeFromContext lookup is always populated by the time we
+// run; if it isn't (an unwrapped call would be a route-registration
+// bug), we report the safest tier ("read-only") rather than guessing.
+func (s *Server) handleAuthScope(w http.ResponseWriter, r *http.Request) {
+	scope, ok := scopeFromContext(r.Context())
+	if !ok {
+		s.writeJSON(w, AuthScopeResponse{Scope: ScopeReadOnly.String()})
+
+		return
+	}
+	s.writeJSON(w, AuthScopeResponse{Scope: scope.String()})
+}

--- a/internal/api/handlers_auth_scope_test.go
+++ b/internal/api/handlers_auth_scope_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleAuthScope_EchoesContextScope proves the UI scope-discovery
+// endpoint returns whatever auth() stashed (#762, companion to #743).
+func TestHandleAuthScope_EchoesContextScope(t *testing.T) {
+	t.Parallel()
+	server := createTestServerForMiddleware(t)
+
+	cases := []struct {
+		name      string
+		stash     TokenScope
+		stashed   bool
+		wantScope string
+	}{
+		{"read-only stashed", ScopeReadOnly, true, "read-only"},
+		{"read-write stashed", ScopeReadWrite, true, "read-write"},
+		{"admin stashed", ScopeAdmin, true, "admin"},
+		// Unstashed context is the wiring-bug fallback: report the
+		// safest tier so a misregistered route never accidentally
+		// surfaces admin controls to the UI.
+		{"no scope stashed => report read-only", 0, false, "read-only"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/scope", nil)
+			if c.stashed {
+				req = req.WithContext(withScope(req.Context(), c.stash))
+			}
+			w := httptest.NewRecorder()
+			server.handleAuthScope(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+			}
+			var got AuthScopeResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+			}
+			if got.Scope != c.wantScope {
+				t.Errorf("scope = %q, want %q", got.Scope, c.wantScope)
+			}
+		})
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -147,6 +147,11 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 	)
 	mux.HandleFunc("/api/v1/version", s.recoverMiddleware(s.auth(s.handleVersion)))
 	mux.HandleFunc("/api/v1/neighbors", s.recoverMiddleware(s.auth(s.handleNeighbors)))
+	// #762: scope discovery endpoint for the UI. auth() upstream
+	// stashes the resolved scope on the context; handleAuthScope
+	// echoes it as JSON. Safe GET method so no csrfProtect /
+	// writeRateLimit wrappers needed.
+	mux.HandleFunc("/api/v1/auth/scope", s.recoverMiddleware(s.auth(s.handleAuthScope)))
 }
 
 // registerWalkRoutes registers SNMP walk file validation endpoints.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary, PageErrorBoundary } from './components/ErrorBoundary';
 import { HeaderBar } from './components/HeaderBar';
 import { HelpDrawer } from './components/HelpDrawer';
 import { SettingsDrawer } from './components/SettingsDrawer';
+import { ReadOnlyView } from './components/ui/ReadOnlyView';
 import { AppProvider, useAppState } from './contexts/AppContext';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useNavGroups } from './navGroups';
@@ -58,65 +59,72 @@ function AppShell() {
       onOpenSettings={() => setSettingsOpen(true)}
     >
       <ToastContainer />
-      <Suspense fallback={<PageLoader />}>
-        <Routes>
-          {pages.map((page) => (
+      {/* #762: a read-only-scoped token sees every page read-only via
+          one wrap. ReadOnlyView's HTML <fieldset disabled> propagates
+          `disabled` to every descendant button/input/select/textarea
+          so individual pages don't need to gate their own controls.
+          Read-write and admin tokens see no chrome change. */}
+      <ReadOnlyView>
+        <Suspense fallback={<PageLoader />}>
+          <Routes>
+            {pages.map((page) => (
+              <Route
+                key={page.path}
+                path={page.path}
+                element={
+                  <PageWithErrorBoundary page={page}>
+                    <page.component />
+                  </PageWithErrorBoundary>
+                }
+              />
+            ))}
+            {/* Dynamic routes for the device editor — both reuse the
+              same lazy-loaded component as the Device Library, but
+              wear different page-header metadata. */}
             <Route
-              key={page.path}
-              path={page.path}
+              path="/device-config/new"
               element={
-                <PageWithErrorBoundary page={page}>
-                  <page.component />
+                <PageWithErrorBoundary
+                  page={{
+                    path: '/device-config/new',
+                    label: t('deviceEditor.newLabel'),
+                    title: t('deviceEditor.newTitle'),
+                    description: t('deviceEditor.newDescription'),
+                    icon: Wrench,
+                    component: DeviceEditorPageRef,
+                  }}
+                >
+                  <DeviceEditorPageRef />
                 </PageWithErrorBoundary>
               }
             />
-          ))}
-          {/* Dynamic routes for the device editor — both reuse the
-              same lazy-loaded component as the Device Library, but
-              wear different page-header metadata. */}
-          <Route
-            path="/device-config/new"
-            element={
-              <PageWithErrorBoundary
-                page={{
-                  path: '/device-config/new',
-                  label: t('deviceEditor.newLabel'),
-                  title: t('deviceEditor.newTitle'),
-                  description: t('deviceEditor.newDescription'),
-                  icon: Wrench,
-                  component: DeviceEditorPageRef,
-                }}
-              >
-                <DeviceEditorPageRef />
-              </PageWithErrorBoundary>
-            }
-          />
-          <Route
-            path="/device-config/:hostname"
-            element={
-              <PageWithErrorBoundary
-                page={{
-                  path: '/device-config/:hostname',
-                  label: t('deviceEditor.editLabel'),
-                  title: t('deviceEditor.editTitle'),
-                  description: t('deviceEditor.editDescription'),
-                  icon: Wrench,
-                  component: DeviceEditorPageRef,
-                }}
-              >
-                <DeviceEditorPageRef />
-              </PageWithErrorBoundary>
-            }
-          />
-          {/* Back-compat for folded-in pages — bookmarks and copied URLs
+            <Route
+              path="/device-config/:hostname"
+              element={
+                <PageWithErrorBoundary
+                  page={{
+                    path: '/device-config/:hostname',
+                    label: t('deviceEditor.editLabel'),
+                    title: t('deviceEditor.editTitle'),
+                    description: t('deviceEditor.editDescription'),
+                    icon: Wrench,
+                    component: DeviceEditorPageRef,
+                  }}
+                >
+                  <DeviceEditorPageRef />
+                </PageWithErrorBoundary>
+              }
+            />
+            {/* Back-compat for folded-in pages — bookmarks and copied URLs
               continue to work after pages moved into their host sections. */}
-          <Route path="/templates" element={<Navigate to="/runtime" replace={true} />} />
-          <Route path="/neighbors" element={<Navigate to="/topology" replace={true} />} />
-          <Route path="/analysis" element={<Navigate to="/traffic" replace={true} />} />
-          <Route path="/pcap-analyzer" element={<Navigate to="/packets" replace={true} />} />
-          <Route path="*" element={<Navigate to="/" replace={true} />} />
-        </Routes>
-      </Suspense>
+            <Route path="/templates" element={<Navigate to="/runtime" replace={true} />} />
+            <Route path="/neighbors" element={<Navigate to="/topology" replace={true} />} />
+            <Route path="/analysis" element={<Navigate to="/traffic" replace={true} />} />
+            <Route path="/pcap-analyzer" element={<Navigate to="/packets" replace={true} />} />
+            <Route path="*" element={<Navigate to="/" replace={true} />} />
+          </Routes>
+        </Suspense>
+      </ReadOnlyView>
       <SettingsDrawer
         isOpen={settingsOpen}
         onClose={() => setSettingsOpen(false)}

--- a/ui/src/components/ui/ReadOnlyView.tsx
+++ b/ui/src/components/ui/ReadOnlyView.tsx
@@ -1,0 +1,47 @@
+/**
+ * ReadOnlyView — wraps a panel so a read-only-scoped token sees the
+ * current state but cannot mutate it (#762).
+ *
+ * Renders an explanatory banner when the active scope lacks write
+ * access, and disables every descendant native form control via a
+ * `<fieldset disabled>`. The fieldset trick works because the HTML
+ * spec propagates `disabled` to every nested input, select, textarea,
+ * and button — one wrap on a panel root locks down the whole surface
+ * regardless of how many sub-controls exist.
+ *
+ * Read-write and admin tokens see no chrome change: children render
+ * directly, no banner, no fieldset.
+ *
+ * For controls that should remain visible-but-disabled with a custom
+ * tooltip, prefer the inline `useScope().canWrite` + `disabled`
+ * pattern so the title can compose with other gates (e.g. license).
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { useScope } from '../../contexts/ScopeContext';
+
+interface ReadOnlyViewProps {
+  children: ReactNode;
+  /** Optional override for the banner copy. */
+  notice?: string;
+}
+
+export function ReadOnlyView({ children, notice }: ReadOnlyViewProps): ReactElement {
+  const { canWrite } = useScope();
+  if (canWrite) {
+    return <>{children}</>;
+  }
+  return (
+    <div className="stack-sm">
+      <div
+        role="status"
+        className="rounded-lg border border-status-info/30 bg-status-info/5 pad-sm text-sm text-status-info"
+      >
+        {notice ?? 'Read-only — your token does not allow changes on this panel.'}
+      </div>
+      <fieldset disabled className="contents">
+        {children}
+      </fieldset>
+    </div>
+  );
+}

--- a/ui/src/components/ui/RequireScope.tsx
+++ b/ui/src/components/ui/RequireScope.tsx
@@ -1,0 +1,45 @@
+/**
+ * RequireScope — render children only if the current token meets a
+ * minimum scope. Hide-variant gating, parallel to <RequireFeature>
+ * for license tier (#762).
+ *
+ * Use this for entire pages, drawer sections, nav items, or any UI
+ * surface that should simply not exist below the threshold:
+ *
+ *   <RequireScope min="admin">
+ *     <ConfigImportPanel />
+ *   </RequireScope>
+ *
+ * For controls that should remain visible but disabled with a
+ * tooltip, read `useScope().canWrite` / `isAdmin` directly and apply
+ * `disabled` + a `title` attribute.
+ *
+ * Fail-closed: while the initial scope fetch is in flight `canWrite`
+ * and `isAdmin` are false so children render the `fallback` (default
+ * null), matching <RequireFeature>'s behavior.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { type Scope, useScope } from '../../contexts/ScopeContext';
+
+interface RequireScopeProps {
+  /** Minimum scope required for children to render. */
+  min: Scope;
+  children: ReactNode;
+  /** Rendered when the active scope ranks below `min` (or unknown). */
+  fallback?: ReactNode;
+}
+
+const SCOPE_RANK: Record<Scope, number> = {
+  'read-only': 1,
+  'read-write': 2,
+  admin: 3,
+};
+
+export function RequireScope({ min, children, fallback = null }: RequireScopeProps): ReactElement {
+  const { scope } = useScope();
+  if (scope === null || SCOPE_RANK[scope] < SCOPE_RANK[min]) {
+    return <>{fallback}</>;
+  }
+  return <>{children}</>;
+}

--- a/ui/src/contexts/ScopeContext.test.tsx
+++ b/ui/src/contexts/ScopeContext.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * ScopeContext tests — pin the canWrite/isAdmin matrix and the
+ * fail-closed loading/error state so the #762 UI gate can't silently
+ * regress. Also exercise the wrapper components in their viewer +
+ * operator paths.
+ */
+
+import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ReadOnlyView } from '../components/ui/ReadOnlyView';
+import { RequireScope } from '../components/ui/RequireScope';
+import { type Scope, ScopeProvider, useScope } from './ScopeContext';
+
+const mockGet = vi.fn<(path: string) => Promise<unknown>>();
+vi.mock('../api/requestCore', () => ({
+  deduplicatedGet: (path: string): Promise<unknown> => mockGet(path),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }): React.ReactElement => (
+  <ScopeProvider>{children}</ScopeProvider>
+);
+
+const respond = (scope: Scope): { scope: Scope } => ({ scope });
+
+describe('ScopeContext / useScope', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('fetches /api/v1/auth/scope on mount and exposes scope + helpers', async () => {
+    mockGet.mockResolvedValueOnce(respond('read-write'));
+    const { result } = renderHook(() => useScope(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/auth/scope');
+    expect(result.current.scope).toBe('read-write');
+    expect(result.current.canWrite).toBe(true);
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('read-only token cannot write and is not admin', async () => {
+    mockGet.mockResolvedValueOnce(respond('read-only'));
+    const { result } = renderHook(() => useScope(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canWrite).toBe(false);
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('admin token can write and is admin', async () => {
+    mockGet.mockResolvedValueOnce(respond('admin'));
+    const { result } = renderHook(() => useScope(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canWrite).toBe(true);
+    expect(result.current.isAdmin).toBe(true);
+  });
+
+  it('fails closed on fetch error: canWrite=false, error surfaced', async () => {
+    mockGet.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useScope(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.scope).toBeNull();
+    expect(result.current.canWrite).toBe(false);
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('refresh() re-fetches /auth/scope and updates state', async () => {
+    mockGet.mockResolvedValueOnce(respond('read-only'));
+    const { result } = renderHook(() => useScope(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canWrite).toBe(false);
+
+    mockGet.mockResolvedValueOnce(respond('admin'));
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.isAdmin).toBe(true);
+  });
+
+  it('throws when used outside <ScopeProvider>', () => {
+    const orig = console.error;
+    console.error = (): void => {};
+    try {
+      expect(() => renderHook(() => useScope())).toThrow(/inside <ScopeProvider>/);
+    } finally {
+      console.error = orig;
+    }
+  });
+});
+
+describe('<RequireScope>', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('renders children when scope meets minimum', async () => {
+    mockGet.mockResolvedValueOnce(respond('admin'));
+    const { findByText } = render(
+      <ScopeProvider>
+        <RequireScope min="admin" fallback={<span>nope</span>}>
+          <span>admin-only</span>
+        </RequireScope>
+      </ScopeProvider>,
+    );
+    await findByText('admin-only');
+  });
+
+  it('renders fallback when scope is below minimum', async () => {
+    mockGet.mockResolvedValueOnce(respond('read-write'));
+    const { findByText } = render(
+      <ScopeProvider>
+        <RequireScope min="admin" fallback={<span>nope</span>}>
+          <span>admin-only</span>
+        </RequireScope>
+      </ScopeProvider>,
+    );
+    await findByText('nope');
+  });
+});
+
+describe('<ReadOnlyView>', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('renders children unwrapped for a read-write token', async () => {
+    mockGet.mockResolvedValueOnce(respond('read-write'));
+    const { container, findByTestId, queryByRole } = render(
+      <ScopeProvider>
+        <ReadOnlyView>
+          <input data-testid="probe" />
+        </ReadOnlyView>
+      </ScopeProvider>,
+    );
+    await findByTestId('probe');
+    expect(queryByRole('status')).toBeNull();
+    expect(container.querySelector('fieldset')).toBeNull();
+  });
+
+  it('wraps children in a disabled fieldset and banners for read-only', async () => {
+    mockGet.mockResolvedValueOnce(respond('read-only'));
+    const { findByTestId, findByRole, container } = render(
+      <ScopeProvider>
+        <ReadOnlyView>
+          <input data-testid="probe-input" />
+          <button data-testid="probe-button" type="button">
+            Save
+          </button>
+        </ReadOnlyView>
+      </ScopeProvider>,
+    );
+    await findByRole('status');
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset).not.toBeNull();
+    expect(fieldset?.hasAttribute('disabled')).toBe(true);
+    const input = await findByTestId('probe-input');
+    const button = await findByTestId('probe-button');
+    expect(fieldset?.contains(input)).toBe(true);
+    expect(fieldset?.contains(button)).toBe(true);
+  });
+});

--- a/ui/src/contexts/ScopeContext.tsx
+++ b/ui/src/contexts/ScopeContext.tsx
@@ -1,0 +1,114 @@
+/**
+ * ScopeContext — current bearer-token scope and UI gating helpers.
+ *
+ * Fetches GET /api/v1/auth/scope once at app boot, caches the result,
+ * and exposes it via `useScope()`. UI components use this to render
+ * scope-aware controls so a read-only token doesn't see (and click)
+ * write buttons that would 403 against #743's scope enforcement.
+ *
+ * niac's tiers (from internal/api/token_store.go):
+ *   read-only  < read-write  < admin
+ * The auth() middleware stashes the resolved scope on the request
+ * context; handleAuthScope echoes it. On bypass paths (loopback no-
+ * token, NIAC_AUTH_DISABLED) the backend returns "admin" so dev
+ * sessions aren't suddenly locked out of admin controls.
+ *
+ * Fail-closed: on fetch error or while the initial request is in
+ * flight, `canWrite` and `isAdmin` are false so write/admin controls
+ * hide rather than flash visible.
+ */
+
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { deduplicatedGet } from '../api/requestCore';
+
+/** Allowed scope values, mirroring TokenScope.String() on the server. */
+export type Scope = 'read-only' | 'read-write' | 'admin';
+
+const SCOPE_RANK: Record<Scope, number> = {
+  'read-only': 1,
+  'read-write': 2,
+  admin: 3,
+};
+
+interface AuthScopeResponse {
+  scope: Scope;
+}
+
+interface ScopeContextValue {
+  /** Latest /auth/scope fetch, or null while loading / on fetch error. */
+  scope: Scope | null;
+  /** True while the initial fetch is in flight. */
+  loading: boolean;
+  /** Last fetch error message, or null if none. */
+  error: string | null;
+  /** Force a re-fetch (e.g. after rotating tokens via niac CLI). */
+  refresh: () => Promise<void>;
+  /**
+   * True iff the current token may perform state-changing operations
+   * (read-write or admin). Fail-closed while loading / on error.
+   */
+  canWrite: boolean;
+  /**
+   * True iff the current token is admin-scoped. Use for admin-only UI
+   * surfaces such as /api/v1/config/import (#743).
+   */
+  isAdmin: boolean;
+}
+
+const ScopeContext = createContext<ScopeContextValue | null>(null);
+
+interface ScopeProviderProps {
+  children: ReactNode;
+}
+
+export function ScopeProvider({ children }: ScopeProviderProps): ReactElement {
+  const [scope, setScope] = useState<Scope | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const fresh = await deduplicatedGet<AuthScopeResponse>('/api/v1/auth/scope');
+      setScope(fresh.scope);
+    } catch (err) {
+      setScope(null);
+      setError(err instanceof Error ? err.message : 'Failed to load token scope');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const canWrite = scope !== null && SCOPE_RANK[scope] >= SCOPE_RANK['read-write'];
+  const isAdmin = scope === 'admin';
+
+  return (
+    <ScopeContext.Provider value={{ scope, loading, error, refresh, canWrite, isAdmin }}>
+      {children}
+    </ScopeContext.Provider>
+  );
+}
+
+/**
+ * useScope returns the active token scope state. Throws if called
+ * outside a `<ScopeProvider>` — that always indicates a wiring bug.
+ */
+export function useScope(): ScopeContextValue {
+  const ctx = useContext(ScopeContext);
+  if (!ctx) {
+    throw new Error('useScope() must be called inside <ScopeProvider>');
+  }
+  return ctx;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import { LicenseProvider } from './contexts/LicenseContext';
+import { ScopeProvider } from './contexts/ScopeContext';
 import { initThemeFromStorage } from './hooks/useTheme';
 import './i18n';
 import './i18n/types';
@@ -24,7 +25,9 @@ createRoot(rootElement).render(
   <StrictMode>
     <BrowserRouter>
       <LicenseProvider>
-        <App />
+        <ScopeProvider>
+          <App />
+        </ScopeProvider>
       </LicenseProvider>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
Closes #762 · Wave 4 UI companion to #743 (now merged)

## Why

#743 (#769) introduced the ScopeAdmin tier on the backend. The UI side hasn't existed: a read-only-scoped token still saw every button as if it were authoritative. This PR adds the scope-discovery endpoint, the UI scope-context, and the gate primitives so a read-only token visibly cannot mutate state, and admin-only surfaces hide for non-admin tokens.

## Backend

- GET /api/v1/auth/scope (handleAuthScope) — echoes the scope auth() stashed on the request context. Safe GET so no csrfProtect / writeRateLimit; auth() upstream populates the context including the bypass paths that report "admin".
- Wiring-bug fallback reports "read-only" when no scope is stashed rather than guessing — fail-closed so a future misregistered route can't surface admin controls.

## Frontend (mirrors LicenseContext / RequireFeature / TierGate)

- ScopeContext.tsx — fetches /auth/scope once at boot, exposes { scope, loading, error, refresh, canWrite, isAdmin } via useScope(). Fail-closed during loading / on fetch error.
- ScopeProvider mounted in main.tsx between LicenseProvider and App.
- <RequireScope min="read-write" | "admin"> — hide-variant gate for entire surfaces.
- <ReadOnlyView> — wraps a panel in <fieldset disabled> + banner for non-write scopes. The HTML spec propagates the fieldset's disabled to every descendant native form control, so one wrap on App.tsx's routed-page block covers every page's buttons/inputs/selects/textareas without per-page edits.
- AppShell now applies <ReadOnlyView> around the routed page tree. Read-write and admin tokens see no chrome change.

## Tests

- Backend: TestHandleAuthScope_EchoesContextScope (4 subtests).
- UI: ScopeContext.test.tsx (10 tests) — canWrite/isAdmin matrix, fail-closed loading/error, refresh, throw-outside-provider, RequireScope above/below min, ReadOnlyView read-write passthrough vs read-only fieldset+banner.

## Test plan
- [x] go test ./internal/api/ -count=1
- [x] golangci-lint run ./...
- [x] npx vitest run (86/86)
- [x] tsc + biome clean

## Follow-up

Infrastructure now exists; future PRs can wrap admin-only UI controls (config-import button, license activation) with <RequireScope min="admin">.