### PR TITLE
fix(stack): received packets must not alias the reused capture buffer

### DIFF
--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -55,7 +56,15 @@ func (s *Stack) receiveAndQueuePacket(buffer []byte) {
 }
 
 // parseReceivedPacket parses received data into a Packet, updating stats.
+//
+// The incoming slice aliases a capture buffer that ReadPacket reuses on the
+// next read. The returned Packet is queued onto a channel and decoded by a
+// separate goroutine, so it must own its bytes; otherwise the next read
+// corrupts still-in-flight packets — a data race that torn-reads every
+// handler's header parsing. Clone at this ownership boundary.
 func (s *Stack) parseReceivedPacket(data []byte) *Packet {
+	data = bytes.Clone(data)
+
 	s.mu.Lock()
 	s.serialNumber++
 	serialNum := s.serialNumber

--- a/internal/protocols/stack_threads_test.go
+++ b/internal/protocols/stack_threads_test.go
@@ -1,0 +1,34 @@
+package protocols
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestParseReceivedPacketOwnsBuffer verifies a received packet does not alias
+// the reusable capture buffer. ReadPacket hands back a slice of a buffer that
+// the receive loop overwrites on the next read; the packet is decoded on
+// another goroutine, so it must own its bytes or in-flight packets get
+// corrupted (a data race across every handler).
+func TestParseReceivedPacketOwnsBuffer(t *testing.T) {
+	s := &Stack{stats: &Statistics{}}
+
+	// A recognizable "first packet" living in a reusable buffer.
+	shared := bytes.Repeat([]byte{0xAB}, 64)
+	snapshot := bytes.Clone(shared)
+
+	pkt := s.parseReceivedPacket(shared)
+	if pkt == nil {
+		t.Fatal("parseReceivedPacket returned nil")
+	}
+
+	// Simulate the receive loop reading the next packet into the same buffer.
+	for i := range shared {
+		shared[i] = 0xCD
+	}
+
+	if !bytes.Equal(pkt.Buffer, snapshot) {
+		t.Errorf("packet buffer was corrupted by a subsequent read: got %x…, want %x…",
+			pkt.Buffer[:4], snapshot[:4])
+	}
+}


### PR DESCRIPTION
## Summary

Audit of the protocol handlers (after the SNMP crash fixes in #848) surfaced a connective-tissue **data race**: `receiveThread` reuses one capture buffer, `ReadPacket` returns a slice of it, and `ParsePacket` stores that slice as `Packet.Buffer` without copying. The packet is queued onto a 1000-deep channel and decoded on another goroutine, so under any traffic burst (a CyberScope sweeping ARP+ICMP+SNMP, a scanner/fuzzer) `receiveThread` overwrites the buffer while earlier packets are still in flight — torn-reading every handler's header parsing. It fires under `-race` and became easier to hit once capture moved to immediate mode (#848).

Fix: clone the frame at the ownership boundary in `parseReceivedPacket` so every queued packet owns its bytes.

## Linked Issue

Related to #850

## Type of Change

- [x] Defect fix

## Risk

- [x] Low

## Testing Evidence

```text
$ go test -race ./internal/protocols/
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols  1.934s
(new: TestParseReceivedPacketOwnsBuffer — overwrite the source buffer after
 parse, assert the packet's bytes are unchanged)

$ golangci-lint run ./internal/protocols/
0 issues.
```

Remaining audit findings (oversized DHCPv6 response, per-packet O(n) scans, minor correctness) are tracked in #850.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — receive-path memory ownership only.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Internal correctness fix; no behavior/docs change.)