### PR TITLE
fix(e2e): route device-crud to /device-config (was /devices = Running Devices)

### DIFF
--- a/ui/e2e/device-crud.spec.ts
+++ b/ui/e2e/device-crud.spec.ts
@@ -24,7 +24,12 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Device CRUD', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/devices');
+    // `/devices` is the read-only Running Devices live view; the
+    // Device Library (the page hosting <DeviceListHeader> + the Add
+    // Device button) lives at `/device-config`. The original 14-test
+    // file went to `/devices` and never tripped this because every
+    // assertion was gated by `if-visible` (see PR-NAC2 description).
+    await page.goto('/device-config');
     await page.waitForLoadState('domcontentloaded');
   });
 


### PR DESCRIPTION
PR-NAC2 inherited a `/devices` route from the original 14-test file
without verifying it was the right page. Trace from CI #26692032096
shows /devices renders the Running Devices live view (read-only,
"No devices defined in the loaded configuration."), not the Device
Library that hosts <DeviceListHeader> + the device-add button.

Per ui/src/navGroups.ts:
  - `/devices`       → Running Devices live view (read-only)
  - `/device-config` → Device Library (the page with Add Device)

The original 14-test file never tripped this because every assertion
was gated by `if (await x.isVisible())`. PR-NAC2 removed the gating
and the route bug surfaced — exactly the kind of dormant failure
the cleanup was meant to expose. (Confirms the cleanup directive's
premise: junk tests give false coverage signal.)

One-line fix: `/devices` → `/device-config` in the describe-level
beforeEach. Both tests now hit the right page.
