### PR TITLE
test(e2e): device-add testid + migrate device-crud add-button assertion

### DIFF
--- a/ui/e2e/device-crud.spec.ts
+++ b/ui/e2e/device-crud.spec.ts
@@ -22,11 +22,13 @@ test.describe('Device CRUD Operations', () => {
 
   test.describe('Create Device', () => {
     test('should navigate to create device form', async ({ page }) => {
-      const addButton = page.getByRole('button', { name: /add|create|new/i }).first();
-      if (await addButton.isVisible()) {
-        await addButton.click();
-        await expect(page).toHaveURL(/device-config/);
-      }
+      // DeviceListHeader's Add Device button carries `data-testid="device-add"`
+      // (PR-N4 of niac E2E plan). Previously the regex /add|create|new/i was
+      // i18n-fragile and could match unrelated buttons under strict mode.
+      const addButton = page.getByTestId('device-add');
+      await expect(addButton).toBeVisible();
+      await addButton.click();
+      await expect(page).toHaveURL(/device-config/);
     });
 
     test('should display all required form fields', async ({ page }) => {

--- a/ui/src/components/device-list/DeviceListHeader.tsx
+++ b/ui/src/components/device-list/DeviceListHeader.tsx
@@ -112,6 +112,7 @@ export const DeviceListHeader: FC<DeviceListHeaderProps> = ({
           tone="violet"
           leftIcon={<Plus className={iconSizes.md} />}
           onClick={() => navigate('/device-config/new')}
+          data-testid="device-add"
         >
           Add Device
         </Button>


### PR DESCRIPTION
Niac E2E plan N4 — scoped to the highest-value testid first. Full
sweep of config-workflow (13 sites) + device-crud (10 remaining
sites) + device-editor + automation-page is intentionally deferred to
the cleanup phase per the e2e-cleanup-directive memory; this PR adds
the one testid that's needed to unblock the rest of the niac specs
when they stop relying on the brittle `.first()` regex pattern.

UI change:

  - DeviceListHeader.tsx Add Device button: `data-testid="device-add"`.

Spec change:

  - device-crud.spec.ts "should navigate to create device form":
    swapped from `getByRole('button', { name: /add|create|new/i })
    .first()` to `getByTestId('device-add')`. Drops the conditional
    `if (await addButton.isVisible())` envelope that was masking
    failures — the testid is asserted visible explicitly.

Remaining N4 sweep (edit/delete/clone/form-submit/cancel testids,
config-workflow regex sweep, ~25 more sites) is sequenced into the
cleanup phase to keep this PR scoped and merge-able.
