### PR TITLE
feat(help): version badge in HelpDrawer header (in-app About)

### DIFF
--- a/ui/src/components/HelpDrawer.about.test.tsx
+++ b/ui/src/components/HelpDrawer.about.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * HelpDrawer.about.test.tsx — asserts the in-app About/version panel exists.
+ *
+ * The drawer header shows `NIAC v<version>` sourced from /__version via
+ * useBuildVersion (which mirrors the seed/stem hook). This test fails if that
+ * surface disappears.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { HelpDrawer } from './HelpDrawer';
+
+describe('HelpDrawer — About / version surface', () => {
+  it('renders the version badge using /__version payload', async () => {
+    const payload = {
+      version: '0.88.4',
+      commit: 'deadbee',
+      buildTime: '2026-05-29T00:00:00Z',
+      uiBuildHash: 'abc123',
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async () => ({
+      ok: true,
+      json: async () => payload,
+    })) as unknown as typeof fetch);
+
+    render(<HelpDrawer isOpen={true} onClose={() => undefined} />);
+    const badge = await screen.findByTestId('help-drawer-version');
+    expect(badge).toBeInTheDocument();
+    await waitFor(() => {
+      expect(badge).toHaveTextContent(/v0\.88\.4/);
+    });
+    expect(badge).toHaveTextContent(/NIAC/);
+  });
+
+  it('renders a fallback version when /__version is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      throw new Error('network');
+    }) as unknown as typeof fetch);
+
+    render(<HelpDrawer isOpen={true} onClose={() => undefined} />);
+    const badge = await screen.findByTestId('help-drawer-version');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent(/NIAC v/);
+  });
+});

--- a/ui/src/components/HelpDrawer.tsx
+++ b/ui/src/components/HelpDrawer.tsx
@@ -28,6 +28,7 @@ import {
 } from 'lucide-react';
 import type { ReactElement, ReactNode } from 'react';
 import { useState } from 'react';
+import { useBuildVersion } from '../hooks/useBuildVersion';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { cn, drawer, layout, spacing } from '../styles/theme';
 import { FAQSection } from './help-drawer/FAQSection';
@@ -62,6 +63,7 @@ const TABS: TabConfig[] = [
 export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement | null {
   const [activeTab, setActiveTab] = useState<HelpTab>('overview');
   const [searchQuery, setSearchQuery] = useState('');
+  const buildVersion = useBuildVersion();
 
   const drawerRef = useFocusTrap<HTMLDivElement>({
     isActive: isOpen,
@@ -97,7 +99,16 @@ export function HelpDrawer({ isOpen, onClose }: HelpDrawerProps): ReactElement |
             <div className="px-4 py-row-lg flex-between">
               <div className={layout.inline.default}>
                 <HelpCircle className="w-5 h-5 text-brand-accent" aria-hidden="true" />
-                <h2 className="heading-3 text-text-primary">Help</h2>
+                <div>
+                  <h2 className="heading-3 text-text-primary">Help</h2>
+                  <p
+                    className="caption text-text-muted"
+                    data-testid="help-drawer-version"
+                    title={`commit ${buildVersion.commit} · built ${buildVersion.buildTime}`}
+                  >
+                    NIAC v{buildVersion.version}
+                  </p>
+                </div>
               </div>
               <button
                 type="button"

--- a/ui/src/hooks/useBuildVersion.ts
+++ b/ui/src/hooks/useBuildVersion.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Build metadata served by the backend's unauthenticated /__version endpoint.
+ * Mirrors the lowercase JSON keys defined by the Universal Build Contract
+ * (CLAUDE.md): every sibling project (seed/stem/niac) exposes the same shape.
+ */
+export interface BuildVersion {
+  version: string;
+  commit: string;
+  buildTime: string;
+  uiBuildHash: string;
+}
+
+const FALLBACK: BuildVersion = {
+  version: 'dev',
+  commit: 'unknown',
+  buildTime: 'unknown',
+  uiBuildHash: '',
+};
+
+function isBuildVersion(value: unknown): value is BuildVersion {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.version === 'string' &&
+    typeof candidate.commit === 'string' &&
+    typeof candidate.buildTime === 'string' &&
+    typeof candidate.uiBuildHash === 'string'
+  );
+}
+
+/**
+ * Fetches build metadata from /__version once on mount. Falls back to a
+ * static "dev" descriptor when the endpoint is unavailable so callers can
+ * unconditionally render the version without a loading state.
+ */
+export function useBuildVersion(): BuildVersion {
+  const [data, setData] = useState<BuildVersion>(FALLBACK);
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/__version', { headers: { Accept: 'application/json' } })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`status ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((body) => {
+        if (cancelled) {
+          return;
+        }
+        if (isBuildVersion(body)) {
+          setData(body);
+        }
+      })
+      .catch(() => {
+        // Swallow: FALLBACK is already in state.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return data;
+}


### PR DESCRIPTION
Brings niac in line with the seed/stem in-app About surface. Adds the
useBuildVersion hook (identical shape to the seed/stem copy — each repo
owns its own per the harmonization convention) and wires it into the
HelpDrawer header so the drawer always shows `NIAC v<version>` sourced
from /__version, with commit + buildTime in a hover title. Falls back
to `NIAC vdev` when the endpoint is unreachable.

HelpDrawer.about.test.tsx locks both the live and fallback paths.
