### PR TITLE
test(e2e): rewrite smoke.spec.ts as a golden-path required-status gate

### DIFF
--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -1,52 +1,46 @@
 import { expect, test } from '@playwright/test';
+import { AUTH_STORAGE_STATE } from './helpers/auth';
 
-/**
- * Smoke Tests
- *
- * Basic sanity checks to verify the application loads correctly.
- * These tests should be fast and run on every PR.
- */
+const VERSION_KEYS = ['version', 'commit', 'buildTime', 'uiBuildHash'] as const;
 
-test.describe('Smoke Tests', () => {
-  test('homepage loads successfully', async ({ page }) => {
+test.describe('smoke @ unauthenticated', { tag: '@smoke' }, () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('GET /__version returns canonical build metadata', async ({ request }) => {
+    const res = await request.get('/__version');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    for (const k of VERSION_KEYS) {
+      expect(body[k], `missing ${k} in /__version`).toBeTruthy();
+      expect(typeof body[k]).toBe('string');
+    }
+  });
+});
+
+test.describe('smoke @ authenticated', { tag: '@smoke' }, () => {
+  test.use({ storageState: AUTH_STORAGE_STATE });
+
+  test('NIAC shell renders with page-header-title', async ({ page }) => {
     await page.goto('/');
-    await expect(page).toHaveTitle(/NIAC/i);
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
   });
 
-  test('navigation is visible', async ({ page }) => {
+  test('settings drawer opens and closes', async ({ page }) => {
     await page.goto('/');
-    // Wait for page to fully load, then check for any visible navigation
-    await page.waitForLoadState('domcontentloaded');
-    const visibleNav = page.locator('nav:visible, [role="navigation"]:visible').first();
-    await expect(visibleNav).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('sidebar-settings-button').click();
+    await expect(page.getByTestId('settings-drawer')).toBeVisible();
+    await page.getByTestId('settings-drawer-close').click();
+    await expect(page.getByTestId('settings-drawer')).toBeHidden();
   });
 
-  test('no console errors on load', async ({ page }) => {
-    const errors: string[] = [];
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') {
-        errors.push(msg.text());
-      }
-    });
-
+  test('help drawer opens with NIAC version badge', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('domcontentloaded');
-
-    // Filter out expected errors:
-    // - favicon: Not always present in dev
-    // - 404/500/503: Backend may not be running during E2E tests
-    // - Failed to load resource: Network errors when backend is down
-    // - Service Unavailable: Backend service errors
-    const criticalErrors = errors.filter(
-      (e) =>
-        !e.includes('favicon') &&
-        !e.includes('404') &&
-        !e.includes('500') &&
-        !e.includes('503') &&
-        !e.includes('Failed to load resource') &&
-        !e.includes('Service Unavailable') &&
-        !e.includes('Internal Server Error'),
-    );
-    expect(criticalErrors).toHaveLength(0);
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('sidebar-help-button').click();
+    await expect(page.getByTestId('help-drawer')).toBeVisible();
+    await expect(page.getByTestId('help-drawer-version')).toContainText(/NIAC v.+/);
+    await page.getByTestId('help-drawer-close').click();
+    await expect(page.getByTestId('help-drawer')).toBeHidden();
   });
 });


### PR DESCRIPTION
Mirror of seed PR-AC4 / stem PR-S-AC4. Same shape adapted to
niac's testid inventory.

The previous 3 tests:
  - "homepage loads successfully" → `expect(page).toHaveTitle(/NIAC/i)`.
    Title check; not a contract — passes on any non-blank page.
  - "navigation is visible" → `locator('nav:visible, [role="navigation"]:visible')`.
    Generic role-or-tag fallback; brittle to layout changes.
  - "no console errors on load" → filters favicon/404/500/503/Service
    Unavailable/Failed-to-load — so the assertion only fires for
    non-network non-server errors that contain the word "error".
    Console-log scraping doesn't belong in smoke.

Replaced with 4 contract-driven tests:

  Unauthenticated:
    1. /__version returns the canonical four-field metadata
       (version, commit, buildTime, uiBuildHash) — the Universal
       Build Contract surface from CLAUDE.md.

  Authenticated:
    2. page-header-title visible at `/`.
    3. settings-drawer opens via sidebar-settings-button, then
       closes via settings-drawer-close.
    4. help-drawer opens and help-drawer-version contains
       /NIAC v.+/ — locks in the version-badge contract from
       niac PR #774.

All selectors are getByTestId. Zero regex, zero console scraping,
zero generic role/tag fallbacks. The version-badge assertion in #4
makes the canonical CLAUDE.md UI-build-hash invariant a true
merge gate.
