### PR TITLE
refactor(api): extract CSRF manager into internal/api/csrf leaf package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -262,6 +262,12 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/niac-go/internal/api
               desc: "ratelimit is a leaf — per-IP limiter + middleware factories take injected ClientIPFunc/ErrorFunc, so it never imports the api transport layer"
+        "api-csrf-isolated":
+          files:
+            - "**/internal/api/csrf/**"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/niac-go/internal/api
+              desc: "csrf is a leaf — per-session token manager + Protect factory (injected ErrorFunc), so it never imports the api transport layer"
 
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.

--- a/internal/api/csrf/manager.go
+++ b/internal/api/csrf/manager.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-package api
+package csrf
 
 import (
 	"context"
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-// CSRF manager configuration constants. Mirrors stem's CSRFManager
+// CSRF manager configuration constants. Mirrors stem's Manager
 // (#1257 sub-4 port) so the per-session model and the 24h expiry are
 // uniform across the two repos.
 const (
@@ -46,28 +46,28 @@ type csrfTokenEntry struct {
 	expiresAt time.Time
 }
 
-// CSRFManager mints, stores, and validates per-session CSRF tokens.
+// Manager mints, stores, and validates per-session CSRF tokens.
 // Keyed by sha256(bearer-token) so the bearer plaintext is never
 // retained in memory.
 //
-// #1257 (Wave 5) sub-4: port of stem's CSRFManager pattern. Pre-port
+// #1257 (Wave 5) sub-4: port of stem's Manager pattern. Pre-port
 // niac shared a single global CSRF token across all clients which,
 // while functionally protective against cross-site requests, meant
 // any client could replay another's value. The per-session model
 // pins each token to its issuer.
-type CSRFManager struct {
+type Manager struct {
 	mu     sync.RWMutex
 	tokens map[string]*csrfTokenEntry
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
-// NewCSRFManager constructs a manager and starts its cleanup loop.
+// NewManager constructs a manager and starts its cleanup loop.
 // Stop the returned manager via Stop() during server shutdown to
 // terminate the background goroutine.
-func NewCSRFManager() *CSRFManager {
+func NewManager() *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
-	m := &CSRFManager{
+	m := &Manager{
 		tokens: make(map[string]*csrfTokenEntry),
 		ctx:    ctx,
 		cancel: cancel,
@@ -77,7 +77,7 @@ func NewCSRFManager() *CSRFManager {
 	return m
 }
 
-// SessionKey derives the CSRFManager's session key from a bearer
+// SessionKey derives the Manager's session key from a bearer
 // token. Hashing the bearer prevents storing the plaintext in the
 // manager's internal map (already-hashed values keep the manager's
 // memory profile uniform regardless of bearer length / format).
@@ -92,7 +92,7 @@ func SessionKey(bearer string) string {
 
 // Generate mints a fresh CSRF token for the given session key,
 // replacing any existing one.
-func (m *CSRFManager) Generate(sessionKey string) (string, error) {
+func (m *Manager) Generate(sessionKey string) (string, error) {
 	buf := make([]byte, csrfPerSessionTokenLength)
 	if _, err := rand.Read(buf); err != nil {
 		return "", fmt.Errorf("generate CSRF token: %w", err)
@@ -120,7 +120,7 @@ func (m *CSRFManager) Generate(sessionKey string) (string, error) {
 // token that no longer matches the stored entry, which makes its next
 // X-Csrf-Token request fail validation with 403. Surfaced as an
 // intermittent TestAlertConfig_ConcurrentUpdates failure under -race.
-func (m *CSRFManager) GetOrCreate(sessionKey string) (string, error) {
+func (m *Manager) GetOrCreate(sessionKey string) (string, error) {
 	m.mu.RLock()
 	entry, ok := m.tokens[sessionKey]
 	m.mu.RUnlock()
@@ -154,7 +154,7 @@ func (m *CSRFManager) GetOrCreate(sessionKey string) (string, error) {
 // stored for sessionKey. Returns one of errCSRFTokenMissing /
 // errCSRFTokenInvalid / errCSRFTokenExpired so callers can render
 // different messages or audit-log differently per failure mode.
-func (m *CSRFManager) Validate(sessionKey, token string) error {
+func (m *Manager) Validate(sessionKey, token string) error {
 	if token == "" {
 		return errCSRFTokenMissing
 	}
@@ -184,13 +184,13 @@ func (m *CSRFManager) Validate(sessionKey, token string) error {
 }
 
 // Stop terminates the background cleanup goroutine. Idempotent.
-func (m *CSRFManager) Stop() {
+func (m *Manager) Stop() {
 	m.cancel()
 }
 
 // cleanupLoop sweeps expired tokens from the map at a fixed cadence
 // so memory doesn't grow unbounded across long-running sessions.
-func (m *CSRFManager) cleanupLoop() {
+func (m *Manager) cleanupLoop() {
 	ticker := time.NewTicker(time.Duration(csrfPerSessionCleanupSeconds) * time.Second)
 	defer ticker.Stop()
 	for {
@@ -210,10 +210,10 @@ func (m *CSRFManager) cleanupLoop() {
 	}
 }
 
-// sessionKeyFromRequest derives the CSRF session key for the request
-// from its Authorization header. Mirrors the bearer extraction in
-// auth() so the same token always hashes to the same key.
-func sessionKeyFromRequest(r *http.Request) string {
+// SessionKeyFromRequest derives the CSRF session key for a request from its
+// Authorization header. Mirrors the bearer extraction in the api auth
+// middleware so the same token always hashes to the same key.
+func SessionKeyFromRequest(r *http.Request) string {
 	authz := r.Header.Get("Authorization")
 	if authz == "" {
 		return csrfLoopbackSessionKey

--- a/internal/api/csrf/manager_test.go
+++ b/internal/api/csrf/manager_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-package api
+package csrf
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 // invalid for session B even with identical content.
 func TestCSRFManager_PerSessionIsolation(t *testing.T) {
 	t.Parallel()
-	m := NewCSRFManager()
+	m := NewManager()
 	t.Cleanup(m.Stop)
 
 	tokenA, genErrA := m.Generate(SessionKey("bearer-A"))
@@ -61,7 +61,7 @@ func TestCSRFManager_LoopbackBypassSharesKey(t *testing.T) {
 // error codes / messages per cause.
 func TestCSRFManager_ValidateErrorClassification(t *testing.T) {
 	t.Parallel()
-	m := NewCSRFManager()
+	m := NewManager()
 	t.Cleanup(m.Stop)
 
 	// Missing.
@@ -88,7 +88,7 @@ func TestCSRFManager_ValidateErrorClassification(t *testing.T) {
 // every in-flight request when it polls.
 func TestCSRFManager_GetOrCreateIsIdempotent(t *testing.T) {
 	t.Parallel()
-	m := NewCSRFManager()
+	m := NewManager()
 	t.Cleanup(m.Stop)
 
 	first, err := m.GetOrCreate("session")
@@ -118,7 +118,7 @@ func TestCSRFManager_GetOrCreateIsIdempotent(t *testing.T) {
 // accept every one of those returned tokens.
 func TestCSRFManager_GetOrCreate_ConcurrentSameSession(t *testing.T) {
 	t.Parallel()
-	m := NewCSRFManager()
+	m := NewManager()
 	t.Cleanup(m.Stop)
 
 	const (

--- a/internal/api/csrf/protect.go
+++ b/internal/api/csrf/protect.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package csrf
+
+import (
+	"errors"
+	"net/http"
+)
+
+// ErrorFunc writes a structured error response. CSRF rejections carry no
+// structured details, so the signature is intentionally narrower than the api
+// package's writeError (which takes a []ErrorDetail the leaf must not import).
+// The api package adapts writeError to this type.
+type ErrorFunc func(w http.ResponseWriter, r *http.Request, status int, code, message string)
+
+// Protect wraps a handler so state-changing methods (POST/PUT/PATCH/DELETE)
+// require a valid per-session CSRF token; safe methods pass through. #1257
+// sub-4 moved validation from a single global token to per-session tokens
+// keyed by sha256(bearer): each authenticated session has its own token, so a
+// leaked token from one client cannot unlock another's mutations.
+//
+// mgr nil is treated as a server misconfiguration (500) rather than a silent
+// bypass. writeErr renders the failure; the distinct error codes let the UI
+// react (missing → fetch a token, expired → refetch, invalid → hard 403).
+func Protect(mgr *Manager, writeErr ErrorFunc, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost || r.Method == http.MethodPut ||
+			r.Method == http.MethodPatch || r.Method == http.MethodDelete {
+			if mgr == nil {
+				writeErr(w, r, http.StatusInternalServerError, "csrf_unavailable",
+					"CSRF protection is unavailable, server misconfigured")
+				return
+			}
+			clientToken := r.Header.Get(csrfHeaderName)
+			sessionKey := SessionKeyFromRequest(r)
+			switch err := mgr.Validate(sessionKey, clientToken); {
+			case err == nil:
+				// passes
+			case errors.Is(err, errCSRFTokenMissing):
+				writeErr(w, r, http.StatusForbidden, "csrf_token_missing",
+					"CSRF token required for state-changing requests. Include X-CSRF-Token header.")
+				return
+			case errors.Is(err, errCSRFTokenExpired):
+				writeErr(w, r, http.StatusForbidden, "csrf_token_expired",
+					"CSRF token expired; refetch /api/v1/csrf-token")
+				return
+			default:
+				writeErr(w, r, http.StatusForbidden, "csrf_token_invalid",
+					"Invalid CSRF token")
+				return
+			}
+		}
+
+		next(w, r)
+	}
+}

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/capture"
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
@@ -594,7 +596,7 @@ func (s *Server) handleCSRFToken(w http.ResponseWriter, r *http.Request) {
 	// caller's bearer (or the loopback bypass key on no-token paths).
 	// Same caller fetching twice within the 24h expiry gets the same
 	// value, so the UI can cache it.
-	token, err := s.csrf.GetOrCreate(sessionKeyFromRequest(r))
+	token, err := s.csrf.GetOrCreate(csrf.SessionKeyFromRequest(r))
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "[API] CSRF token mint failed", "error", err)
 		http.Error(w, "csrf token unavailable", http.StatusInternalServerError)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
@@ -371,9 +373,9 @@ func TestCSRFProtection(t *testing.T) {
 	server, _ := createTestServer(t)
 	// #1257: per-session CSRF manager; mint the loopback-bypass
 	// token so the "valid" subtest can present it.
-	server.csrf = NewCSRFManager()
+	server.csrf = csrf.NewManager()
 	t.Cleanup(server.csrf.Stop)
-	validToken, err := server.csrf.Generate(SessionKey(""))
+	validToken, err := server.csrf.Generate(csrf.SessionKey(""))
 	if err != nil {
 		t.Fatalf("mint CSRF: %v", err)
 	}
@@ -382,7 +384,7 @@ func TestCSRFProtection(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	protected := server.csrfProtect(handler)
+	protected := csrf.Protect(server.csrf, simpleErr, handler)
 
 	t.Run("GET request allowed", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -32,52 +31,6 @@ func withScope(ctx context.Context, scope tokenstore.TokenScope) context.Context
 func scopeFromContext(ctx context.Context) (tokenstore.TokenScope, bool) {
 	v, ok := ctx.Value(scopeContextKey{}).(tokenstore.TokenScope)
 	return v, ok
-}
-
-// csrfProtect wraps handlers that modify state and require CSRF token
-// validation. #1257 sub-4 moved validation from a single global token
-// to per-session tokens keyed by sha256(bearer): each authenticated
-// session has its own CSRF token, so a leaked / harvested token from
-// one client doesn't unlock another's mutations.
-func (s *Server) csrfProtect(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Only check CSRF for state-changing methods.
-		if r.Method == http.MethodPost || r.Method == http.MethodPut ||
-			r.Method == http.MethodPatch || r.Method == http.MethodDelete {
-			if s.csrf == nil {
-				writeError(w, r, http.StatusInternalServerError, "csrf_unavailable",
-					"CSRF protection is unavailable, server misconfigured", nil)
-
-				return
-			}
-			clientToken := r.Header.Get("X-Csrf-Token")
-			sessionKey := sessionKeyFromRequest(r)
-			switch err := s.csrf.Validate(sessionKey, clientToken); {
-			case err == nil:
-				// passes
-			case errors.Is(err, errCSRFTokenMissing):
-				writeError(
-					w, r, http.StatusForbidden, "csrf_token_missing",
-					"CSRF token required for state-changing requests. Include X-CSRF-Token header.",
-					nil,
-				)
-
-				return
-			case errors.Is(err, errCSRFTokenExpired):
-				writeError(w, r, http.StatusForbidden, "csrf_token_expired",
-					"CSRF token expired; refetch /api/v1/csrf-token", nil)
-
-				return
-			default:
-				writeError(w, r, http.StatusForbidden, "csrf_token_invalid",
-					"Invalid CSRF token", nil)
-
-				return
-			}
-		}
-
-		next(w, r)
-	}
 }
 
 // addSecurityHeaders adds security headers to all HTTP responses

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
@@ -84,14 +86,14 @@ func TestRecoverMiddlewareNoPanic(t *testing.T) {
 
 func TestCSRFProtectionGETAllowed(t *testing.T) {
 	server := createTestServerForMiddleware(t)
-	server.csrf = NewCSRFManager()
+	server.csrf = csrf.NewManager()
 	t.Cleanup(server.csrf.Stop)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrapped := server.csrfProtect(handler)
+	wrapped := csrf.Protect(server.csrf, simpleErr, handler)
 
 	// GET should always be allowed
 	for _, method := range []string{"GET", "HEAD", "OPTIONS"} {
@@ -110,12 +112,12 @@ func TestCSRFProtectionGETAllowed(t *testing.T) {
 
 func TestCSRFProtectionStateMethods(t *testing.T) {
 	server := createTestServerForMiddleware(t)
-	server.csrf = NewCSRFManager()
+	server.csrf = csrf.NewManager()
 	t.Cleanup(server.csrf.Stop)
 
 	// Mint the per-session token for the loopback bypass key (no
 	// Authorization header => csrfLoopbackSessionKey).
-	validToken, err := server.csrf.Generate(SessionKey(""))
+	validToken, err := server.csrf.Generate(csrf.SessionKey(""))
 	if err != nil {
 		t.Fatalf("mint CSRF: %v", err)
 	}
@@ -124,7 +126,7 @@ func TestCSRFProtectionStateMethods(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrapped := server.csrfProtect(handler)
+	wrapped := csrf.Protect(server.csrf, simpleErr, handler)
 
 	// State-changing methods require CSRF token
 	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
@@ -174,7 +176,7 @@ func TestCSRFProtectionRejectsWhenNoToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrapped := server.csrfProtect(handler)
+	wrapped := csrf.Protect(server.csrf, simpleErr, handler)
 
 	// POST must be rejected when csrfToken is empty (fail-closed security)
 	req := httptest.NewRequest(http.MethodPost, "/test", nil)

--- a/internal/api/route.go
+++ b/internal/api/route.go
@@ -11,13 +11,16 @@ package api
 import (
 	"net/http"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
 )
 
-// rateLimitErr adapts the api package's writeError to ratelimit.ErrorFunc.
-// Rate-limit rejections carry no structured details, so the adapter always
-// passes nil — this keeps the ratelimit leaf free of any api type (ErrorDetail).
-func rateLimitErr(w http.ResponseWriter, r *http.Request, status int, code, message string) {
+// simpleErr adapts the api package's writeError to the narrow ErrorFunc that the
+// ratelimit and csrf leaf packages accept. Those middleware rejections carry no
+// structured details, so the adapter always passes nil — keeping the leaves free
+// of any api type (ErrorDetail).
+func simpleErr(w http.ResponseWriter, r *http.Request, status int, code, message string) {
 	writeError(w, r, status, code, message, nil)
 }
 
@@ -42,7 +45,7 @@ type apiRoute struct {
 	handler http.HandlerFunc
 	// rl selects the rate limiter (rlNone for unmetered reads/streams).
 	rl rateLimitKind
-	// csrf wraps the route in csrfProtect (csrfProtect itself skips safe GETs).
+	// csrf wraps the route in csrf.Protect (which itself skips safe GETs).
 	csrf bool
 	// admin requires an admin-scoped token (adminProtect) — whole-topology ops.
 	admin bool
@@ -66,19 +69,19 @@ func (s *Server) register(mux *http.ServeMux, rt apiRoute) {
 		h = s.adminProtect(h)
 	}
 	if rt.csrf {
-		h = s.csrfProtect(h)
+		h = csrf.Protect(s.csrf, simpleErr, h)
 	}
 	switch rt.rl {
 	case rlNone:
 		// no rate limiter
 	case rlWrite:
-		h = ratelimit.Write(s.writeLimiter, s.logger, getClientIP, rateLimitErr, h)
+		h = ratelimit.Write(s.writeLimiter, s.logger, getClientIP, simpleErr, h)
 	case rlWalk:
-		h = ratelimit.Walk(s.walkLimiter, s.logger, getClientIP, rateLimitErr, h)
+		h = ratelimit.Walk(s.walkLimiter, s.logger, getClientIP, simpleErr, h)
 	case rlUpload:
-		h = ratelimit.Upload(s.uploadLimiter, s.logger, getClientIP, rateLimitErr, h)
+		h = ratelimit.Upload(s.uploadLimiter, s.logger, getClientIP, simpleErr, h)
 	case rlFile:
-		h = ratelimit.File(s.fileLimiter, s.logger, getClientIP, rateLimitErr, h)
+		h = ratelimit.File(s.fileLimiter, s.logger, getClientIP, simpleErr, h)
 	}
 	h = s.auth(h)
 	h = s.recoverMiddleware(h)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
@@ -269,7 +271,7 @@ type Server struct {
 	// csrf manages per-session CSRF tokens (#1257). Pre-port niac
 	// shared one global token across all clients; the manager keys
 	// tokens by sha256(bearer) so each session has its own.
-	csrf           *CSRFManager
+	csrf           *csrf.Manager
 	sseHub         *SSEHub
 	uploadLimiter  *ratelimit.RateLimiter
 	writeLimiter   *ratelimit.RateLimiter
@@ -313,7 +315,7 @@ func NewServer(cfg ServerConfig) *Server {
 		logger:        slog.Default(),
 		startTime:     time.Now(),
 		rateLimiter:   ratelimit.NewRateLimiter(DefaultRateLimit, DefaultBurst),
-		csrf:          NewCSRFManager(),
+		csrf:          csrf.NewManager(),
 		sseHub:        NewSSEHub(SSEConfig{}),
 		bgStop:        make(chan struct{}),
 		uploadLimiter: ratelimit.NewRateLimiter(UploadRateLimit, UploadBurst),

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
@@ -33,7 +35,7 @@ func newTestServerWithAuth(t *testing.T) (*Server, string, string) {
 
 	// Initialize server components
 	server.rateLimiter = ratelimit.NewRateLimiter(DefaultRateLimit, DefaultBurst)
-	server.csrf = NewCSRFManager()
+	server.csrf = csrf.NewManager()
 	t.Cleanup(server.csrf.Stop)
 
 	// Generate auth token. Wave 2: seed the tokenstore.TokenStore directly. The
@@ -52,7 +54,7 @@ func newTestServerWithAuth(t *testing.T) (*Server, string, string) {
 // the pre-#1257 testCSRFToken(t, server, token) global the old tests reached for.
 func testCSRFToken(t *testing.T, server *Server, bearer string) string {
 	t.Helper()
-	tok, err := server.csrf.GetOrCreate(SessionKey(bearer))
+	tok, err := server.csrf.GetOrCreate(csrf.SessionKey(bearer))
 	if err != nil {
 		t.Fatalf("mint test CSRF token: %v", err)
 	}
@@ -133,7 +135,7 @@ func TestCSRF_TokenValidation(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.csrfProtect(server.handleAlerts))
+	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusOK {
@@ -156,7 +158,7 @@ func TestCSRF_InvalidTokenRejection(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.csrfProtect(server.handleAlerts))
+	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusForbidden {
@@ -179,7 +181,7 @@ func TestCSRF_MissingTokenRejection(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.csrfProtect(server.handleAlerts))
+	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusForbidden {
@@ -462,7 +464,7 @@ func TestAlertConfig_ConcurrentUpdates(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			handler := server.auth(server.csrfProtect(server.handleAlerts))
+			handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 			handler(w, req)
 
 			if w.Code != http.StatusOK {
@@ -502,7 +504,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.csrfProtect(server.handleAlerts))
+	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusOK {
@@ -562,7 +564,7 @@ func TestAlertConfig_GoroutineCleanup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		handler := server.auth(server.csrfProtect(server.handleAlerts))
+		handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 		handler(w, req)
 
 		if w.Code != http.StatusOK {


### PR DESCRIPTION
## What

Third step of the `internal/api` decomposition (**ADR-0006**, follows tokenstore #804, ratelimit #805). The per-session CSRF token manager and the `csrfProtect` middleware move into **`internal/api/csrf`**.

## How

- The manager moves as **`csrf.Manager`** (renamed from `CSRFManager` to avoid the `csrf.CSRFManager` stutter) + `csrf.NewManager`; `SessionKey`/`Generate`/`GetOrCreate`/`Validate`/`Stop`/cleanup come with it. The session-key helper is exported as **`csrf.SessionKeyFromRequest`** (handlers_read.go needs it for `/csrf-token`); the error vars, header const, and token entry stay unexported in the leaf.
- **`csrfProtect` → `csrf.Protect(mgr, writeErr, next)`**: a free factory taking a narrow `ErrorFunc` (no api `ErrorDetail`), so the leaf imports no api type. The nil-manager 500 guard moves inside. `route.go` composes `csrf.Protect(s.csrf, simpleErr, h)`; the rate-limit adapter `rateLimitErr` is renamed `simpleErr` and shared by both leaf middlewares.
- `middleware.go` loses `csrfProtect` (and its now-unused `errors` import).
- `csrf_manager_test.go` moves to `package csrf`; api test files use the exported surface.
- `depguard` gains **`api-csrf-isolated`**.

## Verification

`go build`, `go vet`, `golangci-lint` (**0 issues**, new rule passes), `go test -race ./internal/api/... ./internal/daemon/...` (all pass), `gofumpt -l` clean, route-policy gate green. No behavioural change (per-session keying + middleware order + `/__capabilities` unchanged).