### PR TITLE
fix(ci): run E2E daemon in dry-run simulation mode (unblock E2E)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,6 +695,15 @@ jobs:
         run: npx playwright install --with-deps chromium webkit
 
       - name: Start backend server
+        env:
+          # The gui-daemon.spec.ts simulation test targets a synthetic
+          # interface (e2e-dry-run0) that does not exist on the runner. The
+          # daemon honours this env var to run simulations in dry-run mode,
+          # skipping the real capture-engine bind. Without it the daemon
+          # returns "interface does not exist" (500), which is exactly the
+          # regression that slipped onto main when 4ebb685 added the test and
+          # daemon support but never wired the env var into CI.
+          NIAC_E2E_DRY_RUN_SIMULATION: "1"
         run: |
           # Backend is HTTPS-only since #663 (the --http flag was removed and
           # the legacy HTTP listener deleted). Self-signed cert auto-generated


### PR DESCRIPTION
## Problem
The `E2E Browser Tests` check fails on **every** open niac PR (#812 #813 #814 #816) on `gui-daemon.spec.ts › shows seeded devices from a daemon simulation`:

```
ERROR [API] Failed to start simulation error="interface does not exist: e2e-dry-run0"
status=500 errorCode=simulation_start_failed
```

## Root cause
The spec posts a simulation to the synthetic interface `e2e-dry-run0` (`E2E_SIM_INTERFACE ?? 'e2e-dry-run0'`). The daemon supports a **dry-run** mode (`NIAC_E2E_DRY_RUN_SIMULATION`, `internal/daemon/daemon.go`) that skips the real capture-engine bind for exactly this scenario. Commit `4ebb685 (feat: modernize niac operator surfaces)` added the test **and** the daemon support but never wired the env var into the E2E job in `ci.yml`. The E2E suite is path-skipped on docs-only merges, so the regression reached `main` unnoticed and only fires on PRs touching frontend/backend.

## Fix
Set `NIAC_E2E_DRY_RUN_SIMULATION=1` on the E2E `Start backend server` step. One-line, scoped to the e2e job (lighthouse doesn't run simulations).

## Impact
Unblocks E2E for all four open niac PRs. Each will still need a rebase onto this once merged. Diagnosis traced via the `e2e-server-logs` artifact.