### PR TITLE
feat(api): capability registry — declarative route policy + /__capabilities + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Output-escaping / XSS gate (#742)
         run: ./scripts/check-output-escaping.sh
 
+      - name: Route-policy gate (capability registry)
+        run: ./scripts/check-route-policy.sh
+
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/internal/api/route.go
+++ b/internal/api/route.go
@@ -1,0 +1,115 @@
+package api
+
+// route.go is the capability registry: API routes are declared as data and a
+// single register() composes their per-route policy — rate limiting, CSRF,
+// admin scope, license feature — in ONE canonical order around the shared
+// recover+auth wrappers. This replaces hand-nesting the middleware at each
+// mux.HandleFunc call site, where the nesting could be applied inconsistently
+// or forgotten. scripts/check-route-policy.sh enforces that every /api route
+// goes through register().
+
+import "net/http"
+
+// rateLimitKind selects which rate limiter wraps a route (or none).
+type rateLimitKind int
+
+const (
+	rlNone   rateLimitKind = iota // no rate limiter
+	rlWrite                       // writeRateLimit (state-changing endpoints)
+	rlWalk                        // walkRateLimit (SNMP walk validation)
+	rlUpload                      // uploadRateLimit (binary uploads)
+	rlFile                        // fileRateLimit (file listing)
+)
+
+// apiRoute declares an API route and its per-route policy. Authentication is
+// applied to every registered route (auth), so it is not a field; /__version
+// and /__capabilities are registered directly because they are unauthenticated.
+type apiRoute struct {
+	// path is the full request path (e.g. "/api/v1/config").
+	path string
+	// handler is the terminal handler.
+	handler http.HandlerFunc
+	// rl selects the rate limiter (rlNone for unmetered reads/streams).
+	rl rateLimitKind
+	// csrf wraps the route in csrfProtect (csrfProtect itself skips safe GETs).
+	csrf bool
+	// admin requires an admin-scoped token (adminProtect) — whole-topology ops.
+	admin bool
+	// feature requires a license feature via requireFeature. "" = none.
+	feature string
+}
+
+// register installs rt on mux, composing middleware in ONE canonical order
+// (outermost → innermost): recover → auth → rateLimit → csrf → admin → feature
+// → handler. Composing here rather than at each call site makes the policy
+// declarative and uniform, records it for /__capabilities, and is the single
+// choke point the route-policy CI gate enforces.
+func (s *Server) register(mux *http.ServeMux, rt apiRoute) {
+	s.routeManifest = append(s.routeManifest, rt)
+
+	h := rt.handler
+	if rt.feature != "" {
+		h = s.requireFeature(rt.feature, h)
+	}
+	if rt.admin {
+		h = s.adminProtect(h)
+	}
+	if rt.csrf {
+		h = s.csrfProtect(h)
+	}
+	switch rt.rl {
+	case rlNone:
+		// no rate limiter
+	case rlWrite:
+		h = s.writeRateLimit(h)
+	case rlWalk:
+		h = s.walkRateLimit(h)
+	case rlUpload:
+		h = s.uploadRateLimit(h)
+	case rlFile:
+		h = s.fileRateLimit(h)
+	}
+	h = s.auth(h)
+	h = s.recoverMiddleware(h)
+	mux.HandleFunc(rt.path, h)
+}
+
+// registerAll installs a slice of routes through register().
+func (s *Server) registerAll(mux *http.ServeMux, routes []apiRoute) {
+	for _, rt := range routes {
+		s.register(mux, rt)
+	}
+}
+
+// routePolicyView is the JSON projection of a route's policy for the
+// /__capabilities manifest (the handler func itself is not exposed).
+type routePolicyView struct {
+	Path        string `json:"path"`
+	RateLimited bool   `json:"rateLimited"`
+	CSRF        bool   `json:"csrf"`
+	Admin       bool   `json:"admin"`
+	Feature     string `json:"feature,omitempty"`
+}
+
+// handleRoutePolicyManifest serves the route-policy manifest: every route
+// registered through register() with its rate-limit / CSRF / admin / feature
+// policy. No auth — like /__version it is a deployment/audit introspection
+// surface (auth itself is applied to every registered route and is implicit).
+func (s *Server) handleRoutePolicyManifest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	views := make([]routePolicyView, 0, len(s.routeManifest))
+	for _, rt := range s.routeManifest {
+		views = append(views, routePolicyView{
+			Path:        rt.path,
+			RateLimited: rt.rl != rlNone,
+			CSRF:        rt.csrf,
+			Admin:       rt.admin,
+			Feature:     rt.feature,
+		})
+	}
+	s.writeJSON(w, views)
+}

--- a/internal/api/route_test.go
+++ b/internal/api/route_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRoutePolicyManifest verifies the capability registry exposes every route
+// via /__capabilities and records each route's policy correctly. The registry
+// is the single source of truth that scripts/check-route-policy.sh enforces.
+func TestRoutePolicyManifest(t *testing.T) {
+	server, _, _ := newTestServerWithAuth(t)
+	server.writeLimiter = NewRateLimiter(WriteRateLimit, WriteBurst)
+	mux := http.NewServeMux()
+	server.registerAPIRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/__capabilities", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /__capabilities: status = %d, want 200", rec.Code)
+	}
+
+	var views []routePolicyView
+	if err := json.Unmarshal(rec.Body.Bytes(), &views); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if len(views) == 0 {
+		t.Fatal("expected a non-empty route manifest")
+	}
+
+	byPath := make(map[string]routePolicyView, len(views))
+	for _, v := range views {
+		byPath[v.Path] = v
+	}
+
+	// Whole-topology import is admin-scoped + CSRF-protected + write-limited.
+	imp, ok := byPath["/api/v1/config/import"]
+	if !ok || !imp.Admin || !imp.CSRF || !imp.RateLimited {
+		t.Errorf("/api/v1/config/import policy = %+v, want admin+csrf+rateLimited", imp)
+	}
+	// A safe read carries none of those.
+	rd, ok := byPath["/api/v1/topology"]
+	if !ok || rd.Admin || rd.CSRF || rd.RateLimited {
+		t.Errorf("/api/v1/topology policy = %+v, want no admin/csrf/rateLimited", rd)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -6,194 +6,125 @@ import (
 )
 
 // registerAPIRoutes registers all API endpoints on the provided mux.
+//
+// Every /api route is installed through the capability registry (register /
+// registerAll in route.go), which composes its policy — auth, rate limiting,
+// CSRF, admin scope, license feature — in one canonical order so a route cannot
+// ship without it. scripts/check-route-policy.sh enforces this. Only the
+// unauthenticated introspection endpoints (/__version, /__capabilities) are
+// registered directly.
 func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
-	// Public version endpoint for deployment validation (no auth required)
-	// Intentionally placed before authenticated routes for clarity
+	// Unauthenticated introspection (no auth wrapper).
 	mux.HandleFunc("/__version", s.recoverMiddleware(s.handleBuildVersion))
+	mux.HandleFunc("/__capabilities", s.recoverMiddleware(s.handleRoutePolicyManifest))
 
-	// SECURITY FIX #2.8.1: Wrap all handlers with panic recovery middleware
-	// SECURITY FIX LOW-1: CSRF token endpoint for clients to retrieve token
-	mux.HandleFunc("/api/v1/csrf-token", s.recoverMiddleware(s.auth(s.handleCSRFToken)))
-	mux.HandleFunc("/api/v1/stats", s.recoverMiddleware(s.auth(s.handleStats)))
-	mux.HandleFunc("/api/v1/devices", s.recoverMiddleware(s.auth(s.handleDevices)))
-	mux.HandleFunc("/api/v1/history", s.recoverMiddleware(s.auth(s.handleHistory)))
-	mux.HandleFunc("/api/v1/license", s.recoverMiddleware(s.auth(s.handleLicenseStatus)))
+	// Top-level authenticated reads + the CSRF-token endpoint.
+	s.registerAll(mux, []apiRoute{
+		{path: "/api/v1/csrf-token", handler: s.handleCSRFToken},
+		{path: "/api/v1/stats", handler: s.handleStats},
+		{path: "/api/v1/devices", handler: s.handleDevices},
+		{path: "/api/v1/history", handler: s.handleHistory},
+		{path: "/api/v1/license", handler: s.handleLicenseStatus},
+	})
 
-	// SECURITY FIX LOW-1: Protect state-changing endpoints with CSRF
-	// SECURITY FIX #156: Apply write rate limiting to state-changing endpoints
 	s.registerWriteProtectedRoutes(mux)
 	s.registerReadOnlyRoutes(mux)
 	s.registerWalkRoutes(mux)
 	s.registerPcapRoutes(mux)
 	s.registerSSERoutes(mux)
 
-	// SECURITY FIX #172: Metrics endpoint requires authentication
-	mux.HandleFunc("/metrics", s.recoverMiddleware(s.auth(s.handleMetrics)))
-	mux.HandleFunc("/", s.recoverMiddleware(s.auth(s.serveSPA())))
+	// Metrics require auth (#172); the SPA is the authenticated catch-all.
+	s.registerAll(mux, []apiRoute{
+		{path: "/metrics", handler: s.handleMetrics},
+		{path: "/", handler: s.serveSPA()},
+	})
 }
 
-// registerWriteProtectedRoutes registers routes that require write protection (CSRF + rate limiting).
+// registerWriteProtectedRoutes registers state-changing routes (write rate
+// limit + CSRF; /config/import additionally requires an admin-scoped token).
 func (s *Server) registerWriteProtectedRoutes(mux *http.ServeMux) {
-	mux.HandleFunc(
-		"/api/v1/config",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleConfig)))),
-	)
-	mux.HandleFunc(
-		"/api/v1/config/devices",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleDevicesV2)))),
-	)
-	mux.HandleFunc(
-		"/api/v1/config/devices/",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleDevicesV2)))),
-	)
-	mux.HandleFunc(
-		"/api/v1/config/merge",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleConfigMerge)))),
-	)
-	mux.HandleFunc(
-		// #743: full topology replacement is admin-class (an
-		// admin-scoped token in addition to read-write). Routine
-		// per-device edits / configs CRUD stay at ScopeReadWrite
-		// because they're normal operator actions, not whole-topology
-		// events.
-		"/api/v1/config/import",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.adminProtect(s.handleConfigImport))))),
-	)
-	mux.HandleFunc(
-		"/api/v1/replay",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleReplay)))),
-	)
-	mux.HandleFunc(
-		"/api/v1/alerts",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleAlerts)))),
-	)
-	mux.HandleFunc(
-		"/api/v1/capture/filter",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleCaptureFilter)))),
-	)
-	// Standalone packet capture (no simulation required). POST=start,
-	// DELETE=stop, GET=status. Distinct from /capture/filter, which
-	// drives the BPF filter on the sim-managed capture engine.
-	mux.HandleFunc(
-		"/api/v1/capture",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleStandaloneCapture)))),
-	)
+	s.registerAll(mux, []apiRoute{
+		{path: "/api/v1/config", handler: s.handleConfig, rl: rlWrite, csrf: true},
+		{path: "/api/v1/config/devices", handler: s.handleDevicesV2, rl: rlWrite, csrf: true},
+		{path: "/api/v1/config/devices/", handler: s.handleDevicesV2, rl: rlWrite, csrf: true},
+		{path: "/api/v1/config/merge", handler: s.handleConfigMerge, rl: rlWrite, csrf: true},
+		// #743: whole-topology replacement is admin-class (an admin-scoped token
+		// in addition to read-write); routine per-device edits / configs CRUD
+		// stay at ScopeReadWrite because they are normal operator actions.
+		{path: "/api/v1/config/import", handler: s.handleConfigImport, rl: rlWrite, csrf: true, admin: true},
+		{path: "/api/v1/replay", handler: s.handleReplay, rl: rlWrite, csrf: true},
+		{path: "/api/v1/alerts", handler: s.handleAlerts, rl: rlWrite, csrf: true},
+		{path: "/api/v1/capture/filter", handler: s.handleCaptureFilter, rl: rlWrite, csrf: true},
+		// Standalone packet capture (POST=start, DELETE=stop, GET=status).
+		{path: "/api/v1/capture", handler: s.handleStandaloneCapture, rl: rlWrite, csrf: true},
+	})
 }
 
-// registerReadOnlyRoutes registers routes that only require authentication.
+// registerReadOnlyRoutes registers reads plus the mutating CRUD endpoints that
+// historically shared this group; the mutating ones carry write rate limit +
+// CSRF (#740). csrfProtect internally skips GET, so reads pass through.
 func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("/api/v1/config/schema", s.recoverMiddleware(s.auth(s.handleConfigSchema)))
-	// SECURITY FIX #171: Apply file-specific rate limiting
-	mux.HandleFunc("/api/v1/files", s.recoverMiddleware(s.auth(s.fileRateLimit(s.handleFiles))))
-
-	// Templates API. POST (upload), DELETE, and the "use" subpath all
-	// mutate state, so these go through csrfProtect like the other
-	// mutating routes (#740). csrfProtect internally skips GET, so reads
-	// still pass through untouched.
-	mux.HandleFunc("/api/v1/templates",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleTemplates)))))
-	mux.HandleFunc("/api/v1/templates/",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleTemplateByName)))))
-
-	// User Configs API. POST (upload) on /configs and DELETE on
-	// /configs/ mutate state — gate with csrfProtect (#740).
-	mux.HandleFunc("/api/v1/configs",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleUserConfigs)))))
-	mux.HandleFunc("/api/v1/configs/",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleUserConfigByName)))))
-
-	// Unified Library API (#548). Networks landed in PR 1 with full
-	// CRUD; walks/pcaps land in PR 3 as read-only browser endpoints —
-	// uploads + deletes for binary content are a separate follow-up
-	// once the picker integrations have validated the read shape.
-	mux.HandleFunc("/api/v1/library/networks",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleLibraryNetworks)))))
-	mux.HandleFunc("/api/v1/library/networks/",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleLibraryNetworkByName)))))
-	mux.HandleFunc("/api/v1/library/walks",
-		s.recoverMiddleware(s.auth(s.handleLibraryWalks)))
-	mux.HandleFunc("/api/v1/library/pcaps",
-		s.recoverMiddleware(s.auth(s.handleLibraryPcaps)))
-
-	// Per-device baseline SNMP walk synthesis (#546 part 2). POST-only.
-	// Distinct from /api/v1/config/devices/ (the editor's CRUD); this
-	// path lives under /api/v1/devices/{hostname}/... and dispatches
-	// to a per-action handler. CSRF + rate limiting applied since the
-	// handler mutates both the library and the running config YAML.
-	mux.HandleFunc("/api/v1/devices/",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.dispatchDeviceSubpath)))))
-
-	// Vendor + model catalog for the Generate-walk UI picker (#570).
-	// Read-only; the response is the same list returned by
-	// synth.AllModels() so the dropdown can group/sort client-side.
-	mux.HandleFunc("/api/v1/synthesize-walk/models",
-		s.recoverMiddleware(s.auth(s.handleSynthesizeWalkModels)))
-
-	// Per-type device editor schema (#546 part 1). Read-only — the
-	// schema is a static table the daemon serves so the UI can hide
-	// sections that don't apply (e.g. switch should not see DNS).
-	mux.HandleFunc("/api/v1/device-schemas",
-		s.recoverMiddleware(s.auth(s.handleDeviceEditorSchema)))
-	mux.HandleFunc("/api/v1/device-schemas/",
-		s.recoverMiddleware(s.auth(s.handleDeviceEditorSchema)))
-	mux.HandleFunc("/api/v1/topology", s.recoverMiddleware(s.auth(s.handleTopology)))
-	mux.HandleFunc("/api/v1/topology/export", s.recoverMiddleware(s.auth(s.handleTopologyExport)))
-	mux.HandleFunc("/api/v1/errors", s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleErrors)))))
-	mux.HandleFunc("/api/v1/interfaces", s.recoverMiddleware(s.auth(s.handleInterfaces)))
-	mux.HandleFunc("/api/v1/runtime", s.recoverMiddleware(s.auth(s.handleRuntime)))
-	mux.HandleFunc(
-		"/api/v1/simulation",
-		s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(s.handleSimulation)))),
-	)
-	mux.HandleFunc("/api/v1/version", s.recoverMiddleware(s.auth(s.handleVersion)))
-	mux.HandleFunc("/api/v1/neighbors", s.recoverMiddleware(s.auth(s.handleNeighbors)))
-	// #762: scope discovery endpoint for the UI. auth() upstream
-	// stashes the resolved scope on the context; handleAuthScope
-	// echoes it as JSON. Safe GET method so no csrfProtect /
-	// writeRateLimit wrappers needed.
-	mux.HandleFunc("/api/v1/auth/scope", s.recoverMiddleware(s.auth(s.handleAuthScope)))
+	s.registerAll(mux, []apiRoute{
+		{path: "/api/v1/config/schema", handler: s.handleConfigSchema},
+		{path: "/api/v1/files", handler: s.handleFiles, rl: rlFile},
+		// Templates: POST (upload), DELETE, and "use" mutate — write + CSRF.
+		{path: "/api/v1/templates", handler: s.handleTemplates, rl: rlWrite, csrf: true},
+		{path: "/api/v1/templates/", handler: s.handleTemplateByName, rl: rlWrite, csrf: true},
+		// User configs: POST/DELETE mutate — write + CSRF (#740).
+		{path: "/api/v1/configs", handler: s.handleUserConfigs, rl: rlWrite, csrf: true},
+		{path: "/api/v1/configs/", handler: s.handleUserConfigByName, rl: rlWrite, csrf: true},
+		// Library (#548): networks full CRUD (write + CSRF); walks/pcaps read-only.
+		{path: "/api/v1/library/networks", handler: s.handleLibraryNetworks, rl: rlWrite, csrf: true},
+		{path: "/api/v1/library/networks/", handler: s.handleLibraryNetworkByName, rl: rlWrite, csrf: true},
+		{path: "/api/v1/library/walks", handler: s.handleLibraryWalks},
+		{path: "/api/v1/library/pcaps", handler: s.handleLibraryPcaps},
+		// Per-device baseline walk synthesis (#546 p2). POST-only; mutates the
+		// library + running config YAML, so write + CSRF.
+		{path: "/api/v1/devices/", handler: s.dispatchDeviceSubpath, rl: rlWrite, csrf: true},
+		// Read-only catalogs / schemas.
+		{path: "/api/v1/synthesize-walk/models", handler: s.handleSynthesizeWalkModels},
+		{path: "/api/v1/device-schemas", handler: s.handleDeviceEditorSchema},
+		{path: "/api/v1/device-schemas/", handler: s.handleDeviceEditorSchema},
+		{path: "/api/v1/topology", handler: s.handleTopology},
+		{path: "/api/v1/topology/export", handler: s.handleTopologyExport},
+		{path: "/api/v1/errors", handler: s.handleErrors, rl: rlWrite, csrf: true},
+		{path: "/api/v1/interfaces", handler: s.handleInterfaces},
+		{path: "/api/v1/runtime", handler: s.handleRuntime},
+		{path: "/api/v1/simulation", handler: s.handleSimulation, rl: rlWrite, csrf: true},
+		{path: "/api/v1/version", handler: s.handleVersion},
+		{path: "/api/v1/neighbors", handler: s.handleNeighbors},
+		// #762: scope discovery — safe GET, no CSRF / write wrappers needed.
+		{path: "/api/v1/auth/scope", handler: s.handleAuthScope},
+	})
 }
 
-// registerWalkRoutes registers SNMP walk file validation endpoints.
+// registerWalkRoutes registers SNMP walk validation endpoints (walk rate limit).
 func (s *Server) registerWalkRoutes(mux *http.ServeMux) {
-	// SECURITY FIX #156: Apply walk-specific rate limiting
-	mux.HandleFunc(
-		"/api/v1/walk/validate",
-		s.recoverMiddleware(s.auth(s.walkRateLimit(s.csrfProtect(s.handleWalkValidation)))),
-	)
-	mux.HandleFunc(
-		"/api/v1/walk/fix",
-		s.recoverMiddleware(s.auth(s.walkRateLimit(s.csrfProtect(s.handleWalkValidation)))),
-	)
-	mux.HandleFunc(
-		"/api/v1/walk/list",
-		s.recoverMiddleware(s.auth(s.walkRateLimit(s.handleWalkList))),
-	)
-	mux.HandleFunc(
-		"/api/v1/walk/validate-all",
-		s.recoverMiddleware(s.auth(s.walkRateLimit(s.csrfProtect(s.handleWalkBatchValidate)))),
-	)
+	s.registerAll(mux, []apiRoute{
+		{path: "/api/v1/walk/validate", handler: s.handleWalkValidation, rl: rlWalk, csrf: true},
+		{path: "/api/v1/walk/fix", handler: s.handleWalkValidation, rl: rlWalk, csrf: true},
+		{path: "/api/v1/walk/list", handler: s.handleWalkList, rl: rlWalk},
+		{path: "/api/v1/walk/validate-all", handler: s.handleWalkBatchValidate, rl: rlWalk, csrf: true},
+	})
 }
 
-// registerPcapRoutes registers PCAP analysis endpoints.
+// registerPcapRoutes registers PCAP analysis endpoints (gated by the
+// pcap_ingest license feature; upload additionally rate-limited + CSRF).
 func (s *Server) registerPcapRoutes(mux *http.ServeMux) {
-	// SECURITY FIX #156: Apply upload-specific rate limiting for uploads
-	mux.HandleFunc(
-		"/api/v1/pcap/upload",
-		s.recoverMiddleware(s.auth(s.uploadRateLimit(s.csrfProtect(
-			s.requireFeature("pcap_ingest", s.handlePcapUpload))))),
-	)
-	mux.HandleFunc("/api/v1/pcap/",
-		s.recoverMiddleware(s.auth(
-			s.requireFeature("pcap_ingest", s.handlePcapAnalysis))))
+	s.registerAll(mux, []apiRoute{
+		{path: "/api/v1/pcap/upload", handler: s.handlePcapUpload, rl: rlUpload, csrf: true, feature: "pcap_ingest"},
+		{path: "/api/v1/pcap/", handler: s.handlePcapAnalysis, feature: "pcap_ingest"},
+	})
 }
 
-// registerSSERoutes registers Server-Sent Events endpoints for real-time streaming.
+// registerSSERoutes registers Server-Sent Events streams (auth only).
 func (s *Server) registerSSERoutes(mux *http.ServeMux) {
-	mux.HandleFunc("/api/v1/stream/packets", s.recoverMiddleware(s.auth(s.handleSSEPackets)))
-	mux.HandleFunc("/api/v1/stream/logs", s.recoverMiddleware(s.auth(s.handleSSELogs)))
-	mux.HandleFunc("/api/v1/stream/stats", s.recoverMiddleware(s.auth(s.handleSSEStats)))
-	mux.HandleFunc("/api/v1/stream/status", s.recoverMiddleware(s.auth(s.handleSSEStatus)))
+	s.registerAll(mux, []apiRoute{
+		{path: "/api/v1/stream/packets", handler: s.handleSSEPackets},
+		{path: "/api/v1/stream/logs", handler: s.handleSSELogs},
+		{path: "/api/v1/stream/stats", handler: s.handleSSEStats},
+		{path: "/api/v1/stream/status", handler: s.handleSSEStatus},
+	})
 }
 
 // newSecureHTTPServer creates an HTTP server with security timeouts configured.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -261,6 +261,7 @@ type Server struct {
 	captureController CaptureController
 	startTime         time.Time
 	rateLimiter       *RateLimiter
+	routeManifest     []apiRoute // capability registry: routes registered via register() (route.go)
 	// csrf manages per-session CSRF tokens (#1257). Pre-port niac
 	// shared one global token across all clients; the manager keys
 	// tokens by sha256(bearer) so each session has its own.

--- a/scripts/check-route-policy.sh
+++ b/scripts/check-route-policy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# check-route-policy.sh — capability-registry enforcement gate.
+#
+# Every API route MUST be registered through the capability registry
+# (register / registerAll in internal/api/route.go), which composes its
+# per-route policy — auth, rate limiting, CSRF, admin scope, license feature —
+# in ONE canonical order. Hand-wrapping a route directly via
+# mux.HandleFunc("/api/...") bypasses that composition and is how a mutating
+# route can silently ship without CSRF or scope enforcement (the foot-gun the
+# audit flagged in the old registerReadOnlyRoutes mix).
+#
+# This gate fails if any "/api/..." path is registered directly instead of via
+# register(). register() installs routes with a variable path (rt.path), so it
+# never matches; only direct literal registrations do. The unauthenticated
+# introspection endpoints (/__version, /__capabilities) and the SPA/metrics
+# catch-alls are not /api/ literals and are intentionally direct.
+#
+# Run locally: scripts/check-route-policy.sh
+set -euo pipefail
+
+API_DIR="internal/api"
+
+violations=$(grep -rnE 'mux\.HandleFunc\("/api/' "$API_DIR"/*.go \
+	| grep -v '_test.go' || true)
+
+if [[ -n "$violations" ]]; then
+	echo "❌ Route-policy gate: API routes must be registered through the"
+	echo "   capability registry (registerAll/register in route.go), not via a"
+	echo "   raw mux.HandleFunc(\"/api/...\"). A direct registration skips the"
+	echo "   auth/rate-limit/CSRF/scope composition. Add an apiRoute{} entry to"
+	echo "   the appropriate register*Routes function instead."
+	echo ""
+	echo "$violations"
+	exit 1
+fi
+
+echo "✓ Route-policy gate: all /api routes go through the capability registry."


### PR DESCRIPTION
**Phase 3 enforcement (niac half).** Mirrors stem #401: replaces niac's hand-nested per-route middleware with a capability registry, so route policy is *enforced by construction*.

### What
- **`internal/api/route.go`** — `apiRoute{path, handler, rl, csrf, admin, feature}` + `register()`/`registerAll()` composing `recover → auth → rateLimit → csrf → admin → feature → handler` in one canonical order; a `routeManifest`; and **`/__capabilities`**.
- **`routes.go`** — all ~45 routes converted to declarative `apiRoute{}` entries, **preserving each route's exact rate limiter / CSRF / admin / feature** policy. The mutating routes that used to hide in `registerReadOnlyRoutes` are now visibly tagged `rl: rlWrite, csrf: true`.
- **`scripts/check-route-policy.sh`** (CI-wired) — fails if any `/api/` route is registered directly instead of via `register()`.
- **`route_test.go`** — verifies the manifest records policy (config/import = admin+csrf+write-limited).

### Verified
build ✅ · golangci golden config **0 issues** ✅ · full `internal/api` suite green ✅ (incl. the existing #740 CSRF-wiring regression test, which drives the real mux) · gate passes clean + fails on injection ✅

Completes 'registry for both repos'. niac's policy model is richer than stem's (write/walk/upload/file limiters + csrf + admin + license feature) — all captured declaratively.