### PR TITLE
feat(api): make HTTP method and body-size authoritative in route registry

### DIFF
--- a/internal/api/config_ops.go
+++ b/internal/api/config_ops.go
@@ -53,12 +53,7 @@ var ErrConfigImportFormat = errors.New("unsupported import format (use yaml or j
 
 // handleConfigMerge merges two configs and returns the merged YAML. POST only.
 func (s *Server) handleConfigMerge(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", "POST")
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
-
+	// Method gating (POST-only) is enforced declaratively by the route registry.
 	var req MergeConfigsRequest
 	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
@@ -130,12 +125,7 @@ func mergeConfigsByName(base, overlay *config.Config) *config.Config {
 // handleConfigImport converts a non-YAML config (currently: legacy Java DSL)
 // to YAML, or normalises an already-YAML config. POST only.
 func (s *Server) handleConfigImport(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", "POST")
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
-
+	// Method gating (POST-only) is enforced declaratively by the route registry.
 	var req ConfigImportRequest
 	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return

--- a/internal/api/config_ops_test.go
+++ b/internal/api/config_ops_test.go
@@ -115,9 +115,13 @@ func TestMergeConfigs_BadInput(t *testing.T) {
 
 func TestMergeConfigs_MethodNotAllowed(t *testing.T) {
 	server, _ := newTestServer(t)
+	// Method gating moved from the handler to the route registry (ADR-0002);
+	// exercise the methodGate wrapper register() composes for the POST-only
+	// /api/v1/config/merge route.
+	gated := server.methodGate([]string{http.MethodPost}, server.handleConfigMerge)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/merge", nil)
 	rec := httptest.NewRecorder()
-	server.handleConfigMerge(rec, req)
+	gated(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("got %d, want 405", rec.Code)
 	}

--- a/internal/api/handlers_device_schema.go
+++ b/internal/api/handlers_device_schema.go
@@ -106,12 +106,7 @@ var deviceEditorSchemas = map[string]DeviceEditorSchema{ //nolint:gochecknogloba
 // schema rather than 404'ing, so a type new to the daemon that the UI
 // hasn't been updated for still gives a usable form.
 func (s *Server) handleDeviceEditorSchema(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
-
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	rest := strings.TrimPrefix(r.URL.Path, "/api/v1/device-schemas")
 	rest = strings.TrimPrefix(rest, "/")
 

--- a/internal/api/handlers_device_schema_test.go
+++ b/internal/api/handlers_device_schema_test.go
@@ -121,9 +121,13 @@ func TestDeviceEditorSchemaCaseInsensitiveLookup(t *testing.T) {
 
 func TestDeviceEditorSchemaRejectsNonGet(t *testing.T) {
 	server := newSchemaTestServer()
+	// Method gating moved from the handler to the route registry (ADR-0002);
+	// exercise the methodGate wrapper register() composes for the GET-only
+	// /api/v1/device-schemas route.
+	gated := server.methodGate([]string{http.MethodGet}, server.handleDeviceEditorSchema)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/device-schemas/switch", nil)
 	rec := httptest.NewRecorder()
-	server.handleDeviceEditorSchema(rec, req)
+	gated(rec, req)
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status = %d, want 405", rec.Code)

--- a/internal/api/handlers_library.go
+++ b/internal/api/handlers_library.go
@@ -153,11 +153,8 @@ func (s *Server) handleLibraryFiles(w http.ResponseWriter, r *http.Request, kind
 		s.writeLibraryUnavailable(w, r)
 		return
 	}
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
+	// Method gating (GET-only) is enforced declaratively by the route registry
+	// on /api/v1/library/{walks,pcaps}.
 	entries, err := s.library.ListFiles(kind)
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "[API] library: list files", "kind", string(kind), "error", err)

--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -97,9 +97,13 @@ func TestHandleLibraryPcapsEmpty(t *testing.T) {
 func TestHandleLibraryWalksRejectsNonGet(t *testing.T) {
 	server, _ := newLibraryTestServer(t)
 
+	// Method gating moved from the handler to the route registry (ADR-0002);
+	// exercise the methodGate wrapper register() composes for the GET-only
+	// /api/v1/library/walks route.
+	gated := server.methodGate([]string{http.MethodGet}, server.handleLibraryWalks)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/library/walks", nil)
 	rec := httptest.NewRecorder()
-	server.handleLibraryWalks(rec, req)
+	gated(rec, req)
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status = %d, want 405", rec.Code)

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -374,13 +374,7 @@ func (s *Server) handleTopology(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) handleTopologyExport(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-
-		return
-	}
-
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	format := r.URL.Query().Get("format")
 	if format == "" {
 		format = "json"
@@ -461,13 +455,7 @@ func (s *Server) handleNeighbors(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) handleInterfaces(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-
-		return
-	}
-
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	// Check for filter parameter
 	filter := r.URL.Query().Get("filter")
 
@@ -530,14 +518,8 @@ func (s *Server) handleInterfaces(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) handleRuntime(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-
-		return
-	}
-
+func (s *Server) handleRuntime(w http.ResponseWriter, _ *http.Request) {
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	// SECURITY FIX #161: Thread-safe access to all config fields
 	s.configMu.RLock()
 	stack := s.cfg.Stack
@@ -585,13 +567,7 @@ func (s *Server) handleRuntime(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleCSRFToken(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-
-		return
-	}
-
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	// #1257: mint or retrieve a per-session CSRF token keyed by the
 	// caller's bearer (or the loopback bypass key on no-token paths).
 	// Same caller fetching twice within the 24h expiry gets the same

--- a/internal/api/handlers_synthesize_walk.go
+++ b/internal/api/handlers_synthesize_walk.go
@@ -46,12 +46,8 @@ type SynthesizeWalkResponse struct {
 // build the cascading Generate-walk picker without a per-vendor
 // round-trip. Read-only; the response body is the same list returned
 // by synth.AllModels() so callers can group/sort client-side.
-func (s *Server) handleSynthesizeWalkModels(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
+func (s *Server) handleSynthesizeWalkModels(w http.ResponseWriter, _ *http.Request) {
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	s.writeJSON(w, synth.AllModels())
 }
 
@@ -84,26 +80,22 @@ func (s *Server) dispatchDeviceSubpath(w http.ResponseWriter, r *http.Request) {
 // it to <library>/walks/synthesized/{hostname}.walk, and updates the
 // device's walk_file field to point at it.
 //
-// Validation order (matches design-doc resolutions):
+// Method gating (POST-only) is enforced by the route registry before this
+// runs. Validation order (matches design-doc resolutions):
 //  1. library must be open (else 503)
-//  2. method must be POST (else 405)
-//  3. hostname valid name (else 400)
-//  4. JSON body decodes (else 400)
-//  5. device exists in current config (else 404)
-//  6. (vendor, device.type) is synthesizable (else 422 — no silent
+//  2. hostname valid name (else 400)
+//  3. JSON body decodes (else 400)
+//  4. device exists in current config (else 404)
+//  5. (vendor, device.type) is synthesizable (else 422 — no silent
 //     fallback per resolution #2)
-//  7. write + attach (any failure → 500)
+//  6. write + attach (any failure → 500)
 func (s *Server) handleSynthesizeWalk(w http.ResponseWriter, r *http.Request) {
 	if !s.libraryReady() {
 		s.writeLibraryUnavailable(w, r)
 		return
 	}
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", "POST")
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
-
+	// Method gating (POST-only) is enforced declaratively by the route registry
+	// on /api/v1/devices/ before dispatchDeviceSubpath routes here.
 	hostname := extractHostnameFromSynthesizePath(r.URL.Path)
 	if hostname == "" {
 		writeError(w, r, http.StatusBadRequest, "invalid_request", "Hostname required", nil)

--- a/internal/api/pcap.go
+++ b/internal/api/pcap.go
@@ -305,12 +305,7 @@ func decodePcapUpload(w http.ResponseWriter, r *http.Request) ([]byte, PcapUploa
 
 // handlePcapUpload handles POST /api/v1/pcap/upload.
 func (s *Server) handlePcapUpload(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed",
-			"Only POST method is allowed", nil)
-		return
-	}
-
+	// Method gating (POST-only) is enforced declaratively by the route registry.
 	pcapData, req, ok := decodePcapUpload(w, r)
 	if !ok {
 		return
@@ -352,13 +347,7 @@ func (s *Server) handlePcapUpload(w http.ResponseWriter, r *http.Request) {
 
 // handlePcapAnalysis handles GET /api/v1/pcap/{id}.
 func (s *Server) handlePcapAnalysis(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed",
-			"Only GET method is allowed", nil)
-
-		return
-	}
-
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	// Extract analysis ID from path
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/pcap/")
 	analysisID := strings.TrimSuffix(path, "/")

--- a/internal/api/pcap_test.go
+++ b/internal/api/pcap_test.go
@@ -263,12 +263,20 @@ func TestPcapPacketCollector(t *testing.T) {
 func TestHandlePcapUploadMethodNotAllowed(t *testing.T) {
 	server, _ := newTestServer(t)
 
+	// Method gating moved from the handler to the route registry (ADR-0002).
+	// Exercise the same methodGate wrapper register() composes for the
+	// POST-only /api/v1/pcap/upload route.
+	gated := server.methodGate([]string{http.MethodPost}, server.handlePcapUpload)
+
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/pcap/upload", nil)
-	server.handlePcapUpload(rec, req)
+	gated(rec, req)
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("GET /pcap/upload: status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+	if allow := rec.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("Allow header = %q, want %q", allow, http.MethodPost)
 	}
 }
 
@@ -314,12 +322,20 @@ func TestHandlePcapUploadBadJSON(t *testing.T) {
 func TestHandlePcapAnalysisMethodNotAllowed(t *testing.T) {
 	server, _ := newTestServer(t)
 
+	// Method gating moved from the handler to the route registry (ADR-0002).
+	// Exercise the methodGate wrapper register() composes for the GET-only
+	// /api/v1/pcap/ route.
+	gated := server.methodGate([]string{http.MethodGet}, server.handlePcapAnalysis)
+
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/pcap/test-id", nil)
-	server.handlePcapAnalysis(rec, req)
+	gated(rec, req)
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("POST /pcap/{id}: status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+	if allow := rec.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("Allow header = %q, want %q", allow, http.MethodGet)
 	}
 }
 

--- a/internal/api/route.go
+++ b/internal/api/route.go
@@ -10,6 +10,8 @@ package api
 
 import (
 	"net/http"
+	"slices"
+	"strings"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
 
@@ -45,6 +47,16 @@ type apiRoute struct {
 	path string
 	// handler is the terminal handler.
 	handler http.HandlerFunc
+	// methods is the set of HTTP methods the route accepts. register() gates
+	// to these with a 405 + Allow header (before csrf/admin/feature checks).
+	// Empty preserves the handler's own method dispatch (e.g. devices.go's
+	// multi-method switch keeps dispatching when methods covers its full set).
+	methods []string
+	// maxBodyBytes caps the request body (DoS guard) via bodyLimited, applied
+	// innermost so r.Body is capped before the handler reads it. 0 means the
+	// default MaxRequestBodySize; set explicitly for larger uploads (pcap,
+	// replay) so the registry cap never undercuts a handler's own decode limit.
+	maxBodyBytes int64
 	// rl selects the rate limiter (rlNone for unmetered reads/streams).
 	rl rateLimitKind
 	// csrf wraps the route in csrf.Protect (which itself skips safe GETs).
@@ -55,15 +67,54 @@ type apiRoute struct {
 	feature string
 }
 
+// methodGate rejects any method outside allowed with a 405 + Allow header,
+// preserving niac's JSON error envelope (matching handleRoutePolicyManifest's
+// 405 shape via the standard writeError path).
+func (s *Server) methodGate(allowed []string, next http.HandlerFunc) http.HandlerFunc {
+	allowHeader := strings.Join(allowed, ", ")
+	return func(w http.ResponseWriter, r *http.Request) {
+		if slices.Contains(allowed, r.Method) {
+			next(w, r)
+			return
+		}
+		w.Header().Set("Allow", allowHeader)
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed",
+			"Method not allowed", nil)
+	}
+}
+
+// bodyLimited caps the request body before the handler reads it. Handlers that
+// decode via decodeJSONStrict still apply their own (per-call) MaxBytesReader;
+// this is the registry-level backstop, set per route so it never undercuts a
+// handler's own decode limit.
+func bodyLimited(limit int64, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, limit)
+		next(w, r)
+	}
+}
+
 // register installs rt on mux, composing middleware in ONE canonical order
 // (outermost → innermost): recover → auth → rateLimit → csrf → admin → feature
-// → handler. Composing here rather than at each call site makes the policy
-// declarative and uniform, records it for /__capabilities, and is the single
-// choke point the route-policy CI gate enforces.
+// → methodGate → bodyLimit → handler. Composing here rather than at each call
+// site makes the policy declarative and uniform, records it for
+// /__capabilities, and is the single choke point the route-policy CI gate
+// enforces.
 func (s *Server) register(mux *http.ServeMux, rt apiRoute) {
+	// Resolve the effective body cap before recording it for the manifest.
+	if rt.maxBodyBytes == 0 {
+		rt.maxBodyBytes = MaxRequestBodySize
+	}
 	s.routeManifest = append(s.routeManifest, rt)
 
 	h := rt.handler
+	// bodyLimit innermost so r.Body is capped before any handler read.
+	h = bodyLimited(rt.maxBodyBytes, h)
+	// methodGate just outside bodyLimit: a wrong method 405s before the body
+	// is touched. Empty methods leaves the handler's own dispatch in charge.
+	if len(rt.methods) > 0 {
+		h = s.methodGate(rt.methods, h)
+	}
 	if rt.feature != "" {
 		h = s.requireFeature(rt.feature, h)
 	}
@@ -100,11 +151,13 @@ func (s *Server) registerAll(mux *http.ServeMux, routes []apiRoute) {
 // routePolicyView is the JSON projection of a route's policy for the
 // /__capabilities manifest (the handler func itself is not exposed).
 type routePolicyView struct {
-	Path        string `json:"path"`
-	RateLimited bool   `json:"rateLimited"`
-	CSRF        bool   `json:"csrf"`
-	Admin       bool   `json:"admin"`
-	Feature     string `json:"feature,omitempty"`
+	Path         string   `json:"path"`
+	Methods      []string `json:"methods,omitempty"`
+	MaxBodyBytes int64    `json:"maxBodyBytes,omitempty"`
+	RateLimited  bool     `json:"rateLimited"`
+	CSRF         bool     `json:"csrf"`
+	Admin        bool     `json:"admin"`
+	Feature      string   `json:"feature,omitempty"`
 }
 
 // handleRoutePolicyManifest serves the route-policy manifest: every route
@@ -120,11 +173,13 @@ func (s *Server) handleRoutePolicyManifest(w http.ResponseWriter, r *http.Reques
 	views := make([]routePolicyView, 0, len(s.routeManifest))
 	for _, rt := range s.routeManifest {
 		views = append(views, routePolicyView{
-			Path:        rt.path,
-			RateLimited: rt.rl != rlNone,
-			CSRF:        rt.csrf,
-			Admin:       rt.admin,
-			Feature:     rt.feature,
+			Path:         rt.path,
+			Methods:      rt.methods,
+			MaxBodyBytes: rt.maxBodyBytes,
+			RateLimited:  rt.rl != rlNone,
+			CSRF:         rt.csrf,
+			Admin:        rt.admin,
+			Feature:      rt.feature,
 		})
 	}
 	s.writeJSON(w, views)

--- a/internal/api/route_test.go
+++ b/internal/api/route_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
@@ -40,13 +41,110 @@ func TestRoutePolicyManifest(t *testing.T) {
 	}
 
 	// Whole-topology import is admin-scoped + CSRF-protected + write-limited.
-	imp, ok := byPath["/api/v1/config/import"]
-	if !ok || !imp.Admin || !imp.CSRF || !imp.RateLimited {
+	imp, impOK := byPath["/api/v1/config/import"]
+	if !impOK || !imp.Admin || !imp.CSRF || !imp.RateLimited {
 		t.Errorf("/api/v1/config/import policy = %+v, want admin+csrf+rateLimited", imp)
 	}
 	// A safe read carries none of those.
-	rd, ok := byPath["/api/v1/topology"]
-	if !ok || rd.Admin || rd.CSRF || rd.RateLimited {
+	rd, rdOK := byPath["/api/v1/topology"]
+	if !rdOK || rd.Admin || rd.CSRF || rd.RateLimited {
 		t.Errorf("/api/v1/topology policy = %+v, want no admin/csrf/rateLimited", rd)
+	}
+}
+
+// TestRoutePolicyManifestMethodAndBody verifies the ADR-0002 parity additions:
+// every route reports a non-zero body cap and its accepted methods, upload /
+// replay routes carry the larger PCAP cap (not the 1MB default), and method-
+// gated routes report the exact method set the registry enforces.
+func TestRoutePolicyManifestMethodAndBody(t *testing.T) {
+	byPath := fetchRouteManifest(t)
+
+	// Every route must record a non-zero body cap (register() defaults 0 to
+	// MaxRequestBodySize) and must declare its accepted methods.
+	for _, v := range byPath {
+		if v.MaxBodyBytes == 0 {
+			t.Errorf("%s: maxBodyBytes = 0, want a non-zero cap (default %d)",
+				v.Path, int64(MaxRequestBodySize))
+		}
+		if len(v.Methods) == 0 {
+			t.Errorf("%s: methods empty, want declared HTTP methods", v.Path)
+		}
+	}
+
+	// Upload / replay routes accept inline PCAP payloads and MUST carry the
+	// larger cap, not the 1MB default — a regression here silently truncates
+	// valid captures.
+	for _, p := range []string{"/api/v1/pcap/upload", "/api/v1/replay"} {
+		if v := byPath[p]; v.MaxBodyBytes != int64(MaxPCAPUploadSize) {
+			t.Errorf("%s: maxBodyBytes = %d, want MaxPCAPUploadSize (%d)",
+				p, v.MaxBodyBytes, int64(MaxPCAPUploadSize))
+		}
+	}
+
+	// Method-gated routes report their methods: a multi-method dispatcher
+	// declares its full set, a single-method route declares exactly one.
+	wantMethods := map[string][]string{
+		"/api/v1/config": {http.MethodGet, http.MethodPut, http.MethodPatch, http.MethodPost},
+		"/api/v1/config/devices": {
+			http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete,
+		},
+		"/api/v1/topology": {http.MethodGet},
+	}
+	for p, want := range wantMethods {
+		if got := byPath[p].Methods; !slices.Equal(got, want) {
+			t.Errorf("%s methods = %v, want %v", p, got, want)
+		}
+	}
+}
+
+// fetchRouteManifest registers the full route table and returns the
+// /__capabilities manifest keyed by path.
+func fetchRouteManifest(t *testing.T) map[string]routePolicyView {
+	t.Helper()
+	server, _, _ := newTestServerWithAuth(t)
+	server.writeLimiter = ratelimit.NewRateLimiter(WriteRateLimit, WriteBurst)
+	mux := http.NewServeMux()
+	server.registerAPIRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/__capabilities", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /__capabilities: status = %d, want 200", rec.Code)
+	}
+
+	var views []routePolicyView
+	if err := json.Unmarshal(rec.Body.Bytes(), &views); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	byPath := make(map[string]routePolicyView, len(views))
+	for _, v := range views {
+		byPath[v.Path] = v
+	}
+	return byPath
+}
+
+// TestMethodGateRejectsWrongMethod verifies register()'s methodGate returns 405
+// with an Allow header for a method outside the route's declared set, exercising
+// the declarative path that replaced the in-handler guards.
+func TestMethodGateRejectsWrongMethod(t *testing.T) {
+	server, _, token := newTestServerWithAuth(t)
+	server.writeLimiter = ratelimit.NewRateLimiter(WriteRateLimit, WriteBurst)
+	mux := http.NewServeMux()
+	server.registerAPIRoutes(mux)
+
+	// /api/v1/topology is GET-only; a DELETE (with a read-write bearer so it
+	// clears auth's scope-by-method check) must 405 with Allow: GET from the
+	// registry's methodGate, not pass through to the handler.
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/topology", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("DELETE /api/v1/topology: status = %d, want 405", rec.Code)
+	}
+	if allow := rec.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("Allow header = %q, want %q", allow, http.MethodGet)
 	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -22,11 +22,11 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 
 	// Top-level authenticated reads + the CSRF-token endpoint.
 	s.registerAll(mux, []apiRoute{
-		{path: "/api/v1/csrf-token", handler: s.handleCSRFToken},
-		{path: "/api/v1/stats", handler: s.handleStats},
-		{path: "/api/v1/devices", handler: s.handleDevices},
-		{path: "/api/v1/history", handler: s.handleHistory},
-		{path: "/api/v1/license", handler: s.handleLicenseStatus},
+		{path: "/api/v1/csrf-token", handler: s.handleCSRFToken, methods: []string{http.MethodGet}},
+		{path: "/api/v1/stats", handler: s.handleStats, methods: []string{http.MethodGet}},
+		{path: "/api/v1/devices", handler: s.handleDevices, methods: []string{http.MethodGet}},
+		{path: "/api/v1/history", handler: s.handleHistory, methods: []string{http.MethodGet}},
+		{path: "/api/v1/license", handler: s.handleLicenseStatus, methods: []string{http.MethodGet}},
 	})
 
 	s.registerWriteProtectedRoutes(mux)
@@ -37,8 +37,9 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 
 	// Metrics require auth (#172); the SPA is the authenticated catch-all.
 	s.registerAll(mux, []apiRoute{
-		{path: "/metrics", handler: s.handleMetrics},
-		{path: "/", handler: s.serveSPA()},
+		{path: "/metrics", handler: s.handleMetrics, methods: []string{http.MethodGet}},
+		// The SPA serves static assets only; HEAD is honored for asset probes.
+		{path: "/", handler: s.serveSPA(), methods: []string{http.MethodGet, http.MethodHead}},
 	})
 }
 
@@ -46,19 +47,77 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 // limit + CSRF; /config/import additionally requires an admin-scoped token).
 func (s *Server) registerWriteProtectedRoutes(mux *http.ServeMux) {
 	s.registerAll(mux, []apiRoute{
-		{path: "/api/v1/config", handler: s.handleConfig, rl: rlWrite, csrf: true},
-		{path: "/api/v1/config/devices", handler: s.handleDevicesV2, rl: rlWrite, csrf: true},
-		{path: "/api/v1/config/devices/", handler: s.handleDevicesV2, rl: rlWrite, csrf: true},
-		{path: "/api/v1/config/merge", handler: s.handleConfigMerge, rl: rlWrite, csrf: true},
+		{
+			path:    "/api/v1/config",
+			handler: s.handleConfig,
+			methods: []string{http.MethodGet, http.MethodPut, http.MethodPatch, http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/config/devices",
+			handler: s.handleDevicesV2,
+			methods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/config/devices/",
+			handler: s.handleDevicesV2,
+			methods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/config/merge",
+			handler: s.handleConfigMerge,
+			methods: []string{http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+		},
 		// #743: whole-topology replacement is admin-class (an admin-scoped token
 		// in addition to read-write); routine per-device edits / configs CRUD
 		// stay at ScopeReadWrite because they are normal operator actions.
-		{path: "/api/v1/config/import", handler: s.handleConfigImport, rl: rlWrite, csrf: true, admin: true},
-		{path: "/api/v1/replay", handler: s.handleReplay, rl: rlWrite, csrf: true},
-		{path: "/api/v1/alerts", handler: s.handleAlerts, rl: rlWrite, csrf: true},
-		{path: "/api/v1/capture/filter", handler: s.handleCaptureFilter, rl: rlWrite, csrf: true},
+		{
+			path:    "/api/v1/config/import",
+			handler: s.handleConfigImport,
+			methods: []string{http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+			admin:   true,
+		},
+		// Replay accepts inline PCAP payloads (handleReplay POST decodes up to
+		// MaxPCAPUploadSize), so the registry cap must match that, not 1MB.
+		{
+			path:         "/api/v1/replay",
+			handler:      s.handleReplay,
+			methods:      []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+			maxBodyBytes: MaxPCAPUploadSize,
+			rl:           rlWrite,
+			csrf:         true,
+		},
+		{
+			path:    "/api/v1/alerts",
+			handler: s.handleAlerts,
+			methods: []string{http.MethodGet, http.MethodPut, http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/capture/filter",
+			handler: s.handleCaptureFilter,
+			methods: []string{http.MethodGet, http.MethodPut, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
 		// Standalone packet capture (POST=start, DELETE=stop, GET=status).
-		{path: "/api/v1/capture", handler: s.handleStandaloneCapture, rl: rlWrite, csrf: true},
+		{
+			path:    "/api/v1/capture",
+			handler: s.handleStandaloneCapture,
+			methods: []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
 	})
 }
 
@@ -67,46 +126,122 @@ func (s *Server) registerWriteProtectedRoutes(mux *http.ServeMux) {
 // CSRF (#740). csrfProtect internally skips GET, so reads pass through.
 func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 	s.registerAll(mux, []apiRoute{
-		{path: "/api/v1/config/schema", handler: s.handleConfigSchema},
-		{path: "/api/v1/files", handler: s.handleFiles, rl: rlFile},
+		{path: "/api/v1/config/schema", handler: s.handleConfigSchema, methods: []string{http.MethodGet}},
+		{path: "/api/v1/files", handler: s.handleFiles, methods: []string{http.MethodGet}, rl: rlFile},
 		// Templates: POST (upload), DELETE, and "use" mutate — write + CSRF.
-		{path: "/api/v1/templates", handler: s.handleTemplates, rl: rlWrite, csrf: true},
-		{path: "/api/v1/templates/", handler: s.handleTemplateByName, rl: rlWrite, csrf: true},
+		{
+			path:    "/api/v1/templates",
+			handler: s.handleTemplates,
+			methods: []string{http.MethodGet, http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/templates/",
+			handler: s.handleTemplateByName,
+			methods: []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
 		// User configs: POST/DELETE mutate — write + CSRF (#740).
-		{path: "/api/v1/configs", handler: s.handleUserConfigs, rl: rlWrite, csrf: true},
-		{path: "/api/v1/configs/", handler: s.handleUserConfigByName, rl: rlWrite, csrf: true},
+		{
+			path:    "/api/v1/configs",
+			handler: s.handleUserConfigs,
+			methods: []string{http.MethodGet, http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/configs/",
+			handler: s.handleUserConfigByName,
+			methods: []string{http.MethodGet, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
 		// Library (#548): networks full CRUD (write + CSRF); walks/pcaps read-only.
-		{path: "/api/v1/library/networks", handler: s.handleLibraryNetworks, rl: rlWrite, csrf: true},
-		{path: "/api/v1/library/networks/", handler: s.handleLibraryNetworkByName, rl: rlWrite, csrf: true},
-		{path: "/api/v1/library/walks", handler: s.handleLibraryWalks},
-		{path: "/api/v1/library/pcaps", handler: s.handleLibraryPcaps},
+		{
+			path:    "/api/v1/library/networks",
+			handler: s.handleLibraryNetworks,
+			methods: []string{http.MethodGet, http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/library/networks/",
+			handler: s.handleLibraryNetworkByName,
+			methods: []string{http.MethodGet, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{path: "/api/v1/library/walks", handler: s.handleLibraryWalks, methods: []string{http.MethodGet}},
+		{path: "/api/v1/library/pcaps", handler: s.handleLibraryPcaps, methods: []string{http.MethodGet}},
 		// Per-device baseline walk synthesis (#546 p2). POST-only; mutates the
 		// library + running config YAML, so write + CSRF.
-		{path: "/api/v1/devices/", handler: s.dispatchDeviceSubpath, rl: rlWrite, csrf: true},
+		{
+			path:    "/api/v1/devices/",
+			handler: s.dispatchDeviceSubpath,
+			methods: []string{http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+		},
 		// Read-only catalogs / schemas.
-		{path: "/api/v1/synthesize-walk/models", handler: s.handleSynthesizeWalkModels},
-		{path: "/api/v1/device-schemas", handler: s.handleDeviceEditorSchema},
-		{path: "/api/v1/device-schemas/", handler: s.handleDeviceEditorSchema},
-		{path: "/api/v1/topology", handler: s.handleTopology},
-		{path: "/api/v1/topology/export", handler: s.handleTopologyExport},
-		{path: "/api/v1/errors", handler: s.handleErrors, rl: rlWrite, csrf: true},
-		{path: "/api/v1/interfaces", handler: s.handleInterfaces},
-		{path: "/api/v1/runtime", handler: s.handleRuntime},
-		{path: "/api/v1/simulation", handler: s.handleSimulation, rl: rlWrite, csrf: true},
-		{path: "/api/v1/version", handler: s.handleVersion},
-		{path: "/api/v1/neighbors", handler: s.handleNeighbors},
+		{
+			path:    "/api/v1/synthesize-walk/models",
+			handler: s.handleSynthesizeWalkModels,
+			methods: []string{http.MethodGet},
+		},
+		{path: "/api/v1/device-schemas", handler: s.handleDeviceEditorSchema, methods: []string{http.MethodGet}},
+		{path: "/api/v1/device-schemas/", handler: s.handleDeviceEditorSchema, methods: []string{http.MethodGet}},
+		{path: "/api/v1/topology", handler: s.handleTopology, methods: []string{http.MethodGet}},
+		{path: "/api/v1/topology/export", handler: s.handleTopologyExport, methods: []string{http.MethodGet}},
+		{
+			path:    "/api/v1/errors",
+			handler: s.handleErrors,
+			methods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{path: "/api/v1/interfaces", handler: s.handleInterfaces, methods: []string{http.MethodGet}},
+		{path: "/api/v1/runtime", handler: s.handleRuntime, methods: []string{http.MethodGet}},
+		{
+			path:    "/api/v1/simulation",
+			handler: s.handleSimulation,
+			methods: []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+		{path: "/api/v1/version", handler: s.handleVersion, methods: []string{http.MethodGet}},
+		{path: "/api/v1/neighbors", handler: s.handleNeighbors, methods: []string{http.MethodGet}},
 		// #762: scope discovery — safe GET, no CSRF / write wrappers needed.
-		{path: "/api/v1/auth/scope", handler: s.handleAuthScope},
+		{path: "/api/v1/auth/scope", handler: s.handleAuthScope, methods: []string{http.MethodGet}},
 	})
 }
 
 // registerWalkRoutes registers SNMP walk validation endpoints (walk rate limit).
 func (s *Server) registerWalkRoutes(mux *http.ServeMux) {
 	s.registerAll(mux, []apiRoute{
-		{path: "/api/v1/walk/validate", handler: s.handleWalkValidation, rl: rlWalk, csrf: true},
-		{path: "/api/v1/walk/fix", handler: s.handleWalkValidation, rl: rlWalk, csrf: true},
-		{path: "/api/v1/walk/list", handler: s.handleWalkList, rl: rlWalk},
-		{path: "/api/v1/walk/validate-all", handler: s.handleWalkBatchValidate, rl: rlWalk, csrf: true},
+		{
+			path:    "/api/v1/walk/validate",
+			handler: s.handleWalkValidation,
+			methods: []string{http.MethodPost},
+			rl:      rlWalk,
+			csrf:    true,
+		},
+		{
+			path:    "/api/v1/walk/fix",
+			handler: s.handleWalkValidation,
+			methods: []string{http.MethodPost},
+			rl:      rlWalk,
+			csrf:    true,
+		},
+		{path: "/api/v1/walk/list", handler: s.handleWalkList, methods: []string{http.MethodGet}, rl: rlWalk},
+		{
+			path:    "/api/v1/walk/validate-all",
+			handler: s.handleWalkBatchValidate,
+			methods: []string{http.MethodPost},
+			rl:      rlWalk,
+			csrf:    true,
+		},
 	})
 }
 
@@ -114,18 +249,34 @@ func (s *Server) registerWalkRoutes(mux *http.ServeMux) {
 // pcap_ingest license feature; upload additionally rate-limited + CSRF).
 func (s *Server) registerPcapRoutes(mux *http.ServeMux) {
 	s.registerAll(mux, []apiRoute{
-		{path: "/api/v1/pcap/upload", handler: s.handlePcapUpload, rl: rlUpload, csrf: true, feature: "pcap_ingest"},
-		{path: "/api/v1/pcap/", handler: s.handlePcapAnalysis, feature: "pcap_ingest"},
+		// Upload decodes a base64 PCAP payload up to MaxPCAPUploadSize (100MB)
+		// via decodeJSONStrict; the registry cap must match so it never truncates
+		// a valid capture before the handler reads it.
+		{
+			path:         "/api/v1/pcap/upload",
+			handler:      s.handlePcapUpload,
+			methods:      []string{http.MethodPost},
+			maxBodyBytes: MaxPCAPUploadSize,
+			rl:           rlUpload,
+			csrf:         true,
+			feature:      "pcap_ingest",
+		},
+		{
+			path:    "/api/v1/pcap/",
+			handler: s.handlePcapAnalysis,
+			methods: []string{http.MethodGet},
+			feature: "pcap_ingest",
+		},
 	})
 }
 
 // registerSSERoutes registers Server-Sent Events streams (auth only).
 func (s *Server) registerSSERoutes(mux *http.ServeMux) {
 	s.registerAll(mux, []apiRoute{
-		{path: "/api/v1/stream/packets", handler: s.handleSSEPackets},
-		{path: "/api/v1/stream/logs", handler: s.handleSSELogs},
-		{path: "/api/v1/stream/stats", handler: s.handleSSEStats},
-		{path: "/api/v1/stream/status", handler: s.handleSSEStatus},
+		{path: "/api/v1/stream/packets", handler: s.handleSSEPackets, methods: []string{http.MethodGet}},
+		{path: "/api/v1/stream/logs", handler: s.handleSSELogs, methods: []string{http.MethodGet}},
+		{path: "/api/v1/stream/stats", handler: s.handleSSEStats, methods: []string{http.MethodGet}},
+		{path: "/api/v1/stream/status", handler: s.handleSSEStatus, methods: []string{http.MethodGet}},
 	})
 }
 

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -89,12 +89,7 @@ type ConfigSchema struct {
 // handleConfigSchema returns the JSON Schema for device configuration
 // GET /api/v1/config/schema.
 func (s *Server) handleConfigSchema(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-
-		return
-	}
-
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	schema := buildDeviceSchema()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/schema_test.go
+++ b/internal/api/schema_test.go
@@ -182,9 +182,14 @@ func TestHandleConfigSchema(t *testing.T) {
 	})
 
 	t.Run("POST not allowed", func(t *testing.T) {
+		// Method gating moved from the handler to the route registry (ADR-0002).
+		// Exercise the methodGate wrapper register() composes for the GET-only
+		// /api/v1/config/schema route.
+		gated := server.methodGate([]string{http.MethodGet}, server.handleConfigSchema)
+
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/config/schema", nil)
-		server.handleConfigSchema(rec, req)
+		gated(rec, req)
 
 		if rec.Code != http.StatusMethodNotAllowed {
 			t.Errorf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)

--- a/internal/api/sse_handlers.go
+++ b/internal/api/sse_handlers.go
@@ -27,12 +27,8 @@ func (s *Server) handleSSEStats(w http.ResponseWriter, r *http.Request) {
 // handleSSEStatus returns SSE hub status: running state, per-stream client
 // counts, and the configured caps. Used by the SSE Status page in the UI to
 // confirm the hub is healthy and to surface client churn.
-func (s *Server) handleSSEStatus(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
-
+func (s *Server) handleSSEStatus(w http.ResponseWriter, _ *http.Request) {
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	var status map[string]any
 	if s.sseHub != nil {
 		st := s.sseHub.Status()

--- a/internal/api/walk.go
+++ b/internal/api/walk.go
@@ -226,11 +226,8 @@ func buildWalkValidationResponse(result *snmp.ValidationResult, autoFix bool) Wa
 }
 
 func (s *Server) handleWalkValidation(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
-
+	// Method gating (POST-only) is enforced declaratively by the route registry
+	// on /api/v1/walk/{validate,fix}.
 	isAutoFix := strings.HasSuffix(r.URL.Path, "/fix")
 
 	var req WalkValidationRequest
@@ -267,12 +264,7 @@ func (s *Server) handleWalkValidation(w http.ResponseWriter, r *http.Request) {
 // handleWalkList lists available walk files
 // GET /api/v1/walk/list - List walk files in the config directory.
 func (s *Server) handleWalkList(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-
-		return
-	}
-
+	// Method gating (GET-only) is enforced declaratively by the route registry.
 	// SECURITY FIX: Thread-safe access to config via currentConfig()
 	cfg := s.currentConfig()
 	if cfg == nil {
@@ -418,11 +410,7 @@ func buildBatchWalkResponse(
 }
 
 func (s *Server) handleWalkBatchValidate(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-		return
-	}
-
+	// Method gating (POST-only) is enforced declaratively by the route registry.
 	cfg := s.currentConfig()
 	if cfg == nil {
 		writeError(w, r, http.StatusInternalServerError, "config_unavailable",


### PR DESCRIPTION
Bring niac's capability registry to ADR-0002 parity with seed: HTTP method
and request body-size limit are now declared as data on apiRoute and enforced
by register()-composed middleware, instead of relying on per-handler guards
and inline MaxBytesReader.

- apiRoute gains `methods []string` (methodGate: 405 + Allow header; empty
  preserves the handler's own dispatch) and `maxBodyBytes int64` (bodyLimited,
  applied innermost; 0 defaults to MaxRequestBodySize).
- register() composes recover → auth → rateLimit → csrf → admin → feature →
  methodGate → bodyLimit → handler, and records both new fields for the
  /__capabilities manifest (routePolicyView gains Methods + MaxBodyBytes).
- Every route in routes.go is annotated with its accepted methods (source of
  truth: the in-handler guards / dispatch switches). devices.go's multi-method
  dispatcher keeps its switch and declares GET,POST,PUT,DELETE.
- Upload-class routes keep their real limits: /api/v1/pcap/upload and
  /api/v1/replay set maxBodyBytes=MaxPCAPUploadSize (100MB) to match their
  decodeJSONStrict caps; all other routes safely take the 1MB default
  (config/import etc. already decode at MaxRequestBodySize).
- Redundant single-method in-handler guards removed (schema, sse_handlers,
  config_ops, walk, pcap, synthesize-walk, device-schema, library files, and
  read handlers). Multi-method dispatch switches and templates/use's sub-path
  POST check are kept. Existing 405 unit tests rewired to exercise methodGate.
- Route-policy manifest test asserts every route records a non-zero body cap
  and its methods; new test verifies methodGate returns 405 + Allow.
