### PR TITLE
fix(snmp): make walk replay scale and stop dropping valid OIDs

### DIFF
--- a/internal/protocols/snmp/mib.go
+++ b/internal/protocols/snmp/mib.go
@@ -105,22 +105,28 @@ func (m *MIB) GetNext(oid string) (string, *OIDValue) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	// Find next OID in sorted list
-	for _, nextOID := range m.sorted {
-		if compareOIDs(nextOID, oid) > 0 {
-			value := m.entries[nextOID]
+	// Binary search the sorted list for the first OID strictly greater than
+	// the requested one. The list is kept in ascending compareOIDs order, so a
+	// full snmpwalk costs O(walk_len · log n) instead of O(walk_len · n) — the
+	// difference between responding and timing out on a 30k-OID device walk.
+	idx := sort.Search(len(m.sorted), func(i int) bool {
+		return compareOIDs(m.sorted[i], oid) > 0
+	})
 
-			// If dynamic, call function
-			if value.Dynamic != nil {
-				return nextOID, value.Dynamic()
-			}
-
-			return nextOID, value
-		}
+	if idx >= len(m.sorted) {
+		// End of MIB
+		return "", nil
 	}
 
-	// End of MIB
-	return "", nil
+	nextOID := m.sorted[idx]
+	value := m.entries[nextOID]
+
+	// If dynamic, call function
+	if value.Dynamic != nil {
+		return nextOID, value.Dynamic()
+	}
+
+	return nextOID, value
 }
 
 // updateSortedList updates the sorted OID list (caller must hold write lock).

--- a/internal/protocols/snmp/walk.go
+++ b/internal/protocols/snmp/walk.go
@@ -20,6 +20,78 @@ const (
 	snmpTypeUnknown = "Unknown"
 )
 
+// Walk-file scanner buffer sizes. Long Hex-STRING and multi-line values in a
+// large device walk can exceed bufio.Scanner's 64KiB default token size.
+const (
+	walkScanBufInitial = 64 * 1024
+	walkScanBufMax     = 4 * 1024 * 1024
+)
+
+// isHexStringLine reports whether a parsed walk line declared a Hex-STRING
+// value, and therefore may be continued on following bare-hex lines.
+func isHexStringLine(line string) bool {
+	_, rest, ok := strings.Cut(line, "=")
+	if !ok {
+		return false
+	}
+
+	typeTok, _, ok := strings.Cut(rest, ":")
+	if !ok {
+		return false
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(typeTok)) {
+	case "HEX-STRING", "HEX":
+		return true
+	default:
+		return false
+	}
+}
+
+// isHexContinuation reports whether a line is a bare Hex-STRING continuation:
+// one or more whitespace-separated pairs of hex digits and nothing else. These
+// lines are emitted by net-snmp when a Hex-STRING value wraps across lines.
+func isHexContinuation(line string) bool {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return false
+	}
+
+	for _, f := range fields {
+		if len(f) != 2 || !isHexByte(f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isHexByte(s string) bool {
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+
+	return true
+}
+
+// appendHexContinuation folds a Hex-STRING continuation line's octets into the
+// preceding entry. Hex values are stored as a space-free upper-of-lower hex
+// string (see parseHexStringValue), so append the same normalized form.
+func appendHexContinuation(entry *WalkEntry, line string) {
+	if entry.Type != gosnmp.OctetString {
+		return
+	}
+
+	prev, ok := entry.Value.(string)
+	if !ok {
+		return
+	}
+
+	entry.Value = prev + strings.ReplaceAll(line, " ", "")
+}
+
 // WalkEntry represents a single entry from an SNMP walk file.
 type WalkEntry struct {
 	OID   string
@@ -77,7 +149,13 @@ func ParseWalkFile(filename string) ([]WalkEntry, error) {
 	var entries []WalkEntry
 
 	scanner := bufio.NewScanner(file)
+	// net-snmp wraps long Hex-STRING and multi-line octet-string values across
+	// several lines; a 30k-OID switch walk can carry lines well over the 64KiB
+	// default token size, so grow the buffer to avoid a mid-walk scan error.
+	scanner.Buffer(make([]byte, 0, walkScanBufInitial), walkScanBufMax)
+
 	lineNum := 0
+	lastWasHex := false // previous entry came from a Hex-STRING (may continue)
 
 	for scanner.Scan() {
 		lineNum++
@@ -85,6 +163,16 @@ func ParseWalkFile(filename string) ([]WalkEntry, error) {
 
 		// Skip empty lines and comments
 		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// net-snmp continues long Hex-STRING values on subsequent lines that
+		// carry only whitespace-separated hex octets (no "OID = TYPE:" prefix).
+		// Fold such a line into the previous entry instead of dropping it —
+		// otherwise the parent value is silently truncated and the line lost.
+		if lastWasHex && len(entries) > 0 && isHexContinuation(line) {
+			appendHexContinuation(&entries[len(entries)-1], line)
+
 			continue
 		}
 
@@ -96,6 +184,7 @@ func ParseWalkFile(filename string) ([]WalkEntry, error) {
 			continue
 		}
 
+		lastWasHex = isHexStringLine(line)
 		entries = append(entries, *entry)
 	}
 
@@ -118,6 +207,14 @@ func parseWalkLine(line string) (*WalkEntry, error) {
 
 	oid := strings.TrimSpace(parts[0])
 	rest := strings.TrimSpace(parts[1])
+
+	// net-snmp emits zero-length octet strings with no type prefix, as
+	// `OID = ""` (or a bare `OID = `). Treat these as an empty OctetString
+	// rather than dropping the OID — a c3750 walk carries ~1,275 of them
+	// (empty ifAlias, LLDP remote fields, etc.).
+	if rest == "" || rest == `""` {
+		return &WalkEntry{OID: oid, Type: gosnmp.OctetString, Value: ""}, nil
+	}
 
 	// Parse TYPE: VALUE
 	typeParts := strings.SplitN(rest, ":", OIDPartsMinPDU)

--- a/internal/protocols/snmp/walk_replay_test.go
+++ b/internal/protocols/snmp/walk_replay_test.go
@@ -1,0 +1,111 @@
+package snmp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// reproWalk is a small but representative sanitized walk. It includes:
+//   - a real sysDescr (should override the config-derived value)
+//   - ifTable / ifXTable style rows
+//   - the malformed empty-value line reported from the sanitized catalog
+//     (`... = ""` with no TYPE: prefix)
+const reproWalk = `.1.3.6.1.2.1.1.1.0 = STRING: "Cisco IOS Software, C3750 Software"
+.1.3.6.1.2.1.1.2.0 = OID: .1.3.6.1.4.1.9.1.516
+.1.3.6.1.2.1.1.5.0 = STRING: "cos-acc-sw1"
+.1.3.6.1.2.1.2.2.1.2.1 = STRING: "GigabitEthernet1/0/1"
+.1.3.6.1.2.1.2.2.1.2.2 = STRING: "GigabitEthernet1/0/2"
+.1.3.6.1.2.1.2.2.1.5.1 = Gauge32: 1000000000
+.1.3.6.1.2.1.2.2.1.5.2 = Gauge32: 1000000000
+.1.3.6.1.2.1.31.1.1.1.1.1 = STRING: "Gi1/0/1"
+.1.3.6.1.2.1.31.1.1.1.1.2 = STRING: "Gi1/0/2"
+.1.3.6.1.2.1.31.1.10.100.42.92 = ""
+`
+
+// TestReproSnmpwalk simulates what net-snmp `snmpwalk` does: a chain of
+// GET-NEXT requests starting at the mib-2 root, following each returned OID,
+// until end-of-mib. It asserts the walk-file entries are actually reachable.
+func TestReproSnmpwalk(t *testing.T) {
+	dir := t.TempDir()
+	walkPath := filepath.Join(dir, "repro.walk")
+	if err := os.WriteFile(walkPath, []byte(reproWalk), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	device := createTestDevice()
+	device.Properties["sysDescr"] = "router test-device" // config-derived default
+	agent := NewAgent(device, 0)
+
+	if err := agent.LoadWalkFile(walkPath); err != nil {
+		t.Fatalf("LoadWalkFile: %v", err)
+	}
+
+	// 1) GET on sysDescr must return the WALK value, not the config default.
+	got, err := agent.HandleGet(".1.3.6.1.2.1.1.1.0")
+	if err != nil {
+		t.Fatalf("GET sysDescr: %v", err)
+	}
+	if s, _ := got.Value.(string); s != "Cisco IOS Software, C3750 Software" {
+		t.Errorf("sysDescr = %q; want the walk value (config default leaked)", s)
+	}
+
+	// 2) Walk the whole mib-2 subtree via repeated GET-NEXT (like snmpwalk).
+	root := ".1.3.6.1.2.1"
+	current := root
+	seen := map[string]bool{}
+	var walked []string
+	for range 100 {
+		resp := agent.ProcessPDU(gosnmp.GetNextRequest, []gosnmp.SnmpPDU{{Name: current}}, 0)
+		if len(resp) != 1 {
+			t.Fatalf("GET-NEXT returned %d vars", len(resp))
+		}
+		v := resp[0]
+		if v.Type == gosnmp.EndOfMibView || v.Type == gosnmp.NoSuchObject {
+			break
+		}
+		name := normalizeName(v.Name)
+		if !hasPrefixOID(name, root) {
+			break // left the subtree — snmpwalk stops here
+		}
+		if seen[name] {
+			t.Fatalf("GET-NEXT looped on %s (walk would never terminate)", name)
+		}
+		seen[name] = true
+		walked = append(walked, name)
+		current = v.Name
+	}
+
+	t.Logf("snmpwalk reached %d OIDs: %v", len(walked), walked)
+	if len(walked) == 0 {
+		t.Fatal("snmpwalk reached 0 OIDs — walk replay is broken")
+	}
+	// We expect at least the interface OIDs from the walk to be reachable.
+	if !seen["1.3.6.1.2.1.2.2.1.2.1"] {
+		t.Errorf("walk did not reach ifDescr.1 from the walk file")
+	}
+	if !seen["1.3.6.1.2.1.31.1.1.1.1.1"] {
+		t.Errorf("walk did not reach ifName.1 from the walk file")
+	}
+}
+
+func normalizeName(oid string) string {
+	if len(oid) > 0 && oid[0] == '.' {
+		return oid[1:]
+	}
+	return oid
+}
+
+func hasPrefixOID(oid, prefix string) bool {
+	oid = normalizeName(oid)
+	prefix = normalizeName(prefix)
+	if len(oid) < len(prefix) {
+		return false
+	}
+	if oid[:len(prefix)] != prefix {
+		return false
+	}
+	return len(oid) == len(prefix) || oid[len(prefix)] == '.'
+}

--- a/internal/protocols/snmp/walk_test.go
+++ b/internal/protocols/snmp/walk_test.go
@@ -314,3 +314,76 @@ IF-MIB::ifAdminStatus.1 = INTEGER: 1
 		}
 	}
 }
+
+// TestParseWalkFile_EmptyOctetString verifies net-snmp's zero-length octet
+// string form (`OID = ""`, no TYPE: prefix) is parsed as an empty OctetString
+// rather than dropped. A large device walk carries hundreds of these.
+func TestParseWalkFile_EmptyOctetString(t *testing.T) {
+	tmpDir := t.TempDir()
+	walkFile := filepath.Join(tmpDir, "empty.walk")
+
+	walkData := `.1.3.6.1.2.1.1.5.0 = STRING: "sw1"
+.1.3.6.1.2.1.31.1.1.1.18.1 = ""
+.1.3.6.1.2.1.31.1.1.1.18.2 =
+.1.3.6.1.2.1.1.6.0 = STRING: "lab"
+`
+	if err := os.WriteFile(walkFile, []byte(walkData), 0o600); err != nil {
+		t.Fatalf("write walk: %v", err)
+	}
+
+	entries, err := ParseWalkFile(walkFile)
+	if err != nil {
+		t.Fatalf("ParseWalkFile: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries (2 empty strings kept), got %d", len(entries))
+	}
+
+	for _, oid := range []string{".1.3.6.1.2.1.31.1.1.1.18.1", ".1.3.6.1.2.1.31.1.1.1.18.2"} {
+		found := false
+		for _, e := range entries {
+			if e.OID == oid {
+				found = true
+				if e.Type != gosnmp.OctetString {
+					t.Errorf("%s: type = %v, want OctetString", oid, e.Type)
+				}
+				if s, _ := e.Value.(string); s != "" {
+					t.Errorf("%s: value = %q, want empty string", oid, s)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("empty-value OID %s was dropped", oid)
+		}
+	}
+}
+
+// TestParseWalkFile_HexContinuation verifies that a Hex-STRING value wrapped by
+// net-snmp across multiple bare-hex lines is folded back into a single entry
+// (parent not truncated, continuation lines not dropped), while a bare-hex line
+// following a non-hex entry is not mistaken for a continuation.
+func TestParseWalkFile_HexContinuation(t *testing.T) {
+	tmpDir := t.TempDir()
+	walkFile := filepath.Join(tmpDir, "hex.walk")
+
+	walkData := `.1.3.6.1.2.1.4.35.1.4.1 = Hex-STRING: 00 11 22 33 44 55
+66 77 88 99 AA BB
+.1.3.6.1.2.1.1.5.0 = STRING: "sw1"
+`
+	if err := os.WriteFile(walkFile, []byte(walkData), 0o600); err != nil {
+		t.Fatalf("write walk: %v", err)
+	}
+
+	entries, err := ParseWalkFile(walkFile)
+	if err != nil {
+		t.Fatalf("ParseWalkFile: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (continuation folded, not a new OID), got %d", len(entries))
+	}
+
+	const wantHex = "00112233445566778899AABB" // 12 octets: line 1 + folded line 2
+	if hex, _ := entries[0].Value.(string); hex != wantHex {
+		t.Errorf("hex value = %q, want %q (continuation not folded)", hex, wantHex)
+	}
+}

--- a/internal/protocols/snmp_wire_test.go
+++ b/internal/protocols/snmp_wire_test.go
@@ -1,0 +1,102 @@
+package protocols
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp"
+)
+
+const wireReproWalk = `.1.3.6.1.2.1.1.1.0 = STRING: "Cisco IOS Software, C3750"
+.1.3.6.1.2.1.1.5.0 = STRING: "cos-acc-sw1"
+.1.3.6.1.2.1.2.2.1.2.1 = STRING: "GigabitEthernet1/0/1"
+.1.3.6.1.2.1.2.2.1.5.1 = Gauge32: 1000000000
+.1.3.6.1.2.1.31.1.1.1.1.1 = STRING: "Gi1/0/1"
+`
+
+// buildAgent builds an agent with the walk loaded, mirroring stack_snmp.go.
+func buildAgent(t *testing.T) *snmp.Agent {
+	t.Helper()
+	dir := t.TempDir()
+	walkPath := filepath.Join(dir, "w.walk")
+	if err := os.WriteFile(walkPath, []byte(wireReproWalk), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dev := &config.Device{Name: "sw1", Type: "switch", Properties: map[string]string{}}
+	agent := snmp.NewAgentWithCommunity(dev, "public", 0)
+	if err := agent.LoadWalkFile(walkPath); err != nil {
+		t.Fatal(err)
+	}
+	return agent
+}
+
+// roundTrip marshals an agent response the way the live handler does
+// (internal/protocols/snmp.go buildResponse) and decodes it back the way a
+// net-snmp client would, returning the decoded variables.
+func roundTrip(t *testing.T, agent *snmp.Agent, pduType gosnmp.PDUType, name string, maxRep uint32) []gosnmp.SnmpPDU {
+	t.Helper()
+	respVars := agent.ProcessPDU(pduType, []gosnmp.SnmpPDU{{Name: name}}, maxRep)
+	resp := &gosnmp.SnmpPacket{
+		Version:   gosnmp.Version2c,
+		Community: "public",
+		PDUType:   gosnmp.GetResponse,
+		RequestID: 1,
+		Variables: respVars,
+	}
+	raw, err := resp.MarshalMsg()
+	if err != nil {
+		t.Fatalf("marshal (%v): %v", pduType, err)
+	}
+	decoder := gosnmp.GoSNMP{Version: gosnmp.Version2c, Community: "public", MaxOids: gosnmp.MaxOids}
+	decoded, err := decoder.SnmpDecodePacket(raw)
+	if err != nil {
+		t.Fatalf("client decode (%v): %v", pduType, err)
+	}
+	return decoded.Variables
+}
+
+func TestWireGetNext(t *testing.T) {
+	agent := buildAgent(t)
+	vars := roundTrip(t, agent, gosnmp.GetNextRequest, ".1.3.6.1.2.1.2.2.1.2", 0)
+	if len(vars) != 1 {
+		t.Fatalf("got %d vars", len(vars))
+	}
+	t.Logf("GETNEXT(.1.3.6.1.2.1.2.2.1.2) -> name=%q type=%v value=%v", vars[0].Name, vars[0].Type, vars[0].Value)
+	if vars[0].Name != ".1.3.6.1.2.1.2.2.1.2.1" {
+		t.Errorf("GETNEXT returned name %q; want .1.3.6.1.2.1.2.2.1.2.1", vars[0].Name)
+	}
+}
+
+func TestWireGetBulkSnmpwalk(t *testing.T) {
+	agent := buildAgent(t)
+	// Simulate snmpbulkwalk: GETBULK from the mib-2 root, follow responses.
+	root := ".1.3.6.1.2.1"
+	current := root
+	var reached []string
+	for range 50 {
+		vars := roundTrip(t, agent, gosnmp.GetBulkRequest, current, 10)
+		if len(vars) == 0 {
+			break
+		}
+		done := false
+		for _, v := range vars {
+			if v.Type == gosnmp.EndOfMibView || v.Type == gosnmp.NoSuchObject {
+				done = true
+				break
+			}
+			reached = append(reached, v.Name)
+			current = v.Name
+		}
+		if done {
+			break
+		}
+	}
+	t.Logf("snmpbulkwalk reached %d OIDs: %v", len(reached), reached)
+	if len(reached) == 0 {
+		t.Fatal("GETBULK snmpwalk reached 0 OIDs")
+	}
+}


### PR DESCRIPTION
## Summary

Replaying real sanitized device walks (the 32,700-line `niac-cisco-c3750-16.walk` from `niac-demo-catalog`) through niac-go's SNMP agent surfaced three defects behind the lab symptom `snmpwalk → 0 OIDs` / sparse discovery. The core replay engine is **functionally correct** (proven by a full marshal→client-decode wire round-trip for GET-NEXT and GET-BULK); the problems were one scaling gap and two parser gaps:

1. **Quadratic `GetNext` → walk timeouts.** `MIB.GetNext` linear-scanned the sorted OID list every call, so a full client bulk-walk was `O(walk_len · n)`. On a 30k-OID switch a full walk went from **>120s (timeout) → ~9s** after switching to a binary search over the already-sorted slice. Most likely cause of the lab's sparse/empty results (timeouts, not a logic bug).
2. **Empty octet strings dropped.** net-snmp emits zero-length strings as `OID = ""` (no `TYPE:`). The parser rejected these as "missing colon" — **~1,275 OIDs lost** on the c3750 walk. Now parsed as an empty `OctetString`.
3. **Multi-line Hex-STRING truncation.** Long Hex-STRING values wrap across bare-hex continuation lines; those ~588 lines were dropped and the parent value silently truncated to its first line. Now folded into the preceding entry; scanner buffer grown past the 64KiB default.

End-to-end, a real c3750 walk now serves **32,078 / 32,700 lines (98.1%, up from 94.2%)**; the remainder are non-OID sanitizer artifacts (captured end-of-MIB terminator lines) correctly skipped.

## Linked Issue

Fixes #845

## Type of Change

- [x] Defect fix

## Risk

- [x] Low

## Testing Evidence

```text
$ go test ./internal/protocols/...
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols          0.700s
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp     0.374s
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp/synth 0.012s

# Full real-walk round-trip (local diagnostic, machine-path, not in CI):
#   walk lines(non-empty)=32700  parsed+served OIDs reached=32078  (dropped ~622, all non-OID artifacts)
#   before binary-search fix: >120s timeout; after: ~9s

$ golangci-lint run ./internal/protocols/snmp/... ./internal/protocols/
0 issues.

$ gofmt -l <changed files>   # clean
$ go vet ./internal/protocols/snmp/ ./internal/protocols/   # clean
```

New/updated tests: `walk_test.go` (`TestParseWalkFile_EmptyOctetString`, `TestParseWalkFile_HexContinuation`), `walk_replay_test.go` (full GET-NEXT snmpwalk + sysDescr override), `snmp_wire_test.go` (marshal→client-decode round-trip for GET-NEXT and GET-BULK).

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — read-only SNMP responder; walk-file path traversal/symlink guards untouched.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Behavior change is broader SNMP walk coverage; no docs affected.)