### PR TITLE
refactor(topology): extract topology graph into internal/topology domain package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -244,9 +244,10 @@ linters:
             - "**/internal/converter/**"
             - "**/internal/device/**"
             - "**/internal/mibdb/**"
+            - "**/internal/topology/**"
           deny:
             - pkg: github.com/MustardSeedNetworks/niac-go/internal/api
-              desc: "the simulation/domain core must not import the web/API layer — dependencies point inward; wire transport at internal/api or internal/daemon"
+              desc: "the simulation/domain core must not import the web/API layer — dependencies point inward; wire transport at internal/api or internal/daemon. topology is derived domain (config→graph) consumed by api/ipc/interactive, so it stays inward too"
         # Sub-API leaf packages extracted from the internal/api monolith must
         # not import back into the api transport layer — they are self-contained
         # building blocks that the Server (and daemon) compose inward. See ADR-0006.
@@ -632,6 +633,10 @@ linters:
           - testpackage
       # API tests require access to handler internals.
       - path: 'internal/api/.*_test\.go'
+        linters:
+          - testpackage
+      # Topology tests require access to the graph-builder/export internals.
+      - path: 'internal/topology/.*_test\.go'
         linters:
           - testpackage
       # SNMP tests require access to agent internals.

--- a/cmd/niac/runtime_services.go
+++ b/cmd/niac/runtime_services.go
@@ -16,6 +16,7 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
 	"github.com/MustardSeedNetworks/niac-go/internal/replay"
 	"github.com/MustardSeedNetworks/niac-go/internal/storage"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 type runtimeServices struct {
@@ -55,7 +56,7 @@ func (rs *runtimeServices) initAPIServer(
 	interfaceName string,
 	services *serviceOptions,
 ) error {
-	topology := api.BuildTopology(cfg)
+	graph := topology.Build(cfg)
 	info := readVersionInfo()
 	cfgCopy := &api.ServerConfig{
 		Addr:         apiAddr,
@@ -71,7 +72,7 @@ func (rs *runtimeServices) initAPIServer(
 		BuildTime:    info.date,
 		ReleaseTrain: info.releaseTrain,
 		UIBuildHash:  info.uiBuildHash,
-		Topology:     topology,
+		Topology:     graph,
 		Alert: api.AlertConfig{
 			PacketsThreshold: services.alertPacketsThreshold,
 			WebhookURL:       services.alertWebhook,

--- a/cmd/niac/topology.go
+++ b/cmd/niac/topology.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/api"
 	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 const (
@@ -177,7 +177,7 @@ func runTopologyExport(options *topologyOptions) error {
 }
 
 // exportTopologyJSON exports topology as formatted JSON.
-func exportTopologyJSON(topology *api.Topology) (string, error) {
+func exportTopologyJSON(topology *topology.Graph) (string, error) {
 	// Create an extended structure with more details
 	var export TopologyExport
 	export.Nodes = make([]TopologyNodeExport, len(topology.Nodes))
@@ -227,7 +227,7 @@ func exportTopologyJSON(topology *api.Topology) (string, error) {
 }
 
 // exportTopologyYAML exports topology as YAML.
-func exportTopologyYAML(topology *api.Topology) (string, error) {
+func exportTopologyYAML(topology *topology.Graph) (string, error) {
 	// Create an extended structure with more details
 	var export TopologyExport
 	export.Nodes = make([]TopologyNodeExport, len(topology.Nodes))
@@ -277,7 +277,7 @@ func exportTopologyYAML(topology *api.Topology) (string, error) {
 }
 
 // countDevicesByType counts devices by their type.
-func countDevicesByType(nodes []api.TopologyNode) map[string]int {
+func countDevicesByType(nodes []topology.Node) map[string]int {
 	counts := make(map[string]int)
 	for _, node := range nodes {
 		deviceType := node.Type

--- a/cmd/niac/topology_test.go
+++ b/cmd/niac/topology_test.go
@@ -5,23 +5,23 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 func TestCountDevicesByType(t *testing.T) {
 	tests := []struct {
 		name     string
-		nodes    []api.TopologyNode
+		nodes    []topology.Node
 		expected map[string]int
 	}{
 		{
 			name:     "empty nodes",
-			nodes:    []api.TopologyNode{},
+			nodes:    []topology.Node{},
 			expected: map[string]int{},
 		},
 		{
 			name: "single type",
-			nodes: []api.TopologyNode{
+			nodes: []topology.Node{
 				{Name: "sw1", Type: "switch"},
 				{Name: "sw2", Type: "switch"},
 			},
@@ -29,7 +29,7 @@ func TestCountDevicesByType(t *testing.T) {
 		},
 		{
 			name: "multiple types",
-			nodes: []api.TopologyNode{
+			nodes: []topology.Node{
 				{Name: "rtr1", Type: "router"},
 				{Name: "sw1", Type: "switch"},
 				{Name: "sw2", Type: "switch"},
@@ -39,7 +39,7 @@ func TestCountDevicesByType(t *testing.T) {
 		},
 		{
 			name: "empty type defaults to unknown",
-			nodes: []api.TopologyNode{
+			nodes: []topology.Node{
 				{Name: "dev1", Type: ""},
 				{Name: "dev2", Type: ""},
 			},
@@ -47,7 +47,7 @@ func TestCountDevicesByType(t *testing.T) {
 		},
 		{
 			name: "mixed with empty type",
-			nodes: []api.TopologyNode{
+			nodes: []topology.Node{
 				{Name: "rtr1", Type: "router"},
 				{Name: "dev1", Type: ""},
 			},
@@ -73,12 +73,12 @@ func TestCountDevicesByType(t *testing.T) {
 }
 
 func TestExportTopologyJSON(t *testing.T) {
-	topology := &api.Topology{
-		Nodes: []api.TopologyNode{
+	graph := &topology.Graph{
+		Nodes: []topology.Node{
 			{Name: "router-1", Type: "router"},
 			{Name: "switch-1", Type: "switch"},
 		},
-		Links: []api.TopologyLink{
+		Links: []topology.Link{
 			{
 				Source:          "router-1",
 				Target:          "switch-1",
@@ -92,7 +92,7 @@ func TestExportTopologyJSON(t *testing.T) {
 		},
 	}
 
-	output, err := exportTopologyJSON(topology)
+	output, err := exportTopologyJSON(graph)
 	if err != nil {
 		t.Fatalf("exportTopologyJSON() error = %v", err)
 	}
@@ -133,12 +133,12 @@ func TestExportTopologyJSON(t *testing.T) {
 }
 
 func TestExportTopologyJSONEmpty(t *testing.T) {
-	topology := &api.Topology{
-		Nodes: []api.TopologyNode{},
-		Links: []api.TopologyLink{},
+	graph := &topology.Graph{
+		Nodes: []topology.Node{},
+		Links: []topology.Link{},
 	}
 
-	output, err := exportTopologyJSON(topology)
+	output, err := exportTopologyJSON(graph)
 	if err != nil {
 		t.Fatalf("exportTopologyJSON() error = %v", err)
 	}
@@ -149,12 +149,12 @@ func TestExportTopologyJSONEmpty(t *testing.T) {
 }
 
 func TestExportTopologyYAML(t *testing.T) {
-	topology := &api.Topology{
-		Nodes: []api.TopologyNode{
+	graph := &topology.Graph{
+		Nodes: []topology.Node{
 			{Name: "router-1", Type: "router"},
 			{Name: "switch-1", Type: "switch"},
 		},
-		Links: []api.TopologyLink{
+		Links: []topology.Link{
 			{
 				Source:          "router-1",
 				Target:          "switch-1",
@@ -167,7 +167,7 @@ func TestExportTopologyYAML(t *testing.T) {
 		},
 	}
 
-	output, err := exportTopologyYAML(topology)
+	output, err := exportTopologyYAML(graph)
 	if err != nil {
 		t.Fatalf("exportTopologyYAML() error = %v", err)
 	}
@@ -190,12 +190,12 @@ func TestExportTopologyYAML(t *testing.T) {
 }
 
 func TestExportTopologyYAMLEmpty(t *testing.T) {
-	topology := &api.Topology{
-		Nodes: []api.TopologyNode{},
-		Links: []api.TopologyLink{},
+	graph := &topology.Graph{
+		Nodes: []topology.Node{},
+		Links: []topology.Link{},
 	}
 
-	output, err := exportTopologyYAML(topology)
+	output, err := exportTopologyYAML(graph)
 	if err != nil {
 		t.Fatalf("exportTopologyYAML() error = %v", err)
 	}
@@ -253,12 +253,12 @@ func TestTopologyExportStructs(t *testing.T) {
 }
 
 func TestTopologyWithVLANs(t *testing.T) {
-	topology := &api.Topology{
-		Nodes: []api.TopologyNode{
+	graph := &topology.Graph{
+		Nodes: []topology.Node{
 			{Name: "sw1", Type: "switch"},
 			{Name: "sw2", Type: "switch"},
 		},
-		Links: []api.TopologyLink{
+		Links: []topology.Link{
 			{
 				Source:     "sw1",
 				Target:     "sw2",
@@ -270,7 +270,7 @@ func TestTopologyWithVLANs(t *testing.T) {
 		},
 	}
 
-	output, err := exportTopologyJSON(topology)
+	output, err := exportTopologyJSON(graph)
 	if err != nil {
 		t.Fatalf("exportTopologyJSON() error = %v", err)
 	}

--- a/internal/api/config_state.go
+++ b/internal/api/config_state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 type configDocument struct {
@@ -116,7 +117,7 @@ func (s *Server) currentConfig() *config.Config {
 	return s.cfg.Config
 }
 
-func (s *Server) currentTopology() Topology {
+func (s *Server) currentTopology() topology.Graph {
 	s.configMu.RLock()
 	defer s.configMu.RUnlock()
 
@@ -126,7 +127,7 @@ func (s *Server) currentTopology() Topology {
 func (s *Server) replaceConfig(cfg *config.Config) {
 	s.configMu.Lock()
 	s.cfg.Config = cfg
-	s.cfg.Topology = BuildTopology(cfg)
+	s.cfg.Topology = topology.Build(cfg)
 	s.configMu.Unlock()
 }
 

--- a/internal/api/config_state_test.go
+++ b/internal/api/config_state_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 func TestCurrentConfig(t *testing.T) {
@@ -112,7 +113,7 @@ func TestCurrentStackNil(t *testing.T) {
 
 func TestCurrentTopology(t *testing.T) {
 	cfg := mustLoadConfig(t, baseConfigYAML)
-	topo := BuildTopology(cfg)
+	topo := topology.Build(cfg)
 
 	server := &Server{
 		cfg: ServerConfig{

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -389,24 +389,24 @@ func (s *Server) handleTopologyExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topology := s.currentTopology()
+	graph := s.currentTopology()
 
 	// Note: format is validated above, so only json/graphml/dot can reach here
 	switch format {
 	case "json":
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Disposition", "attachment; filename=\"topology.json\"")
-		s.writeJSON(w, topology)
+		s.writeJSON(w, graph)
 
 	case "graphml":
 		w.Header().Set("Content-Type", "application/xml")
 		w.Header().Set("Content-Disposition", "attachment; filename=\"topology.graphml\"")
-		_, _ = fmt.Fprint(w, topology.ExportGraphML())
+		_, _ = fmt.Fprint(w, graph.ExportGraphML())
 
 	case "dot":
 		w.Header().Set("Content-Type", "text/vnd.graphviz")
 		w.Header().Set("Content-Disposition", "attachment; filename=\"topology.dot\"")
-		_, _ = fmt.Fprint(w, topology.ExportDOT())
+		_, _ = fmt.Fprint(w, graph.ExportDOT())
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/sse"
 
@@ -190,7 +191,7 @@ type ServerConfig struct {
 	BuildTime    string
 	ReleaseTrain string
 	UIBuildHash  string
-	Topology     Topology
+	Topology     topology.Graph
 	Alert        AlertConfig
 	// EnableTLS controls whether the API listener uses HTTPS. When true,
 	// CertFile/KeyFile (or, when both are empty, the auto-generated
@@ -729,7 +730,7 @@ func (s *Server) UpdateSimulation(
 	s.cfg.ConfigPath = configPath
 	s.cfg.Interface = iface
 	s.cfg.Replay = replay
-	s.cfg.Topology = BuildTopology(cfg)
+	s.cfg.Topology = topology.Build(cfg)
 
 	// Wire the stack's packet stream into the SSE hub so the
 	// /api/v1/stream/packets subscribers actually see frames.

--- a/internal/interactive/topology_view.go
+++ b/internal/interactive/topology_view.go
@@ -6,7 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 // generateTopologyView generates an ASCII network topology diagram.
@@ -14,7 +14,7 @@ func (m *model) generateTopologyView() {
 	var sb strings.Builder
 
 	// Build topology using the api package
-	topology := api.BuildTopology(m.cfg)
+	graph := topology.Build(m.cfg)
 
 	sb.WriteString(diffHeaderStyle.Render("=== Network Topology ==="))
 	sb.WriteString("\n\n")
@@ -24,8 +24,8 @@ func (m *model) generateTopologyView() {
 	sb.WriteString("\n")
 
 	// Group nodes by type
-	nodesByType := make(map[string][]api.TopologyNode)
-	for _, node := range topology.Nodes {
+	nodesByType := make(map[string][]topology.Node)
+	for _, node := range graph.Nodes {
 		nodesByType[node.Type] = append(nodesByType[node.Type], node)
 	}
 
@@ -41,10 +41,10 @@ func (m *model) generateTopologyView() {
 	sb.WriteString(topologyLinkStyle.Render("Links:"))
 	sb.WriteString("\n")
 
-	if len(topology.Links) == 0 {
+	if len(graph.Links) == 0 {
 		sb.WriteString("  (no trunk connections defined)\n")
 	} else {
-		for _, link := range topology.Links {
+		for _, link := range graph.Links {
 			linkInfo := fmt.Sprintf("  %s [%s] <---> [%s] %s",
 				link.Source,
 				link.SourceInterface,
@@ -68,16 +68,16 @@ func (m *model) generateTopologyView() {
 	sb.WriteString("\n\n")
 
 	// Generate simple ASCII diagram
-	sb.WriteString(m.generateASCIIDiagram(topology))
+	sb.WriteString(m.generateASCIIDiagram(graph))
 
 	m.topologyContent = sb.String()
 }
 
 // categorizeTopologyNodes splits nodes into routers, switches, and others.
 func categorizeTopologyNodes(
-	nodes []api.TopologyNode,
-) ([]api.TopologyNode, []api.TopologyNode, []api.TopologyNode) {
-	var routers, switches, others []api.TopologyNode
+	nodes []topology.Node,
+) ([]topology.Node, []topology.Node, []topology.Node) {
+	var routers, switches, others []topology.Node
 	for _, node := range nodes {
 		switch node.Type {
 		case "router":
@@ -92,7 +92,7 @@ func categorizeTopologyNodes(
 }
 
 // writeNodeRow writes a row of device boxes to the builder.
-func writeNodeRow(sb *strings.Builder, nodes []api.TopologyNode) {
+func writeNodeRow(sb *strings.Builder, nodes []topology.Node) {
 	sb.WriteString("  ")
 	for i, n := range nodes {
 		if i > 0 {
@@ -116,7 +116,7 @@ func writeConnectors(sb *strings.Builder, count int) {
 func writeDeviceLayer(
 	sb *strings.Builder,
 	label string,
-	nodes []api.TopologyNode,
+	nodes []topology.Node,
 	hasMoreBelow bool,
 ) {
 	if len(nodes) == 0 {
@@ -131,13 +131,13 @@ func writeDeviceLayer(
 	}
 }
 
-func (m *model) generateASCIIDiagram(topology api.Topology) string {
-	if len(topology.Nodes) == 0 {
+func (m *model) generateASCIIDiagram(graph topology.Graph) string {
+	if len(graph.Nodes) == 0 {
 		return "  (no devices configured)\n"
 	}
 
 	var sb strings.Builder
-	routers, switches, others := categorizeTopologyNodes(topology.Nodes)
+	routers, switches, others := categorizeTopologyNodes(graph.Nodes)
 
 	hasDevicesBelow := len(switches) > 0 || len(others) > 0
 	writeDeviceLayer(&sb, "ROUTERS", routers, hasDevicesBelow)

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/api"
 	apperr "github.com/MustardSeedNetworks/niac-go/internal/apperr"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 // Sentinel errors for IPC commands.
@@ -356,7 +356,7 @@ func (c *Client) DumpPackets(device, iface string, count int) ([]PacketData, err
 
 // GetTopology retrieves the current network topology from the server.
 // Returns the topology graph with nodes (devices) and links (connections).
-func (c *Client) GetTopology() (*api.Topology, error) {
+func (c *Client) GetTopology() (*topology.Graph, error) {
 	resp, err := c.SendCommand(CommandTopology, nil)
 	if err != nil {
 		return nil, err
@@ -378,7 +378,7 @@ func (c *Client) GetTopology() (*api.Topology, error) {
 		return nil, fmt.Errorf("failed to marshal topology data: %w", err)
 	}
 
-	var topology api.Topology
+	var topology topology.Graph
 
 	err = json.Unmarshal(topologyBytes, &topology)
 	if err != nil {

--- a/internal/ipc/socket.go
+++ b/internal/ipc/socket.go
@@ -13,11 +13,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/api"
 	apperr "github.com/MustardSeedNetworks/niac-go/internal/apperr"
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 // ErrIPCServerAlreadyRunning is returned when the IPC server is already running.
@@ -760,12 +760,12 @@ func (s *Server) handleTopology(_ *Request) *Response {
 	defer s.mu.RUnlock()
 
 	// Build topology from current configuration
-	topology := api.BuildTopology(s.cfg)
+	graph := topology.Build(s.cfg)
 
 	return &Response{
 		Success: true,
 		Data: map[string]any{
-			"topology": topology,
+			"topology": graph,
 		},
 	}
 }

--- a/internal/topology/topology.go
+++ b/internal/topology/topology.go
@@ -1,4 +1,4 @@
-package api
+package topology
 
 import (
 	"fmt"
@@ -26,20 +26,20 @@ const (
 	deviceTypeAP     = "ap"
 )
 
-// Topology describes a simple graph for visualization.
-type Topology struct {
-	Nodes []TopologyNode `json:"nodes"`
-	Links []TopologyLink `json:"links"`
+// Graph describes a simple graph for visualization.
+type Graph struct {
+	Nodes []Node `json:"nodes"`
+	Links []Link `json:"links"`
 }
 
-// TopologyNode represents a device.
-type TopologyNode struct {
+// Node represents a device.
+type Node struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
-// TopologyLink represents a connection between devices with detailed information.
-type TopologyLink struct {
+// Link represents a connection between devices with detailed information.
+type Link struct {
 	Source          string  `json:"source"`
 	Target          string  `json:"target"`
 	Label           string  `json:"label"`
@@ -154,15 +154,15 @@ func sortedPairKey(a, b string) string {
 	return b + "|" + a
 }
 
-// processTrunkPort creates a TopologyLink from a trunk port configuration.
+// processTrunkPort creates a Link from a trunk port configuration.
 func processTrunkPort(
 	trunk config.TrunkPort,
 	deviceName string,
 	interfaceMap map[string]map[string]config.Interface,
-) TopologyLink {
+) Link {
 	speed, duplex, status := getInterfaceDetails(interfaceMap, deviceName, trunk.Interface)
 
-	return TopologyLink{
+	return Link{
 		Source: deviceName,
 		Target: trunk.RemoteDevice,
 		Label:  buildTrunkLabel(trunk),
@@ -182,21 +182,21 @@ func processTrunkPort(
 	}
 }
 
-// BuildTopology derives a topology graph from the configuration.
+// Build derives a topology graph from the configuration.
 //
 // Trunk links are inherently bidirectional — both switches declare a
 // trunk_port pointing at each other, so we'd otherwise emit two
-// TopologyLink entries for one physical wire and ReactFlow would draw
+// Link entries for one physical wire and ReactFlow would draw
 // a second edge looping back around the cards. We dedupe via a
 // sorted-pair key so each physical adjacency yields exactly one link.
-func BuildTopology(cfg *config.Config) Topology {
-	nodes := make(map[string]TopologyNode)
-	links := make([]TopologyLink, 0)
+func Build(cfg *config.Config) Graph {
+	nodes := make(map[string]Node)
+	links := make([]Link, 0)
 	interfaceMap := buildInterfaceMap(cfg.Devices)
 	seenLinks := make(map[string]bool)
 
 	for _, dev := range cfg.Devices {
-		nodes[dev.Name] = TopologyNode{
+		nodes[dev.Name] = Node{
 			Name: dev.Name,
 			Type: dev.Type,
 		}
@@ -217,7 +217,7 @@ func BuildTopology(cfg *config.Config) Topology {
 			seenLinks[pair] = true
 
 			if _, exists := nodes[trunk.RemoteDevice]; !exists {
-				nodes[trunk.RemoteDevice] = TopologyNode{
+				nodes[trunk.RemoteDevice] = Node{
 					Name: trunk.RemoteDevice,
 					Type: "external",
 				}
@@ -227,8 +227,8 @@ func BuildTopology(cfg *config.Config) Topology {
 		}
 	}
 
-	topology := Topology{
-		Nodes: make([]TopologyNode, 0, len(nodes)),
+	topology := Graph{
+		Nodes: make([]Node, 0, len(nodes)),
 		Links: links,
 	}
 	for _, node := range nodes {
@@ -262,7 +262,7 @@ func formatVLANList(vlans []int) string {
 }
 
 // ExportGraphML exports the topology in GraphML format (for yEd, Gephi).
-func (t *Topology) ExportGraphML() string {
+func (t *Graph) ExportGraphML() string {
 	var sb strings.Builder
 	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
 	sb.WriteString(`<graphml xmlns="http://graphml.graphdrawing.org/xmlns"` + "\n")
@@ -320,7 +320,7 @@ func (t *Topology) ExportGraphML() string {
 }
 
 // ExportDOT exports the topology in DOT format (for Graphviz).
-func (t *Topology) ExportDOT() string {
+func (t *Graph) ExportDOT() string {
 	var sb strings.Builder
 	sb.WriteString("graph niac_topology {\n")
 	sb.WriteString("  // Nodes\n")

--- a/internal/topology/topology_test.go
+++ b/internal/topology/topology_test.go
@@ -1,4 +1,4 @@
-package api
+package topology
 
 import (
 	"testing"
@@ -204,7 +204,7 @@ func TestBuildTopology(t *testing.T) {
 		},
 	}
 
-	topology := BuildTopology(cfg)
+	topology := Build(cfg)
 
 	// Check nodes
 	if len(topology.Nodes) != 2 {
@@ -242,7 +242,7 @@ func TestBuildTopologyEmptyConfig(t *testing.T) {
 		Devices: []config.Device{},
 	}
 
-	topology := BuildTopology(cfg)
+	topology := Build(cfg)
 
 	if len(topology.Nodes) != 0 {
 		t.Errorf("nodes count = %d, want 0", len(topology.Nodes))
@@ -253,7 +253,7 @@ func TestBuildTopologyEmptyConfig(t *testing.T) {
 }
 
 func TestTopologyNodeJSON(t *testing.T) {
-	node := TopologyNode{
+	node := Node{
 		Name: "router1",
 		Type: "router",
 	}
@@ -267,7 +267,7 @@ func TestTopologyNodeJSON(t *testing.T) {
 }
 
 func TestTopologyLinkFields(t *testing.T) {
-	link := TopologyLink{
+	link := Link{
 		Source:          "switch1",
 		Target:          "router1",
 		Label:           "trunk",
@@ -370,12 +370,12 @@ func TestEscapeDOT(t *testing.T) {
 }
 
 func TestExportGraphML(t *testing.T) {
-	topology := &Topology{
-		Nodes: []TopologyNode{
+	topology := &Graph{
+		Nodes: []Node{
 			{Name: "router1", Type: "router"},
 			{Name: "switch1", Type: "switch"},
 		},
-		Links: []TopologyLink{
+		Links: []Link{
 			{
 				Source:          "switch1",
 				Target:          "router1",
@@ -422,14 +422,14 @@ func TestExportGraphML(t *testing.T) {
 }
 
 func TestExportDOT(t *testing.T) {
-	topology := &Topology{
-		Nodes: []TopologyNode{
+	topology := &Graph{
+		Nodes: []Node{
 			{Name: "router1", Type: "router"},
 			{Name: "switch1", Type: "switch"},
 			{Name: "ap1", Type: "ap"},
 			{Name: "device1", Type: "unknown"},
 		},
-		Links: []TopologyLink{
+		Links: []Link{
 			{
 				Source:          "switch1",
 				Target:          "router1",
@@ -495,9 +495,9 @@ func TestExportDOT(t *testing.T) {
 }
 
 func TestExportGraphMLEmpty(t *testing.T) {
-	topology := &Topology{
-		Nodes: []TopologyNode{},
-		Links: []TopologyLink{},
+	topology := &Graph{
+		Nodes: []Node{},
+		Links: []Link{},
 	}
 
 	result := topology.ExportGraphML()
@@ -512,9 +512,9 @@ func TestExportGraphMLEmpty(t *testing.T) {
 }
 
 func TestExportDOTEmpty(t *testing.T) {
-	topology := &Topology{
-		Nodes: []TopologyNode{},
-		Links: []TopologyLink{},
+	topology := &Graph{
+		Nodes: []Node{},
+		Links: []Link{},
 	}
 
 	result := topology.ExportDOT()


### PR DESCRIPTION
## Summary

Extracts the topology graph builder + exporters out of `internal/api` into a new **top-level domain package** `internal/topology` (sibling to `internal/config`), and decouples the IPC/TUI/CLI surfaces from the api transport package.

**Why this is a domain package, not an api leaf:** the config→graph builder lived in `internal/api/topology.go`, but `internal/ipc`, `internal/interactive`, and `cmd/niac` all imported the *entire* `internal/api` transport package **solely** to reach `Topology`/`BuildTopology`. Topology is a pure function of `config` — shared derived domain, not a transport concern. Housing it under `internal/api` forced a TUI and an IPC server to depend on the web layer for a graph type.

- New package `internal/topology` (was `internal/api/topology.go`): `Build(cfg) Graph`, `Graph.ExportGraphML()`/`ExportDOT()`, and the graph-shaping helpers. Types drop the now-redundant prefix since the package name supplies it: `Topology`→`Graph`, `TopologyNode`→`Node`, `TopologyLink`→`Link`, `BuildTopology`→`Build`. **Every `json:"…"` tag is byte-identical**, so the `/api/v1/topology` (and `/topology/export`) wire shape is unchanged.
- Imports `internal/config` only (inward); added to the existing `domain-core-inward-only` depguard rule so it can never import the api transport layer.
- `internal/ipc/{client,socket}.go`, `internal/interactive/topology_view.go`, and `cmd/niac/topology.go` now import `internal/topology` directly and **drop their `internal/api` dependency entirely** — they only ever needed topology. This removes a real coupling of the TUI/IPC/CLI from the web transport package.
- `internal/api` (`server.go`/`config_state.go`/`handlers_read.go`) composes `topology.Build`/`topology.Graph` inward; renamed a shadowing local `topology` var to `graph` at each call site.
- `cmd/niac/runtime_services.go` keeps its `internal/api` import (it constructs the Server) and just swaps `BuildTopology`→`topology.Build`.

Net −9 lines.

## Linked Issue

Related to #830

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go build ./...                 # OK (only benign "ld: warning: ... duplicate libraries: '-lpcap'")
$ go vet ./...                   # clean
$ golangci-lint run ./internal/topology/... ./internal/api/... ./internal/ipc/... ./internal/interactive/... ./cmd/...
0 issues.
$ go test ./...                  # all packages pass
$ go test -race ./internal/topology/...
ok  github.com/MustardSeedNetworks/niac-go/internal/topology  1.048s
$ bash scripts/check-route-policy.sh      OK
$ bash scripts/check-output-escaping.sh   OK
$ bash scripts/check-json-casing.sh       OK  (json tags unchanged)
$ bash scripts/check-filename-policy.sh   OK
$ gofmt -l internal cmd                   (clean)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (No route/handler behavior change; `handleTopology`/`handleTopologyExport` still call the same builder/exporters, now via the leaf. The GraphML/DOT XML-escaping moved with the exporters unchanged.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (No behavior change; wire shape identical.)
