### PR TITLE
refactor(api): extract auth middleware into internal/api/auth leaf package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -274,6 +274,13 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/niac-go/internal/api
               desc: "sse is a leaf — hub/engine + Serve factory; it may import internal/protocols (inward) for the packet observer, but never the api transport layer"
+        # internal/api/auth has NO isolation rule by design. Unlike the four
+        # leaves above, auth COMPOSES siblings (internal/api/tokenstore +
+        # ratelimit), and a deny on "internal/api" prefix-matches those sibling
+        # packages too. It's also redundant: internal/api imports auth
+        # (route.go wires auth.Middleware), so auth importing internal/api back
+        # is already a compile-time import cycle. The boundary is enforced by
+        # Go itself; auth takes the remaining api concerns as injected deps.
 
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.

--- a/internal/api/admin_scope_test.go
+++ b/internal/api/admin_scope_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
 )
 
@@ -43,7 +45,7 @@ func TestAdminProtect_Matrix(t *testing.T) {
 		{
 			name: "read-only token => forbidden",
 			setup: func(r *http.Request) *http.Request {
-				return r.WithContext(withScope(r.Context(), tokenstore.ScopeReadOnly))
+				return r.WithContext(auth.WithScope(r.Context(), tokenstore.ScopeReadOnly))
 			},
 			wantStatus: http.StatusForbidden,
 			wantCalled: false,
@@ -51,7 +53,7 @@ func TestAdminProtect_Matrix(t *testing.T) {
 		{
 			name: "read-write token => forbidden (write != admin)",
 			setup: func(r *http.Request) *http.Request {
-				return r.WithContext(withScope(r.Context(), tokenstore.ScopeReadWrite))
+				return r.WithContext(auth.WithScope(r.Context(), tokenstore.ScopeReadWrite))
 			},
 			wantStatus: http.StatusForbidden,
 			wantCalled: false,
@@ -59,7 +61,7 @@ func TestAdminProtect_Matrix(t *testing.T) {
 		{
 			name: "admin token => passes through",
 			setup: func(r *http.Request) *http.Request {
-				return r.WithContext(withScope(r.Context(), tokenstore.ScopeAdmin))
+				return r.WithContext(auth.WithScope(r.Context(), tokenstore.ScopeAdmin))
 			},
 			wantStatus: http.StatusOK,
 			wantCalled: true,
@@ -77,7 +79,7 @@ func TestAdminProtect_Matrix(t *testing.T) {
 				called = true
 				w.WriteHeader(http.StatusOK)
 			})
-			gated := server.adminProtect(probe)
+			gated := auth.AdminProtect(server.logger, getClientIP, simpleErr, probe)
 
 			req := c.setup(httptest.NewRequest(http.MethodPost, "/api/v1/config/import", nil))
 			w := httptest.NewRecorder()
@@ -108,13 +110,13 @@ func TestAuth_StashesScopeOnContext(t *testing.T) {
 	var captured tokenstore.TokenScope
 	var capturedOK bool
 	tail := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		captured, capturedOK = scopeFromContext(r.Context())
+		captured, capturedOK = auth.ScopeFromContext(r.Context())
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/something", nil)
 	req.Header.Set("Authorization", "Bearer admin-token")
 	w := httptest.NewRecorder()
-	server.auth(tail)(w, req)
+	auth.Middleware(server.authDeps(), tail)(w, req)
 
 	if !capturedOK {
 		t.Fatal("auth() did not stash scope on context")

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
+	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
+)
+
+// ErrorFunc writes a structured error response. Auth rejections carry no
+// structured details, so the signature is narrower than the api package's
+// writeError (which takes a []ErrorDetail this leaf must not import); the api
+// package adapts writeError to this type.
+type ErrorFunc func(w http.ResponseWriter, r *http.Request, status int, code, message string)
+
+// ClientIPFunc extracts the client IP from a request (the api injects its
+// getClientIP, which encodes the proxy-header policy).
+type ClientIPFunc func(*http.Request) string
+
+// Deps are the dependencies Middleware needs. Data values (RateLimiter, Logger,
+// Addr) are captured at registration; Tokens is a getter so a SIGHUP token
+// rotation that swaps the store is still seen on the next request. The function
+// values are the api-specific concerns the leaf must not own.
+type Deps struct {
+	// Tokens returns the currently-active token store. A getter (not a value)
+	// so token rotation via SetTokens is reflected per request.
+	Tokens          func() *tokenstore.TokenStore
+	RateLimiter     *ratelimit.RateLimiter
+	Logger          *slog.Logger
+	Addr            string
+	SecurityHeaders func(http.ResponseWriter, *http.Request)
+	RequestID       func() string
+	ClientIP        ClientIPFunc
+	WriteErr        ErrorFunc
+	NonLoopback     func(addr string) (bool, error)
+}
+
+// Middleware wraps a handler with request-ID tagging, security headers, per-IP
+// rate limiting, bearer-token authentication, and scope enforcement. It stashes
+// the resolved scope on the request context (see WithScope) for downstream
+// gates like AdminProtect. Logic is unchanged from the previous *Server method;
+// only the dependencies are now injected.
+func Middleware(d Deps, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// FEATURE #118: unique request ID for tracing.
+		requestID := d.RequestID()
+		r.Header.Set("X-Request-ID", requestID)
+		w.Header().Set("X-Request-ID", requestID)
+
+		d.SecurityHeaders(w, r)
+
+		// FEATURE #104: per-IP rate limiting.
+		clientIP := d.ClientIP(r)
+		if !d.RateLimiter.GetLimiter(clientIP).Allow() {
+			d.WriteErr(w, r, http.StatusTooManyRequests, "rate_limit_exceeded",
+				"Rate limit exceeded. Please try again later.")
+			d.Logger.WarnContext(r.Context(), "[API] Rate limit exceeded",
+				"event", "api.rate_limited",
+				"requestID", requestID,
+				"clientIP", clientIP,
+				"userAgent", r.UserAgent(),
+				"path", r.URL.Path)
+
+			return
+		}
+
+		// Wave 2: auth is keyed off the token store. An empty/unset store means
+		// "no auth configured". The startup gate already refuses to bind a
+		// non-loopback address without a token; #739 hardens this at request
+		// time too, so a refactor that weakens the startup gate can never
+		// silently expose a non-loopback listener. The bypass is allowed only
+		// when the bind is loopback-only OR the operator opted out via
+		// NIAC_AUTH_DISABLED=true.
+		tokens := d.Tokens()
+		if tokens == nil || tokens.Len() == 0 {
+			if os.Getenv("NIAC_AUTH_DISABLED") == "true" {
+				// #743: dev-only bypass — treat as admin so dev workflows can
+				// still exercise admin-gated routes.
+				next(w, r.WithContext(WithScope(r.Context(), tokenstore.ScopeAdmin)))
+
+				return
+			}
+			nonLoopback, _ := d.NonLoopback(d.Addr)
+			if !nonLoopback {
+				// Loopback-only, no token: the documented local-dev path.
+				// #743: stash admin so local-dev keeps full access.
+				next(w, r.WithContext(WithScope(r.Context(), tokenstore.ScopeAdmin)))
+
+				return
+			}
+			// Non-loopback + no token + no explicit opt-out. The startup gate
+			// should have prevented this; failing closed here is the
+			// defense-in-depth backstop.
+			d.Logger.ErrorContext(
+				r.Context(),
+				"[API] Refusing request: non-loopback bind has no tokens and NIAC_AUTH_DISABLED is not set",
+				"event",
+				"auth.misconfigured",
+				"requestID",
+				requestID,
+				"addr",
+				d.Addr,
+				"path",
+				r.URL.Path,
+			)
+			d.WriteErr(w, r, http.StatusUnauthorized, "auth_not_configured",
+				"Server is bound to a non-loopback address without authentication tokens. "+
+					"Set NIAC_API_TOKEN, or NIAC_AUTH_DISABLED=true to explicitly disable auth (development only).")
+
+			return
+		}
+
+		// Only accept the Authorization header (not query params, for security).
+		token := r.Header.Get("Authorization")
+		token = strings.TrimPrefix(token, "Bearer ")
+
+		scope, ok := tokens.Lookup(token)
+		if !ok {
+			d.WriteErr(w, r, http.StatusUnauthorized, "unauthorized",
+				"Invalid or missing authentication token")
+			d.Logger.WarnContext(r.Context(),
+				"[API] Unauthorized request",
+				"event", "auth.unauthorized",
+				"requestID", requestID,
+				"clientIP", clientIP,
+				"userAgent", r.UserAgent(),
+				"path", r.URL.Path,
+				"tokenPresent", token != "",
+			)
+
+			return
+		}
+
+		// Wave 2: scope enforcement. Safe methods (GET/HEAD/OPTIONS/TRACE)
+		// accept ScopeReadOnly; state-changing methods require ScopeReadWrite.
+		// A read-only token attempting a write returns 403 (valid token, just
+		// under-privileged) rather than 401.
+		required := tokenstore.RequiredScopeForMethod(r.Method)
+		if scope < required {
+			d.WriteErr(w, r, http.StatusForbidden, "forbidden", "token lacks required scope")
+			// #1257 (Wave 5): unified `event=auth.forbidden` across
+			// seed/niac/stem so SIEM rules can filter authz denials with one
+			// expression. `reason` distinguishes niac's scope-based denial from
+			// seed's role-based denial so detections can still split on mechanism.
+			d.Logger.WarnContext(r.Context(),
+				"[API] Forbidden request: token scope insufficient",
+				"event", "auth.forbidden",
+				"reason", "scope",
+				"requestID", requestID,
+				"clientIP", clientIP,
+				"userAgent", r.UserAgent(),
+				"path", r.URL.Path,
+				"method", r.Method,
+				"tokenScope", scope.String(),
+				"requiredScope", required.String(),
+			)
+			return
+		}
+
+		// #743: stash the resolved scope so AdminProtect (and future scope-aware
+		// middleware) can read it without re-doing token lookup.
+		next(w, r.WithContext(WithScope(r.Context(), scope)))
+	}
+}
+
+// AdminProtect wraps handlers that require ScopeAdmin (typically destructive
+// whole-config operations like /api/v1/config/import). Middleware must run
+// upstream — AdminProtect reads the scope it stashed; an unstashed context is
+// treated as 403 so missing wiring fails closed rather than silently bypassing.
+func AdminProtect(
+	logger *slog.Logger,
+	clientIP ClientIPFunc,
+	writeErr ErrorFunc,
+	next http.HandlerFunc,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		scope, ok := ScopeFromContext(r.Context())
+		if !ok || scope < tokenstore.ScopeAdmin {
+			writeErr(w, r, http.StatusForbidden, "forbidden",
+				"this operation requires an admin-scoped token")
+			logger.WarnContext(r.Context(),
+				"[API] Forbidden request: admin scope required",
+				"event", "auth.forbidden",
+				"reason", "scope",
+				"requestID", r.Header.Get("X-Request-ID"),
+				"clientIP", clientIP(r),
+				"userAgent", r.UserAgent(),
+				"path", r.URL.Path,
+				"method", r.Method,
+				"requiredScope", tokenstore.ScopeAdmin.String(),
+			)
+
+			return
+		}
+
+		next(w, r)
+	}
+}

--- a/internal/api/auth/middleware_test.go
+++ b/internal/api/auth/middleware_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth_test
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+}
+
+func testClientIP(*http.Request) string { return "203.0.113.1" }
+
+// recordErr is an auth.ErrorFunc that records the status it was asked to write.
+func recordErr(status *int) auth.ErrorFunc {
+	return func(w http.ResponseWriter, _ *http.Request, code int, _, _ string) {
+		*status = code
+		w.WriteHeader(code)
+	}
+}
+
+func TestScopeRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := auth.WithScope(t.Context(), tokenstore.ScopeAdmin)
+	got, ok := auth.ScopeFromContext(ctx)
+	if !ok {
+		t.Fatal("ScopeFromContext: ok=false after WithScope")
+	}
+	if got != tokenstore.ScopeAdmin {
+		t.Errorf("scope = %v, want %v", got, tokenstore.ScopeAdmin)
+	}
+}
+
+func TestScopeFromContext_Missing(t *testing.T) {
+	t.Parallel()
+	if _, ok := auth.ScopeFromContext(t.Context()); ok {
+		t.Error("ScopeFromContext on a bare context should report ok=false")
+	}
+}
+
+// TestAdminProtect_Matrix covers the gate's inputs: no scope (forbidden —
+// defense in depth for routes wired without auth upstream), under-privileged
+// scope (read-only and read-write both 403), and admin scope (passes).
+func TestAdminProtect_Matrix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		setup      func(*http.Request) *http.Request
+		wantStatus int
+		wantCalled bool
+	}{
+		{"no scope => forbidden", func(r *http.Request) *http.Request { return r }, http.StatusForbidden, false},
+		{"read-only => forbidden", func(r *http.Request) *http.Request {
+			return r.WithContext(auth.WithScope(r.Context(), tokenstore.ScopeReadOnly))
+		}, http.StatusForbidden, false},
+		{"read-write => forbidden", func(r *http.Request) *http.Request {
+			return r.WithContext(auth.WithScope(r.Context(), tokenstore.ScopeReadWrite))
+		}, http.StatusForbidden, false},
+		{"admin => passes", func(r *http.Request) *http.Request {
+			return r.WithContext(auth.WithScope(r.Context(), tokenstore.ScopeAdmin))
+		}, http.StatusOK, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			var gotStatus int
+			gated := auth.AdminProtect(discardLogger(), testClientIP, recordErr(&gotStatus),
+				func(w http.ResponseWriter, _ *http.Request) {
+					called = true
+					w.WriteHeader(http.StatusOK)
+				})
+
+			req := c.setup(httptest.NewRequest(http.MethodPost, "/api/v1/config/import", nil))
+			w := httptest.NewRecorder()
+			gated(w, req)
+
+			if called != c.wantCalled {
+				t.Errorf("handler called = %v, want %v", called, c.wantCalled)
+			}
+			if c.wantStatus == http.StatusForbidden && gotStatus != http.StatusForbidden {
+				t.Errorf("status = %d, want 403", gotStatus)
+			}
+			if c.wantCalled && w.Code != http.StatusOK {
+				t.Errorf("admin passthrough: status = %d, want 200", w.Code)
+			}
+		})
+	}
+}

--- a/internal/api/auth/scope.go
+++ b/internal/api/auth/scope.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package auth is the api transport's authentication middleware, extracted
+// from internal/api as a leaf (ADR-0006). It composes the tokenstore and
+// ratelimit leaves behind a request-time bearer-token check + scope model,
+// taking the remaining api-specific concerns (security headers, request IDs,
+// client-IP extraction, error rendering, non-loopback detection) as injected
+// function values so it never imports the api transport layer.
+package auth
+
+import (
+	"context"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
+)
+
+// scopeContextKey is the request-context key under which Middleware stashes the
+// resolved tokenstore.TokenScope. AdminProtect (and any future scope-aware
+// middleware) reads it via ScopeFromContext so the gate stays a single concern
+// rather than re-doing token lookup.
+type scopeContextKey struct{}
+
+// WithScope returns a context carrying scope, for the auth middleware to stash
+// the resolved token scope (and for tests to simulate it).
+func WithScope(ctx context.Context, scope tokenstore.TokenScope) context.Context {
+	return context.WithValue(ctx, scopeContextKey{}, scope)
+}
+
+// ScopeFromContext returns the scope stashed by Middleware. The second return
+// reports whether a value was actually stashed — false means the request never
+// went through Middleware (a wiring bug), in which case callers must fail
+// closed.
+func ScopeFromContext(ctx context.Context) (tokenstore.TokenScope, bool) {
+	v, ok := ctx.Value(scopeContextKey{}).(tokenstore.TokenScope)
+	return v, ok
+}

--- a/internal/api/handlers_auth_scope.go
+++ b/internal/api/handlers_auth_scope.go
@@ -5,6 +5,8 @@ package api
 import (
 	"net/http"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
 )
 
@@ -29,7 +31,7 @@ type AuthScopeResponse struct {
 // run; if it isn't (an unwrapped call would be a route-registration
 // bug), we report the safest tier ("read-only") rather than guessing.
 func (s *Server) handleAuthScope(w http.ResponseWriter, r *http.Request) {
-	scope, ok := scopeFromContext(r.Context())
+	scope, ok := auth.ScopeFromContext(r.Context())
 	if !ok {
 		s.writeJSON(w, AuthScopeResponse{Scope: tokenstore.ScopeReadOnly.String()})
 

--- a/internal/api/handlers_auth_scope_test.go
+++ b/internal/api/handlers_auth_scope_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
 )
 
@@ -36,7 +38,7 @@ func TestHandleAuthScope_EchoesContextScope(t *testing.T) {
 			t.Parallel()
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/scope", nil)
 			if c.stashed {
-				req = req.WithContext(withScope(req.Context(), c.stash))
+				req = req.WithContext(auth.WithScope(req.Context(), c.stash))
 			}
 			w := httptest.NewRecorder()
 			server.handleAuthScope(w, req)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,36 +1,28 @@
 package api
 
 import (
-	"context"
 	"net/http"
-	"os"
 	"runtime/debug"
-	"strings"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
 )
 
-// scopeContextKey is the request-context key under which the auth()
-// middleware stashes the resolved tokenstore.TokenScope for the request. The
-// downstream adminProtect middleware reads it via scopeFromContext so
-// the gate stays a single concern rather than re-doing token lookup.
-// Bypass paths (loopback no-token, NIAC_AUTH_DISABLED=true) stash
-// tokenstore.ScopeAdmin so dev workflows aren't suddenly locked out of admin
-// operations they could perform pre-#743.
-type scopeContextKey struct{}
-
-func withScope(ctx context.Context, scope tokenstore.TokenScope) context.Context {
-	return context.WithValue(ctx, scopeContextKey{}, scope)
-}
-
-// scopeFromContext returns the scope stashed by auth(). The second
-// return reports whether a value was actually stashed — false means
-// either the request never went through auth() (which would itself be
-// a configuration bug) or it pre-dates #743. In the false case the
-// caller should fail closed.
-func scopeFromContext(ctx context.Context) (tokenstore.TokenScope, bool) {
-	v, ok := ctx.Value(scopeContextKey{}).(tokenstore.TokenScope)
-	return v, ok
+// authDeps builds the dependency set the auth.Middleware needs from this
+// server. Tokens is a getter so a SIGHUP token rotation (SetTokens swaps the
+// store) is reflected on the next request rather than frozen at registration.
+func (s *Server) authDeps() auth.Deps {
+	return auth.Deps{
+		Tokens:          func() *tokenstore.TokenStore { return s.tokens },
+		RateLimiter:     s.rateLimiter,
+		Logger:          s.logger,
+		Addr:            s.cfg.Addr,
+		SecurityHeaders: addSecurityHeaders,
+		RequestID:       generateRequestID,
+		ClientIP:        getClientIP,
+		WriteErr:        simpleErr,
+		NonLoopback:     addrIsNonLoopback,
+	}
 }
 
 // addSecurityHeaders adds security headers to all HTTP responses
@@ -110,177 +102,6 @@ func (s *Server) recoverMiddleware(next http.HandlerFunc) http.HandlerFunc {
 					"An internal error occurred. Please try again later.", nil)
 			}
 		}()
-
-		next(w, r)
-	}
-}
-
-// auth wraps handlers with authentication, rate limiting, and security headers.
-func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// FEATURE #118: Generate unique request ID for tracing
-		requestID := generateRequestID()
-		r.Header.Set("X-Request-ID", requestID)
-		w.Header().Set("X-Request-ID", requestID)
-
-		// Add security headers to all responses
-		addSecurityHeaders(w, r)
-
-		// FEATURE #104: Apply rate limiting per IP address
-		clientIP := getClientIP(r)
-
-		limiter := s.rateLimiter.GetLimiter(clientIP)
-		if !limiter.Allow() {
-			// FEATURE #105: Use standardized error response
-			writeError(w, r, http.StatusTooManyRequests, "rate_limit_exceeded",
-				"Rate limit exceeded. Please try again later.", nil)
-			// Structured audit fields (task #77): tagged event + UA so SIEM
-			// pipelines can filter and so abusive clients are identifiable
-			// beyond just IP.
-			s.logger.WarnContext(r.Context(), "[API] Rate limit exceeded",
-				"event", "api.rate_limited",
-				"requestID", requestID,
-				"clientIP", clientIP,
-				"userAgent", r.UserAgent(),
-				"path", r.URL.Path)
-
-			return
-		}
-
-		// Wave 2: auth is keyed off the tokenstore.TokenStore, not the legacy
-		// single-token field on ServerConfig. An empty / unset store
-		// means "no auth configured". The startup gate
-		// (enforceNonLoopbackAuthGate) already refuses to bind a
-		// non-loopback address without a token — but #739 hardens this
-		// at request time too, so a refactor that weakens or relocates
-		// the startup gate can never silently expose a non-loopback
-		// listener. The bypass is allowed only when the bind is
-		// loopback-only OR the operator explicitly opted out via
-		// NIAC_AUTH_DISABLED=true.
-		if s.tokens == nil || s.tokens.Len() == 0 {
-			if os.Getenv("NIAC_AUTH_DISABLED") == "true" {
-				// #743: dev-only bypass — treat as admin so dev
-				// workflows can still exercise admin-gated routes.
-				next(w, r.WithContext(withScope(r.Context(), tokenstore.ScopeAdmin)))
-
-				return
-			}
-			nonLoopback, _ := addrIsNonLoopback(s.cfg.Addr)
-			if !nonLoopback {
-				// Loopback-only, no token: the documented local-dev path.
-				// #743: stash admin so local-dev keeps full access.
-				next(w, r.WithContext(withScope(r.Context(), tokenstore.ScopeAdmin)))
-
-				return
-			}
-			// Non-loopback + no token + no explicit opt-out. The startup
-			// gate should have prevented this; failing closed here is the
-			// defense-in-depth backstop.
-			s.logger.ErrorContext(r.Context(),
-				"[API] Refusing request: non-loopback bind has no tokens and NIAC_AUTH_DISABLED is not set",
-				"event", "auth.misconfigured",
-				"requestID", requestID,
-				"addr", s.cfg.Addr,
-				"path", r.URL.Path)
-			writeError(w, r, http.StatusUnauthorized, "auth_not_configured",
-				"Server is bound to a non-loopback address without authentication tokens. "+
-					"Set NIAC_API_TOKEN, or NIAC_AUTH_DISABLED=true to explicitly disable auth (development only).",
-				nil)
-
-			return
-		}
-
-		// Only accept Authorization header (not query parameters for security)
-		token := r.Header.Get("Authorization")
-		token = strings.TrimPrefix(token, "Bearer ")
-
-		scope, ok := s.tokens.Lookup(token)
-		if !ok {
-			// FEATURE #105: Use standardized error response
-			writeError(w, r, http.StatusUnauthorized, "unauthorized",
-				"Invalid or missing authentication token", nil)
-			// Structured audit fields (task #77): tagged event + UA so this
-			// shows up as a security event in log pipelines, not just a
-			// generic API warning. tokenPresent records the outcome shape
-			// without ever logging the token value itself.
-			s.logger.WarnContext(r.Context(),
-				"[API] Unauthorized request",
-				"event", "auth.unauthorized",
-				"requestID", requestID,
-				"clientIP", clientIP,
-				"userAgent", r.UserAgent(),
-				"path", r.URL.Path,
-				"tokenPresent", token != "",
-			)
-
-			return
-		}
-
-		// Wave 2: scope enforcement. Safe methods (GET/HEAD/OPTIONS/
-		// TRACE) accept tokenstore.ScopeReadOnly; state-changing methods require
-		// tokenstore.ScopeReadWrite. A read-only token attempting a write returns
-		// 403 (the token is valid, just under-privileged) rather than
-		// 401 (which means "we don't know who you are").
-		required := tokenstore.RequiredScopeForMethod(r.Method)
-		if scope < required {
-			writeError(w, r, http.StatusForbidden, "forbidden",
-				"token lacks required scope", nil)
-			// #1257 (Wave 5): unified `event=auth.forbidden` across
-			// seed/niac/stem so SIEM rules can filter authz denials
-			// with one expression regardless of which repo emitted
-			// the record. The `reason` field distinguishes niac's
-			// scope-based denial from seed's role-based denial so
-			// detections can still split on mechanism when needed.
-			s.logger.WarnContext(r.Context(),
-				"[API] Forbidden request: token scope insufficient",
-				"event", "auth.forbidden",
-				"reason", "scope",
-				"requestID", requestID,
-				"clientIP", clientIP,
-				"userAgent", r.UserAgent(),
-				"path", r.URL.Path,
-				"method", r.Method,
-				"tokenScope", scope.String(),
-				"requiredScope", required.String(),
-			)
-			return
-		}
-
-		// #743: stash the resolved scope on the context so adminProtect
-		// (and any future scope-aware middleware) can read it without
-		// re-doing token lookup.
-		next(w, r.WithContext(withScope(r.Context(), scope)))
-	}
-}
-
-// adminProtect wraps handlers that require tokenstore.ScopeAdmin (typically
-// destructive whole-config operations like /api/v1/config/import).
-// The auth() middleware must run upstream — adminProtect reads the
-// scope stashed there; an unstashed context is treated as a 403 so
-// missing wiring fails closed rather than silently bypassing the gate.
-//
-// #743 (Wave 4). New admin-only routes go through this wrapper rather
-// than re-implementing the gate inline.
-func (s *Server) adminProtect(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		scope, ok := scopeFromContext(r.Context())
-		if !ok || scope < tokenstore.ScopeAdmin {
-			writeError(w, r, http.StatusForbidden, "forbidden",
-				"this operation requires an admin-scoped token", nil)
-			s.logger.WarnContext(r.Context(),
-				"[API] Forbidden request: admin scope required",
-				"event", "auth.forbidden",
-				"reason", "scope",
-				"requestID", r.Header.Get("X-Request-ID"),
-				"clientIP", getClientIP(r),
-				"userAgent", r.UserAgent(),
-				"path", r.URL.Path,
-				"method", r.Method,
-				"requiredScope", tokenstore.ScopeAdmin.String(),
-			)
-
-			return
-		}
 
 		next(w, r)
 	}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
@@ -201,7 +203,7 @@ func TestAuthMiddlewareWithoutToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
@@ -223,7 +225,7 @@ func TestAuthMiddlewareWithValidToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
@@ -246,7 +248,7 @@ func TestAuthMiddlewareWithInvalidToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
@@ -270,7 +272,7 @@ func TestAuthMiddlewareNoTokenConfigured(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
@@ -294,7 +296,7 @@ func TestAuthMiddleware_ReadOnlyTokenOnGet_200(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
@@ -319,7 +321,7 @@ func TestAuthMiddleware_ReadOnlyTokenOnPost_403(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
 		t.Run(method, func(t *testing.T) {
@@ -347,7 +349,7 @@ func TestAuthMiddleware_ReadWriteTokenOnPost_200(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/config", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
@@ -371,7 +373,7 @@ func TestAuthMiddleware_UnknownToken_401(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	wrapped := server.auth(handler)
+	wrapped := auth.Middleware(server.authDeps(), handler)
 
 	for _, method := range []string{http.MethodGet, http.MethodPost} {
 		t.Run(method, func(t *testing.T) {
@@ -416,7 +418,7 @@ func TestAuth_EmptyStore_LoopbackBypasses(t *testing.T) {
 	server.cfg.Addr = "127.0.0.1:8445"
 
 	called := false
-	wrapped := server.auth(func(w http.ResponseWriter, _ *http.Request) {
+	wrapped := auth.Middleware(server.authDeps(), func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
@@ -440,7 +442,7 @@ func TestAuth_EmptyStore_NonLoopbackFailsClosed(t *testing.T) {
 	server.cfg.Addr = "0.0.0.0:8445"              // non-loopback
 
 	called := false
-	wrapped := server.auth(func(w http.ResponseWriter, _ *http.Request) {
+	wrapped := auth.Middleware(server.authDeps(), func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
@@ -467,7 +469,7 @@ func TestAuth_EmptyStore_NonLoopbackExplicitOptOut(t *testing.T) {
 	server.cfg.Addr = "0.0.0.0:8445"
 
 	called := false
-	wrapped := server.auth(func(w http.ResponseWriter, _ *http.Request) {
+	wrapped := auth.Middleware(server.authDeps(), func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/api/route.go
+++ b/internal/api/route.go
@@ -11,6 +11,8 @@ package api
 import (
 	"net/http"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
@@ -66,7 +68,7 @@ func (s *Server) register(mux *http.ServeMux, rt apiRoute) {
 		h = s.requireFeature(rt.feature, h)
 	}
 	if rt.admin {
-		h = s.adminProtect(h)
+		h = auth.AdminProtect(s.logger, getClientIP, simpleErr, h)
 	}
 	if rt.csrf {
 		h = csrf.Protect(s.csrf, simpleErr, h)
@@ -83,7 +85,7 @@ func (s *Server) register(mux *http.ServeMux, rt apiRoute) {
 	case rlFile:
 		h = ratelimit.File(s.fileLimiter, s.logger, getClientIP, simpleErr, h)
 	}
-	h = s.auth(h)
+	h = auth.Middleware(s.authDeps(), h)
 	h = s.recoverMiddleware(h)
 	mux.HandleFunc(rt.path, h)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/sse"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
@@ -456,7 +458,7 @@ func (s *Server) Start() error {
 
 	if s.cfg.MetricsAddr != "" && s.cfg.MetricsAddr != s.cfg.Addr {
 		mux := http.NewServeMux()
-		mux.HandleFunc("/metrics", s.recoverMiddleware(s.auth(s.handleMetrics)))
+		mux.HandleFunc("/metrics", s.recoverMiddleware(auth.Middleware(s.authDeps(), s.handleMetrics)))
 		s.metricsServer = newSecureHTTPServer(s.cfg.MetricsAddr, mux)
 
 		metricsLn, metricsAddr, bindErr := bindWithFallback(context.Background(), s.logger, s.cfg.MetricsAddr)

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api/csrf"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
@@ -135,7 +137,7 @@ func TestCSRF_TokenValidation(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
+	handler := auth.Middleware(server.authDeps(), csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusOK {
@@ -158,7 +160,7 @@ func TestCSRF_InvalidTokenRejection(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
+	handler := auth.Middleware(server.authDeps(), csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusForbidden {
@@ -181,7 +183,7 @@ func TestCSRF_MissingTokenRejection(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
+	handler := auth.Middleware(server.authDeps(), csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusForbidden {
@@ -200,7 +202,7 @@ func TestAuth_ValidToken(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.handleStats)
+	handler := auth.Middleware(server.authDeps(), server.handleStats)
 	handler(w, req)
 
 	if w.Code != http.StatusOK {
@@ -220,7 +222,7 @@ func TestAuth_InvalidToken(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.handleStats)
+	handler := auth.Middleware(server.authDeps(), server.handleStats)
 	handler(w, req)
 
 	if w.Code != http.StatusUnauthorized {
@@ -238,7 +240,7 @@ func TestAuth_MissingToken(t *testing.T) {
 	// Deliberately omit Authorization header
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.handleStats)
+	handler := auth.Middleware(server.authDeps(), server.handleStats)
 	handler(w, req)
 
 	if w.Code != http.StatusUnauthorized {
@@ -259,7 +261,7 @@ func TestAuth_NoAuthRequired(t *testing.T) {
 	// No Authorization header
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.handleStats)
+	handler := auth.Middleware(server.authDeps(), server.handleStats)
 	handler(w, req)
 
 	if w.Code != http.StatusOK {
@@ -464,7 +466,7 @@ func TestAlertConfig_ConcurrentUpdates(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
+			handler := auth.Middleware(server.authDeps(), csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 			handler(w, req)
 
 			if w.Code != http.StatusOK {
@@ -481,7 +483,7 @@ func TestAlertConfig_ConcurrentUpdates(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(server.handleAlerts)
+	handler := auth.Middleware(server.authDeps(), server.handleAlerts)
 	handler(w, req)
 
 	if w.Code != http.StatusOK {
@@ -504,7 +506,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
+	handler := auth.Middleware(server.authDeps(), csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 	handler(w, req)
 
 	if w.Code != http.StatusOK {
@@ -564,7 +566,7 @@ func TestAlertConfig_GoroutineCleanup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		handler := server.auth(csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
+		handler := auth.Middleware(server.authDeps(), csrf.Protect(server.csrf, simpleErr, server.handleAlerts))
 		handler(w, req)
 
 		if w.Code != http.StatusOK {


### PR DESCRIPTION
## What

Fifth and **final** `internal/api` decomposition step (**ADR-0006**; completes tokenstore #804, ratelimit #805, csrf #806, sse #807). `auth()` + `adminProtect()` and the scope-context model move into **`internal/api/auth`**.

## How

- **`scope.go`**: `WithScope` / `ScopeFromContext` (exported — `handlers_auth_scope.go` reads the stashed scope) keyed by an unexported `scopeContextKey`.
- **`middleware.go`**: `auth()` → `auth.Middleware(Deps, next)`, `adminProtect()` → `auth.AdminProtect(logger, clientIP, writeErr, next)`. Security logic moved **verbatim**. Since auth orchestrates many api-transport concerns, `Deps` injects them — a **`Tokens` getter** (so a SIGHUP rotation that swaps the store is seen on the next request, not frozen at registration), `RateLimiter`, `Logger`, `Addr`, and `SecurityHeaders`/`RequestID`/`ClientIP`/`WriteErr`/`NonLoopback`. `WriteErr` is the narrow `ErrorFunc` (no api `ErrorDetail`).
- api keeps `addSecurityHeaders`/`recoverMiddleware`/`generateRequestID`; a new `s.authDeps()` builds the `Deps`. `route.go` composes `auth.Middleware(s.authDeps(), h)` + `auth.AdminProtect(...)`; the `/metrics` route and `handlers_auth_scope.go` rewire. Middleware order + `/__capabilities` unchanged.

## Why no depguard rule for auth

The other four leaves get an `api-<leaf>-isolated` rule; auth deliberately does **not**. It composes the `tokenstore` + `ratelimit` leaves, and `internal/api` already imports `auth` (route wiring), so auth importing api back is a **compile-time import cycle Go forbids**. A deny on the `internal/api` prefix would be redundant *and* would wrongly catch the sibling leaves. Documented inline in `.golangci.yml`.

## Tests

New `auth` package test covers the scope round-trip + `AdminProtect` matrix; the full `Middleware` stays exercised by the api server/middleware suites.

## Verification

`go build`, `go vet`, `golangci-lint` (**0 issues**), `go test -race ./internal/api/... ./internal/daemon/...` (all pass incl. new `auth`), `gofumpt -l` clean, and **all four CI gates** (route-policy, output-escaping, file-size, token-discipline) green. No behavioural change.