### PR TITLE
feat(api): per-session CSRF tokens via CSRFManager (#1257 sub-4)

### DIFF
--- a/internal/api/csrf_manager.go
+++ b/internal/api/csrf_manager.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// CSRF manager configuration constants. Mirrors stem's CSRFManager
+// (#1257 sub-4 port) so the per-session model and the 24h expiry are
+// uniform across the two repos.
+const (
+	csrfPerSessionTokenLength    = 32
+	csrfPerSessionTokenExpiry    = 24 * time.Hour
+	csrfPerSessionCleanupSeconds = 5 * 60 // 5 minutes between cleanup sweeps
+	csrfHeaderName               = "X-Csrf-Token"
+	// csrfLoopbackSessionKey is the synthetic session key for the
+	// no-token bypass path (loopback / NIAC_AUTH_DISABLED). All bypass
+	// requests share one CSRF token under this key, which preserves
+	// the pre-#1257 single-token behavior for that dev path while
+	// keeping authenticated requests on per-bearer keys.
+	csrfLoopbackSessionKey = "_loopback_bypass"
+)
+
+// CSRF errors. Match stem's error vars for cross-repo parity.
+var (
+	errCSRFTokenMissing = errors.New("CSRF token missing")
+	errCSRFTokenInvalid = errors.New("CSRF token invalid")
+	errCSRFTokenExpired = errors.New("CSRF token expired")
+)
+
+// csrfTokenEntry stores a minted token plus its expiry.
+type csrfTokenEntry struct {
+	token     string
+	expiresAt time.Time
+}
+
+// CSRFManager mints, stores, and validates per-session CSRF tokens.
+// Keyed by sha256(bearer-token) so the bearer plaintext is never
+// retained in memory.
+//
+// #1257 (Wave 5) sub-4: port of stem's CSRFManager pattern. Pre-port
+// niac shared a single global CSRF token across all clients which,
+// while functionally protective against cross-site requests, meant
+// any client could replay another's value. The per-session model
+// pins each token to its issuer.
+type CSRFManager struct {
+	mu     sync.RWMutex
+	tokens map[string]*csrfTokenEntry
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewCSRFManager constructs a manager and starts its cleanup loop.
+// Stop the returned manager via Stop() during server shutdown to
+// terminate the background goroutine.
+func NewCSRFManager() *CSRFManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &CSRFManager{
+		tokens: make(map[string]*csrfTokenEntry),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	go m.cleanupLoop()
+
+	return m
+}
+
+// SessionKey derives the CSRFManager's session key from a bearer
+// token. Hashing the bearer prevents storing the plaintext in the
+// manager's internal map (already-hashed values keep the manager's
+// memory profile uniform regardless of bearer length / format).
+func SessionKey(bearer string) string {
+	if bearer == "" {
+		return csrfLoopbackSessionKey
+	}
+	sum := sha256.Sum256([]byte(bearer))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// Generate mints a fresh CSRF token for the given session key,
+// replacing any existing one.
+func (m *CSRFManager) Generate(sessionKey string) (string, error) {
+	buf := make([]byte, csrfPerSessionTokenLength)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate CSRF token: %w", err)
+	}
+	tok := base64.URLEncoding.EncodeToString(buf)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tokens[sessionKey] = &csrfTokenEntry{
+		token:     tok,
+		expiresAt: time.Now().Add(csrfPerSessionTokenExpiry),
+	}
+
+	return tok, nil
+}
+
+// GetOrCreate returns an existing unexpired token or mints a new
+// one. Used by the /csrf-token endpoint so a UI that polls for the
+// token receives the same value within a session lifetime.
+func (m *CSRFManager) GetOrCreate(sessionKey string) (string, error) {
+	m.mu.RLock()
+	entry, ok := m.tokens[sessionKey]
+	m.mu.RUnlock()
+	if ok && time.Now().Before(entry.expiresAt) {
+		return entry.token, nil
+	}
+
+	return m.Generate(sessionKey)
+}
+
+// Validate constant-time-compares the supplied token against the one
+// stored for sessionKey. Returns one of errCSRFTokenMissing /
+// errCSRFTokenInvalid / errCSRFTokenExpired so callers can render
+// different messages or audit-log differently per failure mode.
+func (m *CSRFManager) Validate(sessionKey, token string) error {
+	if token == "" {
+		return errCSRFTokenMissing
+	}
+	m.mu.RLock()
+	entry, ok := m.tokens[sessionKey]
+	m.mu.RUnlock()
+	if !ok {
+		return errCSRFTokenInvalid
+	}
+	if time.Now().After(entry.expiresAt) {
+		// Re-check under write lock to avoid a TOCTOU racing two
+		// expiring sessions into the same delete.
+		m.mu.Lock()
+		current, stillExists := m.tokens[sessionKey]
+		if stillExists && current == entry {
+			delete(m.tokens, sessionKey)
+		}
+		m.mu.Unlock()
+
+		return errCSRFTokenExpired
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(entry.token)) != 1 {
+		return errCSRFTokenInvalid
+	}
+
+	return nil
+}
+
+// Stop terminates the background cleanup goroutine. Idempotent.
+func (m *CSRFManager) Stop() {
+	m.cancel()
+}
+
+// cleanupLoop sweeps expired tokens from the map at a fixed cadence
+// so memory doesn't grow unbounded across long-running sessions.
+func (m *CSRFManager) cleanupLoop() {
+	ticker := time.NewTicker(time.Duration(csrfPerSessionCleanupSeconds) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			m.mu.Lock()
+			for k, entry := range m.tokens {
+				if now.After(entry.expiresAt) {
+					delete(m.tokens, k)
+				}
+			}
+			m.mu.Unlock()
+		}
+	}
+}
+
+// sessionKeyFromRequest derives the CSRF session key for the request
+// from its Authorization header. Mirrors the bearer extraction in
+// auth() so the same token always hashes to the same key.
+func sessionKeyFromRequest(r *http.Request) string {
+	authz := r.Header.Get("Authorization")
+	if authz == "" {
+		return csrfLoopbackSessionKey
+	}
+
+	return SessionKey(strings.TrimPrefix(authz, "Bearer "))
+}

--- a/internal/api/csrf_manager_test.go
+++ b/internal/api/csrf_manager_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestCSRFManager_PerSessionIsolation is the load-bearing #1257 test:
+// the pre-port single-token model let any client replay another's
+// token. Per-session means a token minted for session A must be
+// invalid for session B even with identical content.
+func TestCSRFManager_PerSessionIsolation(t *testing.T) {
+	t.Parallel()
+	m := NewCSRFManager()
+	t.Cleanup(m.Stop)
+
+	tokenA, genErrA := m.Generate(SessionKey("bearer-A"))
+	if genErrA != nil {
+		t.Fatalf("generate A: %v", genErrA)
+	}
+	tokenB, genErrB := m.Generate(SessionKey("bearer-B"))
+	if genErrB != nil {
+		t.Fatalf("generate B: %v", genErrB)
+	}
+	if tokenA == tokenB {
+		t.Fatal("two sessions must not share a CSRF token")
+	}
+
+	if vErr := m.Validate(SessionKey("bearer-A"), tokenA); vErr != nil {
+		t.Errorf("A's token must validate against A's session: %v", vErr)
+	}
+	if vErr := m.Validate(SessionKey("bearer-B"), tokenB); vErr != nil {
+		t.Errorf("B's token must validate against B's session: %v", vErr)
+	}
+	// The actual regression guard.
+	if vErr := m.Validate(SessionKey("bearer-A"), tokenB); !errors.Is(vErr, errCSRFTokenInvalid) {
+		t.Errorf("B's token presented to A's session must be invalid, got %v", vErr)
+	}
+	if vErr := m.Validate(SessionKey("bearer-B"), tokenA); !errors.Is(vErr, errCSRFTokenInvalid) {
+		t.Errorf("A's token presented to B's session must be invalid, got %v", vErr)
+	}
+}
+
+// TestCSRFManager_LoopbackBypassSharesKey proves that the no-token
+// bypass path (loopback or NIAC_AUTH_DISABLED) maps every request to
+// a single key — different empty bearers still share state, which
+// preserves the pre-port behavior for that dev-only path.
+func TestCSRFManager_LoopbackBypassSharesKey(t *testing.T) {
+	t.Parallel()
+	if SessionKey("") != csrfLoopbackSessionKey {
+		t.Errorf("empty bearer should map to loopback key, got %q", SessionKey(""))
+	}
+}
+
+// TestCSRFManager_ValidateErrorClassification proves the three failure
+// modes are distinguishable so the middleware can render different
+// error codes / messages per cause.
+func TestCSRFManager_ValidateErrorClassification(t *testing.T) {
+	t.Parallel()
+	m := NewCSRFManager()
+	t.Cleanup(m.Stop)
+
+	// Missing.
+	if err := m.Validate("session", ""); !errors.Is(err, errCSRFTokenMissing) {
+		t.Errorf("empty token => %v, want errCSRFTokenMissing", err)
+	}
+	// Invalid (no token ever minted for this session).
+	if err := m.Validate("session-with-no-mint", "anything"); !errors.Is(err, errCSRFTokenInvalid) {
+		t.Errorf("unminted session => %v, want errCSRFTokenInvalid", err)
+	}
+	// Wrong value for a minted session.
+	tok, genErr := m.Generate("session2")
+	if genErr != nil {
+		t.Fatalf("generate: %v", genErr)
+	}
+	if vErr := m.Validate("session2", tok+"X"); !errors.Is(vErr, errCSRFTokenInvalid) {
+		t.Errorf("wrong token => %v, want errCSRFTokenInvalid", vErr)
+	}
+}
+
+// TestCSRFManager_GetOrCreateIsIdempotent proves a UI polling
+// /api/v1/csrf-token within the expiry window receives the same
+// token back — important so the UI can cache and not invalidate
+// every in-flight request when it polls.
+func TestCSRFManager_GetOrCreateIsIdempotent(t *testing.T) {
+	t.Parallel()
+	m := NewCSRFManager()
+	t.Cleanup(m.Stop)
+
+	first, err := m.GetOrCreate("session")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := m.GetOrCreate("session")
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first != second {
+		t.Errorf("repeat GetOrCreate must return same token: %q vs %q", first, second)
+	}
+}
+
+// TestSessionKey_HashedNotPlaintext proves the bearer never lands in
+// the manager's internal map as plaintext — important so a heap dump
+// or debug log of the manager doesn't leak live bearer tokens.
+func TestSessionKey_HashedNotPlaintext(t *testing.T) {
+	t.Parallel()
+	bearer := "extremely-secret-bearer-token"
+	key := SessionKey(bearer)
+	if strings.Contains(key, bearer) {
+		t.Errorf("session key must not embed bearer plaintext (key=%q)", key)
+	}
+	if len(key) != 64 { // sha256 hex = 64 chars
+		t.Errorf("session key length = %d, want 64 (sha256 hex)", len(key))
+	}
+}

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -590,7 +590,18 @@ func (s *Server) handleCSRFToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #1257: mint or retrieve a per-session CSRF token keyed by the
+	// caller's bearer (or the loopback bypass key on no-token paths).
+	// Same caller fetching twice within the 24h expiry gets the same
+	// value, so the UI can cache it.
+	token, err := s.csrf.GetOrCreate(sessionKeyFromRequest(r))
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "[API] CSRF token mint failed", "error", err)
+		http.Error(w, "csrf token unavailable", http.StatusInternalServerError)
+
+		return
+	}
 	s.writeJSON(w, map[string]string{
-		"token": s.csrfToken,
+		"token": token,
 	})
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -369,8 +369,14 @@ func TestRecoverMiddleware(t *testing.T) {
 
 func TestCSRFProtection(t *testing.T) {
 	server, _ := createTestServer(t)
-	// Set a CSRF token to enable CSRF protection
-	server.csrfToken = "test-csrf-token"
+	// #1257: per-session CSRF manager; mint the loopback-bypass
+	// token so the "valid" subtest can present it.
+	server.csrf = NewCSRFManager()
+	t.Cleanup(server.csrf.Stop)
+	validToken, err := server.csrf.Generate(SessionKey(""))
+	if err != nil {
+		t.Fatalf("mint CSRF: %v", err)
+	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -404,7 +410,7 @@ func TestCSRFProtection(t *testing.T) {
 	t.Run("POST with valid CSRF token allowed", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader([]byte(`{}`)))
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-Csrf-Token", "test-csrf-token")
+		req.Header.Set("X-Csrf-Token", validToken)
 		rec := httptest.NewRecorder()
 
 		protected(rec, req)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -2,10 +2,7 @@ package api
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/subtle"
-	"encoding/hex"
-	"fmt"
+	"errors"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -35,49 +32,41 @@ func scopeFromContext(ctx context.Context) (TokenScope, bool) {
 	return v, ok
 }
 
-// generateCSRFToken generates a cryptographically secure random token
-// SECURITY FIX LOW-1: CSRF protection.
-func generateCSRFToken() (string, error) {
-	b := make([]byte, csrfTokenBytes)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("failed to generate random bytes: %w", err)
-	}
-
-	return hex.EncodeToString(b), nil
-}
-
-// csrfProtect wraps handlers that modify state and require CSRF token validation
-// SECURITY FIX LOW-1: Prevents Cross-Site Request Forgery attacks.
+// csrfProtect wraps handlers that modify state and require CSRF token
+// validation. #1257 sub-4 moved validation from a single global token
+// to per-session tokens keyed by sha256(bearer): each authenticated
+// session has its own CSRF token, so a leaked / harvested token from
+// one client doesn't unlock another's mutations.
 func (s *Server) csrfProtect(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Only check CSRF for state-changing methods
+		// Only check CSRF for state-changing methods.
 		if r.Method == http.MethodPost || r.Method == http.MethodPut ||
 			r.Method == http.MethodPatch || r.Method == http.MethodDelete {
-			// Reject all state-changing requests if CSRF token was not generated
-			if s.csrfToken == "" {
+			if s.csrf == nil {
 				writeError(w, r, http.StatusInternalServerError, "csrf_unavailable",
 					"CSRF protection is unavailable, server misconfigured", nil)
 
 				return
 			}
-
-			// Get CSRF token from header
 			clientToken := r.Header.Get("X-Csrf-Token")
-			if clientToken == "" {
+			sessionKey := sessionKeyFromRequest(r)
+			switch err := s.csrf.Validate(sessionKey, clientToken); {
+			case err == nil:
+				// passes
+			case errors.Is(err, errCSRFTokenMissing):
 				writeError(
-					w,
-					r,
-					http.StatusForbidden,
-					"csrf_token_missing",
+					w, r, http.StatusForbidden, "csrf_token_missing",
 					"CSRF token required for state-changing requests. Include X-CSRF-Token header.",
 					nil,
 				)
 
 				return
-			}
+			case errors.Is(err, errCSRFTokenExpired):
+				writeError(w, r, http.StatusForbidden, "csrf_token_expired",
+					"CSRF token expired; refetch /api/v1/csrf-token", nil)
 
-			// Constant-time comparison to prevent timing attacks
-			if subtle.ConstantTimeCompare([]byte(clientToken), []byte(s.csrfToken)) != 1 {
+				return
+			default:
 				writeError(w, r, http.StatusForbidden, "csrf_token_invalid",
 					"Invalid CSRF token", nil)
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -80,7 +80,8 @@ func TestRecoverMiddlewareNoPanic(t *testing.T) {
 
 func TestCSRFProtectionGETAllowed(t *testing.T) {
 	server := createTestServerForMiddleware(t)
-	server.csrfToken = "test-token"
+	server.csrf = NewCSRFManager()
+	t.Cleanup(server.csrf.Stop)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -105,7 +106,15 @@ func TestCSRFProtectionGETAllowed(t *testing.T) {
 
 func TestCSRFProtectionStateMethods(t *testing.T) {
 	server := createTestServerForMiddleware(t)
-	server.csrfToken = "valid-csrf-token"
+	server.csrf = NewCSRFManager()
+	t.Cleanup(server.csrf.Stop)
+
+	// Mint the per-session token for the loopback bypass key (no
+	// Authorization header => csrfLoopbackSessionKey).
+	validToken, err := server.csrf.Generate(SessionKey(""))
+	if err != nil {
+		t.Fatalf("mint CSRF: %v", err)
+	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -128,7 +137,7 @@ func TestCSRFProtectionStateMethods(t *testing.T) {
 
 		t.Run(method+"_with_valid_token", func(t *testing.T) {
 			req := httptest.NewRequest(method, "/test", nil)
-			req.Header.Set("X-Csrf-Token", "valid-csrf-token")
+			req.Header.Set("X-Csrf-Token", validToken)
 			rec := httptest.NewRecorder()
 
 			wrapped(rec, req)
@@ -154,7 +163,8 @@ func TestCSRFProtectionStateMethods(t *testing.T) {
 
 func TestCSRFProtectionRejectsWhenNoToken(t *testing.T) {
 	server := createTestServerForMiddleware(t)
-	server.csrfToken = "" // No CSRF token set
+	// #1257: nil csrf manager => server misconfigured.
+	server.csrf = nil
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -70,7 +70,6 @@ const (
 
 	// Validation and limit constants.
 	requestIDBytes      = 16       // bytes for unique request ID
-	csrfTokenBytes      = 32       // bytes for CSRF token
 	maxURLLength        = 2048     // max webhook URL length
 	maxInterfaceNameLen = 15       // Linux IFNAMSIZ limit
 	maxPathLength       = 4096     // max file path length
@@ -270,16 +269,19 @@ type Server struct {
 	captureController CaptureController
 	startTime         time.Time
 	rateLimiter       *RateLimiter
-	csrfToken         string
-	sseHub            *SSEHub
-	uploadLimiter     *RateLimiter
-	writeLimiter      *RateLimiter
-	walkLimiter       *RateLimiter
-	fileLimiter       *RateLimiter
-	bgStop            chan struct{}
-	bgStopOnce        sync.Once
-	library           *library.Library
-	tlsFingerprint    tlsFingerprintCache
+	// csrf manages per-session CSRF tokens (#1257). Pre-port niac
+	// shared one global token across all clients; the manager keys
+	// tokens by sha256(bearer) so each session has its own.
+	csrf           *CSRFManager
+	sseHub         *SSEHub
+	uploadLimiter  *RateLimiter
+	writeLimiter   *RateLimiter
+	walkLimiter    *RateLimiter
+	fileLimiter    *RateLimiter
+	bgStop         chan struct{}
+	bgStopOnce     sync.Once
+	library        *library.Library
+	tlsFingerprint tlsFingerprintCache
 	// license is the offline license manager. Populated lazily in
 	// NewServer; may be nil in tests / dev builds that don't exercise
 	// license-gated endpoints.
@@ -294,13 +296,6 @@ type Server struct {
 
 // NewServer returns a configured API server.
 func NewServer(cfg ServerConfig) *Server {
-	csrfToken, err := generateCSRFToken()
-	if err != nil {
-		slog.Error("[API] Failed to generate CSRF token, server cannot start securely", "error", err)
-
-		return nil
-	}
-
 	libraryRoot := cfg.LibraryRoot
 	if libraryRoot == "" {
 		libraryRoot = library.DefaultRoot()
@@ -321,7 +316,7 @@ func NewServer(cfg ServerConfig) *Server {
 		logger:        slog.Default(),
 		startTime:     time.Now(),
 		rateLimiter:   NewRateLimiter(DefaultRateLimit, DefaultBurst),
-		csrfToken:     csrfToken,
+		csrf:          NewCSRFManager(),
 		sseHub:        NewSSEHub(SSEConfig{}),
 		bgStop:        make(chan struct{}),
 		uploadLimiter: NewRateLimiter(UploadRateLimit, UploadBurst),
@@ -504,6 +499,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// Stop SSE hub to release its goroutine and clients.
 	if s.sseHub != nil {
 		s.sseHub.Stop()
+	}
+
+	// #1257: stop the CSRF manager's cleanup goroutine.
+	if s.csrf != nil {
+		s.csrf.Stop()
 	}
 
 	var errs []error

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -18,21 +18,19 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// newTestServerWithAuth creates a test server with auth and rate limiting initialized.
+// newTestServerWithAuth creates a test server with auth and rate
+// limiting initialized. Returns (server, tmpDir, bearerToken). The
+// CSRF token for the bearer is minted via the manager and exposed via
+// testCSRFToken(server, bearerToken) so each test case can request a
+// token for the session it's exercising (#1257 per-session CSRF).
 func newTestServerWithAuth(t *testing.T) (*Server, string, string) {
 	t.Helper()
 	server, tmpDir := newTestServer(t)
 
 	// Initialize server components
 	server.rateLimiter = NewRateLimiter(DefaultRateLimit, DefaultBurst)
-
-	// Generate CSRF token
-	csrfToken, err := generateCSRFToken()
-	if err != nil {
-		t.Fatalf("Failed to generate CSRF token: %v", err)
-	}
-
-	server.csrfToken = csrfToken
+	server.csrf = NewCSRFManager()
+	t.Cleanup(server.csrf.Stop)
 
 	// Generate auth token. Wave 2: seed the TokenStore directly. The
 	// cfg.Token field is left set so the legacy Wave 1 gate code path
@@ -43,6 +41,19 @@ func newTestServerWithAuth(t *testing.T) (*Server, string, string) {
 	server.SetTokens([]ScopedToken{{Value: token, Scope: ScopeReadWrite}})
 
 	return server, tmpDir, token
+}
+
+// testCSRFToken mints (or fetches) the per-session CSRF token for the
+// given bearer so test cases can pass it as X-Csrf-Token. Replaces
+// the pre-#1257 testCSRFToken(t, server, token) global the old tests reached for.
+func testCSRFToken(t *testing.T, server *Server, bearer string) string {
+	t.Helper()
+	tok, err := server.csrf.GetOrCreate(SessionKey(bearer))
+	if err != nil {
+		t.Fatalf("mint test CSRF token: %v", err)
+	}
+
+	return tok
 }
 
 // TestRateLimiter_ExcessiveRequests verifies rate limiting blocks excessive requests.
@@ -221,7 +232,7 @@ func TestCSRF_TokenValidation(t *testing.T) {
 	reqBody := strings.NewReader(`{"packets_threshold":1000}`)
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", reqBody)
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Csrf-Token", server.csrfToken)
+	req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
@@ -550,7 +561,7 @@ func TestAlertConfig_ConcurrentUpdates(t *testing.T) {
 			reqBody := fmt.Sprintf(`{"packets_threshold":%d}`, threshold*1000)
 			req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 			req.Header.Set("Authorization", "Bearer "+token)
-			req.Header.Set("X-Csrf-Token", server.csrfToken)
+			req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 			req.Header.Set("Content-Type", "application/json")
 
 			w := httptest.NewRecorder()
@@ -590,7 +601,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 	reqBody := `{"packets_threshold":1000}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Csrf-Token", server.csrfToken)
+	req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
@@ -607,7 +618,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 		reqBody = fmt.Sprintf(`{"packets_threshold":%d}`, (i+1)*1000)
 		req = httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("X-Csrf-Token", server.csrfToken)
+		req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 		req.Header.Set("Content-Type", "application/json")
 
 		w = httptest.NewRecorder()
@@ -623,7 +634,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 	reqBody = `{"packets_threshold":0}`
 	req = httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Csrf-Token", server.csrfToken)
+	req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 	req.Header.Set("Content-Type", "application/json")
 
 	w = httptest.NewRecorder()
@@ -650,7 +661,7 @@ func TestAlertConfig_GoroutineCleanup(t *testing.T) {
 		reqBody := `{"packets_threshold":1000}`
 		req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("X-Csrf-Token", server.csrfToken)
+		req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 		req.Header.Set("Content-Type", "application/json")
 
 		w := httptest.NewRecorder()
@@ -666,7 +677,7 @@ func TestAlertConfig_GoroutineCleanup(t *testing.T) {
 		reqBody = `{"packets_threshold":0}`
 		req = httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("X-Csrf-Token", server.csrfToken)
+		req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 		req.Header.Set("Content-Type", "application/json")
 
 		w = httptest.NewRecorder()
@@ -734,7 +745,7 @@ func TestCSRFWiring_TemplatesAndConfigs(t *testing.T) {
 				bytes.NewReader([]byte(`{"name":"x","content":"y"}`)))
 			req.Header.Set("Authorization", "Bearer "+token)
 			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("X-Csrf-Token", server.csrfToken)
+			req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
 			rec := httptest.NewRecorder()
 			mux.ServeHTTP(rec, req)
 


### PR DESCRIPTION
Refs seed#1257 (sub-item 4) · Wave 5 cross-repo deferred → executed

## Why

Pre-port niac used a single global CSRF token shared across every client. A token harvested from one client unlocked another's mutations. This PR ports stem's CSRFManager pattern so each bearer token has its own CSRF token, scoped to that session.

## Mechanism

- New CSRFManager: thread-safe map[sessionKey]*csrfTokenEntry, 24h expiry, 5-minute cleanup goroutine. Stop() terminates the cleanup loop for graceful shutdown.
- SessionKey(bearer) = sha256(bearer) hex — the bearer plaintext never lands in the manager's internal map (preventive against heap dumps and debug-log leaks). Empty bearer (bypass paths) maps to a synthetic loopback key so the no-auth dev path still shares one token, matching pre-port behavior for that path only.
- Server.csrf replaces the old Server.csrfToken string. NewServer constructs the manager; Server.Shutdown stops it.
- csrfProtect derives sessionKey from the request, calls Validate, and maps the three error classifications (missing / invalid / expired) to distinct error codes so SIEMs can alert on expired vs replayed.
- handleCSRFToken calls GetOrCreate(sessionKey) so a UI polling within the 24h window gets the same value back.

## Tests

- TestCSRFManager_PerSessionIsolation: the load-bearing guard — A's token must not validate against B's session.
- TestCSRFManager_LoopbackBypassSharesKey: empty bearer maps to one shared key (preserves pre-port behavior on the loopback dev path).
- TestCSRFManager_ValidateErrorClassification: missing / invalid distinguishable.
- TestCSRFManager_GetOrCreateIsIdempotent: UI caching contract.
- TestSessionKey_HashedNotPlaintext: bearer never embedded in key.
- Existing TestCSRFProtection* / TestCSRF_* updated to mint via the manager (testCSRFToken helper) instead of poking the removed s.csrfToken field.

## Test plan
- [x] go test ./... -count=1 — passes
- [x] golangci-lint run ./... — 0 issues
- [x] go build ./... — clean

## Operator note

The /api/v1/csrf-token endpoint contract is unchanged from the UI's perspective — it still returns {"token": "..."}. The value is now per-session; clients that share bearer tokens (which they should not) will see the same CSRF token, matching prior behavior; clients with their own bearers now each get their own CSRF token.