### PR TITLE
refactor(api,cmd,daemon): remove HTTP→HTTPS redirector — HTTPS-only

### DIFF
--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -19,14 +19,13 @@ import (
 )
 
 // Daemon listen port defaults. The TLS port is the Wave 1 canonical for
-// niac (mirrors seed:8443 and stem:8444). The legacy HTTP port stays at
-// 8080 for `niac daemon --http` so existing deployment scripts keep
-// working until they cut over.
+// niac (mirrors seed:8443 and stem:8444). HTTPS-only — the HTTP port
+// constant remains for the legacy `niac daemon --http` opt-out path so
+// existing deployment scripts keep working until they cut over to TLS.
 const (
-	daemonTLSPort          = 8445
-	daemonHTTPPort         = 8080
-	daemonHTTPRedirectPort = 8044
-	daemonDefaultListenIP  = "127.0.0.1"
+	daemonTLSPort         = 8445
+	daemonHTTPPort        = 8080
+	daemonDefaultListenIP = "127.0.0.1"
 )
 
 type daemonOptions struct {
@@ -119,9 +118,9 @@ func resolveDaemonTokenFile(o *daemonOptions) string {
 	return os.Getenv("NIAC_API_TOKEN_FILE")
 }
 
-// resolveDaemonAddrs returns the TLS listen address and the HTTP→HTTPS
-// redirector address. HTTPS is always on; no opt-out is supported.
-func resolveDaemonAddrs(o *daemonOptions) (string, string, bool) {
+// resolveDaemonListen returns the TLS listen address (HTTPS-only; no
+// opt-out is supported) and a true for the legacy tlsOn flag.
+func resolveDaemonListen(o *daemonOptions) (string, bool) {
 	listen := o.listen
 	if listen == "" {
 		listen = os.Getenv("NIAC_LISTEN_ADDR")
@@ -132,9 +131,7 @@ func resolveDaemonAddrs(o *daemonOptions) (string, string, bool) {
 	case !strings.Contains(listen, ":"):
 		listen = net.JoinHostPort(listen, strconv.Itoa(daemonTLSPort))
 	}
-
-	redirect := net.JoinHostPort(daemonDefaultListenIP, strconv.Itoa(daemonHTTPRedirectPort))
-	return listen, redirect, true
+	return listen, true
 }
 
 // resolveDaemonCertDir returns the cert-dir to use. Explicit --cert-dir
@@ -164,7 +161,7 @@ func resolveDaemonAPIToken(o *daemonOptions) string {
 func runDaemon(options *daemonOptions, info versionInfo) error {
 	logging.InitColors(true)
 
-	listenAddr, redirectAddr, tlsOn := resolveDaemonAddrs(options)
+	listenAddr, tlsOn := resolveDaemonListen(options)
 	token := resolveDaemonAPIToken(options)
 	tokenFile := resolveDaemonTokenFile(options)
 	certDir := resolveDaemonCertDir(options)
@@ -176,9 +173,6 @@ func runDaemon(options *daemonOptions, info versionInfo) error {
 
 	logging.Infof("Starting NIAC Daemon v%s", info.version)
 	logging.Infof("Web UI will be available at %s://%s", scheme, listenAddr)
-	if tlsOn && redirectAddr != "" {
-		logging.Infof("HTTP→HTTPS redirector listening on %s", redirectAddr)
-	}
 	authEnabled := token != "" || tokenFile != ""
 	switch {
 	case tokenFile != "":
@@ -204,8 +198,6 @@ func runDaemon(options *daemonOptions, info versionInfo) error {
 		WebhookAllowedHosts: options.webhookAllowedHosts,
 		EnableTLS:           tlsOn,
 		CertDir:             certDir,
-		HTTPRedirectAddr:    redirectAddr,
-		TLSPort:             daemonTLSPort,
 	}
 
 	// Sanity-check the listen address up front so we fail with the helpful

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -200,13 +200,6 @@ type ServerConfig struct {
 	// KeyFile is the path to the PEM-encoded private key for CertFile.
 	// Empty triggers auto-generation under CertDir.
 	KeyFile string
-	// HTTPRedirectAddr, when non-empty and EnableTLS is true, starts a
-	// tiny HTTP listener on that address that 308-redirects to the
-	// HTTPS service. Wave 1 default is `:8044`.
-	HTTPRedirectAddr string
-	// TLSPort is the destination HTTPS port the redirect handler advertises.
-	// Defaults to defaultTLSPort (8445) when zero.
-	TLSPort int
 	// WebhookAllowedHosts is an admin-side allowlist of hostnames that the
 	// alert webhook is permitted to dispatch to. Empty = no allowlist (the
 	// existing private-IP / blocked-hostname filters in
@@ -260,7 +253,6 @@ type Server struct {
 	logger            *slog.Logger
 	httpServer        *http.Server
 	metricsServer     *http.Server
-	redirectServer    *http.Server
 	alertStop         chan struct{}
 	lastAlert         uint64
 	alertMu           sync.RWMutex
@@ -522,13 +514,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	if s.redirectServer != nil {
-		if err := s.redirectServer.Shutdown(ctx); err != nil {
-			s.logger.ErrorContext(ctx, "Error shutting down HTTP redirect server", "error", err)
-			errs = append(errs, err)
-		}
-	}
-
 	if len(errs) > 0 {
 		return errs[0]
 	}
@@ -628,9 +613,6 @@ func (s *Server) startAPIListener() error {
 		return err
 	}
 
-	if s.cfg.EnableTLS && s.cfg.HTTPRedirectAddr != "" {
-		s.startHTTPRedirect()
-	}
 	return nil
 }
 
@@ -661,43 +643,6 @@ func (s *Server) serveAPI(ln net.Listener) error {
 		}
 	}()
 	return nil
-}
-
-// startHTTPRedirect spawns the tiny HTTP listener that 308-redirects to
-// the HTTPS service. The redirect target port defaults to defaultTLSPort
-// when ServerConfig.TLSPort is zero. Errors during bind are logged and
-// non-fatal: the API itself is still up via the TLS listener.
-func (s *Server) startHTTPRedirect() {
-	port := s.cfg.TLSPort
-	if port == 0 {
-		port = defaultTLSPort
-	}
-	handler := httpToHTTPSRedirectHandler(port)
-
-	const redirectReadWriteTimeoutSec = 5
-	srv := &http.Server{
-		Addr:              s.cfg.HTTPRedirectAddr,
-		Handler:           handler,
-		ReadTimeout:       redirectReadWriteTimeoutSec * time.Second,
-		WriteTimeout:      redirectReadWriteTimeoutSec * time.Second,
-		ReadHeaderTimeout: redirectReadWriteTimeoutSec * time.Second,
-	}
-
-	ln, boundAddr, bindErr := bindWithFallback(context.Background(), s.logger, s.cfg.HTTPRedirectAddr)
-	if bindErr != nil {
-		s.logger.Error("HTTP→HTTPS redirect listener bind failed",
-			"addr", s.cfg.HTTPRedirectAddr, "error", bindErr)
-		return
-	}
-	srv.Addr = boundAddr
-	s.redirectServer = srv
-	s.logger.Info("Starting HTTP→HTTPS redirect server", "addr", boundAddr, "https_port", port)
-
-	go func() {
-		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			s.logger.Error("HTTP redirect server stopped", "error", err)
-		}
-	}()
 }
 
 // addrIsNonLoopback reports whether the host portion of a "host:port"

--- a/internal/api/tls.go
+++ b/internal/api/tls.go
@@ -1,9 +1,9 @@
 package api
 
-// tls.go provides the self-signed certificate generation and HTTP→HTTPS
-// redirect helpers used when niac binds with TLS enabled (the new default,
-// Wave 1). The cert template mirrors seed's: single-tier self-signed CA so
-// `niac install-ca` can install the same file into the OS trust store.
+// tls.go provides the self-signed certificate generation used when niac
+// binds with TLS enabled (HTTPS-only since Wave 1). The cert template
+// mirrors seed's: single-tier self-signed CA so `niac install-ca` can
+// install the same file into the OS trust store.
 
 import (
 	"crypto/rand"
@@ -14,12 +14,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"net"
-	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -39,17 +35,6 @@ const (
 	defaultCertFileName = "server.crt"
 	defaultKeyFileName  = "server.key"
 )
-
-// defaultTLSPort is the canonical port niac binds when TLS is enabled
-// (mirrors seed:8443 and stem:8444 — niac gets 8445). cmd/niac mirrors
-// this via daemonTLSPort; the duplication is intentional so the api
-// package doesn't have to import cmd-level state.
-const defaultTLSPort = 8445
-
-// httpsStandardPort is RFC 1700's well-known https port. Used by the
-// HTTP→HTTPS redirect handler to decide whether to emit an explicit
-// :port suffix in the Location header.
-const httpsStandardPort = 443
 
 // EnsureSelfSignedCert generates a self-signed certificate at the configured
 // paths if one does not already exist. Reuses existing files when both are
@@ -154,39 +139,4 @@ func DefaultCertPaths(certDir string) (string, string) {
 	}
 	return filepath.Join(certDir, defaultCertFileName),
 		filepath.Join(certDir, defaultKeyFileName)
-}
-
-// httpToHTTPSRedirectHandler returns an [http.Handler] that permanently
-// redirects every request to the equivalent HTTPS URL on the given target
-// port. Extracted so unit tests can exercise it without bringing up a
-// real listener.
-func httpToHTTPSRedirectHandler(httpsPort int) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Strip the source port from r.Host so localhost:8044 → localhost
-		// before re-joining with the HTTPS port. Without this we'd emit
-		// https://localhost:8044:8445 which most clients reject.
-		host := r.Host
-		if colonPos := strings.LastIndex(host, ":"); colonPos != -1 {
-			host = host[:colonPos]
-		}
-
-		// r.URL.RequestURI() returns just /path?query regardless of how
-		// the client encoded the request line (origin-form vs absolute-
-		// form). r.RequestURI carries the raw client value and may be a
-		// full URL — which would double-up scheme+host when concatenated
-		// and produces a broken Location header.
-		requestURI := r.URL.RequestURI()
-
-		var httpsURL string
-		if httpsPort == httpsStandardPort {
-			httpsURL = "https://" + host + requestURI
-		} else {
-			httpsURL = "https://" + net.JoinHostPort(host, strconv.Itoa(httpsPort)) + requestURI
-		}
-
-		// 308 Permanent Redirect (RFC 7538) preserves method and body so
-		// POST/PUT/DELETE survive the redirect. 301 silently downgrades
-		// state-changing requests to GET.
-		http.Redirect(w, r, httpsURL, http.StatusPermanentRedirect)
-	})
 }

--- a/internal/api/tls_security_test.go
+++ b/internal/api/tls_security_test.go
@@ -8,8 +8,6 @@ package api
 import (
 	"errors"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -105,63 +103,6 @@ func TestStart_NonLoopbackWithoutTokenRefused(t *testing.T) {
 	const wantSubst = "NIAC_API_TOKEN"
 	if !strings.Contains(err.Error(), wantSubst) {
 		t.Errorf("error must mention %q, got %q", wantSubst, err.Error())
-	}
-}
-
-func TestHTTPToHTTPSRedirectHandler_Issues308(t *testing.T) {
-	t.Parallel()
-
-	handler := httpToHTTPSRedirectHandler(8445)
-
-	req := httptest.NewRequest(http.MethodGet, "http://example.test:8044/api/foo?x=1", nil)
-	req.Host = "example.test:8044"
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusPermanentRedirect {
-		t.Errorf("expected 308, got %d", rec.Code)
-	}
-
-	loc := rec.Header().Get("Location")
-	const wantLoc = "https://example.test:8445/api/foo?x=1"
-	if loc != wantLoc {
-		t.Errorf("Location = %q, want %q", loc, wantLoc)
-	}
-}
-
-func TestHTTPToHTTPSRedirectHandler_StripsSourcePort(t *testing.T) {
-	t.Parallel()
-
-	handler := httpToHTTPSRedirectHandler(8445)
-
-	req := httptest.NewRequest(http.MethodPost, "/", nil)
-	req.Host = "10.0.0.5:8044"
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusPermanentRedirect {
-		t.Errorf("expected 308 for POST, got %d", rec.Code)
-	}
-	loc := rec.Header().Get("Location")
-	if !strings.HasPrefix(loc, "https://10.0.0.5:8445/") {
-		t.Errorf("Location should rewrite to https://10.0.0.5:8445/..., got %q", loc)
-	}
-}
-
-func TestHTTPToHTTPSRedirectHandler_DefaultPortOmitsColon(t *testing.T) {
-	t.Parallel()
-
-	handler := httpToHTTPSRedirectHandler(443)
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Host = "niac.example"
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	loc := rec.Header().Get("Location")
-	const wantLoc = "https://niac.example/"
-	if loc != wantLoc {
-		t.Errorf("Location = %q, want %q", loc, wantLoc)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -70,12 +70,6 @@ type Config struct {
 	// auto-generation under CertDir.
 	CertFile string
 	KeyFile  string
-	// HTTPRedirectAddr is the address of the small HTTP listener that
-	// 308-redirects to the HTTPS service when TLS is on. Empty disables.
-	HTTPRedirectAddr string
-	// TLSPort is the destination HTTPS port the redirect handler
-	// advertises. Zero falls back to api.defaultTLSPort.
-	TLSPort int
 }
 
 // Daemon manages the NIAC simulation lifecycle.
@@ -151,8 +145,6 @@ func (d *Daemon) Start() error {
 		CertDir:             d.cfg.CertDir,
 		CertFile:            d.cfg.CertFile,
 		KeyFile:             d.cfg.KeyFile,
-		HTTPRedirectAddr:    d.cfg.HTTPRedirectAddr,
-		TLSPort:             d.cfg.TLSPort,
 		// Stack, Config, etc. will be nil until simulation starts
 	}
 


### PR DESCRIPTION
## Why

Strategy decision: niac binds only its HTTPS port. The optional HTTP listener on 8044 that 308-redirected to the HTTPS port has been removed.

An operator who types `niac.example.com` into a browser without a scheme will get connection refused; HTTPS is the only API path.

## What

Code:
- `internal/api/server.go`: dropped `HTTPRedirectAddr` field and `TLSPort` field (both became dead after the redirector left); dropped `redirectServer` field; dropped the startup-time `if EnableTLS && HTTPRedirectAddr != "" { startHTTPRedirect() }` branch; dropped the shutdown branch; deleted the `startHTTPRedirect` function.
- `internal/api/tls.go`: deleted `httpToHTTPSRedirectHandler` and the `defaultTLSPort` + `httpsStandardPort` constants that only the redirector consumed; file-level doc updated.
- `internal/api/tls_security_test.go`: dropped the three tests that exercised `httpToHTTPSRedirectHandler`.
- `internal/daemon/daemon.go`: dropped `HTTPRedirectAddr` + `TLSPort` fields from `daemon.Config`; dropped matching `ServerConfig` wire-through.
- `cmd/niac/cmd_daemon.go`: dropped `daemonHTTPRedirectPort = 8044` constant; renamed `resolveDaemonAddrs (string, string, bool)` → `resolveDaemonListen (string, bool)` since the redirect-address return is gone; dropped the caller's `redirectAddr` destructure; dropped the "HTTP→HTTPS redirector listening on …" info line; dropped `HTTPRedirectAddr` / `TLSPort` fields from the `api.ServerConfig` literal.

## No operator-facing surface changes

Verified: no `--http-redirect-addr` flag and no `NIAC_HTTP_REDIRECT_ADDR` env var existed pre-port. `HTTPRedirectAddr` was set internally from the hardcoded `daemonHTTPRedirectPort = 8044` constant. Removing it requires no migration notice; existing deployments using `NIAC_LISTEN_ADDR` or `--listen` keep working unchanged.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/api/ ./internal/daemon/ -count=1` — passes
- [x] `golangci-lint run ./...` — 0 issues

## Cross-repo

Part of the HTTPS-only effort: seed#1277 + stem#376 drop their respective redirectors in the same Phase.