### PR TITLE
test(e2e): migrate 8 niac heading-name regex sites to page-header-title testid

### DIFF
--- a/ui/e2e/automation-page.spec.ts
+++ b/ui/e2e/automation-page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Automation Page', () => {
   });
 
   test('should render the Alert policy heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /alert policy/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/config-diff-page.spec.ts
+++ b/ui/e2e/config-diff-page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Config Diff Page', () => {
   });
 
   test('should render the Compare & Merge heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^compare & merge$/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/debug-console-page.spec.ts
+++ b/ui/e2e/debug-console-page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Debug Console Page', () => {
   });
 
   test('should render the Debug Console heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^debug console$/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/library-pages.spec.ts
+++ b/ui/e2e/library-pages.spec.ts
@@ -15,7 +15,7 @@ test.describe('Library — SNMP Walks', () => {
   });
 
   test('should render the SNMP Walks heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /snmp walks/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });
@@ -41,7 +41,7 @@ test.describe('Library — PCAP Captures', () => {
   });
 
   test('should render the PCAP Captures heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /pcap captures/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/packet-inspector-page.spec.ts
+++ b/ui/e2e/packet-inspector-page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Packet Inspector Page', () => {
   });
 
   test('should render the Packets heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /^packets$/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/runtime-control-page.spec.ts
+++ b/ui/e2e/runtime-control-page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Runtime Control Page', () => {
   });
 
   test('should render the Start Simulation heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /start simulation/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });

--- a/ui/e2e/topology-page.spec.ts
+++ b/ui/e2e/topology-page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Topology Page', () => {
   });
 
   test('should render the Network Topology heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /network topology/i })).toBeVisible({
+    await expect(page.getByTestId('page-header-title')).toBeVisible({
       timeout: 10000,
     });
   });


### PR DESCRIPTION
Brittleness fix #10 of the i18n-fragile-selector sweep, niac chunk.

Seven niac per-page specs all asserted their main page heading by
language-specific text regex:

  await expect(page.getByRole('heading', { name: /network topology/i }))
    .toBeVisible({ timeout: 10000 });

Each heading text is rendered by the t() helper and translated under
es ("Topologia de red" etc). The regex misses entirely on a locale
switch.

The PageHeader.tsx <h1> already carries data-testid="page-header-
title" (the same surface the smoke spec uses). Replacing the
heading-regex with the stable testid makes the page-render
contract i18n-stable.

Sites migrated (8):
  - topology-page.spec.ts        /network topology/i
  - automation-page.spec.ts      /alert policy/i
  - packet-inspector-page.spec.ts /^packets$/i
  - debug-console-page.spec.ts   /^debug console$/i
  - runtime-control-page.spec.ts /start simulation/i
  - config-diff-page.spec.ts     /^compare & merge$/i
  - library-pages.spec.ts        /snmp walks/i  (1 of 2)
  - library-pages.spec.ts        /pcap captures/i  (2 of 2)

Deferred (2 sites still in config-diff-page.spec.ts):
  - /original file/i and /modified file/i — these are sub-panel
    headings inside the diff view, NOT the page header. Tightening
    them needs data-testid on the DiffPanel component. Tracked
    separately.

Net: -8 i18n-fragile assertion sites in niac. niac button-regex
count drops from 12 to ~4.
