### PR TITLE
fix(api): atomic mint in CSRFManager.GetOrCreate

### DIFF
--- a/internal/api/csrf_manager.go
+++ b/internal/api/csrf_manager.go
@@ -112,6 +112,14 @@ func (m *CSRFManager) Generate(sessionKey string) (string, error) {
 // GetOrCreate returns an existing unexpired token or mints a new
 // one. Used by the /csrf-token endpoint so a UI that polls for the
 // token receives the same value within a session lifetime.
+//
+// The slow path takes the write lock and re-checks before minting.
+// Without the re-check, two concurrent callers for the same session
+// could both miss the cache, both call Generate, and the later write
+// would overwrite the earlier — leaving the earlier caller holding a
+// token that no longer matches the stored entry, which makes its next
+// X-Csrf-Token request fail validation with 403. Surfaced as an
+// intermittent TestAlertConfig_ConcurrentUpdates failure under -race.
 func (m *CSRFManager) GetOrCreate(sessionKey string) (string, error) {
 	m.mu.RLock()
 	entry, ok := m.tokens[sessionKey]
@@ -120,7 +128,26 @@ func (m *CSRFManager) GetOrCreate(sessionKey string) (string, error) {
 		return entry.token, nil
 	}
 
-	return m.Generate(sessionKey)
+	buf := make([]byte, csrfPerSessionTokenLength)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate CSRF token: %w", err)
+	}
+	tok := base64.URLEncoding.EncodeToString(buf)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Re-check under the write lock: another goroutine may have minted
+	// (and stored) a token for this session between our read-lock
+	// release above and the write-lock acquisition here.
+	if existing, exists := m.tokens[sessionKey]; exists && time.Now().Before(existing.expiresAt) {
+		return existing.token, nil
+	}
+	m.tokens[sessionKey] = &csrfTokenEntry{
+		token:     tok,
+		expiresAt: time.Now().Add(csrfPerSessionTokenExpiry),
+	}
+
+	return tok, nil
 }
 
 // Validate constant-time-compares the supplied token against the one

--- a/internal/api/csrf_manager_test.go
+++ b/internal/api/csrf_manager_test.go
@@ -5,6 +5,7 @@ package api
 import (
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -100,6 +101,74 @@ func TestCSRFManager_GetOrCreateIsIdempotent(t *testing.T) {
 	}
 	if first != second {
 		t.Errorf("repeat GetOrCreate must return same token: %q vs %q", first, second)
+	}
+}
+
+// TestCSRFManager_GetOrCreate_ConcurrentSameSession reproduces the TOCTOU
+// race fixed by the double-checked write lock in GetOrCreate. Before the
+// fix, two concurrent callers for the same session could each miss the
+// read-locked cache check, each Generate a new token, and the later write
+// would overwrite the earlier — leaving N-1 of N callers holding a token
+// that no longer matched the stored entry. That mismatch is what caused
+// TestAlertConfig_ConcurrentUpdates to fail intermittently with HTTP 403
+// (csrf_token_invalid) under -race.
+//
+// The fix makes the mint atomic: every concurrent caller for the same
+// session must observe the same token, and a subsequent Validate must
+// accept every one of those returned tokens.
+func TestCSRFManager_GetOrCreate_ConcurrentSameSession(t *testing.T) {
+	t.Parallel()
+	m := NewCSRFManager()
+	t.Cleanup(m.Stop)
+
+	const (
+		session = "shared-session-key"
+		callers = 32
+	)
+
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		tokens = make([]string, 0, callers)
+	)
+
+	start := make(chan struct{})
+	for range callers {
+		wg.Go(func() {
+			<-start // align goroutines to maximize contention
+			tok, err := m.GetOrCreate(session)
+			if err != nil {
+				t.Errorf("GetOrCreate: %v", err)
+				return
+			}
+			mu.Lock()
+			tokens = append(tokens, tok)
+			mu.Unlock()
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	if len(tokens) != callers {
+		t.Fatalf("expected %d tokens, got %d", callers, len(tokens))
+	}
+
+	// Invariant 1: every caller observed the same token (idempotence
+	// under concurrency).
+	for i, tok := range tokens {
+		if tok != tokens[0] {
+			t.Fatalf("token mismatch at index %d: %q vs %q", i, tok, tokens[0])
+		}
+	}
+
+	// Invariant 2: every token any caller saw is still acceptable to
+	// Validate. Before the fix, the overwrite would have produced a
+	// final stored token different from at least one returned value
+	// and Validate would have rejected it as invalid.
+	for i, tok := range tokens {
+		if err := m.Validate(session, tok); err != nil {
+			t.Fatalf("token from caller %d rejected by Validate: %v", i, err)
+		}
 	}
 }
 


### PR DESCRIPTION
GetOrCreate had a TOCTOU race: the read-lock cache check was released
before the slow path called Generate, which then took the write lock
and *unconditionally* overwrote the map. Two concurrent callers for
the same session each missed the cache, each called Generate, and the
later write won. The earlier caller walked away with a token that no
longer matched the stored entry — its next X-Csrf-Token request then
failed validation with HTTP 403 (csrf_token_invalid).

This is the actual cause of the intermittent
TestAlertConfig_ConcurrentUpdates failure that's been miscategorised as
a "Backend (race detector)" flake — the race detector was telling the
truth: there really is a logical race between concurrent CSRF token
mints for the same session.

Fix: do the mint atomically. Read-lock fast path stays; the slow path
takes the write lock, re-checks the map, and only writes if no other
goroutine beat it. Generate stays unchanged for callers that want a
forced rotation.

TestCSRFManager_GetOrCreate_ConcurrentSameSession spawns 32 goroutines
racing on a shared session, asserts every returned token is identical,
and that every returned token is still accepted by Validate. Both
invariants fail on the pre-fix code; both hold on the fixed code.
Confirmed with 20× -race runs of both the new test and
TestAlertConfig_ConcurrentUpdates.
