### PR TITLE
chore(ui): standardize on biome 2.5

### DIFF
--- a/mk/lint.mk
+++ b/mk/lint.mk
@@ -4,7 +4,7 @@
 #
 # Code quality and formatting:
 #   - Linting (golangci-lint, Biome, markdownlint)
-#   - Formatting (gofumpt, Biome, Prettier)
+#   - Formatting (gofumpt, Biome)
 #   - Auto-fix capabilities
 #
 # =============================================================================
@@ -135,7 +135,7 @@ fmt-frontend: ## Format frontend code with Biome
 	@cd $(UI_DIR) && npx @biomejs/biome format --write src/
 	@echo "✅ Frontend code formatted"
 
-fmt-md: ## Format markdown files with Prettier
+fmt-md: ## Format markdown files when a project script is available
 	@if [ -f package.json ] && grep -q "format:md" package.json; then \
 		npm run format:md; \
 	else \

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -542,7 +542,7 @@ export const TopologyPage: FC = () => {
     } catch (err) {
       // Best-effort — surface in console rather than a modal since
       // the PNG path is a convenience, not a primary flow.
-      console.error('Topology PNG export failed:', err); // eslint-disable-line no-console
+      console.error('Topology PNG export failed:', err);
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Pins NIAC UI Biome to 2.5.0, migrates the Biome config schema, removes an obsolete ESLint suppression comment, and updates Makefile text away from Prettier.

## Linked Issue

Fixes #828

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [x] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
npx @biomejs/biome check src/pages/TopologyPage.tsx
Checked 1 file in 588ms. No fixes applied.

Pre-commit hook:
Biome check passed
TypeScript check passed
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.
