### PR TITLE
feat(cli): fill help gaps on license/template/content/etc + completeness test

### DIFF
--- a/cmd/niac/analyze_pcap.go
+++ b/cmd/niac/analyze_pcap.go
@@ -34,6 +34,14 @@ func addAnalyzePcapCommand(root *cobra.Command, _ *serviceOptions) {
 		Long: `Parse a PCAP file and emit protocol counters for rapid troubleshooting.
 The tool classifies packets into ARP, LLDP, CDP, STP, IPv4, IPv6, TCP, UDP,
 and generic application protocols.`,
+		Example: `  # Summarise a capture (text output)
+  niac analyze-pcap capture.pcap
+
+  # Machine-readable JSON output
+  niac analyze-pcap --output json capture.pcap
+
+  # YAML output (handy for diffing two captures)
+  niac analyze-pcap --output yaml capture.pcap`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runAnalyzePcap(args, options)

--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -61,14 +61,21 @@ engine, allowing you to:
   - Manage multiple simulation sessions
 
 TLS is enabled by default and the daemon listens on 127.0.0.1:8445.
-Pass --http to run the legacy HTTP listener on :8080 instead. Binding
-to a non-loopback address (e.g. --listen 0.0.0.0) requires an API
-token via NIAC_API_TOKEN or --api-token.
+The HTTP listener exists only as a 308 redirector. Binding to a
+non-loopback address (e.g. --listen 0.0.0.0) requires an API token via
+NIAC_API_TOKEN or --api-token.`,
+		Example: `  # Default: HTTPS on 127.0.0.1:8445 (loopback only, no token needed)
+  niac daemon
 
-Example:
-  niac daemon                            # https://127.0.0.1:8445
-  niac daemon --listen 0.0.0.0 --api-token $(openssl rand -base64 32)
-  niac daemon --http --listen 127.0.0.1  # http://127.0.0.1:8080`,
+  # Listen on all interfaces — requires an API token
+  export NIAC_API_TOKEN=$(openssl rand -base64 32)
+  niac daemon --listen 0.0.0.0
+
+  # Use a token file with scoped tokens (read-only / read-write)
+  niac daemon --token-file /etc/niac/tokens.json
+
+  # Disable run-history persistence
+  niac daemon --storage disabled`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDaemon(options, info)
 		},

--- a/cmd/niac/content.go
+++ b/cmd/niac/content.go
@@ -36,6 +36,17 @@ Bundled content is published per release at:
 Use 'niac content install' to fetch and unpack the bundle matching the
 running daemon, or 'niac content install --bundle path.tar.gz' to install
 from a local mirror.`,
+		Example: `  # Show what's in the library right now
+  niac content list
+
+  # Refresh the bundle to match the running binary's version
+  niac content update
+
+  # Install a specific release bundle
+  niac content install --version v0.88.3
+
+  # Install from a local mirror
+  niac content install --bundle /tmp/niac-content.tar.gz`,
 	}
 
 	contentCmd.AddCommand(newContentInstallCmd())
@@ -205,6 +216,13 @@ func newContentListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List what's installed in the library",
+		Long: `Print every kind (networks / walks / pcaps) currently in the library
+along with the file count and on-disk size for each, plus a TOTAL row.`,
+		Example: `  # List the default library
+  niac content list
+
+  # Inspect a non-default library
+  niac content list --root /var/lib/niac/library`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			libRoot := root
 			if libRoot == "" {
@@ -245,6 +263,14 @@ after upgrading via the system package manager:
 
   sudo dnf upgrade niac
   niac content update`,
+		Example: `  # Refresh the library after upgrading the niac binary
+  niac content update
+
+  # Preview the changes without writing
+  niac content update --dry-run
+
+  # Don't overwrite files that already exist
+  niac content update --skip-existing`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runContentInstall(cmd.Context(), contentInstallArgs{
 				root:         root,

--- a/cmd/niac/help_completeness_test.go
+++ b/cmd/niac/help_completeness_test.go
@@ -1,0 +1,113 @@
+package main
+
+// help_completeness_test.go — locks CLI help completeness in CI.
+//
+// Walks the full cobra command tree and asserts every command has a non-empty
+// Short, Long, and Example, and every flag has a non-empty Usage. The audit
+// flagged template / license / content subcommands as missing some of these;
+// this test catches the next regression automatically.
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// exemptExample lists commands cobra adds for free (`help`) or that we ship
+// without examples by convention (`completion`).
+func exemptExample() map[string]bool {
+	return map[string]bool{
+		"niac help":       true,
+		"niac completion": true,
+	}
+}
+
+// buildFullRoot constructs the same command tree main() builds, calling every
+// real builder. info+services are stub values — the builders only use them
+// for default population, not for any I/O.
+func buildFullRoot() *cobra.Command {
+	info := versionInfo{version: "test", commit: "abc1234", date: "2026-05-29"}
+	services := new(serviceOptions)
+	root := &cobra.Command{
+		Use:     "niac",
+		Short:   "Network In A Can - Network device simulator",
+		Long:    "Stub root for testing — real root carries the same fields.",
+		Example: "  niac help",
+	}
+	root.SetVersionTemplate("test\n")
+
+	builders := []func(*cobra.Command, *serviceOptions){
+		func(r *cobra.Command, s *serviceOptions) { addRunCommand(r, s, info) },
+		func(r *cobra.Command, _ *serviceOptions) { addCompletionCommand(r) },
+		addAnalyzeCommand,
+		addAnalyzePcapCommand,
+		addConfigCommand,
+		addContentCommand,
+		func(r *cobra.Command, _ *serviceOptions) { addDaemonCommand(r, info) },
+		addDumpCommand,
+		addInitCommand,
+		addInjectCommand,
+		func(r *cobra.Command, _ *serviceOptions) { addInstallCACommand(r) },
+		addLicenseCommand,
+		addInteractiveCommand,
+		addLogsCommand,
+		func(r *cobra.Command, _ *serviceOptions) { addManCommand(r, info) },
+		addMonitorCommand,
+		addNeighborsCommand,
+		addSanitizeCommand,
+		addServiceCommand,
+		addStatusCommand,
+		addTemplateCommand,
+		addTopologyCommand,
+		addValidateCommand,
+	}
+	for _, b := range builders {
+		b(root, services)
+	}
+	return root
+}
+
+func TestCLIHelpCompleteness(t *testing.T) {
+	exempt := exemptExample()
+	root := buildFullRoot()
+
+	var gaps []string
+	walkCommands(root, func(c *cobra.Command) {
+		path := c.CommandPath()
+		if c.Short == "" {
+			gaps = append(gaps, path+": missing Short")
+		}
+		if c.Long == "" {
+			gaps = append(gaps, path+": missing Long")
+		}
+		if c.Example == "" && !exempt[path] {
+			gaps = append(gaps, path+": missing Example")
+		}
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			if f.Usage == "" {
+				gaps = append(gaps, path+" --"+f.Name+": missing flag Usage")
+			}
+		})
+		c.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+			if f.Usage == "" {
+				gaps = append(gaps, path+" --"+f.Name+": missing persistent-flag Usage")
+			}
+		})
+	})
+
+	if len(gaps) == 0 {
+		return
+	}
+	sort.Strings(gaps)
+	t.Fatalf("CLI help completeness gaps (%d):\n  %s", len(gaps), strings.Join(gaps, "\n  "))
+}
+
+func walkCommands(c *cobra.Command, fn func(*cobra.Command)) {
+	fn(c)
+	for _, sub := range c.Commands() {
+		walkCommands(sub, fn)
+	}
+}

--- a/cmd/niac/install_ca.go
+++ b/cmd/niac/install_ca.go
@@ -81,6 +81,17 @@ Verification:
   niac install-ca --print-fingerprint
   curl -k https://localhost:8445/__version | jq -r .tlsFingerprint
 The two values must match.`,
+		Example: `  # Install NIAC's self-signed root into the OS trust store
+  sudo niac install-ca
+
+  # Print the cert's SHA-256 fingerprint (no trust-store change)
+  niac install-ca --print-fingerprint
+
+  # Remove the previously installed root from the OS trust store
+  sudo niac install-ca --uninstall
+
+  # Install a non-default certificate file
+  sudo niac install-ca --cert /etc/niac/certs/server.crt`,
 		RunE: runInstallCA,
 	}
 	installCACmd.Flags().String("cert", defaultInstallCAPath(),

--- a/cmd/niac/license.go
+++ b/cmd/niac/license.go
@@ -28,18 +28,42 @@ simulated devices, common protocols). NIAC Pro ($599/yr) unlocks:
   • REST API access (programmatic control)
 
 A 14-day trial of the full Pro tier is available without a key.`,
+		Example: `  # Check the current tier / activation
+  niac license status
+
+  # Start a 14-day Pro trial (no key required)
+  niac license trial
+
+  # Activate a paid Pro key
+  niac license activate -k XXXX-XXXX-XXXX-XXXX
+
+  # Remove the license from this device
+  niac license deactivate`,
 	}
 
 	licenseCmd.AddCommand(&cobra.Command{
 		Use:   "status",
 		Short: "Show current license status",
-		Run:   func(_ *cobra.Command, _ []string) { runLicenseStatus() },
+		Long: `Print the current license tier, key, activation date, expiry,
+device hash, and unlocked feature count. With no license active, prints the
+Free-tier banner.`,
+		Example: `  # Show the active license / trial status
+  niac license status`,
+		Run: func(_ *cobra.Command, _ []string) { runLicenseStatus() },
 	})
 
 	activateCmd := &cobra.Command{
 		Use:   "activate",
 		Short: "Activate a license key",
-		Run:   func(cmd *cobra.Command, _ []string) { runLicenseActivate(cmd) },
+		Long: `Activate a NIAC license key on this device. Validation is fully
+offline (rotor cipher + device fingerprint); no phone-home. The key is bound
+to this device's hash and unlocks the tier features encoded in the key.`,
+		Example: `  # Activate a Pro key
+  niac license activate -k XXXX-XXXX-XXXX-XXXX
+
+  # The flag is required — this prints the usage
+  niac license activate`,
+		Run: func(cmd *cobra.Command, _ []string) { runLicenseActivate(cmd) },
 	}
 	activateCmd.Flags().StringP("key", "k", "", "License key to activate (XXXX-XXXX-XXXX-XXXX)")
 	_ = activateCmd.MarkFlagRequired("key")
@@ -48,13 +72,24 @@ A 14-day trial of the full Pro tier is available without a key.`,
 	licenseCmd.AddCommand(&cobra.Command{
 		Use:   "deactivate",
 		Short: "Remove the current license from this device",
-		Run:   func(_ *cobra.Command, _ []string) { runLicenseDeactivate() },
+		Long: `Remove the activated license from this device. After deactivation
+NIAC reverts to the Free tier. The license key itself remains valid and can
+be activated on another device.`,
+		Example: `  # Deactivate the current license (revert to Free tier)
+  niac license deactivate`,
+		Run: func(_ *cobra.Command, _ []string) { runLicenseDeactivate() },
 	})
 
 	licenseCmd.AddCommand(&cobra.Command{
 		Use:   "trial",
 		Short: "Start the 14-day Pro trial",
-		Run:   func(_ *cobra.Command, _ []string) { runLicenseTrial() },
+		Long: `Begin a one-time 14-day trial of the full Pro tier. The trial is
+tied to this device's hash and cannot be reset after expiry — activate a
+real key with ` + "`niac license activate -k ...`" + ` to continue using Pro
+features.`,
+		Example: `  # Start the 14-day Pro trial
+  niac license trial`,
+		Run: func(_ *cobra.Command, _ []string) { runLicenseTrial() },
 	})
 
 	root.AddCommand(licenseCmd)

--- a/cmd/niac/template.go
+++ b/cmd/niac/template.go
@@ -33,6 +33,9 @@ func addTemplateCommand(root *cobra.Command, _ *serviceOptions) {
 	templateListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available templates",
+		Long: `Print every bundled template name with a one-line description.
+Templates cover common scenarios (basic-network, small-office, data-center,
+iot-network, etc.) and are the fastest path to a runnable YAML config.`,
 		Example: `  # List all templates with descriptions
   niac template list`,
 		Run: func(_ *cobra.Command, _ []string) {
@@ -43,6 +46,9 @@ func addTemplateCommand(root *cobra.Command, _ *serviceOptions) {
 	templateShowCmd := &cobra.Command{
 		Use:   "show <template-name>",
 		Short: "Show template contents",
+		Long: `Print the YAML body of a named template to stdout. Useful for
+inspecting what a template will produce or piping it into another tool
+without writing to disk.`,
 		Example: `  # Show basic network template
   niac template show basic-network
 
@@ -60,6 +66,9 @@ func addTemplateCommand(root *cobra.Command, _ *serviceOptions) {
 	templateUseCmd := &cobra.Command{
 		Use:   "use <template-name> <output-file>",
 		Short: "Copy template to a new file",
+		Long: `Copy a named template's body into a new YAML file at the given
+output path. The output file becomes the starting point you edit and run
+with 'niac run'; the template itself is unchanged.`,
 		Example: `  # Create small office config
   niac template use small-office office.yaml
 


### PR DESCRIPTION
Closes the 19 cobra help gaps the audit identified:
  • license parent + 4 subcommands (status/activate/deactivate/trial)
    gain Long descriptions and Example blocks.
  • template list/show/use gain Long descriptions (Examples already
    present).
  • content parent + list + update gain Example blocks; list also
    gains a Long.
  • analyze-pcap, install-ca, daemon gain Example blocks (daemon's
    pre-existing example list inside Long is hoisted into the proper
    Example field, where cobra formats it correctly).

Adds help_completeness_test.go: builds the full cobra tree via every
real builder, walks it, and fails if any command lacks Short/Long/
Example or any flag lacks Usage. `help` and `completion` are exempted
from Example by convention.
