### PR TITLE
refactor(api): extract template discovery/parse engine into templates leaf

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -281,6 +281,12 @@ linters:
           deny:
             - pkg: github.com/MustardSeedNetworks/niac-go/internal/api
               desc: "capture is a leaf — the PCAP analysis engine + structure validation over stdlib+gopacket only; the Server composes it inward (s.pcapCache, capture.Analyze/ValidateStructure), never the reverse"
+        "api-templates-isolated":
+          files:
+            - "**/internal/api/templates/**"
+          deny:
+            - pkg: github.com/MustardSeedNetworks/niac-go/internal/api
+              desc: "templates is a leaf — the on-disk template discovery/parse/load engine over stdlib only; the Server composes it inward (templates.Dirs/Scan/Find/Load/SaveConfig), never the reverse"
         # internal/api/auth has NO isolation rule by design. Unlike the four
         # leaves above, auth COMPOSES siblings (internal/api/tokenstore +
         # ratelimit), and a deny on "internal/api" prefix-matches those sibling

--- a/internal/api/configs.go
+++ b/internal/api/configs.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/templates"
 )
 
 // UserConfig represents a user-uploaded configuration file.
@@ -154,7 +156,7 @@ func parseUserConfigFile(path string, info fs.FileInfo) UserConfig {
 	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 
 	// Count devices in the YAML file
-	deviceCount := countDevicesInFile(path)
+	deviceCount := templates.CountDevicesInFile(path)
 
 	return UserConfig{
 		Name:        name,
@@ -237,7 +239,7 @@ func (s *Server) handleUserConfigUpload(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Sanitize and validate name
-	safeName := sanitizeConfigName(req.Name)
+	safeName := templates.SanitizeConfigName(req.Name)
 	if safeName == "" {
 		writeError(w, r, http.StatusBadRequest, "invalid_name", "Invalid config name", nil)
 		return
@@ -279,7 +281,7 @@ func saveUserConfig(name string, content []byte) (string, error) {
 
 	configPath := filepath.Clean(filepath.Join(configDir, name+".yaml"))
 
-	// Defense-in-depth: name has been sanitized upstream (sanitizeConfigName),
+	// Defense-in-depth: name has been sanitized upstream (templates.SanitizeConfigName),
 	// but make the bounded path explicit so static analysers see the barrier.
 	absConfigPath, absErr := filepath.Abs(configPath)
 	if absErr != nil || strings.Contains(configPath, "..") {

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -4,55 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
-	"slices"
 	"strings"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/templates"
 )
-
-// Template type constants matching the UI interface.
-const (
-	templateTypeBasic       = "basic"
-	templateTypeRouter      = "router"
-	templateTypeSwitch      = "switch"
-	templateTypeAccessPoint = "access-point"
-	templateTypeServer      = "server"
-	templateTypeFirewall    = "firewall"
-	templateTypeComplete    = "complete"
-	templateTypeCustom      = "custom"
-)
-
-// Template represents a configuration template.
-//
-// Name is the stable filename-derived identifier ("minimal", "router")
-// used by the /api/v1/templates/{name} and /api/v1/templates/use APIs.
-// DisplayName is the human-readable label optionally provided via the
-// front-matter "# Display: ..." line; clients should prefer it for UI
-// rendering and fall back to Name when absent.
-type Template struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName,omitempty"`
-	Description string `json:"description"`
-	DeviceCount int    `json:"deviceCount"`
-	Type        string `json:"type"`
-	// Vendor is populated from the template's "# Vendor: ..."
-	// front-matter, lowercased. When non-empty the UI groups the
-	// template under a vendor heading instead of (or alongside) the
-	// generic type-based grouping — useful for the vendor template
-	// pack shipped under cmd/niac/templates/vendor-templates/.
-	Vendor string   `json:"vendor,omitempty"`
-	Tags   []string `json:"tags,omitempty"`
-}
-
-// TemplateContent represents the full content of a template.
-type TemplateContent struct {
-	Name    string `json:"name"`
-	Content string `json:"content"`
-	Format  string `json:"format"`
-}
 
 // UseTemplateRequest is the request to create a config from a template.
 type UseTemplateRequest struct {
@@ -65,28 +23,6 @@ type UseTemplateResponse struct {
 	Success    bool   `json:"success"`
 	Message    string `json:"message"`
 	ConfigPath string `json:"configPath"`
-}
-
-// getTemplateDirs returns the directories to scan for templates.
-// Checks multiple locations for compatibility with both development and installed deployments.
-func getTemplateDirs() []string {
-	dirs := []string{
-		// Development paths (relative to working directory)
-		"cmd/niac/templates",
-		"examples",
-		// System-wide installed paths
-		"/usr/share/niac/templates",
-		"/var/lib/niac/templates",
-		// User-specific paths
-		os.ExpandEnv("$HOME/.niac/templates"),
-	}
-
-	// Add custom directory from environment variable
-	if customDir := os.Getenv("NIAC_TEMPLATES_DIR"); customDir != "" {
-		dirs = append([]string{customDir}, dirs...)
-	}
-
-	return dirs
 }
 
 // handleTemplates handles GET /api/v1/templates (list) and POST (upload).
@@ -137,281 +73,18 @@ func (s *Server) handleTemplateByName(w http.ResponseWriter, r *http.Request) {
 
 // handleTemplatesList returns a list of available templates.
 func (s *Server) handleTemplatesList(w http.ResponseWriter, r *http.Request) {
-	templates := []Template{}
+	list := []templates.Template{}
 
-	for _, dir := range getTemplateDirs() {
-		dirTemplates, err := scanTemplateDir(dir)
+	for _, dir := range templates.Dirs() {
+		dirTemplates, err := templates.Scan(dir)
 		if err != nil {
 			s.logger.WarnContext(r.Context(), fmt.Sprintf("Failed to scan template dir %s: %v", dir, err))
 			continue
 		}
-		templates = append(templates, dirTemplates...)
+		list = append(list, dirTemplates...)
 	}
 
-	s.writeJSON(w, templates)
-}
-
-// scanTemplateDir scans a directory for YAML template files.
-func scanTemplateDir(baseDir string) ([]Template, error) {
-	var templates []Template
-
-	err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, walkErr error) error {
-		// Skip entries with errors
-		if walkErr != nil || d.IsDir() {
-			return nil //nolint:nilerr // WalkDir: skip errors, continue walking
-		}
-
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext != ".yaml" && ext != ".yml" {
-			return nil
-		}
-
-		info, infoErr := d.Info()
-		if infoErr != nil {
-			return nil //nolint:nilerr // WalkDir: skip files we can't stat
-		}
-
-		template := parseTemplateFile(path, info)
-		templates = append(templates, template)
-		return nil
-	})
-
-	return templates, err
-}
-
-// parseTemplateFile extracts template metadata from a file.
-//
-// Templates can opt-in to a small front-matter block at the very top of
-// the YAML for richer UI metadata. The parser walks consecutive comment
-// lines and recognises:
-//
-//	# Display: Enterprise Router
-//	# Description: A full enterprise router persona with LLDP, CDP, SNMP, ...
-//
-// When present these win over the legacy "first non-empty comment line"
-// heuristic. The keys are case-insensitive and the rest of the file is
-// untouched.
-func parseTemplateFile(path string, _ fs.FileInfo) Template {
-	// Extract name from filename without extension
-	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-
-	meta := extractFrontMatter(path)
-
-	displayName := meta["display"]
-
-	description := meta["description"]
-	if description == "" {
-		// Fall back to the legacy first-comment heuristic for templates
-		// that haven't been migrated yet.
-		description = extractDescription(path)
-	}
-	if description == "" {
-		base := displayName
-		if base == "" {
-			base = name
-		}
-		description = base + " configuration template"
-	}
-
-	// Count devices in the YAML file
-	deviceCount := countDevicesInFile(path)
-
-	// Determine type: front-matter wins, otherwise infer from name+path.
-	templateType := strings.ToLower(strings.TrimSpace(meta["type"]))
-	if templateType == "" {
-		templateType = determineTemplateType(path, name)
-	}
-
-	// Tags: front-matter "tags:" comma-separated wins, otherwise infer.
-	tags := splitTags(meta["tags"])
-	if len(tags) == 0 {
-		tags = generateTags(path)
-	}
-
-	// Vendor is optional. We lowercase so the UI's group-by key is
-	// stable regardless of how the YAML author cased it.
-	vendor := strings.ToLower(strings.TrimSpace(meta["vendor"]))
-
-	return Template{
-		Name:        name,
-		DisplayName: displayName,
-		Description: description,
-		DeviceCount: deviceCount,
-		Type:        templateType,
-		Vendor:      vendor,
-		Tags:        tags,
-	}
-}
-
-// splitTags parses a comma-separated tags string into a slice. Empty tags
-// are skipped and whitespace is trimmed.
-func splitTags(raw string) []string {
-	if raw == "" {
-		return nil
-	}
-	parts := strings.Split(raw, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		t := strings.TrimSpace(p)
-		if t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
-}
-
-// extractFrontMatter pulls "# Key: Value" lines from the top of a YAML
-// file into a map. Stops at the first non-comment, non-blank line. Keys
-// are lowercased; values are trimmed.
-func extractFrontMatter(path string) map[string]string {
-	// filepath.Clean keeps gosec G304 quiet — callers walk a
-	// server-owned templates directory, but cleaning is cheap and
-	// satisfies the linter without a //nolint exception.
-	data, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
-		return nil
-	}
-	meta := make(map[string]string)
-	for line := range strings.SplitSeq(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		comment, isComment := strings.CutPrefix(trimmed, "#")
-		if !isComment {
-			break
-		}
-		comment = strings.TrimSpace(comment)
-		key, value, ok := strings.Cut(comment, ":")
-		if !ok {
-			continue
-		}
-		k := strings.ToLower(strings.TrimSpace(key))
-		v := strings.TrimSpace(value)
-		if k != "" && v != "" {
-			meta[k] = v
-		}
-	}
-	return meta
-}
-
-// countDevicesInFile counts the number of devices defined in a YAML config.
-func countDevicesInFile(path string) int {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return 1 // Default to 1 if can't read
-	}
-
-	// Simple heuristic: count lines that start with "  - name:" (device entries)
-	count := 0
-	for line := range strings.SplitSeq(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "- name:") {
-			count++
-		}
-	}
-
-	if count == 0 {
-		return 1 // At least 1 device assumed
-	}
-	return count
-}
-
-// determineTemplateType determines the template type from its path and name.
-func determineTemplateType(path, name string) string {
-	pathLower := strings.ToLower(path)
-	nameLower := strings.ToLower(name)
-
-	// Check filename first for specific types
-	switch {
-	case strings.Contains(nameLower, "router"):
-		return templateTypeRouter
-	case strings.Contains(nameLower, "switch"):
-		return templateTypeSwitch
-	case strings.Contains(nameLower, "ap") || strings.Contains(nameLower, "wireless") ||
-		strings.Contains(nameLower, "access-point"):
-		return templateTypeAccessPoint
-	case strings.Contains(nameLower, "firewall") || strings.Contains(nameLower, "asa") ||
-		strings.Contains(nameLower, "srx") || strings.Contains(nameLower, "ftd"):
-		return templateTypeFirewall
-	case strings.Contains(nameLower, "server"):
-		return templateTypeServer
-	case strings.Contains(nameLower, "complete") || strings.Contains(nameLower, "full"):
-		return templateTypeComplete
-	}
-
-	// Check path for type hints
-	switch {
-	case strings.Contains(pathLower, "/services/"):
-		return templateTypeServer
-	case strings.Contains(pathLower, "/combinations/"):
-		return templateTypeComplete
-	case strings.Contains(pathLower, "/vendors/"):
-		return templateTypeCustom
-	default:
-		return templateTypeBasic
-	}
-}
-
-// extractDescription extracts description from first comment line of YAML file.
-func extractDescription(path string) string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-
-	for line := range strings.SplitSeq(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if desc, found := strings.CutPrefix(line, "#"); found {
-			desc = strings.TrimSpace(desc)
-			if desc != "" && !strings.HasPrefix(strings.ToLower(desc), "yaml") {
-				return desc
-			}
-		} else if line != "" {
-			// First non-comment, non-empty line - stop
-			break
-		}
-	}
-	return ""
-}
-
-// generateTags generates tags from the file path.
-func generateTags(path string) []string {
-	tags := []string{}
-	pathLower := strings.ToLower(path)
-
-	// Add tags based on path components
-	tagPatterns := map[string]string{
-		"router":     "router",
-		"switch":     "switch",
-		"wireless":   "wireless",
-		"ap":         "wireless",
-		"snmp":       "snmp",
-		"firewall":   "security",
-		"security":   "security",
-		"datacenter": "datacenter",
-		"enterprise": "enterprise",
-		"campus":     "enterprise",
-	}
-
-	for pattern, tag := range tagPatterns {
-		if strings.Contains(pathLower, pattern) && !slices.Contains(tags, tag) {
-			tags = append(tags, tag)
-		}
-	}
-
-	// Add vendor tags
-	vendors := []string{
-		"cisco", "juniper", "arista", "dell", "aruba",
-		"meraki", "fortinet", "paloalto", "extreme", "foundry",
-	}
-	for _, vendor := range vendors {
-		if strings.Contains(pathLower, vendor) {
-			tags = append(tags, vendor)
-		}
-	}
-
-	return tags
+	s.writeJSON(w, list)
 }
 
 // handleTemplateContent returns the content of a specific template.
@@ -423,59 +96,26 @@ func (s *Server) handleTemplateContent(w http.ResponseWriter, r *http.Request, n
 	}
 
 	// Search for template using recursive search
-	foundPath := findTemplateRecursive(name)
+	foundPath := templates.Find(name)
 
 	if foundPath == "" {
 		writeError(w, r, http.StatusNotFound, "not_found", "Template not found: "+name, nil)
 		return
 	}
 
-	content, err := os.ReadFile(foundPath)
+	content, err := os.ReadFile(filepath.Clean(foundPath))
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "read_error", "Failed to read template", nil)
 		return
 	}
 
-	response := TemplateContent{
+	response := templates.Content{
 		Name:    name,
 		Content: string(content),
 		Format:  "yaml",
 	}
 
 	s.writeJSON(w, response)
-}
-
-// FindTemplateOnDisk searches for a template by name in all template
-// directories and returns the absolute path, or empty string if not
-// found. Exposed for callers like the daemon's StartSimulation that
-// need to load a template directly off disk (so include_path resolves
-// against the template's source directory rather than the wherever
-// inline data happens to be persisted).
-func FindTemplateOnDisk(name string) string {
-	return findTemplateRecursive(name)
-}
-
-// findTemplateRecursive searches for a template by name in all template directories.
-func findTemplateRecursive(name string) string {
-	for _, dir := range getTemplateDirs() {
-		var found string
-		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil //nolint:nilerr // WalkDir: continue on errors
-			}
-
-			baseName := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-			if strings.EqualFold(baseName, name) {
-				found = path
-				return filepath.SkipAll
-			}
-			return nil
-		})
-		if found != "" {
-			return found
-		}
-	}
-	return ""
 }
 
 // handleTemplateUse handles POST /api/v1/templates/use.
@@ -491,19 +131,18 @@ func (s *Server) handleTemplateUse(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	content, templatePath, err := loadTemplate(req.TemplateName)
+	content, _, err := templates.Load(req.TemplateName)
 	if err != nil {
 		writeError(w, r, http.StatusNotFound, "not_found", err.Error(), nil)
 		return
 	}
 
-	configPath, err := saveConfigFromTemplate(req, content)
+	configPath, err := templates.SaveConfig(req.TemplateName, req.NewConfigName, content)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "write_error", err.Error(), nil)
 		return
 	}
 
-	_ = templatePath // Used for logging if needed
 	response := UseTemplateResponse{
 		Success:    true,
 		Message:    fmt.Sprintf("Configuration created from template '%s'", req.TemplateName),
@@ -525,65 +164,6 @@ func parseUseTemplateRequest(r *http.Request) (*UseTemplateRequest, error) {
 	}
 
 	return &req, nil
-}
-
-// loadTemplate finds and reads a template by name.
-func loadTemplate(name string) ([]byte, string, error) {
-	templatePath := findTemplateRecursive(name)
-	if templatePath == "" {
-		return nil, "", fmt.Errorf("template not found: %s", name)
-	}
-
-	content, err := os.ReadFile(templatePath)
-	if err != nil {
-		return nil, "", errors.New("failed to read template")
-	}
-
-	return content, templatePath, nil
-}
-
-// saveConfigFromTemplate creates a config file from template content.
-func saveConfigFromTemplate(req *UseTemplateRequest, content []byte) (string, error) {
-	configName := req.NewConfigName
-	if configName == "" {
-		configName = req.TemplateName + "-config"
-	}
-
-	configName = sanitizeConfigName(configName)
-	configDir := "configs"
-
-	// Use secure permissions: 0750 for directory (owner rwx, group rx)
-	if err := os.MkdirAll(configDir, 0o750); err != nil {
-		return "", errors.New("failed to create configs directory")
-	}
-
-	configPath := filepath.Clean(filepath.Join(configDir, configName+".yaml"))
-
-	// Defense-in-depth: configName has been sanitized upstream
-	// (sanitizeConfigName), but make the bounded path explicit so static
-	// analysers see the barrier.
-	absConfigPath, absErr := filepath.Abs(configPath)
-	if absErr != nil || strings.Contains(configPath, "..") {
-		return "", errors.New("invalid config path")
-	}
-	absConfigDir, absDirErr := filepath.Abs(configDir)
-	if absDirErr != nil || !strings.HasPrefix(absConfigPath, absConfigDir+string(filepath.Separator)) {
-		return "", errors.New("invalid config path")
-	}
-
-	// Use secure permissions: 0600 for file (owner rw only)
-	if err := os.WriteFile(absConfigPath, content, 0o600); err != nil {
-		return "", errors.New("failed to write config file")
-	}
-
-	return absConfigPath, nil
-}
-
-// sanitizeConfigName removes unsafe characters from config name.
-func sanitizeConfigName(name string) string {
-	// Only allow alphanumeric, dash, underscore
-	re := regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
-	return re.ReplaceAllString(name, "-")
 }
 
 // handleTemplateUpload handles POST /api/v1/templates (upload new template).

--- a/internal/api/templates/load.go
+++ b/internal/api/templates/load.go
@@ -1,0 +1,105 @@
+package templates
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Find searches for a template by name across all template directories
+// and returns its absolute path, or empty string if not found. It is
+// used both by the HTTP content/use handlers and by the daemon's
+// StartSimulation path, which loads a template directly off disk so that
+// include_path resolves against the template's own source directory.
+func Find(name string) string {
+	for _, dir := range Dirs() {
+		var found string
+		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil //nolint:nilerr // WalkDir: continue on errors
+			}
+
+			baseName := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+			if strings.EqualFold(baseName, name) {
+				found = path
+				return filepath.SkipAll
+			}
+			return nil
+		})
+		if found != "" {
+			return found
+		}
+	}
+	return ""
+}
+
+// Load finds and reads a template by name, returning its raw content and
+// resolved on-disk path.
+func Load(name string) ([]byte, string, error) {
+	templatePath := Find(name)
+	if templatePath == "" {
+		return nil, "", fmt.Errorf("template not found: %s", name)
+	}
+
+	content, err := os.ReadFile(filepath.Clean(templatePath))
+	if err != nil {
+		return nil, "", errors.New("failed to read template")
+	}
+
+	return content, templatePath, nil
+}
+
+// SaveConfig writes template content to a new config file under the
+// configs/ directory. newConfigName is optional; when empty a name is
+// derived from templateName. The resolved absolute config path is
+// returned.
+func SaveConfig(templateName, newConfigName string, content []byte) (string, error) {
+	configName := newConfigName
+	if configName == "" {
+		configName = templateName + "-config"
+	}
+
+	configName = SanitizeConfigName(configName)
+	configDir := "configs"
+
+	// Use secure permissions: 0750 for directory (owner rwx, group rx)
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
+		return "", errors.New("failed to create configs directory")
+	}
+
+	configPath := filepath.Clean(filepath.Join(configDir, configName+".yaml"))
+
+	// Defense-in-depth: configName has been sanitized upstream
+	// (SanitizeConfigName), but make the bounded path explicit so static
+	// analysers see the barrier.
+	absConfigPath, absErr := filepath.Abs(configPath)
+	if absErr != nil || strings.Contains(configPath, "..") {
+		return "", errors.New("invalid config path")
+	}
+	absConfigDir, absDirErr := filepath.Abs(configDir)
+	if absDirErr != nil || !strings.HasPrefix(absConfigPath, absConfigDir+string(filepath.Separator)) {
+		return "", errors.New("invalid config path")
+	}
+
+	// Use secure permissions: 0600 for file (owner rw only)
+	if err := os.WriteFile(absConfigPath, content, 0o600); err != nil {
+		return "", errors.New("failed to write config file")
+	}
+
+	return absConfigPath, nil
+}
+
+// configNameUnsafe matches any character not allowed in a config name.
+var configNameUnsafe = regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
+
+// SanitizeConfigName removes unsafe characters from a config name,
+// replacing each with a dash. It is a shared config-file utility used by
+// both the template-use handler and the api config-create handler.
+func SanitizeConfigName(name string) string {
+	// Only allow alphanumeric, dash, underscore
+	return configNameUnsafe.ReplaceAllString(name, "-")
+}

--- a/internal/api/templates/parse.go
+++ b/internal/api/templates/parse.go
@@ -1,0 +1,270 @@
+package templates
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Scan walks baseDir for YAML template files and returns the parsed
+// metadata for each. Entries that error or that are not .yaml/.yml are
+// skipped; the walk continues.
+func Scan(baseDir string) ([]Template, error) {
+	var found []Template
+
+	err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, walkErr error) error {
+		// Skip entries with errors
+		if walkErr != nil || d.IsDir() {
+			return nil //nolint:nilerr // WalkDir: skip errors, continue walking
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		found = append(found, parseTemplateFile(path))
+		return nil
+	})
+
+	return found, err
+}
+
+// parseTemplateFile extracts template metadata from a file.
+//
+// Templates can opt-in to a small front-matter block at the very top of
+// the YAML for richer UI metadata. The parser walks consecutive comment
+// lines and recognises:
+//
+//	# Display: Enterprise Router
+//	# Description: A full enterprise router persona with LLDP, CDP, SNMP, ...
+//
+// When present these win over the legacy "first non-empty comment line"
+// heuristic. The keys are case-insensitive and the rest of the file is
+// untouched.
+func parseTemplateFile(path string) Template {
+	// Extract name from filename without extension
+	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+
+	meta := extractFrontMatter(path)
+
+	displayName := meta["display"]
+
+	description := meta["description"]
+	if description == "" {
+		// Fall back to the legacy first-comment heuristic for templates
+		// that haven't been migrated yet.
+		description = extractDescription(path)
+	}
+	if description == "" {
+		base := displayName
+		if base == "" {
+			base = name
+		}
+		description = base + " configuration template"
+	}
+
+	// Count devices in the YAML file
+	deviceCount := CountDevicesInFile(path)
+
+	// Determine type: front-matter wins, otherwise infer from name+path.
+	templateType := strings.ToLower(strings.TrimSpace(meta["type"]))
+	if templateType == "" {
+		templateType = determineTemplateType(path, name)
+	}
+
+	// Tags: front-matter "tags:" comma-separated wins, otherwise infer.
+	tags := splitTags(meta["tags"])
+	if len(tags) == 0 {
+		tags = generateTags(path)
+	}
+
+	// Vendor is optional. We lowercase so the UI's group-by key is
+	// stable regardless of how the YAML author cased it.
+	vendor := strings.ToLower(strings.TrimSpace(meta["vendor"]))
+
+	return Template{
+		Name:        name,
+		DisplayName: displayName,
+		Description: description,
+		DeviceCount: deviceCount,
+		Type:        templateType,
+		Vendor:      vendor,
+		Tags:        tags,
+	}
+}
+
+// splitTags parses a comma-separated tags string into a slice. Empty tags
+// are skipped and whitespace is trimmed.
+func splitTags(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// extractFrontMatter pulls "# Key: Value" lines from the top of a YAML
+// file into a map. Stops at the first non-comment, non-blank line. Keys
+// are lowercased; values are trimmed.
+func extractFrontMatter(path string) map[string]string {
+	// filepath.Clean keeps gosec G304 quiet — callers walk a
+	// server-owned templates directory, but cleaning is cheap and
+	// satisfies the linter without a //nolint exception.
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil
+	}
+	meta := make(map[string]string)
+	for line := range strings.SplitSeq(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		comment, isComment := strings.CutPrefix(trimmed, "#")
+		if !isComment {
+			break
+		}
+		comment = strings.TrimSpace(comment)
+		key, value, ok := strings.Cut(comment, ":")
+		if !ok {
+			continue
+		}
+		k := strings.ToLower(strings.TrimSpace(key))
+		v := strings.TrimSpace(value)
+		if k != "" && v != "" {
+			meta[k] = v
+		}
+	}
+	return meta
+}
+
+// CountDevicesInFile counts the number of devices defined in a YAML
+// config. It is a shared config-file utility: both the template parser
+// and the user-config parser in the api package use it.
+func CountDevicesInFile(path string) int {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return 1 // Default to 1 if can't read
+	}
+
+	// Simple heuristic: count lines that start with "- name:" (device entries)
+	count := 0
+	for line := range strings.SplitSeq(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- name:") {
+			count++
+		}
+	}
+
+	if count == 0 {
+		return 1 // At least 1 device assumed
+	}
+	return count
+}
+
+// determineTemplateType determines the template type from its path and name.
+func determineTemplateType(path, name string) string {
+	pathLower := strings.ToLower(path)
+	nameLower := strings.ToLower(name)
+
+	// Check filename first for specific types
+	switch {
+	case strings.Contains(nameLower, "router"):
+		return typeRouter
+	case strings.Contains(nameLower, "switch"):
+		return typeSwitch
+	case strings.Contains(nameLower, "ap") || strings.Contains(nameLower, "wireless") ||
+		strings.Contains(nameLower, "access-point"):
+		return typeAccessPoint
+	case strings.Contains(nameLower, "firewall") || strings.Contains(nameLower, "asa") ||
+		strings.Contains(nameLower, "srx") || strings.Contains(nameLower, "ftd"):
+		return typeFirewall
+	case strings.Contains(nameLower, "server"):
+		return typeServer
+	case strings.Contains(nameLower, "complete") || strings.Contains(nameLower, "full"):
+		return typeComplete
+	}
+
+	// Check path for type hints
+	switch {
+	case strings.Contains(pathLower, "/services/"):
+		return typeServer
+	case strings.Contains(pathLower, "/combinations/"):
+		return typeComplete
+	case strings.Contains(pathLower, "/vendors/"):
+		return typeCustom
+	default:
+		return typeBasic
+	}
+}
+
+// extractDescription extracts description from first comment line of YAML file.
+func extractDescription(path string) string {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return ""
+	}
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if desc, found := strings.CutPrefix(line, "#"); found {
+			desc = strings.TrimSpace(desc)
+			if desc != "" && !strings.HasPrefix(strings.ToLower(desc), "yaml") {
+				return desc
+			}
+		} else if line != "" {
+			// First non-comment, non-empty line - stop
+			break
+		}
+	}
+	return ""
+}
+
+// generateTags generates tags from the file path.
+func generateTags(path string) []string {
+	tags := []string{}
+	pathLower := strings.ToLower(path)
+
+	// Add tags based on path components
+	tagPatterns := map[string]string{
+		"router":     "router",
+		"switch":     "switch",
+		"wireless":   "wireless",
+		"ap":         "wireless",
+		"snmp":       "snmp",
+		"firewall":   "security",
+		"security":   "security",
+		"datacenter": "datacenter",
+		"enterprise": "enterprise",
+		"campus":     "enterprise",
+	}
+
+	for pattern, tag := range tagPatterns {
+		if strings.Contains(pathLower, pattern) && !slices.Contains(tags, tag) {
+			tags = append(tags, tag)
+		}
+	}
+
+	// Add vendor tags
+	vendors := []string{
+		"cisco", "juniper", "arista", "dell", "aruba",
+		"meraki", "fortinet", "paloalto", "extreme", "foundry",
+	}
+	for _, vendor := range vendors {
+		if strings.Contains(pathLower, vendor) {
+			tags = append(tags, vendor)
+		}
+	}
+
+	return tags
+}

--- a/internal/api/templates/templates.go
+++ b/internal/api/templates/templates.go
@@ -1,0 +1,79 @@
+// Package templates holds the on-disk configuration-template discovery,
+// parsing, and loading engine extracted from the internal/api monolith
+// (ADR-0006). It walks the filesystem template directories, parses YAML
+// front-matter into structured metadata, and materialises a chosen
+// template into a saved config — all with no dependency on the api
+// transport layer, which composes it inward.
+//
+// This is distinct from the sibling internal/templates package, which is
+// the embedded builtin template library compiled into the binary. This
+// leaf is the runtime on-disk engine (development trees, system install
+// paths, and the NIAC_TEMPLATES_DIR override) used by the
+// /api/v1/templates HTTP surface and the daemon's StartSimulation path.
+package templates
+
+import "os"
+
+// Template type constants matching the UI interface.
+const (
+	typeBasic       = "basic"
+	typeRouter      = "router"
+	typeSwitch      = "switch"
+	typeAccessPoint = "access-point"
+	typeServer      = "server"
+	typeFirewall    = "firewall"
+	typeComplete    = "complete"
+	typeCustom      = "custom"
+)
+
+// Template represents a configuration template.
+//
+// Name is the stable filename-derived identifier ("minimal", "router")
+// used by the /api/v1/templates/{name} and /api/v1/templates/use APIs.
+// DisplayName is the human-readable label optionally provided via the
+// front-matter "# Display: ..." line; clients should prefer it for UI
+// rendering and fall back to Name when absent.
+type Template struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description"`
+	DeviceCount int    `json:"deviceCount"`
+	Type        string `json:"type"`
+	// Vendor is populated from the template's "# Vendor: ..."
+	// front-matter, lowercased. When non-empty the UI groups the
+	// template under a vendor heading instead of (or alongside) the
+	// generic type-based grouping — useful for the vendor template
+	// pack shipped under cmd/niac/templates/vendor-templates/.
+	Vendor string   `json:"vendor,omitempty"`
+	Tags   []string `json:"tags,omitempty"`
+}
+
+// Content represents the full content of a template.
+type Content struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+	Format  string `json:"format"`
+}
+
+// Dirs returns the directories to scan for templates. It checks multiple
+// locations for compatibility with both development and installed
+// deployments. A NIAC_TEMPLATES_DIR override, when set, takes precedence.
+func Dirs() []string {
+	dirs := []string{
+		// Development paths (relative to working directory)
+		"cmd/niac/templates",
+		"examples",
+		// System-wide installed paths
+		"/usr/share/niac/templates",
+		"/var/lib/niac/templates",
+		// User-specific paths
+		os.ExpandEnv("$HOME/.niac/templates"),
+	}
+
+	// Add custom directory from environment variable
+	if customDir := os.Getenv("NIAC_TEMPLATES_DIR"); customDir != "" {
+		dirs = append([]string{customDir}, dirs...)
+	}
+
+	return dirs
+}

--- a/internal/api/templates/templates_test.go
+++ b/internal/api/templates/templates_test.go
@@ -1,0 +1,383 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSplitTags(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "router", []string{"router"}},
+		{"multiple", "router,switch,snmp", []string{"router", "switch", "snmp"}},
+		{"trims whitespace", " router , switch ", []string{"router", "switch"}},
+		{"skips empties", "router,,switch,", []string{"router", "switch"}},
+		{"only commas", ",,,", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := splitTags(tc.raw)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("splitTags(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetermineTemplateType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		path     string
+		fileName string
+		want     string
+	}{
+		{"router by name", "/x/edge-router.yaml", "edge-router", typeRouter},
+		{"switch by name", "/x/core-switch.yaml", "core-switch", typeSwitch},
+		{"ap by name", "/x/office-ap.yaml", "office-ap", typeAccessPoint},
+		{"wireless by name", "/x/wireless.yaml", "wireless", typeAccessPoint},
+		{"firewall by name", "/x/asa.yaml", "asa", typeFirewall},
+		{"server by name", "/x/server.yaml", "server", typeServer},
+		{"complete by name", "/x/full.yaml", "full", typeComplete},
+		{"services by path", "/templates/services/dns.yaml", "dns", typeServer},
+		{"combinations by path", "/templates/combinations/x.yaml", "x", typeComplete},
+		{"vendors by path", "/templates/vendors/x.yaml", "x", typeCustom},
+		{"default basic", "/templates/misc/thing.yaml", "thing", typeBasic},
+		{"name beats path", "/templates/services/edge-router.yaml", "edge-router", typeRouter},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := determineTemplateType(tc.path, tc.fileName); got != tc.want {
+				t.Errorf("determineTemplateType(%q,%q) = %q, want %q", tc.path, tc.fileName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerateTags(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want []string // order-independent membership check
+	}{
+		{"no matches", "/templates/plain/thing.yaml", nil},
+		{"router path", "/templates/router/x.yaml", []string{"router"}},
+		{"firewall maps to security", "/templates/firewall/x.yaml", []string{"security"}},
+		{"vendor cisco", "/templates/cisco/x.yaml", []string{"cisco"}},
+		{"path + vendor", "/templates/router/cisco-edge.yaml", []string{"router", "cisco"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := generateTags(tc.path)
+			for _, want := range tc.want {
+				if !slices.Contains(got, want) {
+					t.Errorf("generateTags(%q) = %v, missing %q", tc.path, got, want)
+				}
+			}
+			if len(tc.want) == 0 && len(got) != 0 {
+				t.Errorf("generateTags(%q) = %v, want empty", tc.path, got)
+			}
+		})
+	}
+}
+
+func TestSanitizeConfigName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clean", "my-config_1", "my-config_1"},
+		{"spaces", "my config", "my-config"},
+		{"slashes blocked", "../etc/passwd", "---etc-passwd"},
+		{"special chars", "a@b#c", "a-b-c"},
+		{"alnum preserved", "ABC123", "ABC123"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := SanitizeConfigName(tc.in); got != tc.want {
+				t.Errorf("SanitizeConfigName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractFrontMatter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.yaml")
+	content := "# Display: Edge Router\n" +
+		"# Description: A full router persona\n" +
+		"# Vendor: Cisco\n" +
+		"# Tags: router, snmp\n" +
+		"devices:\n" +
+		"# this comment is below the body and ignored\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := extractFrontMatter(path)
+	want := map[string]string{
+		"display":     "Edge Router",
+		"description": "A full router persona",
+		"vendor":      "Cisco",
+		"tags":        "router, snmp",
+	}
+	for k, v := range want {
+		if meta[k] != v {
+			t.Errorf("meta[%q] = %q, want %q", k, meta[k], v)
+		}
+	}
+	if len(meta) != len(want) {
+		t.Errorf("meta has %d keys, want %d: %v", len(meta), len(want), meta)
+	}
+}
+
+func TestExtractFrontMatter_MissingFile(t *testing.T) {
+	t.Parallel()
+	if meta := extractFrontMatter(filepath.Join(t.TempDir(), "nope.yaml")); meta != nil {
+		t.Errorf("expected nil for missing file, got %v", meta)
+	}
+}
+
+func TestCountDevicesInFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"two devices", "devices:\n  - name: r1\n  - name: r2\n", 2},
+		{"no devices defaults to 1", "metadata:\n  foo: bar\n", 1},
+		{"one device", "devices:\n  - name: only\n", 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "c.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := CountDevicesInFile(path); got != tc.want {
+				t.Errorf("CountDevicesInFile = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountDevicesInFile_MissingFile(t *testing.T) {
+	t.Parallel()
+	if got := CountDevicesInFile(filepath.Join(t.TempDir(), "nope.yaml")); got != 1 {
+		t.Errorf("missing file = %d, want 1", got)
+	}
+}
+
+func TestExtractDescription(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"first comment", "# A nice router\ndevices:\n", "A nice router"},
+		{"skips yaml header", "# yaml-language-server: foo\n# Real desc\ndevices:\n", "Real desc"},
+		{"stops at body", "devices:\n# too late\n", ""},
+		{"no comment", "devices:\n", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "d.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := extractDescription(path); got != tc.want {
+				t.Errorf("extractDescription = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseTemplateFile_FrontMatterWins(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "edge-router.yaml")
+	content := "# Display: Enterprise Router\n" +
+		"# Description: Full enterprise router\n" +
+		"# Type: firewall\n" +
+		"# Vendor: Juniper\n" +
+		"# Tags: custom-tag\n" +
+		"devices:\n  - name: r1\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl := parseTemplateFile(path)
+	if tmpl.Name != "edge-router" {
+		t.Errorf("Name = %q, want edge-router", tmpl.Name)
+	}
+	if tmpl.DisplayName != "Enterprise Router" {
+		t.Errorf("DisplayName = %q", tmpl.DisplayName)
+	}
+	if tmpl.Description != "Full enterprise router" {
+		t.Errorf("Description = %q", tmpl.Description)
+	}
+	if tmpl.Type != "firewall" { // front-matter type wins over name "router"
+		t.Errorf("Type = %q, want firewall", tmpl.Type)
+	}
+	if tmpl.Vendor != "juniper" { // lowercased
+		t.Errorf("Vendor = %q, want juniper", tmpl.Vendor)
+	}
+	if !slices.Equal(tmpl.Tags, []string{"custom-tag"}) {
+		t.Errorf("Tags = %v, want [custom-tag]", tmpl.Tags)
+	}
+	if tmpl.DeviceCount != 1 {
+		t.Errorf("DeviceCount = %d, want 1", tmpl.DeviceCount)
+	}
+}
+
+func TestParseTemplateFile_InfersFromNameWhenNoFrontMatter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "core-switch.yaml")
+	if err := os.WriteFile(path, []byte("devices:\n  - name: s1\n  - name: s2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl := parseTemplateFile(path)
+	if tmpl.Type != typeSwitch {
+		t.Errorf("Type = %q, want %q", tmpl.Type, typeSwitch)
+	}
+	if tmpl.Description != "core-switch configuration template" {
+		t.Errorf("Description = %q (expected synthesized fallback)", tmpl.Description)
+	}
+	if tmpl.DeviceCount != 2 {
+		t.Errorf("DeviceCount = %d, want 2", tmpl.DeviceCount)
+	}
+}
+
+func TestScan(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "router.yaml"), "# A router\ndevices:\n  - name: r1\n")
+	mustWrite(t, filepath.Join(dir, "switch.yml"), "# A switch\ndevices:\n  - name: s1\n")
+	mustWrite(t, filepath.Join(dir, "notes.txt"), "ignored")
+	// nested dir is walked recursively
+	sub := filepath.Join(dir, "vendors")
+	if err := os.Mkdir(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(sub, "cisco.yaml"), "# Cisco\ndevices:\n  - name: c1\n")
+
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+	if len(got) != 3 { // .txt skipped, 3 yaml found
+		t.Fatalf("Scan found %d templates, want 3: %v", len(got), got)
+	}
+	names := make([]string, len(got))
+	for i, tmpl := range got {
+		names[i] = tmpl.Name
+	}
+	for _, want := range []string{"router", "switch", "cisco"} {
+		if !slices.Contains(names, want) {
+			t.Errorf("Scan missing %q in %v", want, names)
+		}
+	}
+}
+
+func TestScan_MissingDirIsNotFatal(t *testing.T) {
+	t.Parallel()
+	got, _ := Scan(filepath.Join(t.TempDir(), "does-not-exist"))
+	if len(got) != 0 {
+		t.Errorf("Scan of missing dir = %v, want empty", got)
+	}
+}
+
+func TestFindAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "myrouter.yaml"), "# router\ndevices:\n  - name: r1\n")
+	t.Setenv("NIAC_TEMPLATES_DIR", dir)
+
+	// case-insensitive match
+	found := Find("MyRouter")
+	if found == "" {
+		t.Fatal("Find returned empty for existing template")
+	}
+	if filepath.Base(found) != "myrouter.yaml" {
+		t.Errorf("Find = %q, want myrouter.yaml", found)
+	}
+
+	if Find("nonexistent") != "" {
+		t.Error("Find returned non-empty for missing template")
+	}
+
+	content, path, err := Load("myrouter")
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if !strings.Contains(string(content), "devices:") {
+		t.Errorf("Load content unexpected: %q", content)
+	}
+	if path != found {
+		t.Errorf("Load path = %q, want %q", path, found)
+	}
+
+	if _, _, loadErr := Load("nope"); loadErr == nil {
+		t.Error("Load of missing template should error")
+	}
+}
+
+func TestSaveConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir) // SaveConfig writes under ./configs
+
+	content := []byte("devices:\n  - name: r1\n")
+
+	// derives name from templateName when newConfigName empty
+	path, err := SaveConfig("router", "", content)
+	if err != nil {
+		t.Fatalf("SaveConfig error: %v", err)
+	}
+	if filepath.Base(path) != "router-config.yaml" {
+		t.Errorf("derived name = %q, want router-config.yaml", filepath.Base(path))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written config: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("written content = %q, want %q", got, content)
+	}
+
+	// explicit name is sanitized
+	path2, err := SaveConfig("router", "my custom/name", content)
+	if err != nil {
+		t.Fatalf("SaveConfig error: %v", err)
+	}
+	if filepath.Base(path2) != "my-custom-name.yaml" {
+		t.Errorf("sanitized name = %q, want my-custom-name.yaml", filepath.Base(path2))
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/api/templates"
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
 	"github.com/MustardSeedNetworks/niac-go/internal/capture"
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
@@ -279,7 +280,7 @@ func loadSimulationConfig(req api.SimulationRequest) (*config.Config, string, er
 		// refs that resolve to sibling directories (e.g. examples/
 		// device_walks_sanitized/...). Fetching the YAML text and
 		// POSTing it as ConfigData would lose that context.
-		templatePath := api.FindTemplateOnDisk(req.TemplateName)
+		templatePath := templates.Find(req.TemplateName)
 		if templatePath == "" {
 			return nil, "", fmt.Errorf("%w: %s", ErrTemplateNotFound, req.TemplateName)
 		}


### PR DESCRIPTION
## Summary

Extracts the on-disk configuration-template discovery/parse/load engine out of the
`internal/api` monolith into a new stdlib-only `internal/api/templates` leaf
(package `templates`), continuing the ADR-0006 strangle. The `Server` composes the
leaf inward; the leaf has no dependency on the transport layer, enforced by a new
`api-templates-isolated` depguard rule.

- **Engine → leaf:** `Dirs`/`Scan`/`Find`/`Load`/`SaveConfig` plus the pure helpers
  (`parseTemplateFile`, `extractFrontMatter`, `splitTags`, `determineTemplateType`,
  `extractDescription`, `generateTags`). Exported names drop the redundant `Template`
  prefix the package now supplies (`scanTemplateDir`→`Scan`, `findTemplateRecursive`→`Find`,
  `loadTemplate`→`Load`, `getTemplateDirs`→`Dirs`, `TemplateContent`→`Content`).
  **All `json:"…"` tags are byte-identical — no wire change.**
- `saveConfigFromTemplate` redesigned to `SaveConfig(templateName, newConfigName, content)`
  so the leaf no longer depends on the HTTP `UseTemplateRequest` body type.
- `CountDevicesInFile` + `SanitizeConfigName` are exported from the leaf because
  `configs.go` shares both; `api`→leaf is the allowed inward direction.
- **Stays transport** (`internal/api/templates.go` 599→179): `UseTemplateRequest/Response`,
  all `handle*` methods, `parseUseTemplateRequest`.
- `internal/daemon/daemon.go` migrated from `api.FindTemplateOnDisk` to `templates.Find`,
  decoupling the simulation loader from the web transport package.
- `templates.go` shipped with **no tests**; this PR adds table-driven engine tests
  in the leaf (front-matter parsing, type/description/tag inference, scan, find/load,
  save-config sanitization).

Distinct from the existing `internal/templates` package, which is the embedded builtin
template library; this leaf is the runtime on-disk engine (dev trees, install paths,
`NIAC_TEMPLATES_DIR`). Different import paths, no single-file collision.

## Linked Issue

Related to #830

## Type of Change

- [x] Chore / refactor / dependency update

## Risk

- [x] Low

## Testing Evidence

```text
$ go build ./...                      # BUILD OK (pre-existing -lpcap link warning only)
$ go vet ./internal/api/... ./internal/daemon/...   # VET OK
$ golangci-lint run ./...             # 0 issues
$ go test ./internal/api/...          # all ok (api, templates, capture, csrf, ratelimit, sse, tokenstore, auth)
$ go test ./internal/daemon/...       # ok
$ bash scripts/check-route-policy.sh      # ✓ all /api routes via capability registry
$ bash scripts/check-output-escaping.sh   # OK
$ bash scripts/check-json-casing.sh       # OK — no snake_case wire tags (ADR-0007)
$ bash scripts/check-filename-policy.sh   # ✓ no monolith prefixes outside internal/api
$ STRICT=1 bash scripts/check-file-size.sh
  # only pre-existing UI red flags (PacketInspectorPage.tsx, pageRegistry.tsx);
  # all new/changed Go files well under limit (transport 179; leaf 79/105/270; test 383)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (config_templates feature-gate + path-traversal guards preserved; SaveConfig keeps the bounded-path defense-in-depth and 0600/0750 perms.)
- [x] Dependencies are pinned and justified if changed. (no dependency changes)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (no behavior/wire change; ADR-0006 already covers the leaf pattern, consistent with the capture/topology precedent)
