### PR TITLE
test(e2e): port shared helpers + global-setup; bump workers to 4

### DIFF
--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -1,0 +1,23 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { AUTH_STORAGE_STATE } from './helpers/auth';
+
+/**
+ * Playwright globalSetup — runs ONCE per test process before any
+ * test fixtures spawn.
+ *
+ * niac has no auth surface (loopback-only by default; no token
+ * required, no login form), so there is no real "session" to mint.
+ * What this file does is write an empty-but-well-formed storage state
+ * to `AUTH_STORAGE_STATE` so that `playwright.config.ts`'s
+ * `use.storageState` resolves without an EBUSY/ENOENT, AND so the
+ * cross-repo specs that mirror the seed/stem shape (`test.use({
+ * storageState: AUTH_STORAGE_STATE })`) keep working when ported.
+ *
+ * No login, no API calls — just a literal empty state file.
+ */
+export default async function globalSetup(): Promise<void> {
+  const path = AUTH_STORAGE_STATE;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify({ cookies: [], origins: [] }, null, 2));
+}

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -1,0 +1,49 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Shared E2E helpers — niac flavor.
+ *
+ * niac is loopback-only by default and has NO auth surface (no token,
+ * no login form), so the helpers here are a smaller subset of the seed
+ * / stem siblings. The file shape (TEST_CREDENTIALS, AUTH_STORAGE_STATE,
+ * disableAnimations) is kept parallel so spec patterns port across the
+ * three repos verbatim per the cross-repo `feedback_harmonization_no_master`
+ * convention.
+ *
+ * Each repo owns its own copy — do not import from seed/stem.
+ */
+
+/**
+ * Placeholder for shape parity with seed/stem. niac doesn't drive a
+ * login form, but specs that want to mirror the sibling pattern can
+ * still reference this constant rather than hard-coding a value.
+ */
+export const TEST_CREDENTIALS = {
+  username: 'admin',
+  password: 'niac-loopback-no-auth-needed', // gitleaks:allow — placeholder fixture; niac has no login form, no real credential here
+} as const;
+
+/**
+ * Path (relative to `ui/`) where global-setup persists the
+ * (empty-but-disableAnimations-armed) storage state. Mirrors the
+ * seed/stem path so per-spec storageState overrides use the same
+ * literal.
+ */
+export const AUTH_STORAGE_STATE = 'playwright/.auth/user.json';
+
+/**
+ * Disable CSS transitions/animations on the page. The dropdown,
+ * drawer, and topology-graph transitions otherwise race Playwright's
+ * scroll-into-view + actionability checks under parallel CI load,
+ * causing intermittent click failures on deep elements. Must be
+ * called before `page.goto()` so the style installs on every
+ * navigation.
+ */
+export async function disableAnimations(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const style = document.createElement('style');
+    style.textContent =
+      '*,*::before,*::after{transition:none!important;animation:none!important;scroll-behavior:auto!important}';
+    document.documentElement.appendChild(style);
+  });
+}

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -20,14 +20,16 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   // retries 1 (not 2) — one retry is enough to dodge transient flakes; the
   //   second retry was costing ~30s × N flaky tests with no incremental signal.
-  // workers 2 in CI (was 1) — GH Actions runners are 4-vCPU; 1 worker wastes
-  //   75% of the box. Mirrors seed #1080 and the cross-repo perf push.
+  // workers 4 in CI (bumped from 2 in PR-N1) — GH Actions ubuntu-latest is
+  //   4-vCPU. fullyParallel + workers=4 fills the box and roughly halves
+  //   per-shard wall-clock under the seed cross-repo perf pattern.
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   timeout: 30000,
   expect: {
     timeout: 10000,
   },
+  globalSetup: './e2e/global-setup.ts',
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['list'],
@@ -35,6 +37,7 @@ export default defineConfig({
   ],
   use: {
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:5173',
+    storageState: 'playwright/.auth/user.json',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'on-first-retry',


### PR DESCRIPTION
Mirrors the seed/stem `ui/e2e/helpers/auth.ts` + `ui/e2e/global-setup.ts`
shape per the `feedback_harmonization_no_master` convention. Each repo
owns its own copy — code is ported, never imported across.

  - `helpers/auth.ts`: exports `TEST_CREDENTIALS` (placeholder for shape
    parity — niac is loopback-only, no auth surface), `AUTH_STORAGE_
    STATE`, and `disableAnimations(page)`. The latter is the load-
    bearing helper: dropdown/drawer/topology transitions otherwise
    race Playwright's scroll-into-view + actionability checks under
    parallel CI load.
  - `global-setup.ts`: writes an empty `{cookies:[], origins:[]}`
    storageState to `playwright/.auth/user.json` so the config's
    `use.storageState` resolves cleanly. No login, no API — niac has
    nothing to mint against. The file exists for cross-repo shape
    parity so seed/stem specs that override per-describe port verbatim.
  - `playwright.config.ts`: wires `globalSetup` + `use.storageState`,
    and bumps `workers: 4` in CI (was 2). ubuntu-latest is 4-vCPU;
    fullyParallel is already on. Mirrors the cross-repo perf push.

Niac E2E plan N1 of 4.
