### PR TITLE
test(ui): add nav↔route parity guard (enforcement parity with seed)

### DIFF
--- a/ui/src/navGroups.test.ts
+++ b/ui/src/navGroups.test.ts
@@ -1,0 +1,39 @@
+/**
+ * navGroups <-> pageRegistry parity guard.
+ *
+ * Enforces two architecture invariants:
+ *   1. Every routable page defined in pageRegistry appears in the sidebar.
+ *   2. Every sidebar entry points at a route that exists in pageRegistry.
+ *
+ * This mirrors the same guard in seed (ui/src/navGroups.test.ts) so both
+ * products enforce the same nav-drift invariant.
+ *
+ * Implementation note: both useNavGroups() and usePages() call
+ * useTranslation('pages') internally. Importing '../i18n' initialises
+ * i18next synchronously (see useLocale.test.ts for the same pattern),
+ * so renderHook works without a wrapper.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import './i18n'; // initialise i18next before hooks run
+import { useNavGroups } from './navGroups';
+import { usePages } from './pageRegistry';
+
+describe('navGroups <-> pageRegistry parity', () => {
+  const { result: navResult } = renderHook(() => useNavGroups());
+  const { result: pagesResult } = renderHook(() => usePages());
+
+  const navPaths = new Set(navResult.current.flatMap((g) => g.items.map((i) => i.path)));
+  const routePaths = new Set(pagesResult.current.map((p) => p.path));
+
+  it('exposes every routable page in the sidebar', () => {
+    const missing = pagesResult.current.map((p) => p.path).filter((p) => !navPaths.has(p));
+    expect(missing, `pages missing from navGroups: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('has no sidebar entries pointing at a non-existent route', () => {
+    const orphaned = [...navPaths].filter((p) => !routePaths.has(p));
+    expect(orphaned, `navGroups entries without a page: ${orphaned.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Ports seed's nav↔route parity guard to niac's UI
- Adds `ui/src/navGroups.test.ts` with two invariant assertions:
  1. Every page in `pageRegistry` appears in the sidebar (`useNavGroups`)
  2. Every sidebar entry points at a route that exists in `pageRegistry`

## Approach

Both `useNavGroups()` and `usePages()` are hooks (i18n-resolved labels), so the test uses `renderHook` after importing `./i18n` to initialise i18next — the same pattern as `useLocale.test.ts`. No wrapper needed since neither hook depends on React context beyond react-i18next's built-in provider.

## Result on current main

Both assertions **pass clean** — no nav drift exists on main. The guard now enforces this going forward.

## Test plan

- [x] `npx vitest run src/navGroups.test` — 2/2 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check src/navGroups.test.ts` — no issues