### PR TITLE
ci(gates): add filename-policy gate (no monolith naming outside internal/api)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: JSON wire-casing gate — camelCase ratchet (ADR-0007)
         run: ./scripts/check-json-casing.sh
 
+      - name: Filename-policy gate — no monolith naming outside internal/api
+        run: ./scripts/check-filename-policy.sh
+
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/scripts/check-filename-policy.sh
+++ b/scripts/check-filename-policy.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# check-filename-policy.sh — capability-package file-naming gate.
+#
+# The flat internal/api package uses filename prefixes (handlers_, jobs_) to
+# separate concerns within one large package. Those prefixes are meaningful
+# *only* there. Once code is decomposed into a dedicated capability package
+# (internal/<cap>/), the package declaration already supplies that context, so
+# the prefix becomes stutter: internal/health/handlers_health_api.go re-states
+# "health" twice and re-asserts a layer fact the package name already makes.
+#
+# Best practice in a decomposed package is to name files for their role *within*
+# the package (health.go, checks.go, handler.go) — never by re-stating the layer
+# (handlers_/jobs_) or the capability the package itself already represents.
+# This is not a Go *language* rule (the toolchain accepts these names); it is an
+# architecture-consistency rule that keeps the internal/api strangle honest:
+# monolith vocabulary stays in the monolith and is dropped on the way out.
+#
+# This gate fails if any handlers_*.go / jobs_*.go file exists outside
+# internal/api, UNLESS the file's own package directory is named for that token
+# (e.g. internal/platform/jobs/jobs.go is the eponymous file of package `jobs`,
+# and jobs_test.go is its standard test — both idiomatic, not monolith baggage).
+# The gate is green on the current tree and only fires when a decomposition
+# carries the monolith's grouping prefix forward instead of dropping it.
+#
+# Run locally: scripts/check-filename-policy.sh
+set -euo pipefail
+
+violations=""
+while IFS= read -r f; do
+	[[ -z "$f" ]] && continue
+	dir=$(basename "$(dirname "$f")")  # parent package directory
+	prefix="${f##*/}"; prefix="${prefix%%_*}"  # handlers | jobs
+	# Allow the eponymous package file/test (dir named for the prefix token).
+	[[ "$dir" == "$prefix" ]] && continue
+	violations+="$f"$'\n'
+# Scan git-tracked files only — never a raw worktree walk. CI sets GOMODCACHE
+# inside the repo (./.cache/go/pkg/mod), so a find(1) sweep would trip on
+# third-party handlers_*.go in the module cache (a false positive). git ls-files
+# inherently ignores the cache, build artifacts, and anything gitignored.
+done < <(git ls-files -- \
+	':(glob)**/handlers_*.go' ':(glob)**/jobs_*.go' \
+	':(exclude)internal/api/**' ':(exclude)vendor/**')
+violations=$(printf '%s' "$violations" | sed '/^[[:space:]]*$/d' | sort)
+
+if [[ -n "$violations" ]]; then
+	echo "❌ Filename-policy gate: monolith file-naming prefixes (handlers_/jobs_)"
+	echo "   must not appear outside internal/api. A decomposed capability package"
+	echo "   names files for their role within the package — drop the prefix:"
+	echo "     internal/health/handlers_health_api.go  →  internal/health/health.go"
+	echo ""
+	echo "$violations"
+	exit 1
+fi
+
+echo "✓ Filename-policy gate: no monolith naming prefixes outside internal/api."


### PR DESCRIPTION
## Summary

Ports seed's `check-filename-policy.sh` to niac for **fleet enforcement
parity**. The gate fails if any `handlers_*.go` / `jobs_*.go` file exists
outside `internal/api` (unless it is the eponymous file of a package named
for that token, e.g. `internal/platform/jobs/jobs.go`).

The `handlers_`/`jobs_` filename prefixes are meaningful grouping **only**
inside the flat `internal/api` monolith. Once a concern is decomposed into a
capability package (`internal/<cap>/`), the package declaration already
supplies that context, so the prefix becomes stutter and must be dropped
(`internal/health/handlers_health_api.go` → `internal/health/health.go`).
This is not a Go language rule — the toolchain accepts these names — it is
an architecture-consistency gate that keeps the ADR-0006 `internal/api`
strangle honest: monolith vocabulary stays in the monolith and is dropped
on the way out.

Seed already runs this gate; stem gets it in a sibling PR. The gate is
**green on the current tree** (zero `handlers_`/`jobs_` files outside
`internal/api`) and only ever fires when a future decomposition carries the
prefix forward.

## Linked Issue

Related to #830

## Testing Evidence

```
$ bash scripts/check-filename-policy.sh
✓ Filename-policy gate: no monolith naming prefixes outside internal/api.

$ git ls-files -- ':(glob)**/handlers_*.go' ':(glob)**/jobs_*.go' \
    ':(exclude)internal/api/**' ':(exclude)vendor/**' | wc -l
0

$ git ls-files -s scripts/check-filename-policy.sh
100755 ...  scripts/check-filename-policy.sh   # executable bit set

$ gitleaks protect --staged --no-banner
no leaks found
```

The new CI step runs after the JSON wire-casing gate, mirroring seed's
ordering.

## Security and Release Checklist

- [x] CI-only change — adds an architecture-consistency gate; no product
  code, no behaviour change.
- [x] New workflow step is a static script invocation with no untrusted
  input (no command-injection surface).
- [x] Script is byte-identical to seed's (fleet parity); executable bit set.
- [x] Gate is green on the current tree — does not block existing code.
- [x] No new secrets; gitleaks clean.
- [x] No customer-facing copy; no banned vocabulary.