### PR TITLE
fix(snmp): stop the simulator returning 0 OIDs — crash-safety, capture latency, bulk sizing

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -39,16 +39,9 @@ type Engine struct {
 
 // New creates a new capture engine.
 func New(interfaceName string, debugLevel int) (*Engine, error) {
-	// Open interface in promiscuous mode with timeout
-	// Use 100ms timeout to allow responsive shutdown on Ctrl+C
-	handle, err := pcap.OpenLive(
-		interfaceName,
-		snapshotLength,                    // snapshot length
-		true,                              // promiscuous mode
-		captureTimeoutMs*time.Millisecond, // timeout for responsive shutdown
-	)
+	handle, err := openImmediate(interfaceName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open interface %s: %w", interfaceName, err)
+		return nil, err
 	}
 
 	return &Engine{
@@ -56,6 +49,62 @@ func New(interfaceName string, debugLevel int) (*Engine, error) {
 		handle:        handle,
 		debugLevel:    debugLevel,
 	}, nil
+}
+
+// openImmediate opens the interface in promiscuous, immediate mode.
+//
+// Immediate mode is essential for a simulator: without it, libpcap holds
+// captured frames in the kernel buffer until it fills or the read timeout
+// expires, adding up to captureTimeoutMs of latency to every request on a
+// quiet link. That turns a 30k-OID SNMP walk into a slow, timing-out crawl.
+// Immediate mode delivers each frame as it arrives while the read timeout
+// still bounds shutdown responsiveness.
+//
+// Falls back to OpenLive if the platform's libpcap cannot honor the inactive
+// handle builder, so behavior degrades to correct-but-slower rather than
+// failing to start.
+func openImmediate(interfaceName string) (*pcap.Handle, error) {
+	inactive, err := pcap.NewInactiveHandle(interfaceName)
+	if err != nil {
+		return openLiveFallback(interfaceName)
+	}
+	defer inactive.CleanUp()
+
+	// Any failure to configure the inactive handle degrades to the legacy
+	// buffered open so the simulator still starts (correct but slower).
+	configure := []func() error{
+		func() error { return inactive.SetSnapLen(snapshotLength) },
+		func() error { return inactive.SetPromisc(true) },
+		func() error { return inactive.SetTimeout(captureTimeoutMs * time.Millisecond) },
+		func() error { return inactive.SetImmediateMode(true) },
+	}
+	for _, apply := range configure {
+		if applyErr := apply(); applyErr != nil {
+			return openLiveFallback(interfaceName)
+		}
+	}
+
+	handle, err := inactive.Activate()
+	if err != nil {
+		return openLiveFallback(interfaceName)
+	}
+
+	return handle, nil
+}
+
+// openLiveFallback opens the interface with the legacy buffered API.
+func openLiveFallback(interfaceName string) (*pcap.Handle, error) {
+	handle, err := pcap.OpenLive(
+		interfaceName,
+		snapshotLength,
+		true,
+		captureTimeoutMs*time.Millisecond,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open interface %s: %w", interfaceName, err)
+	}
+
+	return handle, nil
 }
 
 // Close closes the capture engine.

--- a/internal/protocols/errors.go
+++ b/internal/protocols/errors.go
@@ -31,6 +31,12 @@ var ErrOriginalIPLayerMissing = errors.New("original IP layer missing")
 // ErrDecodingPacket is a sentinel error for packet decoding failures.
 var ErrDecodingPacket = errors.New("error decoding packet")
 
+// ErrUnsupportedSNMPVersion is returned when an SNMP request uses a version the
+// simulator cannot safely marshal a response for (currently anything other than
+// v1/v2c). Marshalling a Version3 response via gosnmp without security
+// parameters panics, so such requests are declined rather than answered.
+var ErrUnsupportedSNMPVersion = errors.New("unsupported SNMP version")
+
 // Sentinel errors for Stack.
 var (
 	ErrStackAlreadyRunning = errors.New("stack already running")

--- a/internal/protocols/snmp.go
+++ b/internal/protocols/snmp.go
@@ -104,6 +104,15 @@ func (h *SNMPHandler) findAgent(device *config.Device, srcIP net.IP, community s
 
 // buildResponse creates and marshals an SNMP response.
 func (h *SNMPHandler) buildResponse(agent *snmp.Agent, request *gosnmp.SnmpPacket) ([]byte, error) {
+	// The simulator speaks SNMP v1/v2c only. gosnmp's MarshalMsg dispatches a
+	// Version3 packet to marshalV3, which dereferences SecurityParameters we
+	// never populate → nil-pointer SIGSEGV. Discovery tools such as NetAlly
+	// CyberScope/AirCheck send SNMPv3 probes, so decline unsupported versions
+	// here rather than letting one probe crash the whole simulator.
+	if request.Version != gosnmp.Version1 && request.Version != gosnmp.Version2c {
+		return nil, fmt.Errorf("%w: %v", ErrUnsupportedSNMPVersion, request.Version)
+	}
+
 	responseVars := agent.ProcessPDU(request.PDUType, request.Variables, request.MaxRepetitions)
 
 	response := &gosnmp.SnmpPacket{

--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -243,6 +243,16 @@ func (a *Agent) HandleGetNext(oid string) (string, *OIDValue, error) {
 	return nextOID, value, nil
 }
 
+// MaxBulkResponseBytes bounds the estimated size of a GET-BULK response's
+// variable bindings so the marshaled datagram stays inside a single standard
+// Ethernet frame (1500-byte MTU, less L2/L3/L4 and SNMP message headers). A
+// conforming agent returns fewer than maxRepetitions bindings when the message
+// would overflow and lets the manager continue the walk from the last OID.
+// Without this cap, a run of large values (e.g. Cisco AGENT-CAPABILITIES
+// description strings, ~250 bytes each) produces an oversized datagram that is
+// silently dropped on the wire, stalling every bulk walk at that point.
+const MaxBulkResponseBytes = 1400
+
 // HandleGetBulk processes an SNMP GET-BULK request.
 func (a *Agent) HandleGetBulk(oid string, maxRepetitions int) ([]OIDResult, error) {
 	a.mu.RLock()
@@ -250,12 +260,23 @@ func (a *Agent) HandleGetBulk(oid string, maxRepetitions int) ([]OIDResult, erro
 
 	results := make([]OIDResult, 0, maxRepetitions)
 	currentOID := oid
+	budget := MaxBulkResponseBytes
 
 	for range maxRepetitions {
 		nextOID, value := a.mib.GetNext(currentOID)
 		if nextOID == "" || value == nil {
 			break
 		}
+
+		// Always include at least one binding so the walk makes progress even
+		// when a single value is larger than the whole budget; stop before
+		// exceeding the frame budget thereafter.
+		size := estimateVarbindSize(nextOID, value)
+		if len(results) > 0 && size > budget {
+			break
+		}
+
+		budget -= size
 
 		results = append(results, OIDResult{
 			OID:   nextOID,
@@ -280,6 +301,29 @@ func (a *Agent) HandleGetBulk(oid string, maxRepetitions int) ([]OIDResult, erro
 	}
 
 	return results, nil
+}
+
+// estimateVarbindSize returns a deliberately conservative (over-)estimate of a
+// variable binding's marshaled byte size: the OID string length is a safe proxy
+// for its BER-encoded sub-identifiers, plus the value payload, plus TLV
+// overhead. Over-estimating keeps GET-BULK datagrams comfortably under the MTU.
+func estimateVarbindSize(oid string, value *OIDValue) int {
+	const tlvOverhead = 8
+
+	size := len(oid) + tlvOverhead
+
+	switch v := value.Value.(type) {
+	case string:
+		size += len(v)
+	case []byte:
+		size += len(v)
+	default:
+		// Integers, counters, gauges, timeticks, IP addresses and OIDs all
+		// encode to a small, bounded number of bytes.
+		size += 16
+	}
+
+	return size
 }
 
 // SetOID sets an OID value (for SNMP SET operations).

--- a/internal/protocols/snmp_version_test.go
+++ b/internal/protocols/snmp_version_test.go
@@ -1,0 +1,58 @@
+package protocols
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp"
+)
+
+// TestBuildResponseRejectsSNMPv3 reproduces the live simulator crash: a CyberScope
+// (and other discovery tools) send SNMPv3 probes. gosnmp's MarshalMsg dispatches
+// a Version3 response to marshalV3, which dereferences the SecurityParameters the
+// simulator never populates → SIGSEGV, taking down the whole sim (every device
+// goes dark → "0 OIDs"). buildResponse must refuse unsupported versions instead.
+func TestBuildResponseRejectsSNMPv3(t *testing.T) {
+	h := &SNMPHandler{}
+	dev := &config.Device{Name: "sw", Type: "switch", Properties: map[string]string{}}
+	agent := snmp.NewAgentWithCommunity(dev, "public", 0)
+
+	req := &gosnmp.SnmpPacket{
+		Version:   gosnmp.Version3,
+		PDUType:   gosnmp.GetRequest,
+		Variables: []gosnmp.SnmpPDU{{Name: ".1.3.6.1.2.1.1.1.0", Type: gosnmp.Null}},
+	}
+
+	// Must not panic; must decline to answer.
+	payload, err := h.buildResponse(agent, req)
+	if err == nil {
+		t.Fatal("expected an error for an SNMPv3 request, got nil")
+	}
+	if payload != nil {
+		t.Errorf("expected nil payload for unsupported version, got %d bytes", len(payload))
+	}
+}
+
+// TestBuildResponseAcceptsV2c is the companion happy path: v2c still marshals.
+func TestBuildResponseAcceptsV2c(t *testing.T) {
+	h := &SNMPHandler{}
+	dev := &config.Device{Name: "sw", Type: "switch", Properties: map[string]string{}}
+	agent := snmp.NewAgentWithCommunity(dev, "public", 0)
+
+	req := &gosnmp.SnmpPacket{
+		Version:   gosnmp.Version2c,
+		Community: "public",
+		PDUType:   gosnmp.GetRequest,
+		Variables: []gosnmp.SnmpPDU{{Name: ".1.3.6.1.2.1.1.5.0", Type: gosnmp.Null}},
+	}
+
+	payload, err := h.buildResponse(agent, req)
+	if err != nil {
+		t.Fatalf("v2c buildResponse: %v", err)
+	}
+	if len(payload) == 0 {
+		t.Error("expected a non-empty v2c response")
+	}
+}

--- a/internal/protocols/snmp_wire_test.go
+++ b/internal/protocols/snmp_wire_test.go
@@ -3,6 +3,7 @@ package protocols
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/gosnmp/gosnmp"
@@ -99,4 +100,99 @@ func TestWireGetBulkSnmpwalk(t *testing.T) {
 	if len(reached) == 0 {
 		t.Fatal("GETBULK snmpwalk reached 0 OIDs")
 	}
+}
+
+// TestWireGetBulkBoundedBySize reproduces the live walk stall: a run of large
+// values (Cisco AGENT-CAPABILITIES strings are ~250 bytes) in one GET-BULK
+// response overflows the MTU and the datagram is dropped, timing out the walk.
+// The response must stay within one Ethernet frame, and a full bulk walk must
+// still reach every OID (the manager continues from the last returned OID).
+func TestWireGetBulkBoundedBySize(t *testing.T) {
+	dev := &config.Device{Name: "sw", Type: "switch", Properties: map[string]string{}}
+	agent := snmp.NewAgentWithCommunity(dev, "public", 0)
+
+	// 40 OIDs each carrying a ~250-byte string under a private subtree.
+	big := ""
+	for len(big) < 250 {
+		big += "AGENT-CAPABILITIES description padding. "
+	}
+
+	base := ".1.3.6.1.4.1.9.9.999.1.1"
+	want := map[string]bool{}
+
+	for i := 1; i <= 40; i++ {
+		oid := base + "." + strconv.Itoa(i)
+		_ = agent.SetOID(oid, &snmp.OIDValue{Type: gosnmp.OctetString, Value: big})
+		want[oid[1:]] = true // stored without leading dot
+	}
+
+	// Every GET-BULK response with a generous maxRep must fit one frame, and a
+	// full walk must still reach every OID (the manager continues from the last).
+	current := base
+	reached := map[string]bool{}
+
+	for range 100 {
+		respVars := agent.ProcessPDU(gosnmp.GetBulkRequest, []gosnmp.SnmpPDU{{Name: current}}, 20)
+		assertFitsFrame(t, respVars)
+
+		next, done := advanceWalk(respVars, want, reached)
+		if next != "" {
+			current = next
+		}
+
+		if done || len(reached) == len(want) {
+			break
+		}
+	}
+
+	if len(reached) != len(want) {
+		t.Errorf("full bulk walk reached %d/%d big-value OIDs", len(reached), len(want))
+	}
+}
+
+// assertFitsFrame marshals a response and fails if it exceeds the MTU payload.
+func assertFitsFrame(t *testing.T, respVars []gosnmp.SnmpPDU) {
+	t.Helper()
+
+	resp := &gosnmp.SnmpPacket{
+		Version:   gosnmp.Version2c,
+		Community: "public",
+		PDUType:   gosnmp.GetResponse,
+		RequestID: 1,
+		Variables: respVars,
+	}
+
+	raw, err := resp.MarshalMsg()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if len(raw) > 1472 { // 1500 MTU - 20 IP - 8 UDP
+		t.Fatalf("GET-BULK datagram %d bytes exceeds MTU payload budget", len(raw))
+	}
+}
+
+// advanceWalk records which wanted OIDs a response covered and returns the OID
+// to continue from plus whether end-of-MIB was reached.
+func advanceWalk(respVars []gosnmp.SnmpPDU, want, reached map[string]bool) (string, bool) {
+	next := ""
+
+	for _, v := range respVars {
+		if v.Type == gosnmp.EndOfMibView || v.Type == gosnmp.NoSuchObject {
+			return next, true
+		}
+
+		name := v.Name
+		if len(name) > 0 && name[0] == '.' {
+			name = name[1:]
+		}
+
+		if want[name] {
+			reached[name] = true
+		}
+
+		next = v.Name
+	}
+
+	return next, false
 }

--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -105,6 +106,24 @@ func (s *Stack) decodeThread() {
 
 // decodePacket decodes a packet and routes to appropriate handler.
 func (s *Stack) decodePacket(pkt *Packet) {
+	// Defense in depth: a simulator is exposed to arbitrary, adversarial, and
+	// malformed traffic (discovery tools, scanners, fuzzers). A panic while
+	// handling one packet must never take down the whole sim — recover, log,
+	// and drop the offending packet so every other device keeps responding.
+	defer func() {
+		if r := recover(); r != nil {
+			s.stats.mu.Lock()
+			s.stats.Errors++
+			s.stats.mu.Unlock()
+
+			if s.debugConfig.GetGlobal() >= DebugLevelBasic {
+				_, _ = fmt.Fprintf(os.Stderr,
+					"recovered from panic decoding packet sn=%d: %v\n%s\n",
+					pkt.SerialNumber, r, debug.Stack())
+			}
+		}
+	}()
+
 	// Try MAC-based routing first (multicast protocols)
 	if s.routeByMAC(pkt) {
 		return


### PR DESCRIPTION
## Summary

Live validation on the lab (CT304 replaying `niac-cisco-c3750-16.walk` to a NetAlly CyberScope on tagged VLAN 200) had the simulator returning **0 OIDs**. Root-caused to three distinct defects — fixed here and verified end-to-end against the real device:

1. **Crash on SNMPv3 / malformed packets.** `buildResponse` set the response version from the request, and gosnmp's `MarshalMsg` dispatches a Version3 packet to `marshalV3`, which dereferences the `SecurityParameters` the simulator never populates → nil-pointer SIGSEGV. A CyberScope sends SNMPv3 discovery probes, so this crashed the whole process on the first sweep (every simulated device went dark — the real "0 OIDs" cause). Now declines non-v1/v2c requests, and `decodePacket` recovers from any per-packet panic so one bad frame can never take down the sim.
2. **~100ms per-packet latency.** pcap was opened without immediate mode; libpcap buffered frames up to the read timeout on a quiet link. Now `SetImmediateMode(true)` (with an `OpenLive` fallback).
3. **Bulk walks stall on large values.** GET-BULK returned `maxRepetitions` bindings regardless of size; a run of ~250-byte AGENT-CAPABILITIES strings made a >MTU datagram that gets dropped → manager timeout → walk aborts. GET-BULK is now bounded to one Ethernet frame (standard agent behavior: return fewer and let the manager continue).

Full SNMPv3/USM support (so v3 discovery returns data rather than being declined) is a tracked follow-up.

## Linked Issue

Fixes #847

## Type of Change

- [x] Defect fix

## Risk

- [x] Low

## Testing Evidence

```text
$ go test ./internal/protocols/... ./internal/capture/...
ok  .../internal/protocols        0.692s
ok  .../internal/protocols/snmp   0.360s
ok  .../internal/capture          1.221s
(new: TestBuildResponseRejectsSNMPv3, TestWireGetBulkBoundedBySize)

$ golangci-lint run ./internal/protocols/... ./internal/capture/...
0 issues.

# LIVE on CT304 (10.10.200.101, c3750 walk), before vs after this branch:
  ping RTT:            42/93/143 ms   ->  0.13/0.35/0.80 ms   (immediate mode)
  snmpbulkwalk .1:     1930 OIDs, stalls -> 32809 OIDs served
  SNMPv3 probe:        crashes whole sim -> sim alive, 0 panics, v2c still answers
  recovered panics:    n/a -> 0
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — read-only SNMP responder + capture open; adds a version guard and a panic-recovery boundary.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Behavior change = simulator no longer crashes and serves full walks; no docs affected.)