### PR TITLE
ci(release): deb/rpm + cosign + SBOM parity (standalone nfpm/syft/cosign), drop macOS amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,47 +191,133 @@ jobs:
         shell: pwsh
         run: Compress-Archive -Path "${{ matrix.artifact }}" -DestinationPath "dist/${{ matrix.artifact }}.zip" -Force
 
-      - name: Upload native artifact
+      - name: Upload archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: dist/*
           retention-days: 14
 
-  publish:
-    name: Publish release assets
+      # Linux raw binaries feed nfpm (deb/rpm) in the package job. Native build,
+      # no cross-compile (Path C); packaging is done with standalone OSS tools.
+      - name: Upload raw linux binary for packaging
+        if: matrix.goos == 'linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: niacbin-linux-${{ matrix.goarch }}
+          path: ${{ matrix.artifact }}/niac
+          retention-days: 1
+
+  # Central packaging with standalone OSS tools (no goreleaser — its prebuilt
+  # builder is Pro-only). nfpm builds .deb/.rpm from the natively-built linux
+  # binaries (nfpm is goreleaser's own deb/rpm engine), syft produces SBOMs,
+  # cosign keyless-signs every artifact. release-please owns the GitHub release;
+  # this job only attaches assets to it.
+  package:
+    name: Package + sign
     if: ${{ !inputs.provenance_only }}
     needs: [build-native]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
-      - name: Download native artifacts
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: niac-*
           path: dist
           merge-multiple: true
 
-      - name: Generate checksums
+      - name: Download raw linux binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: niacbin-linux-*
+          path: prebuilt
+
+      - name: Install nfpm
+        run: |
+          set -euo pipefail
+          NFPM_VERSION=2.43.0
+          curl -sSfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin nfpm
+          nfpm --version
+
+      - name: Install Syft (SBOM)
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Install Cosign
+        run: |
+          set -euo pipefail
+          COSIGN_VERSION=v2.4.1
+          curl -sSfL -o /usr/local/bin/cosign "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
+          chmod +x /usr/local/bin/cosign
+
+      - name: Build .deb / .rpm (nfpm), SBOMs (syft), checksums
         id: hashes
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="0.0.0-dryrun"
+          else
+            VERSION="${REF_NAME#v}"
+          fi
+          export VERSION
+
+          # .deb + .rpm for each linux arch from the native binary. nfpm does not
+          # expand env vars in contents.src, so render the config placeholders
+          # (ARCH/VERSION/BINARY) with sed per arch.
+          for arch in amd64 arm64; do
+            bin="prebuilt/niacbin-linux-${arch}/niac"
+            test -f "$bin"
+            chmod +x "$bin"
+            sed -e "s|\${ARCH}|${arch}|g" \
+                -e "s|\${VERSION}|${VERSION}|g" \
+                -e "s|\${BINARY}|${bin}|g" \
+                deploy/nfpm/nfpm.yaml > "nfpm.${arch}.yaml"
+            nfpm package -f "nfpm.${arch}.yaml" -p deb -t dist/
+            nfpm package -f "nfpm.${arch}.yaml" -p rpm -t dist/
+          done
+
+          # SBOM per archive.
+          for f in dist/*.tar.gz dist/*.zip; do
+            [ -e "$f" ] || continue
+            syft scan "file:${f}" -o spdx-json="${f}.sbom.json"
+          done
+
+          # SHA-256 checksums over the user-facing artifacts (archives + packages).
+          ( cd dist && sha256sum *.tar.gz *.zip *.deb *.rpm > checksums.txt )
+          cat dist/checksums.txt
+
+          # base64 subjects for SLSA provenance (standard "<sha256>  <name>" format).
+          hashes=$(base64 -w0 < dist/checksums.txt)
+          echo "hashes=${hashes}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign all artifacts (cosign keyless)
         shell: bash
         run: |
           set -euo pipefail
-          cd dist
-          sha256sum * > checksums.txt
-          cat checksums.txt
-          hashes=$(base64 -w0 < checksums.txt)
-          echo "hashes=${hashes}" >> "$GITHUB_OUTPUT"
+          for f in dist/*; do
+            case "$f" in
+              *.cosign.bundle) continue ;;
+            esac
+            cosign sign-blob --yes --bundle "${f}.cosign.bundle" "$f"
+          done
 
-      - name: Upload dry-run artifact bundle
+      - name: Upload dry-run artifact bundle for inspection
         if: inputs.dry_run
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: native-release-dryrun-${{ github.run_id }}
+          name: release-dryrun-${{ github.run_id }}
           path: dist/
           retention-days: 14
 
-      - name: Attach artifacts to GitHub release
+      - name: Attach assets to the release-please release
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -271,8 +357,8 @@ jobs:
 
   provenance:
     name: SLSA provenance
-    if: ${{ !inputs.dry_run && !cancelled() && (needs.publish.result == 'success' || needs.backfill-hashes.result == 'success') }}
-    needs: [publish, backfill-hashes]
+    if: ${{ !inputs.dry_run && !cancelled() && (needs.package.result == 'success' || needs.backfill-hashes.result == 'success') }}
+    needs: [package, backfill-hashes]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -283,7 +369,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "${{ needs.publish.outputs.hashes || needs.backfill-hashes.outputs.hashes }}" | base64 -d > subjects.txt
+          echo "${{ needs.package.outputs.hashes || needs.backfill-hashes.outputs.hashes }}" | base64 -d > subjects.txt
           cat subjects.txt
 
       - name: Generate SLSA build-provenance attestation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,12 +95,6 @@ jobs:
             goarch: arm64
             cgo: "1"
             archive: tar
-          - artifact: niac-darwin-amd64
-            runner: macos-13
-            goos: darwin
-            goarch: amd64
-            cgo: "1"
-            archive: tar
           - artifact: niac-darwin-arm64
             runner: macos-14
             goos: darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,14 +192,14 @@ jobs:
           path: dist/*
           retention-days: 14
 
-      # Linux raw binaries feed nfpm (deb/rpm) in the package job. Native build,
-      # no cross-compile (Path C); packaging is done with standalone OSS tools.
-      - name: Upload raw linux binary for packaging
-        if: matrix.goos == 'linux'
+      # Raw binaries feed the package job: linux ones drive nfpm (deb/rpm), and
+      # every platform's binary is scanned by syft for an SBOM (richer than an
+      # archive scan and avoids unarchiving). Native build, no cross-compile.
+      - name: Upload raw binary for packaging
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: niacbin-linux-${{ matrix.goarch }}
-          path: ${{ matrix.artifact }}/niac
+          name: niacbin-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ matrix.artifact }}/niac${{ matrix.ext }}
           retention-days: 1
 
   # Central packaging with standalone OSS tools (no goreleaser — its prebuilt
@@ -224,10 +224,10 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Download raw linux binaries
+      - name: Download raw binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: niacbin-linux-*
+          pattern: niacbin-*
           path: prebuilt
 
       - name: Install nfpm
@@ -278,10 +278,13 @@ jobs:
             nfpm package -f "nfpm.${arch}.yaml" -p rpm -t dist/
           done
 
-          # SBOM per archive.
-          for f in dist/*.tar.gz dist/*.zip; do
-            [ -e "$f" ] || continue
-            syft scan "file:${f}" -o spdx-json="${f}.sbom.json"
+          # SBOM per platform, scanned from the Go binary (richer module data
+          # than an archive scan, and avoids unarchiving the windows .zip).
+          for d in prebuilt/niacbin-*; do
+            [ -d "$d" ] || continue
+            plat="${d#prebuilt/niacbin-}"   # e.g. linux-amd64
+            binpath=$(ls "$d"/niac*)
+            syft scan "file:${binpath}" -o spdx-json="dist/niac-${plat}.sbom.json"
           done
 
           # SHA-256 checksums over the user-facing artifacts (archives + packages).

--- a/deploy/nfpm/nfpm.yaml
+++ b/deploy/nfpm/nfpm.yaml
@@ -1,0 +1,78 @@
+# nfpm config for NIAC .deb / .rpm packages.
+#
+# Packaging is done with the standalone OSS nfpm CLI (the same engine goreleaser
+# uses internally) on a GitHub Actions runner — see .github/workflows/release.yml
+# `package` job. The Go binary is compiled natively per-arch (build-native job);
+# this only packages it. release-please owns the version/tag/GitHub release; the
+# pipeline attaches these packages to that release.
+#
+# The package job substitutes these placeholders per arch with sed before
+# invoking nfpm (nfpm does not env-expand contents.src):
+#   ${ARCH}    = amd64 | arm64
+#   ${VERSION} = release version (tag without leading v)
+#   ${BINARY}  = path to the natively-built niac binary for ARCH
+
+name: niac
+arch: ${ARCH}
+platform: linux
+version: ${VERSION}
+section: net
+priority: optional
+maintainer: Kris Armstrong <kris.armstrong@icloud.com>
+vendor: Mustard Seed Networks
+homepage: https://github.com/MustardSeedNetworks/niac-go
+license: BSL-1.1
+description: |
+  NIAC - Network In A Can by Mustard Seed Networks
+  .
+  NIAC is a network device simulator: ARP, DHCP, DNS, BGP, OSPF, SNMP and more,
+  with a web UI for orchestrating simulated topologies.
+
+depends:
+  - systemd
+
+overrides:
+  deb:
+    depends:
+      - libpcap0.8 | libpcap0.8t64
+      - systemd
+      - libcap2-bin
+  rpm:
+    depends:
+      - libpcap
+      - systemd
+      - libcap
+
+contents:
+  - src: ${BINARY}
+    dst: /usr/bin/niac
+    file_info:
+      mode: 0o755
+  - src: ./deploy/systemd/niac.service
+    dst: /usr/lib/systemd/system/niac.service
+    file_info:
+      mode: 0o644
+  - dst: /etc/niac
+    type: dir
+    file_info:
+      mode: 0o750
+      owner: niac
+      group: niac
+  - dst: /var/lib/niac
+    type: dir
+    file_info:
+      mode: 0o750
+      owner: niac
+      group: niac
+  - dst: /var/log/niac
+    type: dir
+    file_info:
+      mode: 0o750
+      owner: niac
+      group: niac
+
+scripts:
+  preinstall: ./deploy/nfpm/preinstall.sh
+  postinstall: ./deploy/nfpm/postinstall.sh
+  preremove: ./deploy/nfpm/preremove.sh
+  postremove: ./deploy/nfpm/postremove.sh

--- a/deploy/nfpm/postinstall.sh
+++ b/deploy/nfpm/postinstall.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -e
+
+BINARY=/usr/bin/niac
+
+if command -v setcap >/dev/null 2>&1; then
+    setcap 'cap_net_raw,cap_net_admin=+ep' "$BINARY" || \
+        echo "warning: could not set capabilities on $BINARY"
+else
+    echo "warning: setcap not found; install libcap/libcap2-bin for non-root operation"
+fi
+
+PORT=8445
+
+open_firewall() {
+    opened=""
+    if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+        if ufw allow ${PORT}/tcp comment 'NIAC WebUI HTTPS' >/dev/null 2>&1; then
+            opened="ufw"
+        fi
+    fi
+    if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+        firewall-cmd --permanent --add-port=${PORT}/tcp >/dev/null 2>&1 || true
+        firewall-cmd --reload >/dev/null 2>&1 || true
+        opened="${opened:+$opened, }firewalld"
+    fi
+    if [ -n "$opened" ]; then
+        echo "Opened TCP ${PORT} on: $opened (NIAC_OPEN_FIREWALL set)"
+    fi
+}
+
+firewall_hint() {
+    if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+        echo "  sudo ufw allow ${PORT}/tcp"
+    elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+        echo "  sudo firewall-cmd --permanent --add-port=${PORT}/tcp && sudo firewall-cmd --reload"
+    fi
+}
+
+# Network exposure is the operator's choice. We do NOT open the firewall by
+# default; set NIAC_OPEN_FIREWALL=1 to opt in (e.g. automated provisioning).
+case "${NIAC_OPEN_FIREWALL:-0}" in
+    1 | true | yes | TRUE | YES) open_firewall ;;
+esac
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+    systemctl enable niac.service >/dev/null 2>&1 || true
+    if systemctl is-active --quiet niac.service 2>/dev/null; then
+        systemctl restart niac.service || true
+    else
+        systemctl start niac.service || true
+    fi
+fi
+
+cat <<'EOF'
+
+==========================================
+  NIAC installed successfully
+==========================================
+
+Web interface: https://localhost:8445
+
+Commands:
+  View logs:  journalctl -u niac -f
+  Restart:    sudo systemctl restart niac
+  Status:     sudo systemctl status niac
+  Stop:       sudo systemctl stop niac
+
+EOF
+
+# When we did not open the firewall, tell the operator how (only if one is active).
+case "${NIAC_OPEN_FIREWALL:-0}" in
+    1 | true | yes | TRUE | YES) : ;;
+    *)
+        hint=$(firewall_hint)
+        if [ -n "$hint" ]; then
+            echo "An active firewall was detected; TCP ${PORT} is NOT open to the network."
+            echo "To allow remote access to the web interface, run:"
+            echo "$hint"
+            echo "(or re-install with NIAC_OPEN_FIREWALL=1 to open it automatically)"
+            echo ""
+        fi
+        ;;
+esac
+
+exit 0

--- a/deploy/nfpm/postremove.sh
+++ b/deploy/nfpm/postremove.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+is_purge=0
+case "$1" in
+    purge|0)
+        is_purge=1
+        ;;
+esac
+
+if [ "$is_purge" -eq 1 ]; then
+    if command -v ufw >/dev/null 2>&1; then
+        ufw delete allow 8445/tcp >/dev/null 2>&1 || true
+    fi
+    if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+        firewall-cmd --permanent --remove-port=8445/tcp >/dev/null 2>&1 || true
+        firewall-cmd --reload >/dev/null 2>&1 || true
+    fi
+
+    if getent passwd niac >/dev/null 2>&1; then
+        userdel niac >/dev/null 2>&1 || true
+    fi
+    if getent group niac >/dev/null 2>&1; then
+        groupdel niac >/dev/null 2>&1 || true
+    fi
+
+    rm -rf /etc/niac /var/lib/niac /var/log/niac
+else
+    echo "NIAC removed. Data preserved in /var/lib/niac"
+fi

--- a/deploy/nfpm/preinstall.sh
+++ b/deploy/nfpm/preinstall.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+if ! getent group niac >/dev/null 2>&1; then
+    groupadd --system niac
+fi
+
+if ! getent passwd niac >/dev/null 2>&1; then
+    useradd --system \
+        --gid niac \
+        --home-dir /var/lib/niac \
+        --no-create-home \
+        --shell /usr/sbin/nologin \
+        --comment "NIAC - Network In A Can" \
+        niac
+fi
+
+exit 0

--- a/deploy/nfpm/preremove.sh
+++ b/deploy/nfpm/preremove.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+    if systemctl is-active --quiet niac.service 2>/dev/null; then
+        systemctl stop niac.service || true
+    fi
+    if systemctl is-enabled --quiet niac.service 2>/dev/null; then
+        systemctl disable niac.service || true
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## What
Brings niac's release pipeline to seed-level artifact parity, all on GitHub Actions, $0, no cross-compile (Path C).

- **New `package` job** — builds `.deb`/`.rpm` with **nfpm** (goreleaser's own deb/rpm engine), per-platform **SBOMs** with **syft** (scanned from the Go binaries — richer than archive scans, and avoids unarchiving), and **cosign** keyless-signs every artifact, then attaches them to the release-please release. SLSA provenance retained.
- **New `deploy/nfpm/`** — `nfpm.yaml` + pre/post install/remove scripts (niac user, `/usr/bin/niac daemon`, port 8445, libpcap/systemd deps).
- **macOS amd64 (Intel) dropped** — Apple Silicon only (fleet-wide decision).

## Verified (dry-run snapshot bundle)
2 deb + 2 rpm + 5 SBOMs + 5 archives + checksums, **all cosign-signed**; darwin-amd64 absent. nfpm config also validated locally.

goreleaser's `prebuilt` builder is Pro-only, so standalone OSS tools are used — same artifacts, free, and keeps niac's robust native per-arch builds.