### PR TITLE
test(e2e): help-drawer version-badge contract spec + sidebar-help testid

### DIFF
--- a/ui/e2e/help-drawer.spec.ts
+++ b/ui/e2e/help-drawer.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+import { disableAnimations } from './helpers/auth';
+
+/**
+ * Help Drawer — version-badge contract test.
+ *
+ * niac PR #774 added a `NIAC v<version>` badge to the HelpDrawer
+ * header sourced from /__version. This spec asserts the user-visible
+ * surface: opening the drawer from the sidebar reveals a version badge
+ * matching `/NIAC v.+/`, and the close affordance dismisses it.
+ *
+ * The testids consumed here ship on `main` from PR-C #774
+ * (HelpDrawer.tsx:91/106/115) and from niac E2E N3 (Sidebar.tsx
+ * FooterIconButton's new `data-testid` prop).
+ */
+
+test.describe('Help Drawer', () => {
+  test.beforeEach(async ({ page }) => {
+    await disableAnimations(page);
+    await page.goto('/');
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('clicking the sidebar Help button opens the drawer', async ({ page }) => {
+    await page.getByTestId('sidebar-help-button').click();
+    await expect(page.getByTestId('help-drawer')).toBeVisible();
+  });
+
+  test('the version badge renders and matches /NIAC v.+/', async ({ page }) => {
+    await page.getByTestId('sidebar-help-button').click();
+    const badge = page.getByTestId('help-drawer-version');
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText(/NIAC v.+/);
+  });
+
+  test('clicking the close affordance dismisses the drawer', async ({ page }) => {
+    await page.getByTestId('sidebar-help-button').click();
+    const drawer = page.getByTestId('help-drawer');
+    await expect(drawer).toBeVisible();
+
+    await page.getByTestId('help-drawer-close').click();
+    await expect(drawer).not.toBeVisible();
+  });
+});

--- a/ui/src/ui/Sidebar.tsx
+++ b/ui/src/ui/Sidebar.tsx
@@ -109,6 +109,7 @@ interface FooterIconButtonProps {
   icon: LucideIcon;
   label: string;
   title: string;
+  'data-testid'?: string;
 }
 
 const FooterIconButton: FC<FooterIconButtonProps> = ({
@@ -117,10 +118,12 @@ const FooterIconButton: FC<FooterIconButtonProps> = ({
   icon,
   label,
   title,
+  'data-testid': dataTestId,
 }) => (
   <button
     type="button"
     onClick={onClick}
+    data-testid={dataTestId}
     className={`${collapsed ? 'w-full' : 'flex-1'} flex items-center ${
       collapsed ? 'justify-center' : 'gap-compact'
     } px-3 py-row rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors text-sm font-medium`}
@@ -221,6 +224,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
           icon={HelpCircle}
           label="Help"
           title="Open help"
+          data-testid="sidebar-help-button"
         />
       ) : null}
       {onOpenSettings ? (
@@ -230,6 +234,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
           icon={Settings}
           label="Settings"
           title="Open settings"
+          data-testid="sidebar-settings-button"
         />
       ) : null}
     </div>


### PR DESCRIPTION
Closes the niac E2E coverage gap for PR #774's HelpDrawer version
badge. The badge ships at HelpDrawer.tsx:106 with
data-testid="help-drawer-version", and the drawer + close button
testids were already in place — but no E2E asserted the user-visible
contract that opening Help reveals the version.

UI change (small, additive):

  - ui/src/ui/Sidebar.tsx FooterIconButton: optional
    'data-testid'?: string prop, forwarded to the rendered button.
    Help and Settings call sites pass sidebar-help-button and
    sidebar-settings-button. Mirrors the stem PR-S2 pattern.

New spec — ui/e2e/help-drawer.spec.ts:

  - "clicking the sidebar Help button opens the drawer" asserts the
    drawer mounts after the click.
  - "the version badge renders and matches /NIAC v.+/" opens the
    drawer, asserts the badge is visible AND its text matches the
    NIAC-vX.Y.Z contract.
  - "clicking the close affordance dismisses the drawer" round-
    trips the open/close cycle.

Niac E2E plan N3 of 4.
