### PR TITLE
docs(adr): capability-registry, depguard, auth-posture ADRs + index

### DIFF
--- a/docs/adr/0002-capability-registry.md
+++ b/docs/adr/0002-capability-registry.md
@@ -1,0 +1,50 @@
+# ADR 0002: Capability registry for route policy
+
+| Status  | Date       | Deciders         |
+|---------|------------|------------------|
+| Accepted | 2026-06-07 | @krisarmstrong   |
+
+## Context
+
+API routes were registered imperatively in `internal/api/routes.go`, each
+hand-nested with its middleware across multiple lines, e.g.
+`mux.HandleFunc(path, s.recoverMiddleware(s.auth(s.writeRateLimit(s.csrfProtect(h)))))`.
+Because each call site re-applied the chain by hand, the wrapping could be
+applied inconsistently or forgotten. In particular `registerReadOnlyRoutes`
+mixed genuinely-mutating routes (templates, configs, library CRUD, device
+subpaths) in with reads, each relying on the author remembering to add
+`csrfProtect` + `writeRateLimit` — a foot-gun the security audit flagged.
+
+## Decision
+
+Routes are declared as **data** and a single `register()` / `registerAll()`
+composes their per-route policy in **one canonical order**:
+`recover → auth → rateLimit → csrf → admin → feature → handler`. A route is an
+`apiRoute{path, handler, rl, csrf, admin, feature}` value (`internal/api/route.go`).
+`register()` records each route in a manifest and installs it on the mux.
+
+Supporting mechanisms:
+
+- `GET /__capabilities` serves the route-policy manifest (rate-limit / CSRF /
+  admin / feature per route) for deployment and audit.
+- `scripts/check-route-policy.sh` (a CI gate) fails if any `/api/` route is
+  registered directly via `mux.HandleFunc` instead of through `register()`.
+
+## Consequences
+
+- A route cannot ship without its policy; the manifest makes the policy visible
+  in one place, and the previously-hidden mutating routes are now explicitly
+  tagged `rl: rlWrite, csrf: true`.
+- Mirrors stem's capability registry and seed's ADR-0002, harmonizing the fleet
+  while each repo keeps its own implementation (niac's policy model is
+  scope-based with multiple rate limiters + a license feature).
+
+## Alternatives considered
+
+- **A grep-only CI gate** without the registry: catches a direct registration
+  but does not prevent it. Rejected as a band-aid (kept only as a complement).
+- **Status quo (hand-nested middleware)**: the source of the foot-gun.
+
+## Related issues and PRs
+
+- #800 (this registry: `route.go`, `/__capabilities`, `check-route-policy.sh`)

--- a/docs/adr/0003-dependency-direction-depguard.md
+++ b/docs/adr/0003-dependency-direction-depguard.md
@@ -1,0 +1,38 @@
+# ADR 0003: Dependency direction enforced by depguard
+
+| Status  | Date       | Deciders         |
+|---------|------------|------------------|
+| Accepted | 2026-06-07 | @krisarmstrong   |
+
+## Context
+
+NIAC is already capability-first/flat (no hexagon rings). The simulation/domain
+core — `internal/protocols`, `internal/converter`, `internal/device`,
+`internal/mibdb` — should not depend on the web/API layer (`internal/api`); the
+transport is composed at `internal/api` and `internal/daemon`. This direction
+was clean **by convention** but unenforced, so a future upward import would
+compile and ship silently. (Unlike stem, niac's `internal/api` is legitimately
+imported by orchestration layers — daemon/ipc/replay — so the rule targets the
+genuinely-inward domain packages, not a blanket "nothing imports api".)
+
+## Decision
+
+Add a `depguard` rule (`domain-core-inward-only`) to `.golangci.yml` barring
+`internal/{protocols,converter,device,mibdb}` from importing `internal/api`.
+golangci-lint runs the strict golden config, so the direction becomes a hard CI
+gate.
+
+## Consequences
+
+- An upward import from the domain core now fails CI with an actionable message
+  instead of silently coupling core to transport — enforcement by construction.
+- Clean on the current tree (`depguard: 0 issues`).
+
+## Alternatives considered
+
+- **Convention + code review** (status quo): left the direction unenforced.
+  Rejected.
+
+## Related issues and PRs
+
+- #799 (this rule)

--- a/docs/adr/0004-scope-based-auth-posture.md
+++ b/docs/adr/0004-scope-based-auth-posture.md
@@ -1,0 +1,52 @@
+# ADR 0004: Scope-based bearer-token auth + CSRF posture
+
+| Status  | Date       | Deciders         |
+|---------|------------|------------------|
+| Accepted | 2026-06-07 | @krisarmstrong   |
+
+## Context
+
+NIAC is a network-device simulator driven by operators and automation. It has no
+interactive login or password store; access is via operator-provisioned bearer
+tokens. The requirement is to distinguish read-only consumers (dashboards,
+monitoring) from read-write operators and from administrative whole-topology
+operations, without a full user/role system. This ADR records the security model
+already implemented (and hardened in this pass) so it is a deliberate, durable
+decision rather than incidental.
+
+## Decision
+
+- **Scope-based bearer tokens.** A `TokenStore` issues tokens at one of three
+  scopes — `ReadOnly` < `ReadWrite` < `Admin`. The `auth()` middleware enforces
+  **scope-by-method** (`RequiredScopeForMethod`): safe methods need ReadOnly,
+  mutating methods need ReadWrite. `adminProtect` gates whole-config replacement
+  (`POST /api/v1/config/import`) at Admin and fails closed.
+- **Per-session CSRF**, keyed by `sha256(bearer)` (`CSRFManager`), constant-time
+  compared, fail-closed for mutating requests.
+- **No usable default credentials.** A non-loopback bind refuses to start without
+  a token (re-checked at request time as defense in depth); empty token values
+  and token files wider than `0600` are rejected at load.
+- **Authorization denials emit `event=auth.forbidden`** with `reason=scope` for
+  SIEM filtering.
+- **CORS is same-origin only** (reflects the origin only when it equals the
+  request host); there is no arbitrary-origin reflection.
+
+## Consequences
+
+- Automation gets least-privilege tokens (read-only monitors can't mutate);
+  whole-topology replacement requires an explicit admin token.
+- The route-policy registry (ADR-0002) structurally enforces that mutating
+  routes carry `csrfProtect` + the write rate limiter, so the scope/CSRF wrapping
+  can no longer be forgotten on a new route.
+- No login surface means no dedicated login rate limiter; the generic per-IP
+  limiter throttles token-guessing, which is acceptable given high-entropy tokens
+  + constant-time lookup. A future interactive-login requirement would revisit.
+
+## Alternatives considered
+
+- **Full user accounts + roles**: heavier than an operator/automation appliance
+  needs; the scope model covers the privilege tiers that matter. Deferred.
+
+## Related issues and PRs
+
+- #798 (govulncheck pin), #800 (route-policy registry that locks in the wrapping)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+Durable record of significant architectural decisions for NIAC. Each ADR
+captures Context, Decision, and Consequences so the reasoning survives the
+people and the diffs. Format matches the sibling repos (seed/stem).
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-schema-generation-from-go-structs.md) | Schema generation from Go structs | Accepted |
+| [0002](0002-capability-registry.md) | Capability registry for route policy | Accepted |
+| [0003](0003-dependency-direction-depguard.md) | Dependency direction enforced by depguard | Accepted |
+| [0004](0004-scope-based-auth-posture.md) | Scope-based bearer-token auth + CSRF posture | Accepted |
+
+Status values: Proposed · Accepted · Amended · Superseded.


### PR DESCRIPTION
**Phase 4 (durable decisions).** niac had one ADR (0001). Add a `docs/adr/` index + three ADRs capturing this pass's decisions:

- **0002** Capability registry for route policy — #800
- **0003** Dependency direction enforced by depguard — #799
- **0004** Scope-based bearer-token auth + CSRF posture (records the deliberate security model: TokenScope ReadOnly<ReadWrite<Admin, adminProtect, sha256(bearer) CSRF, auth.forbidden, non-loopback token gate) — #798/#800

Matches seed/stem ADR format. Docs only.