### PR TITLE
fix(protocols): bound DHCPv6 DUID and throttle iperf3 session sweep

### DIFF
--- a/internal/protocols/dhcpv6.go
+++ b/internal/protocols/dhcpv6.go
@@ -111,6 +111,7 @@ const (
 	t2MultiplicandV6    = 4     // T2 = preferred lifetime * 4 / 5 (80%)
 	t2DivisorV6         = 5     // T2 divisor for 80% calculation
 	dhcpv6MinMsgSize    = 4     // Minimum DHCPv6 message size (type + transaction ID)
+	maxDUIDSize         = 130   // RFC 8415 §11.1: DUID is 2-octet type + at most 128 octets
 	macUnicastMask      = 0xfe  // Mask to clear multicast bit in MAC address
 	macLocalBitSet      = 0x02  // Bit to set for locally administered MAC address
 	ipv6VersionVal      = 6     // IPv6 version field
@@ -390,6 +391,16 @@ func (h *DHCPv6Handler) parseDHCPv6Message(data []byte) (*DHCPv6Message, error) 
 
 		if offset+int(opt.Length) > len(data) {
 			return nil, ErrOptionDataExceedsLen
+		}
+
+		// The Client-ID/Server-ID option carries a DUID, which RFC 8415 caps at
+		// 130 octets. A larger one is malformed — and because the server echoes
+		// the client's DUID verbatim into every reply, accepting an oversized
+		// one would build a response that overflows the MTU and gets dropped.
+		// Discard the message instead of emitting an unusable reply.
+		if (opt.Code == DHCPv6OptClientID || opt.Code == DHCPv6OptServerID) &&
+			opt.Length > maxDUIDSize {
+			return nil, ErrDUIDTooLong
 		}
 
 		opt.Data = make([]byte, opt.Length)

--- a/internal/protocols/dhcpv6_test.go
+++ b/internal/protocols/dhcpv6_test.go
@@ -1,0 +1,61 @@
+package protocols
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// buildDHCPv6WithClientID assembles a minimal DHCPv6 Solicit carrying a
+// Client-ID option whose DUID is duidLen bytes.
+func buildDHCPv6WithClientID(duidLen int) []byte {
+	msg := []byte{1, 0x00, 0x00, 0x01} // Solicit + transaction ID
+	opt := make([]byte, 4+duidLen)
+	binary.BigEndian.PutUint16(opt[0:2], DHCPv6OptClientID)
+	binary.BigEndian.PutUint16(opt[2:4], uint16(duidLen))
+
+	return append(msg, opt...)
+}
+
+// TestParseDHCPv6RejectsOversizedDUID verifies the parser discards a message
+// whose Client-ID DUID exceeds the RFC 8415 limit. Accepting it would echo the
+// oversized DUID into the reply and overflow the MTU (a dropped response).
+func TestParseDHCPv6RejectsOversizedDUID(t *testing.T) {
+	h := &DHCPv6Handler{}
+
+	// A conformant DUID (DUID-LL, 10 bytes) must parse.
+	if _, err := h.parseDHCPv6Message(buildDHCPv6WithClientID(duidLLSize)); err != nil {
+		t.Fatalf("valid Client-ID rejected: %v", err)
+	}
+
+	// One octet over the cap must be rejected as malformed.
+	if _, err := h.parseDHCPv6Message(buildDHCPv6WithClientID(maxDUIDSize + 1)); !errors.Is(err, ErrDUIDTooLong) {
+		t.Errorf("oversized DUID: got err %v, want ErrDUIDTooLong", err)
+	}
+
+	// The boundary value itself is still accepted.
+	if _, err := h.parseDHCPv6Message(buildDHCPv6WithClientID(maxDUIDSize)); err != nil {
+		t.Errorf("DUID at the cap rejected: %v", err)
+	}
+}
+
+// TestParseDHCPv6PreservesClientID sanity-checks that a normal Client-ID is
+// parsed intact (regression guard for the length check above).
+func TestParseDHCPv6PreservesClientID(t *testing.T) {
+	h := &DHCPv6Handler{}
+	raw := buildDHCPv6WithClientID(duidLLSize)
+
+	msg, err := h.parseDHCPv6Message(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	got := h.findOption(msg, DHCPv6OptClientID)
+	if got == nil {
+		t.Fatal("Client-ID option missing after parse")
+	}
+	if !bytes.Equal(got.Data, raw[8:]) {
+		t.Errorf("Client-ID data = %x, want %x", got.Data, raw[8:])
+	}
+}

--- a/internal/protocols/errors.go
+++ b/internal/protocols/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrMessageTooShort      = errors.New("message too short")
 	ErrOptionDataExceedsLen = errors.New("option data exceeds message length")
 	ErrNoAvailableAddresses = errors.New("no available addresses")
+	ErrDUIDTooLong          = errors.New("DUID exceeds RFC 8415 maximum length")
 )
 
 // ErrInvalidRequestLine is a sentinel error for HTTP indicating an invalid request line.

--- a/internal/protocols/iperf3.go
+++ b/internal/protocols/iperf3.go
@@ -194,8 +194,9 @@ type iperf3Sum struct {
 
 // IPerf3Handler handles iPerf3 protocol emulation.
 type IPerf3Handler struct {
-	stack    *Stack
-	sessions map[string]*IPerf3Session // keyed by "ip:port"
+	stack       *Stack
+	sessions    map[string]*IPerf3Session // keyed by "ip:port"
+	lastCleanup time.Time                 // throttles the stale-session sweep
 }
 
 // NewIPerf3Handler creates a new iPerf3 handler.
@@ -287,8 +288,13 @@ func (h *IPerf3Handler) HandleIPerf3Request(
 		h.handleIPerf3Data(pkt, ipLayer, tcpLayer, devices, session)
 	}
 
-	// Periodic cleanup
-	h.cleanupStaleSessions(iperf3SessionCleanupMin * time.Minute)
+	// Periodic cleanup — throttled so an iperf3 test (thousands of data-phase
+	// packets) doesn't rescan the whole session map on every packet.
+	maxAge := iperf3SessionCleanupMin * time.Minute
+	if now := time.Now(); now.Sub(h.lastCleanup) >= maxAge {
+		h.lastCleanup = now
+		h.cleanupStaleSessions(maxAge)
+	}
 }
 
 // handleIPerf3Data processes iPerf3 protocol messages.


### PR DESCRIPTION
## Summary

Two findings from the protocol-handler audit (#850):

1. **DHCPv6 oversized response** (same class as the SNMP GET-BULK MTU bug). The server echoes the client's Client-ID (DUID) verbatim into every reply, and the intended MTU cap was dead code — gopacket's `FixLengths: true` recomputes the UDP length from the full payload, ignoring the manual `min(...)`. The parser accepted a DUID up to 65535 bytes, so a crafted Client-ID produces a reply that overflows the MTU and is dropped. RFC 8415 §11.1 caps a DUID at 130 octets, so an oversized Client-ID/Server-ID is now rejected at parse time (the malformed message is discarded rather than answered with an unusable reply).
2. **iperf3 per-packet scan.** `cleanupStaleSessions` swept the whole session map on every data packet; an iperf3 test drives thousands of packets. Throttled to at most once per cleanup interval via a `lastCleanup` timestamp.

Two other audit items were verified as non-bugs: `ip.go`'s per-packet `GetDeviceByTTL` is an indexed `ttlDevices[ttl]` lookup (not a scan), and the ICMP RouterSolicitation/AddressMask "scans" are intended broadcast fan-out. The DHCP pool×leases scan-under-lock remains tracked in #850 as a larger refactor.

## Linked Issue

Related to #850

## Type of Change

- [x] Defect fix

## Risk

- [x] Low

## Testing Evidence

```text
$ go test ./internal/protocols/ -run 'TestParseDHCPv6|TestIPerf3'
--- PASS: TestParseDHCPv6RejectsOversizedDUID
--- PASS: TestParseDHCPv6PreservesClientID
--- PASS: TestIPerf3CleanupStaleSessions  (existing, still green)
ok

$ golangci-lint run ./internal/protocols/
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — DHCPv6 parse hardening + iperf3 throttle.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Malformed DHCPv6 now discarded per RFC 8415; no docs affected.)