### PR TITLE
fix(ui): make the '?' help shortcut actually open the drawer (N1, N5)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -48,7 +48,7 @@ function AppShell() {
   const [helpOpen, setHelpOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  useKeyboardShortcuts();
+  useKeyboardShortcuts(() => setHelpOpen(true));
 
   return (
     <SidebarLayout

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,65 @@
+/**
+ * useKeyboardShortcuts tests — guard the `?` shortcut, which previously
+ * fired a `niac:show-shortcuts` CustomEvent that nothing listened for, so
+ * pressing `?` silently did nothing. These pin that `?` now invokes the
+ * injected onShowHelp callback, and that the chord shortcuts still navigate.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { createElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }): React.ReactElement =>
+  createElement(MemoryRouter, null, children);
+
+function press(key: string): void {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useKeyboardShortcuts', () => {
+  it('invokes onShowHelp when "?" is pressed (was a dead CustomEvent)', () => {
+    const onShowHelp = vi.fn();
+    renderHook(() => useKeyboardShortcuts(onShowHelp), { wrapper });
+
+    press('?');
+
+    expect(onShowHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it('always calls the latest onShowHelp (ref-stable, no stale closure)', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ cb }) => useKeyboardShortcuts(cb), {
+      wrapper,
+      initialProps: { cb: first },
+    });
+
+    rerender({ cb: second });
+    press('?');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates the "g a" chord to /traffic, not the dead /analysis redirect', () => {
+    renderHook(() => useKeyboardShortcuts(vi.fn()), { wrapper });
+
+    press('g');
+    press('a');
+
+    expect(mockNavigate).toHaveBeenCalledWith('/traffic');
+  });
+});

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -7,19 +7,24 @@ interface Shortcut {
   description: string;
 }
 
-function showShortcutHelp(): void {
-  window.dispatchEvent(new CustomEvent('niac:show-shortcuts'));
-}
-
 /**
  * Keyboard shortcuts for power users.
  * Supports chord sequences (e.g., 'g' then 'd' for go-to-devices).
  * Shortcuts are disabled when focus is in an input/textarea.
+ *
+ * @param onShowHelp opens the help drawer (the `?` shortcut). Wired through
+ *   React state from AppShell — previously this fired a `niac:show-shortcuts`
+ *   CustomEvent that nothing listened for, so `?` silently did nothing.
  */
-export function useKeyboardShortcuts(): Shortcut[] {
+export function useKeyboardShortcuts(onShowHelp: () => void): Shortcut[] {
   const navigate = useNavigate();
   const navigateRef = useRef(navigate);
   navigateRef.current = navigate;
+
+  // Keep the latest callback in a ref so the memoised `shortcuts` array stays
+  // stable while still calling the current handler.
+  const onShowHelpRef = useRef(onShowHelp);
+  onShowHelpRef.current = onShowHelp;
 
   const pendingRef = useRef<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
@@ -54,10 +59,10 @@ export function useKeyboardShortcuts(): Shortcut[] {
       { keys: ['g', 'h'], action: () => navigateRef.current('/'), description: 'Go to Home' },
       {
         keys: ['g', 'a'],
-        action: () => navigateRef.current('/analysis'),
-        description: 'Go to Analysis',
+        action: () => navigateRef.current('/traffic'),
+        description: 'Go to Traffic',
       },
-      { keys: ['?'], action: showShortcutHelp, description: 'Show shortcuts' },
+      { keys: ['?'], action: () => onShowHelpRef.current(), description: 'Show shortcuts' },
     ],
     [],
   );


### PR DESCRIPTION
First execution item from `NIAC_UI_ARCH_PLAN.md` (the niac UI audit).

## N1 — `?` shortcut was silently broken
`showShortcutHelp()` fired `window.dispatchEvent(new CustomEvent('niac:show-shortcuts'))` — **no listener exists anywhere in `ui/src`**. The HelpDrawer is controlled by React state (`helpOpen` in AppShell). So pressing `?` (documented in the shortcuts panel) did nothing.

**Fix:** thread an `onShowHelp` callback into `useKeyboardShortcuts(() => setHelpOpen(true))`, kept in a ref so the memoised shortcut list stays stable; delete the dead event + dispatcher. This also removes niac's last `window`-event-bus vestige.

## N5 — stale `g a` chord
Navigated to `/analysis`, a back-compat redirect to `/traffic`. Now points straight at `/traffic` (and relabeled "Go to Traffic").

## Verification
- New regression test (`useKeyboardShortcuts.test.ts`): `?` invokes the latest `onShowHelp` (no stale closure); `g a` navigates to `/traffic`. **3 tests pass.**
- `tsc --noEmit` clean; Biome clean.
- `grep niac:show-shortcuts ui/src` → only doc-comment mentions remain, no live dispatch.