### PR TITLE
refactor(api): camelCase the JSON wire surface (ADR-0007)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Route-policy gate (capability registry)
         run: ./scripts/check-route-policy.sh
 
+      - name: JSON wire-casing gate — camelCase ratchet (ADR-0007)
+        run: ./scripts/check-json-casing.sh
+
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/internal/api/alerts_test.go
+++ b/internal/api/alerts_test.go
@@ -44,7 +44,7 @@ func TestHandleAlertsGetDefault(t *testing.T) {
 func TestHandleAlertsPutValid(t *testing.T) {
 	server := newAlertTestServer(t)
 
-	body := `{"packets_threshold":5000,"webhook_url":"https://hooks.example.com/alert"}`
+	body := `{"packetsThreshold":5000,"webhookUrl":"https://hooks.example.com/alert"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(body))
 	server.handleAlerts(rec, req)
@@ -68,7 +68,7 @@ func TestHandleAlertsPutValid(t *testing.T) {
 func TestHandleAlertsPostValid(t *testing.T) {
 	server := newAlertTestServer(t)
 
-	body := `{"packets_threshold":1000,"webhook_url":"https://example.com/hook"}`
+	body := `{"packetsThreshold":1000,"webhookUrl":"https://example.com/hook"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/alerts", strings.NewReader(body))
 	server.handleAlerts(rec, req)
@@ -106,7 +106,7 @@ func TestHandleAlertsValidationFailed(t *testing.T) {
 	server := newAlertTestServer(t)
 
 	// Use invalid webhook URL (private IP)
-	body := `{"packets_threshold":100,"webhook_url":"http://192.168.1.1/hook"}`
+	body := `{"packetsThreshold":100,"webhookUrl":"http://192.168.1.1/hook"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(body))
 	server.handleAlerts(rec, req)

--- a/internal/api/config_ops.go
+++ b/internal/api/config_ops.go
@@ -28,9 +28,9 @@ type MergeConfigsRequest struct {
 // MergeConfigsResponse is the body for POST /api/v1/config/merge.
 type MergeConfigsResponse struct {
 	Merged      string `json:"merged"`
-	BaseDevices int    `json:"base_devices"`
-	OverlayDevs int    `json:"overlay_devices"`
-	MergedDevs  int    `json:"merged_devices"`
+	BaseDevices int    `json:"baseDevices"`
+	OverlayDevs int    `json:"overlayDevices"`
+	MergedDevs  int    `json:"mergedDevices"`
 }
 
 // ConfigImportRequest is the body for POST /api/v1/config/import.

--- a/internal/api/config_state.go
+++ b/internal/api/config_state.go
@@ -14,9 +14,9 @@ import (
 type configDocument struct {
 	Path        string    `json:"path"`
 	Filename    string    `json:"filename"`
-	ModifiedAt  time.Time `json:"modified_at"`
-	SizeBytes   int64     `json:"size_bytes"`
-	DeviceCount int       `json:"device_count"`
+	ModifiedAt  time.Time `json:"modifiedAt"`
+	SizeBytes   int64     `json:"sizeBytes"`
+	DeviceCount int       `json:"deviceCount"`
 	Content     string    `json:"content"`
 }
 

--- a/internal/api/devices_handlers_test.go
+++ b/internal/api/devices_handlers_test.go
@@ -303,7 +303,7 @@ func TestHandleDeviceUpdateInterfaces(t *testing.T) {
 		return nil
 	}
 
-	body := `{"interfaces":[{"name":"Ethernet1/1","speed":1000,"duplex":"full","admin_status":"up"}]}`
+	body := `{"interfaces":[{"name":"Ethernet1/1","speed":1000,"duplex":"full","adminStatus":"up"}]}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/config/devices/router1", strings.NewReader(body))
 	server.handleDevicesV2(rec, req)
@@ -349,7 +349,7 @@ func TestHandleDeviceUpdateInvalidInterface(t *testing.T) {
 func TestHandleDeviceCloneSuccess(t *testing.T) {
 	server := newDeviceTestServer(t)
 
-	body := `{"new_hostname":"router1-clone","new_ip":"10.0.0.5","new_mac":"AA:BB:CC:DD:EE:01"}`
+	body := `{"newHostname":"router1-clone","newIp":"10.0.0.5","newMac":"AA:BB:CC:DD:EE:01"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/devices/router1/clone", strings.NewReader(body))
 	server.handleDevicesV2(rec, req)
@@ -370,7 +370,7 @@ func TestHandleDeviceCloneSuccess(t *testing.T) {
 func TestHandleDeviceCloneSourceNotFound(t *testing.T) {
 	server := newDeviceTestServer(t)
 
-	body := `{"new_hostname":"clone1"}`
+	body := `{"newHostname":"clone1"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/devices/nonexistent/clone", strings.NewReader(body))
 	server.handleDevicesV2(rec, req)
@@ -383,7 +383,7 @@ func TestHandleDeviceCloneSourceNotFound(t *testing.T) {
 func TestHandleDeviceCloneDuplicateHostname(t *testing.T) {
 	server := newDeviceTestServer(t)
 
-	body := `{"new_hostname":"switch1"}`
+	body := `{"newHostname":"switch1"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/devices/router1/clone", strings.NewReader(body))
 	server.handleDevicesV2(rec, req)
@@ -396,7 +396,7 @@ func TestHandleDeviceCloneDuplicateHostname(t *testing.T) {
 func TestHandleDeviceCloneInvalidHostname(t *testing.T) {
 	server := newDeviceTestServer(t)
 
-	body := `{"new_hostname":""}`
+	body := `{"newHostname":""}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/devices/router1/clone", strings.NewReader(body))
 	server.handleDevicesV2(rec, req)

--- a/internal/api/devices_types.go
+++ b/internal/api/devices_types.go
@@ -9,11 +9,11 @@ type DeviceResponse struct {
 	IPs              []string                  `json:"ips,omitempty"`
 	VLAN             int                       `json:"vlan,omitempty"`
 	Interfaces       []string                  `json:"interfaces,omitempty"`
-	InterfaceDetails []DeviceInterfaceResponse `json:"interface_details,omitempty"`
+	InterfaceDetails []DeviceInterfaceResponse `json:"interfaceDetails,omitempty"`
 	Protocols        []string                  `json:"protocols"`
 
 	// Protocol configurations (optional, included when requested)
-	SNMPAgent     *SNMPAgentResponse     `json:"snmp_agent,omitempty"`
+	SNMPAgent     *SNMPAgentResponse     `json:"snmpAgent,omitempty"`
 	CDP           *CDPResponse           `json:"cdp,omitempty"`
 	LLDP          *LLDPResponse          `json:"lldp,omitempty"`
 	DHCP          *DHCPResponse          `json:"dhcp,omitempty"`
@@ -22,10 +22,10 @@ type DeviceResponse struct {
 	FTP           *FTPResponse           `json:"ftp,omitempty"`
 	NetBIOS       *NetBIOSResponse       `json:"netbios,omitempty"`
 	STP           *STPResponse           `json:"stp,omitempty"`
-	TrafficConfig *TrafficConfigResponse `json:"traffic_config,omitempty"`
+	TrafficConfig *TrafficConfigResponse `json:"trafficConfig,omitempty"`
 
 	// Raw YAML for advanced editing
-	RawYAML string `json:"raw_yaml,omitempty"`
+	RawYAML string `json:"rawYaml,omitempty"`
 }
 
 // SNMPAgentResponse represents SNMP agent configuration.
@@ -36,8 +36,8 @@ type SNMPAgentResponse struct {
 	SysLocation string           `json:"syslocation,omitempty"`
 	SysDescr    string           `json:"sysdescr,omitempty"`
 	SysContact  string           `json:"syscontact,omitempty"`
-	WalkFile    string           `json:"walk_file,omitempty"`
-	AddMibs     []AddMibResponse `json:"add_mibs,omitempty"`
+	WalkFile    string           `json:"walkFile,omitempty"`
+	AddMibs     []AddMibResponse `json:"addMibs,omitempty"`
 }
 
 // AddMibResponse represents an additional MIB entry.
@@ -51,8 +51,8 @@ type AddMibResponse struct {
 type CDPResponse struct {
 	Enabled         bool   `json:"enabled"`
 	Platform        string `json:"platform,omitempty"`
-	SoftwareVersion string `json:"software_version,omitempty"`
-	PortID          string `json:"port_id,omitempty"`
+	SoftwareVersion string `json:"softwareVersion,omitempty"`
+	PortID          string `json:"portId,omitempty"`
 	Version         int    `json:"version,omitempty"`
 	Holdtime        int    `json:"holdtime,omitempty"`
 }
@@ -60,18 +60,18 @@ type CDPResponse struct {
 // LLDPResponse represents LLDP configuration.
 type LLDPResponse struct {
 	Enabled           bool   `json:"enabled"`
-	ChassisIDType     string `json:"chassis_id_type,omitempty"`
-	PortDescription   string `json:"port_description,omitempty"`
-	SystemDescription string `json:"system_description,omitempty"`
+	ChassisIDType     string `json:"chassisIdType,omitempty"`
+	PortDescription   string `json:"portDescription,omitempty"`
+	SystemDescription string `json:"systemDescription,omitempty"`
 	TTL               int    `json:"ttl,omitempty"`
 }
 
 // DHCPResponse represents DHCP server configuration.
 type DHCPResponse struct {
 	Enabled    bool     `json:"enabled"`
-	PoolStart  string   `json:"pool_start,omitempty"`
-	PoolEnd    string   `json:"pool_end,omitempty"`
-	SubnetMask string   `json:"subnet_mask,omitempty"`
+	PoolStart  string   `json:"poolStart,omitempty"`
+	PoolEnd    string   `json:"poolEnd,omitempty"`
+	SubnetMask string   `json:"subnetMask,omitempty"`
 	Router     string   `json:"router,omitempty"`
 	DNS        []string `json:"dns,omitempty"`
 }
@@ -79,21 +79,21 @@ type DHCPResponse struct {
 // DNSResponse represents DNS server configuration.
 type DNSResponse struct {
 	Enabled bool `json:"enabled"`
-	Records int  `json:"record_count,omitempty"`
+	Records int  `json:"recordCount,omitempty"`
 }
 
 // HTTPResponse represents HTTP server configuration.
 type HTTPResponse struct {
 	Enabled       bool   `json:"enabled"`
-	ServerName    string `json:"server_name,omitempty"`
-	EndpointCount int    `json:"endpoint_count,omitempty"`
+	ServerName    string `json:"serverName,omitempty"`
+	EndpointCount int    `json:"endpointCount,omitempty"`
 }
 
 // FTPResponse represents FTP server configuration.
 type FTPResponse struct {
 	Enabled        bool   `json:"enabled"`
-	WelcomeBanner  string `json:"welcome_banner,omitempty"`
-	AllowAnonymous bool   `json:"allow_anonymous,omitempty"`
+	WelcomeBanner  string `json:"welcomeBanner,omitempty"`
+	AllowAnonymous bool   `json:"allowAnonymous,omitempty"`
 }
 
 // NetBIOSResponse represents NetBIOS configuration.
@@ -112,11 +112,11 @@ type STPResponse struct {
 // TrafficConfigResponse represents traffic pattern configuration.
 type TrafficConfigResponse struct {
 	Enabled         bool `json:"enabled"`
-	ARPEnabled      bool `json:"arp_enabled,omitempty"`
-	ARPInterval     int  `json:"arp_interval,omitempty"`
-	PingEnabled     bool `json:"ping_enabled,omitempty"`
-	PingInterval    int  `json:"ping_interval,omitempty"`
-	PingPayloadSize int  `json:"ping_payload_size,omitempty"`
+	ARPEnabled      bool `json:"arpEnabled,omitempty"`
+	ARPInterval     int  `json:"arpInterval,omitempty"`
+	PingEnabled     bool `json:"pingEnabled,omitempty"`
+	PingInterval    int  `json:"pingInterval,omitempty"`
+	PingPayloadSize int  `json:"pingPayloadSize,omitempty"`
 }
 
 // DeviceInterfaceResponse represents configured metadata for a device interface.
@@ -124,8 +124,8 @@ type DeviceInterfaceResponse struct {
 	Name        string `json:"name"`
 	Speed       int    `json:"speed,omitempty"`
 	Duplex      string `json:"duplex,omitempty"`
-	AdminStatus string `json:"admin_status,omitempty"`
-	OperStatus  string `json:"oper_status,omitempty"`
+	AdminStatus string `json:"adminStatus,omitempty"`
+	OperStatus  string `json:"operStatus,omitempty"`
 	Description string `json:"description,omitempty"`
 	VLANs       []int  `json:"vlans,omitempty"`
 }
@@ -135,8 +135,8 @@ type DeviceInterfaceUpdate struct {
 	Name        string `json:"name"`
 	Speed       int    `json:"speed,omitempty"`
 	Duplex      string `json:"duplex,omitempty"`
-	AdminStatus string `json:"admin_status,omitempty"`
-	OperStatus  string `json:"oper_status,omitempty"`
+	AdminStatus string `json:"adminStatus,omitempty"`
+	OperStatus  string `json:"operStatus,omitempty"`
 	Description string `json:"description,omitempty"`
 	VLANs       []int  `json:"vlans,omitempty"`
 }
@@ -148,9 +148,9 @@ type DeviceCreateRequest struct {
 	MAC              string                  `json:"mac,omitempty"`
 	IP               string                  `json:"ip,omitempty"`
 	Interfaces       []DeviceInterfaceUpdate `json:"interfaces,omitempty"`
-	InterfaceDetails []DeviceInterfaceUpdate `json:"interface_details,omitempty"`
+	InterfaceDetails []DeviceInterfaceUpdate `json:"interfaceDetails,omitempty"`
 	Template         string                  `json:"template,omitempty"` // Use template as base
-	RawYAML          string                  `json:"raw_yaml,omitempty"` // Advanced: full YAML
+	RawYAML          string                  `json:"rawYaml,omitempty"`  // Advanced: full YAML
 }
 
 // DeviceUpdateRequest represents a request to update a device.
@@ -159,19 +159,19 @@ type DeviceUpdateRequest struct {
 	MAC              string                  `json:"mac,omitempty"`
 	IP               string                  `json:"ip,omitempty"`
 	Interfaces       []DeviceInterfaceUpdate `json:"interfaces,omitempty"`
-	InterfaceDetails []DeviceInterfaceUpdate `json:"interface_details,omitempty"`
-	RawYAML          string                  `json:"raw_yaml,omitempty"` // Full YAML for the device
+	InterfaceDetails []DeviceInterfaceUpdate `json:"interfaceDetails,omitempty"`
+	RawYAML          string                  `json:"rawYaml,omitempty"` // Full YAML for the device
 }
 
 // DeviceCloneRequest represents a request to clone a device.
 type DeviceCloneRequest struct {
-	NewHostname string `json:"new_hostname"`
-	NewIP       string `json:"new_ip,omitempty"`
-	NewMAC      string `json:"new_mac,omitempty"`
+	NewHostname string `json:"newHostname"`
+	NewIP       string `json:"newIp,omitempty"`
+	NewMAC      string `json:"newMac,omitempty"`
 }
 
 // DeviceListResponse represents the response for listing devices.
 type DeviceListResponse struct {
 	Devices    []DeviceResponse `json:"devices"`
-	TotalCount int              `json:"total_count"`
+	TotalCount int              `json:"totalCount"`
 }

--- a/internal/api/file_collection.go
+++ b/internal/api/file_collection.go
@@ -15,8 +15,8 @@ import (
 type FileEntry struct {
 	Path      string    `json:"path"`
 	Name      string    `json:"name"`
-	SizeBytes int64     `json:"size_bytes"`
-	Modified  time.Time `json:"modified_at"`
+	SizeBytes int64     `json:"sizeBytes"`
+	Modified  time.Time `json:"modifiedAt"`
 }
 
 // getFileKindConfig returns root path and extensions for a file kind.

--- a/internal/api/handlers_capture.go
+++ b/internal/api/handlers_capture.go
@@ -22,7 +22,7 @@ type CaptureStatus struct {
 	Running   bool   `json:"running"`
 	Interface string `json:"interface,omitempty"`
 	Filter    string `json:"filter,omitempty"`
-	StartedAt string `json:"started_at,omitempty"`
+	StartedAt string `json:"startedAt,omitempty"`
 	// Packets is the running count of packets the capture has observed
 	// since it started. Updated by the capture loop.
 	Packets uint64 `json:"packets"`

--- a/internal/api/handlers_errors.go
+++ b/internal/api/handlers_errors.go
@@ -8,9 +8,9 @@ import (
 
 // errorInjectionRequest represents a request to inject an error.
 type errorInjectionRequest struct {
-	DeviceIP  string `json:"device_ip"`
+	DeviceIP  string `json:"deviceIp"`
 	Interface string `json:"interface"`
-	ErrorType string `json:"error_type"`
+	ErrorType string `json:"errorType"`
 	Value     int    `json:"value"`
 }
 
@@ -112,12 +112,12 @@ func (s *Server) handleErrorInjection(
 	errorMgr.SetError(req.DeviceIP, req.Interface, apperr.ErrorType(req.ErrorType), req.Value)
 
 	s.writeJSON(w, map[string]any{
-		"success":    true,
-		"message":    "error injected successfully",
-		"device_ip":  req.DeviceIP,
-		"interface":  req.Interface,
-		"error_type": req.ErrorType,
-		"value":      req.Value,
+		"success":   true,
+		"message":   "error injected successfully",
+		"deviceIp":  req.DeviceIP,
+		"interface": req.Interface,
+		"errorType": req.ErrorType,
+		"value":     req.Value,
 	})
 }
 
@@ -128,7 +128,7 @@ func (s *Server) handleErrorClear(
 	errorMgr *apperr.StateManager,
 ) {
 	query := r.URL.Query()
-	deviceIP := query.Get("device_ip")
+	deviceIP := query.Get("deviceIp")
 	iface := query.Get("interface")
 
 	switch {
@@ -142,14 +142,14 @@ func (s *Server) handleErrorClear(
 			map[string]any{
 				"success":   true,
 				"message":   "error cleared",
-				"device_ip": deviceIP,
+				"deviceIp":  deviceIP,
 				"interface": iface,
 			},
 		)
 	default:
 		http.Error(
 			w,
-			"both device_ip and interface are required, or omit both to clear all",
+			"both deviceIp and interface are required, or omit both to clear all",
 			http.StatusBadRequest,
 		)
 	}

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -10,13 +10,13 @@ import (
 // ErrorResponse represents a standardized API error response
 // FEATURE #105: Consistent error format for all API endpoints.
 type ErrorResponse struct {
-	Error     string        `json:"error"`                // Machine-readable error code
-	Message   string        `json:"message"`              // Human-readable error message
-	Details   []ErrorDetail `json:"details,omitempty"`    // Optional detailed error information
-	RequestID string        `json:"request_id,omitempty"` // Optional request ID for tracing
-	Timestamp time.Time     `json:"timestamp"`            // When the error occurred
-	Path      string        `json:"path"`                 // Request path that caused the error
-	Method    string        `json:"method"`               // HTTP method
+	Error     string        `json:"error"`               // Machine-readable error code
+	Message   string        `json:"message"`             // Human-readable error message
+	Details   []ErrorDetail `json:"details,omitempty"`   // Optional detailed error information
+	RequestID string        `json:"requestId,omitempty"` // Optional request ID for tracing
+	Timestamp time.Time     `json:"timestamp"`           // When the error occurred
+	Path      string        `json:"path"`                // Request path that caused the error
+	Method    string        `json:"method"`              // HTTP method
 }
 
 // ErrorDetail provides detailed information about a specific error.

--- a/internal/api/response_test.go
+++ b/internal/api/response_test.go
@@ -148,7 +148,7 @@ func TestErrorResponseStructure(t *testing.T) {
 		t.Fatalf("unmarshal error: %v", err)
 	}
 
-	expectedFields := []string{"error", "message", "request_id", "path", "method", "timestamp"}
+	expectedFields := []string{"error", "message", "requestId", "path", "method", "timestamp"}
 	for _, field := range expectedFields {
 		if _, ok := m[field]; !ok {
 			t.Errorf("missing expected JSON field: %s", field)

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -199,7 +199,7 @@ func buildProtocolSchemaProperties() map[string]*SchemaProperty {
 	maxTTL := 255.0
 
 	return map[string]*SchemaProperty{
-		"snmp_agent":     buildSNMPAgentSchema(),
+		"snmpAgent":      buildSNMPAgentSchema(),
 		"lldp":           buildLLDPSchema(),
 		"cdp":            buildCDPSchema(),
 		"edp":            buildEDPSchema(),

--- a/internal/api/schema_discovery.go
+++ b/internal/api/schema_discovery.go
@@ -34,7 +34,7 @@ func buildSNMPAgentSchema() *SchemaProperty {
 				Title:       "System Location",
 				Description: "SNMP sysLocation (1.3.6.1.2.1.1.6)",
 			},
-			"walk_file": {
+			"walkFile": {
 				Type:        "string",
 				Title:       "Walk File",
 				Description: "Path to SNMP walk file",
@@ -48,7 +48,7 @@ func buildSNMPAgentSchema() *SchemaProperty {
 					Type: "string",
 				},
 			},
-			"add_mibs": {
+			"addMibs": {
 				Type:        "array",
 				Title:       "Custom MIB Entries",
 				Description: "Custom MIB overrides/additions",
@@ -126,19 +126,19 @@ func buildLLDPSchema() *SchemaProperty {
 				Minimum:     floatPtr(1),
 				Maximum:     floatPtr(maxTTLValue),
 			},
-			"chassis_id_type": {
+			"chassisIdType": {
 				Type:      "string",
 				Title:     "Chassis ID Type",
 				Enum:      []any{"mac", "local", "network_address"},
 				EnumNames: []string{"MAC Address", "Local", "Network Address"},
 				Default:   "mac",
 			},
-			"system_description": {
+			"systemDescription": {
 				Type:        "string",
 				Title:       "System Description",
 				Description: "LLDP system description TLV",
 			},
-			"port_description": {
+			"portDescription": {
 				Type:        "string",
 				Title:       "Port Description",
 				Description: "LLDP port description TLV",
@@ -187,12 +187,12 @@ func buildCDPSchema() *SchemaProperty {
 				Description:   "Device platform string (e.g., 'cisco WS-C3750X-48P')",
 				UIPlaceholder: "cisco WS-C3750X-48P",
 			},
-			"software_version": {
+			"softwareVersion": {
 				Type:        "string",
 				Title:       "Software Version",
 				Description: "Software version string",
 			},
-			"port_id": {
+			"portId": {
 				Type:          "string",
 				Title:         "Port ID",
 				Description:   "Local port identifier",
@@ -253,7 +253,7 @@ func buildFDPSchema() *SchemaProperty {
 				Title:   "Holdtime",
 				Default: fdpDefaultHoldtime,
 			},
-			"software_version": {
+			"softwareVersion": {
 				Type:  "string",
 				Title: "Software Version",
 			},
@@ -261,7 +261,7 @@ func buildFDPSchema() *SchemaProperty {
 				Type:  "string",
 				Title: "Platform",
 			},
-			"port_id": {
+			"portId": {
 				Type:  "string",
 				Title: "Port ID",
 			},

--- a/internal/api/schema_services.go
+++ b/internal/api/schema_services.go
@@ -8,7 +8,7 @@ func buildDHCPSchema() *SchemaProperty {
 		Title:       "DHCP Server",
 		Description: "DHCP server configuration",
 		Properties: map[string]*SchemaProperty{
-			"subnet_mask": {
+			"subnetMask": {
 				Type:          "string",
 				Title:         "Subnet Mask",
 				Format:        "ipv4",
@@ -29,13 +29,13 @@ func buildDHCPSchema() *SchemaProperty {
 				Title:  "Server Identifier",
 				Format: "ipv4",
 			},
-			"pool_start": {
+			"poolStart": {
 				Type:        "string",
 				Title:       "Pool Start",
 				Description: "Start of DHCP address pool",
 				Format:      "ipv4",
 			},
-			"pool_end": {
+			"poolEnd": {
 				Type:        "string",
 				Title:       "Pool End",
 				Description: "End of DHCP address pool",
@@ -135,7 +135,7 @@ func buildHTTPSchema(_ *float64) *SchemaProperty {
 				Title:   "Enable HTTP",
 				Default: false,
 			},
-			"server_name": {
+			"serverName": {
 				Type:        "string",
 				Title:       "Server Name",
 				Description: "HTTP Server header value",
@@ -195,7 +195,7 @@ func buildFTPSchema() *SchemaProperty {
 				Title:   "Enable FTP",
 				Default: false,
 			},
-			"welcome_banner": {
+			"welcomeBanner": {
 				Type:        "string",
 				Title:       "Welcome Banner",
 				Description: "FTP welcome message",
@@ -205,7 +205,7 @@ func buildFTPSchema() *SchemaProperty {
 				Title:   "System Type",
 				Default: "UNIX Type: L8",
 			},
-			"allow_anonymous": {
+			"allowAnonymous": {
 				Type:    "boolean",
 				Title:   "Allow Anonymous",
 				Default: true,

--- a/internal/api/schema_test.go
+++ b/internal/api/schema_test.go
@@ -49,7 +49,7 @@ func TestBuildDeviceSchema(t *testing.T) {
 	}
 
 	// Check protocol properties exist
-	protoProps := []string{"snmp_agent", "lldp", "cdp", "stp", "dhcp", "dns", "http", "ftp", "netbios"}
+	protoProps := []string{"snmpAgent", "lldp", "cdp", "stp", "dhcp", "dns", "http", "ftp", "netbios"}
 	for _, prop := range protoProps {
 		if _, ok := schema.Properties[prop]; !ok {
 			t.Errorf("missing protocol property: %s", prop)
@@ -127,7 +127,7 @@ func TestBuildProtocolSchemaProperties(t *testing.T) {
 	props := buildProtocolSchemaProperties()
 
 	expectedProtocols := []string{
-		"snmp_agent", "lldp", "cdp", "edp", "fdp", "stp",
+		"snmpAgent", "lldp", "cdp", "edp", "fdp", "stp",
 		"dhcp", "dns", "http", "ftp", "netbios",
 		"icmp", "icmpv6", "dhcpv6", "traffic", "ttl",
 		"os_fingerprint", "iperf3",
@@ -250,7 +250,7 @@ func TestBuildSNMPAgentSchema(t *testing.T) {
 	if schema.Type != "object" {
 		t.Errorf("type = %q, want %q", schema.Type, "object")
 	}
-	requiredProps := []string{"community", "sys_name", "walk_file", "add_mibs"}
+	requiredProps := []string{"community", "sys_name", "walkFile", "addMibs"}
 	for _, prop := range requiredProps {
 		if _, ok := schema.Properties[prop]; !ok {
 			t.Errorf("missing property: %s", prop)
@@ -301,7 +301,7 @@ func TestBuildDHCPSchema(t *testing.T) {
 	if schema.Type != "object" {
 		t.Errorf("type = %q, want %q", schema.Type, "object")
 	}
-	props := []string{"subnet_mask", "router", "pool_start", "pool_end"}
+	props := []string{"subnetMask", "router", "poolStart", "poolEnd"}
 	for _, p := range props {
 		if _, ok := schema.Properties[p]; !ok {
 			t.Errorf("missing property: %s", p)
@@ -414,7 +414,7 @@ func TestBuildFTPSchema(t *testing.T) {
 	if schema.Type != "object" {
 		t.Errorf("type = %q, want %q", schema.Type, "object")
 	}
-	if _, ok := schema.Properties["allow_anonymous"]; !ok {
+	if _, ok := schema.Properties["allowAnonymous"]; !ok {
 		t.Error("missing allow_anonymous property")
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -138,14 +138,14 @@ var errNonLoopbackRequiresToken = errors.New(
 
 // AlertConfig controls basic threshold-based alerting.
 type AlertConfig struct {
-	PacketsThreshold uint64 `json:"packets_threshold"`
-	WebhookURL       string `json:"webhook_url"`
+	PacketsThreshold uint64 `json:"packetsThreshold"`
+	WebhookURL       string `json:"webhookUrl"`
 }
 
 // ReplayRequest represents a packet replay request.
 type ReplayRequest struct {
 	File       string  `json:"file"`
-	LoopMs     int     `json:"loop_ms"`
+	LoopMs     int     `json:"loopMs"`
 	Scale      float64 `json:"scale"`
 	InlineData string  `json:"data,omitempty"`
 	Uploaded   bool    `json:"-"`
@@ -155,9 +155,9 @@ type ReplayRequest struct {
 type ReplayState struct {
 	Running   bool      `json:"running"`
 	File      string    `json:"file"`
-	LoopMs    int       `json:"loop_ms"`
+	LoopMs    int       `json:"loopMs"`
 	Scale     float64   `json:"scale"`
-	StartedAt time.Time `json:"started_at,omitzero"`
+	StartedAt time.Time `json:"startedAt,omitzero"`
 }
 
 // ReplayManager controls PCAP playback from the API server.
@@ -227,8 +227,8 @@ type ServerConfig struct {
 // SimulationRequest represents a request to start a simulation.
 type SimulationRequest struct {
 	Interface  string `json:"interface"`
-	ConfigPath string `json:"config_path,omitempty"`
-	ConfigData string `json:"config_data,omitempty"`
+	ConfigPath string `json:"configPath,omitempty"`
+	ConfigData string `json:"configData,omitempty"`
 	// TemplateName, when set, tells the daemon to load a built-in
 	// template directly from disk by name. This preserves the template's
 	// own directory as the include_path base, which matters for templates
@@ -236,18 +236,18 @@ type SimulationRequest struct {
 	// `include_path: ".."` plus a relative `walk_file:` path. Fetching the
 	// template content and POSTing it as ConfigData would lose that
 	// directory context and trip the walk-file path-traversal guard.
-	TemplateName string `json:"template_name,omitempty"`
+	TemplateName string `json:"templateName,omitempty"`
 }
 
 // SimulationStatus represents the current simulation status.
 type SimulationStatus struct {
 	Running       bool      `json:"running"`
 	Interface     string    `json:"interface,omitempty"`
-	ConfigPath    string    `json:"config_path,omitempty"`
-	ConfigName    string    `json:"config_name,omitempty"`
-	DeviceCount   int       `json:"device_count"`
-	StartedAt     time.Time `json:"started_at,omitzero"`
-	UptimeSeconds float64   `json:"uptime_seconds"`
+	ConfigPath    string    `json:"configPath,omitempty"`
+	ConfigName    string    `json:"configName,omitempty"`
+	DeviceCount   int       `json:"deviceCount"`
+	StartedAt     time.Time `json:"startedAt,omitzero"`
+	UptimeSeconds float64   `json:"uptimeSeconds"`
 }
 
 // DaemonController interface for daemon mode operations.

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -129,7 +129,7 @@ func TestCSRF_TokenValidation(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Test valid CSRF token on protected endpoint
-	reqBody := strings.NewReader(`{"packets_threshold":1000}`)
+	reqBody := strings.NewReader(`{"packetsThreshold":1000}`)
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", reqBody)
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
@@ -152,7 +152,7 @@ func TestCSRF_InvalidTokenRejection(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Try to use an invalid CSRF token
-	reqBody := strings.NewReader(`{"packets_threshold":1000}`)
+	reqBody := strings.NewReader(`{"packetsThreshold":1000}`)
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", reqBody)
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("X-Csrf-Token", "invalid-token-12345")
@@ -175,7 +175,7 @@ func TestCSRF_MissingTokenRejection(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Try to make a state-changing request without CSRF token
-	reqBody := strings.NewReader(`{"packets_threshold":1000}`)
+	reqBody := strings.NewReader(`{"packetsThreshold":1000}`)
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", reqBody)
 	req.Header.Set("Authorization", "Bearer "+token)
 	// Deliberately omit X-CSRF-Token header
@@ -458,7 +458,7 @@ func TestAlertConfig_ConcurrentUpdates(t *testing.T) {
 		go func(threshold int) {
 			defer wg.Done()
 
-			reqBody := fmt.Sprintf(`{"packets_threshold":%d}`, threshold*1000)
+			reqBody := fmt.Sprintf(`{"packetsThreshold":%d}`, threshold*1000)
 			req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 			req.Header.Set("Authorization", "Bearer "+token)
 			req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
@@ -498,7 +498,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Enable alerts
-	reqBody := `{"packets_threshold":1000}`
+	reqBody := `{"packetsThreshold":1000}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
@@ -515,7 +515,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 
 	// Update alerts multiple times rapidly (triggers stop/start of goroutine)
 	for i := range 5 {
-		reqBody = fmt.Sprintf(`{"packets_threshold":%d}`, (i+1)*1000)
+		reqBody = fmt.Sprintf(`{"packetsThreshold":%d}`, (i+1)*1000)
 		req = httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
@@ -531,7 +531,7 @@ func TestAlertConfig_NoDoubleClose(t *testing.T) {
 	}
 
 	// Disable alerts (should cleanly close channel)
-	reqBody = `{"packets_threshold":0}`
+	reqBody = `{"packetsThreshold":0}`
 	req = httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
@@ -558,7 +558,7 @@ func TestAlertConfig_GoroutineCleanup(t *testing.T) {
 	// Enable and disable alerts multiple times
 	for range 10 {
 		// Enable
-		reqBody := `{"packets_threshold":1000}`
+		reqBody := `{"packetsThreshold":1000}`
 		req := httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))
@@ -574,7 +574,7 @@ func TestAlertConfig_GoroutineCleanup(t *testing.T) {
 		}
 
 		// Disable
-		reqBody = `{"packets_threshold":0}`
+		reqBody = `{"packetsThreshold":0}`
 		req = httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(reqBody))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, token))

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -139,7 +139,7 @@ func TestServerHandleAlertsLifecycle(t *testing.T) {
 
 	// Update
 	rec = httptest.NewRecorder()
-	body := `{"packets_threshold":12345,"webhook_url":"https://hooks.example.com"}`
+	body := `{"packetsThreshold":12345,"webhookUrl":"https://hooks.example.com"}`
 	req = httptest.NewRequest(http.MethodPut, "/api/v1/alerts", strings.NewReader(body))
 	server.handleAlerts(rec, req)
 
@@ -225,7 +225,7 @@ func TestServerHandleReplayRoutes(t *testing.T) {
 	req = httptest.NewRequest(
 		http.MethodPost,
 		"/api/v1/replay",
-		strings.NewReader(fmt.Sprintf(`{"file":%s,"loop_ms":500}`, strconvJSON(pcapPath))),
+		strings.NewReader(fmt.Sprintf(`{"file":%s,"loopMs":500}`, strconvJSON(pcapPath))),
 	)
 	server.handleReplay(rec, req)
 

--- a/internal/api/topology.go
+++ b/internal/api/topology.go
@@ -43,15 +43,15 @@ type TopologyLink struct {
 	Source          string  `json:"source"`
 	Target          string  `json:"target"`
 	Label           string  `json:"label"`
-	SourceInterface string  `json:"source_interface"`
-	TargetInterface string  `json:"target_interface"`
-	LinkType        string  `json:"link_type"` // trunk, access, lag, p2p
+	SourceInterface string  `json:"sourceInterface"`
+	TargetInterface string  `json:"targetInterface"`
+	LinkType        string  `json:"linkType"` // trunk, access, lag, p2p
 	VLANs           []int   `json:"vlans"`
-	NativeVLAN      int     `json:"native_vlan,omitempty"`
-	Speed           int     `json:"speed_mbps,omitempty"`
+	NativeVLAN      int     `json:"nativeVlan,omitempty"`
+	Speed           int     `json:"speedMbps,omitempty"`
 	Duplex          string  `json:"duplex,omitempty"`
 	Status          string  `json:"status"` // up, down, degraded
-	Utilization     float64 `json:"utilization_percent,omitempty"`
+	Utilization     float64 `json:"utilizationPercent,omitempty"`
 }
 
 // buildInterfaceMap creates a lookup map of device interfaces.

--- a/internal/api/walk.go
+++ b/internal/api/walk.go
@@ -159,7 +159,7 @@ func validateWalkExtension(absPath string) error {
 // WalkValidationRequest is the request body for walk file validation.
 type WalkValidationRequest struct {
 	Filename string `json:"filename"`
-	AutoFix  bool   `json:"auto_fix,omitempty"`
+	AutoFix  bool   `json:"autoFix,omitempty"`
 }
 
 // WalkValidationResponse wraps the validation result.
@@ -381,17 +381,17 @@ func buildBatchWalkResponse(
 ) struct {
 	Success      bool                              `json:"success"`
 	Message      string                            `json:"message"`
-	TotalFiles   int                               `json:"total_files"`
-	InvalidFiles int                               `json:"invalid_files"`
-	TotalIssues  int                               `json:"total_issues"`
+	TotalFiles   int                               `json:"totalFiles"`
+	InvalidFiles int                               `json:"invalidFiles"`
+	TotalIssues  int                               `json:"totalIssues"`
 	Results      map[string]*snmp.ValidationResult `json:"results"`
 } {
 	response := struct {
 		Success      bool                              `json:"success"`
 		Message      string                            `json:"message"`
-		TotalFiles   int                               `json:"total_files"`
-		InvalidFiles int                               `json:"invalid_files"`
-		TotalIssues  int                               `json:"total_issues"`
+		TotalFiles   int                               `json:"totalFiles"`
+		InvalidFiles int                               `json:"invalidFiles"`
+		TotalIssues  int                               `json:"totalIssues"`
 		Results      map[string]*snmp.ValidationResult `json:"results"`
 	}{
 		Success:      invalidCount == 0,

--- a/scripts/check-json-casing.sh
+++ b/scripts/check-json-casing.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# check-json-casing.sh — JSON wire-casing discipline gate (ADR-0007).
+#
+# Convention (mirrors seed's revised ADR-0010, pure boundary mapping): every
+# JSON `json:"..."` wire tag the API emits or accepts is camelCase. snake_case
+# lives only OFF the wire — config files (the YAML simulation configs), SQL,
+# and internal external-system adapters (e.g. iperf3 `-json` parsing in
+# internal/protocols, mapped before emission). There are NO wire-level snake
+# exceptions: the baseline (scripts/json-casing-baseline.txt) is EMPTY.
+#
+# This gate scans `json:"..."` struct tags in internal/api for snake_case keys.
+# It is a RATCHET against the (empty) baseline:
+#   - FAILS if any snake_case wire tag appears, and
+#   - passes when there are none.
+#
+# Note: this scans struct *tags*, not hand-built `map[string]any` JSON keys.
+# Most snake map literals in internal/api build YAML *config* (stay snake);
+# hand-built JSON *responses* are camelCased per-handler (see ADR-0007).
+#
+# Run locally: scripts/check-json-casing.sh   ·   regenerate: --update
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BASELINE="scripts/json-casing-baseline.txt"
+SCAN_DIRS=("internal/api")
+
+current_violations() {
+	# `|| true`: grep exits 1 when there are zero snake tags (the healthy state);
+	# under `set -o pipefail` that would otherwise abort. Empty = success.
+	grep -rnoE 'json:"[a-z][a-z0-9]*_[a-z0-9_]+[^"]*"' "${SCAN_DIRS[@]}" --include='*.go' 2>/dev/null \
+		| grep -v '_test\.go:' \
+		| sed -E 's/^([^:]+):[0-9]+:json:"([^",]+).*/\1\t\2/' \
+		| sort -u || true
+}
+
+if [[ "${1:-}" == "--update" ]]; then
+	current_violations >"$BASELINE"
+	echo "Wrote $(wc -l <"$BASELINE" | tr -d ' ') baselined snake_case JSON tag(s) to $BASELINE"
+	exit 0
+fi
+
+if [[ ! -f "$BASELINE" ]]; then
+	echo "::error::$BASELINE missing — run scripts/check-json-casing.sh --update" >&2
+	exit 1
+fi
+
+new=$(comm -23 <(current_violations) <(sort -u "$BASELINE") || true)
+
+if [[ -n "$new" ]]; then
+	echo "::error::snake_case JSON wire tag(s) — use camelCase (ADR-0007):" >&2
+	echo "$new" | sed 's/^/  /' >&2
+	exit 1
+fi
+
+echo "JSON casing gate OK — no snake_case wire tags in internal/api (ADR-0007, empty baseline)."

--- a/ui/e2e/fullstack/gui-daemon.spec.ts
+++ b/ui/e2e/fullstack/gui-daemon.spec.ts
@@ -54,12 +54,12 @@ test.describe('daemon-served GUI', () => {
 
     const update = await request.put('/api/v1/alerts', {
       headers: { 'X-Csrf-Token': token },
-      data: { packets_threshold: 2500, webhook_url: '' },
+      data: { packetsThreshold: 2500, webhookUrl: '' },
     });
     expect(update.ok()).toBe(true);
 
-    const updated = (await update.json()) as { packets_threshold: number };
-    expect(updated.packets_threshold).toBe(2500);
+    const updated = (await update.json()) as { packetsThreshold: number };
+    expect(updated.packetsThreshold).toBe(2500);
   });
 
   test('shows seeded devices from a daemon simulation', async ({ page, request }) => {
@@ -72,7 +72,7 @@ test.describe('daemon-served GUI', () => {
       headers,
       data: {
         interface: simulationInterface,
-        config_data: simulationConfig,
+        configData: simulationConfig,
       },
     });
     expect(start.ok()).toBe(true);

--- a/ui/e2e/fullstack/gui-daemon.spec.ts
+++ b/ui/e2e/fullstack/gui-daemon.spec.ts
@@ -81,8 +81,8 @@ test.describe('daemon-served GUI', () => {
       await expect
         .poll(async () => {
           const status = await request.get('/api/v1/simulation');
-          const body = (await status.json()) as { running?: boolean; device_count?: number };
-          return body.running === true && body.device_count === 2;
+          const body = (await status.json()) as { running?: boolean; deviceCount?: number };
+          return body.running === true && body.deviceCount === 2;
         })
         .toBe(true);
 

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -174,7 +174,7 @@ export interface TopologyLink {
   speed?: string;
   duplex?: string;
   status?: string;
-  /** Link utilization, 0–100. Source = the daemon's json:"utilization_percent"
+  /** Link utilization, 0–100. Source = the daemon's json:"utilizationPercent"
    *  on api.TopologyLink; the request layer's snake→camel converter rewrites
    *  the wire field to utilizationPercent. Today the daemon emits 0 for
    *  every link (counter wiring is a separate work item); when live counters

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -135,7 +135,7 @@ describe('API Client', () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ packets_threshold: 100, webhook_url: '' }),
+          json: () => Promise.resolve({ packetsThreshold: 100, webhookUrl: '' }),
         });
 
       const { updateAlerts } = await import('./client');

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -181,7 +181,7 @@ export const clearError = (deviceIp: string, iface: string) =>
     deviceIp: string;
     interface: string;
   }>(
-    `/api/v1/errors?device_ip=${encodeURIComponent(deviceIp)}&interface=${encodeURIComponent(iface)}`,
+    `/api/v1/errors?deviceIp=${encodeURIComponent(deviceIp)}&interface=${encodeURIComponent(iface)}`,
     { method: 'DELETE' },
   );
 


### PR DESCRIPTION
Brings niac's API to the fleet casing convention — **ADR-0007** (mirrors seed's revised ADR-0010, pure boundary mapping). Flips ADR-0007 toward Accepted.

## What
- **74 snake_case `json:"..."` wire tags → camelCase** across `internal/api` (the structured request/response contract).
- The **device-editor schema** (`schema*.go` — describes the API request shape) and `handlers_errors.go` (hand-built JSON responses + the `device_ip` query param) camelCased too.
- **FE** API client / response-types / test updated to match.
- Adds **`scripts/check-json-casing.sh`** (empty baseline) + CI step to lock it in.

## Safe for config (verified)
The YAML simulation configs are **untouched** — they're hand-serialized from `config.Device` with literal snake keys (`serializeDeviceToYAML`), fully decoupled from the API json tags. During the migration I caught and reverted blanket renames that would have corrupted YAML-side code (`export.ts` mapping layer, `help-content.ts` YAML docs, `SelectedNetworkPreview.tsx`). snake_case stays where it belongs: YAML config, SQL, external-tool adapters.

## Verification
- `go test ./...` — green (DisallowUnknownFields surfaced every miss).
- FE `tsc` clean; vitest **111 passed**; Biome clean.
- Gate passes clean on this branch; **fails on a seeded `json:"bad_wire"`**.

## Tracked follow-up (ADR-0007 stage 2)
The remaining hand-built `map[string]any` keys in `internal/api` are **predominantly YAML-config builders** (STP/VRRP/DHCP device-sim config — stay snake). Auditing the few that are JSON *responses* (per-handler judgment, not a blanket change) is a tracked follow-up. The json-tag gate enforces the structured wire today (same scope as seed's gate).