### PR TITLE
feat(snmp): implement SNMPv3 USM authoritative engine (authPriv)

### DIFF
--- a/deploy/configs/demo.yaml
+++ b/deploy/configs/demo.yaml
@@ -11,6 +11,17 @@ devices:
     snmp_agent:
       community: "public"
       sysname: "api-router"
+    snmpv3:
+      enabled: true
+      users:
+        # authPriv (SHA + AES) — walk with:
+        #   snmpwalk -v3 -l authPriv -u niacadmin -a SHA -A authpass123 \
+        #            -x AES -X privpass123 <device-ip> system
+        - username: "niacadmin"
+          auth_protocol: "sha"
+          auth_password: "authpass123"
+          priv_protocol: "aes"
+          priv_password: "privpass123"
     http:
       enabled: true
       server_name: "NIAC Demo"

--- a/docs/PROTOCOL_GUIDE.md
+++ b/docs/PROTOCOL_GUIDE.md
@@ -849,6 +849,30 @@ devices:
 | `syslocation` | string | No | "" | Physical location |
 | `traps` | object | No | - | Trap configuration |
 
+#### SNMPv3 (USM)
+
+SNMPv3 is configured with a device-level `snmpv3:` block (a sibling of
+`snmp_agent:`). The simulator acts as an authoritative engine: it performs
+engine discovery and answers `noAuthNoPriv`, `authNoPriv`, and `authPriv`
+requests. Engine IDs are derived from the device MAC unless `engine_id` (hex)
+is set. SNMPv3 is free on all tiers — it is the only SNMP version that does not
+send credentials in cleartext.
+
+```yaml
+snmpv3:
+  enabled: true
+  engine_id: ""        # optional hex; auto-derived from MAC when empty
+  users:
+    - username: "niacadmin"
+      auth_protocol: "sha"   # none | md5 | sha | sha224 | sha256 | sha384 | sha512
+      auth_password: "authpass123"
+      priv_protocol: "aes"   # none | des | aes | aes192 | aes256
+      priv_password: "privpass123"
+```
+
+The same walk data served over v1/v2c is served over v3 — the security model
+only governs authentication and encryption, not the MIB.
+
 #### Testing
 
 ```bash
@@ -860,6 +884,10 @@ snmpwalk -v2c -c public 10.0.0.1 system
 
 # SNMP BULK WALK
 snmpbulkwalk -v2c -c public 10.0.0.1 ifDescr
+
+# SNMPv3 authPriv walk (matches the users block above)
+snmpwalk -v3 -l authPriv -u niacadmin \
+  -a SHA -A authpass123 -x AES -X privpass123 10.0.0.1 system
 
 # Listen for traps
 snmptrapd -f -Lo

--- a/internal/protocols/snmp.go
+++ b/internal/protocols/snmp.go
@@ -16,6 +16,11 @@ import (
 // SNMP protocol constants.
 const (
 	snmpMACAddrLen = 6 // MAC address length in bytes
+
+	// ASN.1 BER length encoding: high bit of the first length octet flags the
+	// long form; the low 7 bits then hold the count of subsequent length octets.
+	asn1LongFormFlag     = 0x80
+	asn1LengthOctetsMask = 0x7f
 )
 
 // SNMPHandler routes SNMP queries to per-device agents.
@@ -35,6 +40,13 @@ func (h *SNMPHandler) HandlePacket(pkt *Packet, ip *layers.IPv4, udp *layers.UDP
 	}
 
 	if len(udp.Payload) == 0 {
+		return
+	}
+
+	// SNMPv3 is handled from the raw datagram (USM engine discovery + auth +
+	// privacy); v1/v2c continue through the community-keyed agent path below.
+	if ver, ok := snmpPeekVersion(udp.Payload); ok && ver == gosnmp.Version3 {
+		h.handleV3(pkt, ip, udp, devices)
 		return
 	}
 
@@ -190,6 +202,64 @@ func (h *SNMPHandler) decodeRequest(payload []byte) (*gosnmp.SnmpPacket, error) 
 		return nil, fmt.Errorf("failed to decode SNMP packet: %w", err)
 	}
 	return pkt, nil
+}
+
+// handleV3 routes an SNMPv3 datagram to each matching device's USM engine,
+// emitting the engine's discovery Report or authenticated response.
+func (h *SNMPHandler) handleV3(pkt *Packet, ip *layers.IPv4, udp *layers.UDP, devices []*config.Device) {
+	for _, device := range devices {
+		group := h.stack.getSNMPAgents(device)
+		if group == nil || group.v3 == nil || group.v3Agent == nil {
+			continue
+		}
+
+		if !snmpAccessAllowed(device, ip.SrcIP) {
+			continue
+		}
+
+		resp, err := group.v3.Respond(udp.Payload, group.v3Agent.ProcessPDU)
+		if err != nil || resp == nil {
+			if err != nil && h.stack.GetProtocolDebugLevel(logging.ProtocolSNMP) >= DebugLevelInfo {
+				_, _ = fmt.Fprintf(os.Stdout,
+					"SNMP: v3 respond declined for %s sn=%d err=%v\n", device.Name, pkt.SerialNumber, err)
+			}
+
+			continue
+		}
+
+		h.stack.stats.mu.Lock()
+		h.stack.stats.SNMPQueries++
+		h.stack.stats.mu.Unlock()
+
+		h.sendResponse(pkt, ip, udp, device, resp)
+	}
+}
+
+// snmpPeekVersion extracts the SNMP version from a raw datagram without a full
+// decode: the outer SEQUENCE's first element is INTEGER version.
+func snmpPeekVersion(payload []byte) (gosnmp.SnmpVersion, bool) {
+	if len(payload) < 2 || payload[0] != byte(gosnmp.Sequence) {
+		return 0, false
+	}
+
+	// Skip the SEQUENCE length octets (short or long form).
+	cursor := 1
+	if payload[cursor]&asn1LongFormFlag != 0 {
+		cursor += 1 + int(payload[cursor]&asn1LengthOctetsMask)
+	} else {
+		cursor++
+	}
+
+	// Expect INTEGER (0x02), single-octet length, then the version value.
+	if cursor+2 >= len(payload) || payload[cursor] != byte(gosnmp.Integer) {
+		return 0, false
+	}
+	length := int(payload[cursor+1])
+	if length != 1 || cursor+2 >= len(payload) {
+		return 0, false
+	}
+
+	return gosnmp.SnmpVersion(payload[cursor+2]), true
 }
 
 func (h *SNMPHandler) sourceMAC(device *config.Device, pkt *Packet) net.HardwareAddr {

--- a/internal/protocols/snmp/v3.go
+++ b/internal/protocols/snmp/v3.go
@@ -1,0 +1,436 @@
+package snmp
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// SNMPv3 (USM) authoritative-engine constants.
+const (
+	// timeWindowSecs is the RFC 3414 §3.2 authenticated-message time window.
+	timeWindowSecs = 150
+
+	// engineTimeWrap is 2^31; engineTime wraps here per RFC 3411.
+	engineTimeWrap = int64(2147483648)
+
+	// niacEnterprisePrefix is the 4-octet SNMP engine-ID enterprise header
+	// (RFC 3411 §5): high bit of octet 0 set, low 31 bits = synthetic PEN.
+	niacEngineFormatMAC = 0x03 // engine-ID format 3 = MAC address
+	engineIDMinLen      = 5    // 4 enterprise octets + 1 format octet
+)
+
+// usmStats report OIDs (RFC 3414 §5).
+const (
+	oidUsmStatsUnknownEngineIDs = ".1.3.6.1.6.3.15.1.1.4.0"
+	oidUsmStatsNotInTimeWindows = ".1.3.6.1.6.3.15.1.1.2.0"
+	oidUsmStatsUnknownUserNames = ".1.3.6.1.6.3.15.1.1.3.0"
+)
+
+// ErrV3NotDiscovery indicates a v3 datagram that is neither a decodable
+// authenticated request nor an engine-discovery probe (e.g. bad credentials).
+var ErrV3NotDiscovery = errors.New("snmpv3: undecodable non-discovery datagram")
+
+// ProcessFunc processes a decoded PDU and returns the response variables. It is
+// the same contract as (*Agent).ProcessPDU, letting the v3 engine reuse the
+// existing v1/v2c MIB machinery without depending on *Agent directly.
+type ProcessFunc func(pduType gosnmp.PDUType, vars []gosnmp.SnmpPDU, maxRepetitions uint32) []gosnmp.SnmpPDU
+
+// v3User is a resolved USM account with gosnmp protocol enums.
+type v3User struct {
+	name      string
+	authProto gosnmp.SnmpV3AuthProtocol
+	authPass  string
+	privProto gosnmp.SnmpV3PrivProtocol
+	privPass  string
+	msgFlags  gosnmp.SnmpV3MsgFlags // security level this user answers at
+}
+
+// V3Engine is a per-device SNMPv3 authoritative engine implementing the
+// User-based Security Model (RFC 3414). It performs engine discovery, verifies
+// inbound authentication, decrypts/encrypts scoped PDUs, and enforces the
+// authenticated-message time window.
+type V3Engine struct {
+	engineID string // raw engine-ID octets (gosnmp represents these as a string)
+	boots    uint32
+	bootTime time.Time
+	users    map[string]v3User
+
+	unknownEngineIDs atomic.Uint32
+	notInTimeWindows atomic.Uint32
+	unknownUsers     atomic.Uint32
+}
+
+// NewV3Engine builds an authoritative engine from a device's SNMPv3 config.
+// It returns (nil, nil) when v3 is not configured or has no users — callers
+// treat a nil engine as "v3 disabled" for this device.
+func NewV3Engine(cfg *config.SNMPv3Config, mac net.HardwareAddr) (*V3Engine, error) {
+	if cfg == nil || !cfg.Enabled || len(cfg.Users) == 0 {
+		return nil, nil //nolint:nilnil // nil engine is the documented "v3 disabled" signal
+	}
+
+	engineID, err := resolveEngineID(cfg.EngineID, mac)
+	if err != nil {
+		return nil, err
+	}
+
+	users := make(map[string]v3User, len(cfg.Users))
+	for i := range cfg.Users {
+		u, uerr := resolveUser(&cfg.Users[i])
+		if uerr != nil {
+			return nil, uerr
+		}
+		users[u.name] = u
+	}
+
+	return &V3Engine{
+		engineID: string(engineID),
+		boots:    1,
+		bootTime: time.Now(),
+		users:    users,
+	}, nil
+}
+
+// engineTime returns seconds since engine boot, wrapped per RFC 3411.
+func (e *V3Engine) engineTime() uint32 {
+	secs := int64(time.Since(e.bootTime).Seconds())
+	return uint32(secs % engineTimeWrap) //nolint:gosec // wrapped into [0,2^31)
+}
+
+// Respond decodes an inbound SNMPv3 datagram and returns the marshalled
+// response bytes (a Report PDU for discovery/time-sync, or an authenticated
+// GetResponse otherwise). A nil response with nil error means "silently drop".
+func (e *V3Engine) Respond(req []byte, process ProcessFunc) ([]byte, error) {
+	decoded, err := e.decode(req)
+	if err == nil {
+		return e.respondToRequest(decoded, process)
+	}
+
+	// Not an authenticated request we could decode — is it an engine-discovery
+	// probe? Parse the (unauthenticated) header to find out.
+	hdr, herr := parseV3Header(req)
+	if herr != nil {
+		return nil, fmt.Errorf("snmpv3: decode failed (%w) and header parse failed: %w", err, herr)
+	}
+
+	usm := usmOf(hdr)
+	if usm == nil {
+		return nil, ErrV3NotDiscovery
+	}
+
+	switch {
+	case usm.AuthoritativeEngineID == "" || usm.UserName == "":
+		// RFC 3414 §4: engine discovery — reply with our engine ID.
+		e.unknownEngineIDs.Add(1)
+		return e.buildReport(hdr, oidUsmStatsUnknownEngineIDs, e.unknownEngineIDs.Load(), gosnmp.NoAuthNoPriv, nil)
+	default:
+		// Known-shaped but undecodable (bad password / wrong engine ID).
+		return nil, ErrV3NotDiscovery
+	}
+}
+
+// respondToRequest handles a fully-decoded, authenticated request: it enforces
+// the time window, then builds an authenticated (and, for authPriv, encrypted)
+// GetResponse.
+func (e *V3Engine) respondToRequest(req *gosnmp.SnmpPacket, process ProcessFunc) ([]byte, error) {
+	usm := usmOf(req)
+	if usm == nil {
+		return nil, ErrV3NotDiscovery
+	}
+
+	user, ok := e.users[usm.UserName]
+	if !ok {
+		e.unknownUsers.Add(1)
+		return e.buildReport(req, oidUsmStatsUnknownUserNames, e.unknownUsers.Load(), gosnmp.NoAuthNoPriv, &user)
+	}
+
+	// Time-window check for authenticated messages (RFC 3414 §3.2).
+	if user.msgFlags&gosnmp.AuthNoPriv > 0 && !e.inTimeWindow(usm) {
+		e.notInTimeWindows.Add(1)
+		return e.buildReport(req, oidUsmStatsNotInTimeWindows, e.notInTimeWindows.Load(), user.msgFlags, &user)
+	}
+
+	respVars := process(req.PDUType, req.Variables, req.MaxRepetitions)
+
+	return e.marshalResponse(req, &user, gosnmp.GetResponse, respVars)
+}
+
+// inTimeWindow reports whether an authenticated message's engine boots/time are
+// within the acceptance window relative to this engine.
+func (e *V3Engine) inTimeWindow(usm *gosnmp.UsmSecurityParameters) bool {
+	if usm.AuthoritativeEngineBoots != e.boots {
+		return false
+	}
+	delta := int64(e.engineTime()) - int64(usm.AuthoritativeEngineTime)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= timeWindowSecs
+}
+
+// buildReport marshals a Report PDU carrying a usmStats counter. When user is
+// non-nil and level requires auth, the report is authenticated/encrypted.
+func (e *V3Engine) buildReport(
+	req *gosnmp.SnmpPacket,
+	statOID string,
+	count uint32,
+	level gosnmp.SnmpV3MsgFlags,
+	user *v3User,
+) ([]byte, error) {
+	vars := []gosnmp.SnmpPDU{{
+		Name:  statOID,
+		Type:  gosnmp.Counter32,
+		Value: count,
+	}}
+
+	u := user
+	if level == gosnmp.NoAuthNoPriv {
+		u = nil // discovery report is unauthenticated regardless of the user
+	}
+
+	return e.marshalPacket(req, u, gosnmp.Report, level, vars)
+}
+
+// marshalResponse marshals an authenticated GetResponse for a decoded request.
+func (e *V3Engine) marshalResponse(
+	req *gosnmp.SnmpPacket,
+	user *v3User,
+	pduType gosnmp.PDUType,
+	vars []gosnmp.SnmpPDU,
+) ([]byte, error) {
+	return e.marshalPacket(req, user, pduType, user.msgFlags, vars)
+}
+
+// marshalPacket constructs and marshals a v3 response/report. A nil user (or
+// NoAuthNoPriv level) produces an unauthenticated message.
+func (e *V3Engine) marshalPacket(
+	req *gosnmp.SnmpPacket,
+	user *v3User,
+	pduType gosnmp.PDUType,
+	level gosnmp.SnmpV3MsgFlags,
+	vars []gosnmp.SnmpPDU,
+) ([]byte, error) {
+	pkt := &gosnmp.SnmpPacket{
+		Version:            gosnmp.Version3,
+		MsgFlags:           level &^ gosnmp.Reportable, // responses are never reportable
+		SecurityModel:      gosnmp.UserSecurityModel,
+		SecurityParameters: e.responseUSM(user, level),
+		ContextEngineID:    e.engineID,
+		ContextName:        req.ContextName,
+		PDUType:            pduType,
+		MsgID:              req.MsgID,
+		RequestID:          req.RequestID,
+		MsgMaxSize:         req.MsgMaxSize,
+		Error:              gosnmp.NoError,
+		Variables:          vars,
+	}
+
+	if err := pkt.SecurityParameters.InitSecurityKeys(); err != nil {
+		return nil, fmt.Errorf("snmpv3: init response keys: %w", err)
+	}
+	if level&gosnmp.AuthPriv > gosnmp.AuthNoPriv {
+		if err := pkt.SecurityParameters.InitPacket(pkt); err != nil {
+			return nil, fmt.Errorf("snmpv3: init response salt: %w", err)
+		}
+	}
+
+	out, err := pkt.MarshalMsg()
+	if err != nil {
+		return nil, fmt.Errorf("snmpv3: marshal response: %w", err)
+	}
+	return out, nil
+}
+
+// responseUSM builds outbound security parameters bound to this engine.
+func (e *V3Engine) responseUSM(user *v3User, level gosnmp.SnmpV3MsgFlags) *gosnmp.UsmSecurityParameters {
+	usm := &gosnmp.UsmSecurityParameters{
+		AuthoritativeEngineID:    e.engineID,
+		AuthoritativeEngineBoots: e.boots,
+		AuthoritativeEngineTime:  e.engineTime(),
+		AuthenticationProtocol:   gosnmp.NoAuth,
+		PrivacyProtocol:          gosnmp.NoPriv,
+	}
+	if user == nil || level == gosnmp.NoAuthNoPriv {
+		return usm
+	}
+
+	usm.UserName = user.name
+	usm.AuthenticationProtocol = user.authProto
+	usm.AuthenticationPassphrase = user.authPass
+	if level&gosnmp.AuthPriv > gosnmp.AuthNoPriv {
+		usm.PrivacyProtocol = user.privProto
+		usm.PrivacyPassphrase = user.privPass
+	}
+	return usm
+}
+
+// decode performs the two-pass USM decode (mirrors gosnmp's own agent-side
+// UnmarshalTrap path): it selects the user by msgUserName, verifies
+// authentication, and decrypts the scoped PDU.
+func (e *V3Engine) decode(req []byte) (*gosnmp.SnmpPacket, error) {
+	table := gosnmp.NewSnmpV3SecurityParametersTable(gosnmp.Logger{})
+	for _, u := range e.users {
+		if err := table.Add(u.name, e.decodeUSM(u)); err != nil {
+			return nil, fmt.Errorf("snmpv3: build decode table: %w", err)
+		}
+	}
+
+	decoder := &gosnmp.GoSNMP{
+		Version:                     gosnmp.Version3,
+		SecurityModel:               gosnmp.UserSecurityModel,
+		TrapSecurityParametersTable: table,
+	}
+
+	pkt, err := decoder.UnmarshalTrap(req, true)
+	if err != nil {
+		return nil, fmt.Errorf("snmpv3: unmarshal request: %w", err)
+	}
+	return pkt, nil
+}
+
+// decodeUSM builds inbound security parameters for a user. Key localization
+// (InitSecurityKeys, run by the table on Add) uses our engine ID — the same
+// value the manager discovered — so the derived keys match the manager's.
+func (e *V3Engine) decodeUSM(u v3User) *gosnmp.UsmSecurityParameters {
+	return &gosnmp.UsmSecurityParameters{
+		AuthoritativeEngineID:    e.engineID,
+		UserName:                 u.name,
+		AuthenticationProtocol:   u.authProto,
+		AuthenticationPassphrase: u.authPass,
+		PrivacyProtocol:          u.privProto,
+		PrivacyPassphrase:        u.privPass,
+	}
+}
+
+// parseV3Header parses just the version/header/security-parameters of a v3
+// datagram without needing keys — used to detect engine-discovery probes.
+func parseV3Header(req []byte) (*gosnmp.SnmpPacket, error) {
+	// gosnmp validates the decoder's own SecurityParameters before parsing and
+	// requires a non-empty UserName; the wire values overwrite this placeholder
+	// during header parsing, so it only needs to satisfy that gate.
+	decoder := &gosnmp.GoSNMP{
+		Version:            gosnmp.Version3,
+		SecurityModel:      gosnmp.UserSecurityModel,
+		SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "niac-discovery"},
+	}
+	pkt, err := decoder.SnmpDecodePacket(req)
+	if err != nil {
+		return nil, fmt.Errorf("snmpv3: parse header: %w", err)
+	}
+	return pkt, nil
+}
+
+// usmOf extracts the USM security parameters from a decoded packet, or nil.
+func usmOf(pkt *gosnmp.SnmpPacket) *gosnmp.UsmSecurityParameters {
+	if pkt == nil {
+		return nil
+	}
+	usm, _ := pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+	return usm
+}
+
+// resolveEngineID returns the configured engine ID (hex) or derives a stable
+// MAC-based engine ID (RFC 3411 §5, format 3).
+func resolveEngineID(configured string, mac net.HardwareAddr) ([]byte, error) {
+	if configured != "" {
+		raw, err := hex.DecodeString(strings.TrimPrefix(configured, "0x"))
+		if err != nil {
+			return nil, fmt.Errorf("snmpv3: invalid engine_id hex %q: %w", configured, err)
+		}
+		if len(raw) < engineIDMinLen {
+			return nil, fmt.Errorf("snmpv3: engine_id too short (%d octets, need >= %d)", len(raw), engineIDMinLen)
+		}
+		return raw, nil
+	}
+
+	// Synthetic private-enterprise header (high bit set) + MAC-address format.
+	id := []byte{0x80, 0x00, 0x4e, 0x1a, niacEngineFormatMAC}
+	if len(mac) == snmpMACLen {
+		id = append(id, mac...)
+	} else {
+		id = append(id, 0, 0, 0, 0, 0, 0)
+	}
+	return id, nil
+}
+
+// snmpMACLen is the octet length of an Ethernet MAC address.
+const snmpMACLen = 6
+
+// resolveUser maps a config user to gosnmp protocol enums and derives the
+// security level the user answers at.
+func resolveUser(u *config.SNMPv3User) (v3User, error) {
+	authProto, err := mapAuthProtocol(u.AuthProtocol)
+	if err != nil {
+		return v3User{}, fmt.Errorf("snmpv3 user %q: %w", u.Username, err)
+	}
+	privProto, err := mapPrivProtocol(u.PrivProtocol)
+	if err != nil {
+		return v3User{}, fmt.Errorf("snmpv3 user %q: %w", u.Username, err)
+	}
+
+	flags := gosnmp.NoAuthNoPriv
+	switch {
+	case authProto != gosnmp.NoAuth && privProto != gosnmp.NoPriv:
+		flags = gosnmp.AuthPriv
+	case authProto != gosnmp.NoAuth:
+		flags = gosnmp.AuthNoPriv
+	}
+	if privProto != gosnmp.NoPriv && authProto == gosnmp.NoAuth {
+		return v3User{}, fmt.Errorf("snmpv3 user %q: privacy requires authentication", u.Username)
+	}
+
+	return v3User{
+		name:      u.Username,
+		authProto: authProto,
+		authPass:  u.AuthPassword,
+		privProto: privProto,
+		privPass:  u.PrivPassword,
+		msgFlags:  flags,
+	}, nil
+}
+
+func mapAuthProtocol(name string) (gosnmp.SnmpV3AuthProtocol, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "none":
+		return gosnmp.NoAuth, nil
+	case "md5":
+		return gosnmp.MD5, nil
+	case "sha", "sha1":
+		return gosnmp.SHA, nil
+	case "sha224":
+		return gosnmp.SHA224, nil
+	case "sha256":
+		return gosnmp.SHA256, nil
+	case "sha384":
+		return gosnmp.SHA384, nil
+	case "sha512":
+		return gosnmp.SHA512, nil
+	default:
+		return gosnmp.NoAuth, fmt.Errorf("unknown auth protocol %q", name)
+	}
+}
+
+func mapPrivProtocol(name string) (gosnmp.SnmpV3PrivProtocol, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "none":
+		return gosnmp.NoPriv, nil
+	case "des":
+		return gosnmp.DES, nil
+	case "aes", "aes128":
+		return gosnmp.AES, nil
+	case "aes192":
+		return gosnmp.AES192, nil
+	case "aes256":
+		return gosnmp.AES256, nil
+	default:
+		return gosnmp.NoPriv, fmt.Errorf("unknown privacy protocol %q", name)
+	}
+}

--- a/internal/protocols/snmp/v3_test.go
+++ b/internal/protocols/snmp/v3_test.go
@@ -1,0 +1,255 @@
+package snmp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// sysDescrOID is the value the fake agent returns for any Get in these tests.
+const sysDescrOID = ".1.3.6.1.2.1.1.1.0"
+
+// echoProcess is a minimal ProcessFunc: it answers a Get for sysDescr with a
+// fixed OctetString and NoSuchObject for anything else.
+func echoProcess(_ gosnmp.PDUType, vars []gosnmp.SnmpPDU, _ uint32) []gosnmp.SnmpPDU {
+	out := make([]gosnmp.SnmpPDU, 0, len(vars))
+	for _, v := range vars {
+		if v.Name == sysDescrOID {
+			out = append(out, gosnmp.SnmpPDU{Name: sysDescrOID, Type: gosnmp.OctetString, Value: []byte("niac-sim")})
+			continue
+		}
+		out = append(out, gosnmp.SnmpPDU{Name: v.Name, Type: gosnmp.NoSuchObject, Value: nil})
+	}
+	return out
+}
+
+// serveEngine runs an SNMPv3 responder on a loopback UDP socket driven by the
+// engine, returning the bound port and a stop func. It is the local stand-in
+// for the CT304 agent socket.
+func serveEngine(t *testing.T, e *V3Engine) (int, func()) {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 64*1024)
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			n, addr, rerr := conn.ReadFromUDP(buf)
+			if rerr != nil {
+				select {
+				case <-done:
+					return
+				default:
+					continue
+				}
+			}
+			req := make([]byte, n)
+			copy(req, buf[:n])
+			resp, aerr := e.Respond(req, echoProcess)
+			if aerr != nil || resp == nil {
+				continue
+			}
+			_, _ = conn.WriteToUDP(resp, addr)
+		}
+	}()
+
+	return conn.LocalAddr().(*net.UDPAddr).Port, func() {
+		close(done)
+		_ = conn.Close()
+	}
+}
+
+// newClient builds a gosnmp v3 manager pointed at the loopback responder.
+func newClient(port int, flags gosnmp.SnmpV3MsgFlags, sp *gosnmp.UsmSecurityParameters) *gosnmp.GoSNMP {
+	return &gosnmp.GoSNMP{
+		Target:             "127.0.0.1",
+		Port:               uint16(port),
+		Version:            gosnmp.Version3,
+		SecurityModel:      gosnmp.UserSecurityModel,
+		MsgFlags:           flags,
+		SecurityParameters: sp,
+		Timeout:            2 * time.Second,
+		Retries:            2,
+	}
+}
+
+func engineFor(t *testing.T, users []config.SNMPv3User) *V3Engine {
+	t.Helper()
+	mac, _ := net.ParseMAC("02:00:00:11:22:33")
+	e, err := NewV3Engine(&config.SNMPv3Config{Enabled: true, Users: users}, mac)
+	if err != nil {
+		t.Fatalf("NewV3Engine: %v", err)
+	}
+	if e == nil {
+		t.Fatal("expected engine, got nil")
+	}
+	return e
+}
+
+// TestV3RoundTripAuthPriv is the headline proof: a real gosnmp manager performs
+// engine discovery and an authPriv (SHA + AES) Get end-to-end against the
+// engine, and reads back the value the agent produced.
+func TestV3RoundTripAuthPriv(t *testing.T) {
+	e := engineFor(t, []config.SNMPv3User{{
+		Username:     "admin",
+		AuthProtocol: "sha",
+		AuthPassword: "authpass123",
+		PrivProtocol: "aes",
+		PrivPassword: "privpass123",
+	}})
+	port, stop := serveEngine(t, e)
+	defer stop()
+
+	client := newClient(port, gosnmp.AuthPriv, &gosnmp.UsmSecurityParameters{
+		UserName:                 "admin",
+		AuthenticationProtocol:   gosnmp.SHA,
+		AuthenticationPassphrase: "authpass123",
+		PrivacyProtocol:          gosnmp.AES,
+		PrivacyPassphrase:        "privpass123",
+	})
+	if err := client.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = client.Conn.Close() }()
+
+	result, err := client.Get([]string{sysDescrOID})
+	if err != nil {
+		t.Fatalf("authPriv Get: %v", err)
+	}
+	if len(result.Variables) != 1 {
+		t.Fatalf("want 1 var, got %d", len(result.Variables))
+	}
+	if got := string(result.Variables[0].Value.([]byte)); got != "niac-sim" {
+		t.Errorf("value = %q, want niac-sim", got)
+	}
+}
+
+// TestV3RoundTripLevels covers noAuthNoPriv, authNoPriv (SHA), and authPriv with
+// DES to exercise both cipher paths and all three security levels.
+func TestV3RoundTripLevels(t *testing.T) {
+	cases := []struct {
+		name  string
+		user  config.SNMPv3User
+		flags gosnmp.SnmpV3MsgFlags
+		sp    *gosnmp.UsmSecurityParameters
+	}{
+		{
+			name:  "noAuthNoPriv",
+			user:  config.SNMPv3User{Username: "noauth"},
+			flags: gosnmp.NoAuthNoPriv,
+			sp:    &gosnmp.UsmSecurityParameters{UserName: "noauth"},
+		},
+		{
+			name:  "authNoPriv-md5",
+			user:  config.SNMPv3User{Username: "authonly", AuthProtocol: "md5", AuthPassword: "authpass123"},
+			flags: gosnmp.AuthNoPriv,
+			sp: &gosnmp.UsmSecurityParameters{
+				UserName:                 "authonly",
+				AuthenticationProtocol:   gosnmp.MD5,
+				AuthenticationPassphrase: "authpass123",
+			},
+		},
+		{
+			name: "authPriv-des",
+			user: config.SNMPv3User{
+				Username: "full", AuthProtocol: "sha", AuthPassword: "authpass123",
+				PrivProtocol: "des", PrivPassword: "privpass123",
+			},
+			flags: gosnmp.AuthPriv,
+			sp: &gosnmp.UsmSecurityParameters{
+				UserName:                 "full",
+				AuthenticationProtocol:   gosnmp.SHA,
+				AuthenticationPassphrase: "authpass123",
+				PrivacyProtocol:          gosnmp.DES,
+				PrivacyPassphrase:        "privpass123",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := engineFor(t, []config.SNMPv3User{tc.user})
+			port, stop := serveEngine(t, e)
+			defer stop()
+
+			client := newClient(port, tc.flags, tc.sp)
+			if err := client.Connect(); err != nil {
+				t.Fatalf("connect: %v", err)
+			}
+			defer func() { _ = client.Conn.Close() }()
+
+			result, err := client.Get([]string{sysDescrOID})
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got := string(result.Variables[0].Value.([]byte)); got != "niac-sim" {
+				t.Errorf("value = %q, want niac-sim", got)
+			}
+		})
+	}
+}
+
+// TestV3WrongPasswordRejected proves the engine authenticates: a manager with
+// the right username but wrong auth passphrase cannot read a value.
+func TestV3WrongPasswordRejected(t *testing.T) {
+	e := engineFor(t, []config.SNMPv3User{{
+		Username: "admin", AuthProtocol: "sha", AuthPassword: "correct-pass",
+	}})
+	port, stop := serveEngine(t, e)
+	defer stop()
+
+	client := newClient(port, gosnmp.AuthNoPriv, &gosnmp.UsmSecurityParameters{
+		UserName:                 "admin",
+		AuthenticationProtocol:   gosnmp.SHA,
+		AuthenticationPassphrase: "wrong-pass",
+	})
+	if err := client.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = client.Conn.Close() }()
+
+	if _, err := client.Get([]string{sysDescrOID}); err == nil {
+		t.Fatal("expected auth failure for wrong passphrase, got success")
+	}
+}
+
+// TestNewV3EngineDisabled confirms the nil-engine "v3 disabled" contract.
+func TestNewV3EngineDisabled(t *testing.T) {
+	mac, _ := net.ParseMAC("02:00:00:11:22:33")
+	for _, cfg := range []*config.SNMPv3Config{
+		nil,
+		{Enabled: false, Users: []config.SNMPv3User{{Username: "x"}}},
+		{Enabled: true},
+	} {
+		e, err := NewV3Engine(cfg, mac)
+		if err != nil {
+			t.Fatalf("NewV3Engine(%v): %v", cfg, err)
+		}
+		if e != nil {
+			t.Errorf("NewV3Engine(%v) = engine, want nil", cfg)
+		}
+	}
+}
+
+// TestEngineIDFromConfigHex validates explicit engine-ID parsing.
+func TestEngineIDFromConfigHex(t *testing.T) {
+	raw, err := resolveEngineID("8000000001020304", nil)
+	if err != nil {
+		t.Fatalf("resolveEngineID: %v", err)
+	}
+	if len(raw) != 8 {
+		t.Errorf("engine ID len = %d, want 8", len(raw))
+	}
+	if _, badErr := resolveEngineID("zz", nil); badErr == nil {
+		t.Error("expected error for invalid hex engine ID")
+	}
+}

--- a/internal/protocols/snmp_agents.go
+++ b/internal/protocols/snmp_agents.go
@@ -9,6 +9,11 @@ import (
 
 type snmpAgentGroup struct {
 	agents map[string]*snmp.Agent
+	// v3 is the device's SNMPv3 authoritative engine (nil when v3 is disabled).
+	v3 *snmp.V3Engine
+	// v3Agent is the MIB-backing agent used to answer v3 scoped PDUs (the base
+	// community agent); v3 has no community, so one agent serves all users.
+	v3Agent *snmp.Agent
 }
 
 func newSnmpAgentGroup() *snmpAgentGroup {

--- a/internal/protocols/snmp_version_test.go
+++ b/internal/protocols/snmp_version_test.go
@@ -9,6 +9,47 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp"
 )
 
+// TestSNMPPeekVersion checks raw-datagram version detection used to route v3
+// traffic to the USM engine. Each fixture is a real marshalled SNMP message.
+func TestSNMPPeekVersion(t *testing.T) {
+	marshal := func(v gosnmp.SnmpVersion, sp gosnmp.SnmpV3SecurityParameters) []byte {
+		pkt := &gosnmp.SnmpPacket{
+			Version:            v,
+			Community:          "public",
+			PDUType:            gosnmp.GetRequest,
+			SecurityModel:      gosnmp.UserSecurityModel,
+			SecurityParameters: sp,
+			Variables:          []gosnmp.SnmpPDU{{Name: ".1.3.6.1.2.1.1.1.0", Type: gosnmp.Null}},
+		}
+		raw, err := pkt.MarshalMsg()
+		if err != nil {
+			t.Fatalf("marshal v%d: %v", v, err)
+		}
+		return raw
+	}
+
+	cases := []struct {
+		name string
+		raw  []byte
+		want gosnmp.SnmpVersion
+		ok   bool
+	}{
+		{"v1", marshal(gosnmp.Version1, nil), gosnmp.Version1, true},
+		{"v2c", marshal(gosnmp.Version2c, nil), gosnmp.Version2c, true},
+		{"v3", marshal(gosnmp.Version3, &gosnmp.UsmSecurityParameters{UserName: "u"}), gosnmp.Version3, true},
+		{"empty", []byte{}, 0, false},
+		{"not-sequence", []byte{0x02, 0x01, 0x00}, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := snmpPeekVersion(tc.raw)
+			if ok != tc.ok || (ok && got != tc.want) {
+				t.Errorf("snmpPeekVersion = (%d,%v), want (%d,%v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
 // TestBuildResponseRejectsSNMPv3 reproduces the live simulator crash: a CyberScope
 // (and other discovery tools) send SNMPv3 probes. gosnmp's MarshalMsg dispatches
 // a Version3 response to marshalV3, which dereferences the SecurityParameters the

--- a/internal/protocols/stack_snmp.go
+++ b/internal/protocols/stack_snmp.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp"
 )
 
 func (s *Stack) initSNMPAgent(device *config.Device) {
-	if !snmpEnabled(device.SNMPConfig) {
+	if !snmpEnabled(device.SNMPConfig) && !snmpv3Enabled(device.SNMPv3Config) {
 		return
 	}
 
@@ -25,6 +26,8 @@ func (s *Stack) initSNMPAgent(device *config.Device) {
 	}
 
 	baseAgent := group.Ensure(baseCommunity, device, debugLevel)
+
+	s.initSNMPv3Engine(device, group, baseAgent, debugLevel)
 
 	// Load walk files into base community agent
 	for _, walkFile := range device.SNMPConfig.WalkFiles {
@@ -82,6 +85,39 @@ func (s *Stack) initSNMPAgent(device *config.Device) {
 	}
 
 	s.snmpAgents[device] = group
+}
+
+// initSNMPv3Engine builds and attaches the device's SNMPv3 authoritative
+// engine to the agent group. The base community agent backs the MIB for all
+// USM users (v3 has no community dimension).
+func (s *Stack) initSNMPv3Engine(
+	device *config.Device,
+	group *snmpAgentGroup,
+	baseAgent *snmp.Agent,
+	debugLevel int,
+) {
+	if !snmpv3Enabled(device.SNMPv3Config) {
+		return
+	}
+
+	engine, err := snmp.NewV3Engine(device.SNMPv3Config, device.MACAddress)
+	if err != nil {
+		if debugLevel >= 1 {
+			_, _ = fmt.Fprintf(os.Stdout, "SNMP: v3 engine init failed for %s: %v\n", device.Name, err)
+		}
+		return
+	}
+	if engine == nil {
+		return
+	}
+
+	group.v3 = engine
+	group.v3Agent = baseAgent
+}
+
+// snmpv3Enabled reports whether a device has usable SNMPv3 USM configuration.
+func snmpv3Enabled(cfg *config.SNMPv3Config) bool {
+	return cfg != nil && cfg.Enabled && len(cfg.Users) > 0
 }
 
 func snmpEnabled(cfg config.SNMPConfig) bool {


### PR DESCRIPTION
## Summary

Implements a per-device SNMPv3 authoritative engine (USM, RFC 3414) so the
simulator answers `noAuthNoPriv`, `authNoPriv`, and `authPriv` requests instead
of refusing all v3 traffic. Discovery tools (NetAlly CyberScope/AirCheck) can
now enumerate simulated devices over the only SNMP version that does not send
credentials in cleartext.

- `internal/protocols/snmp/v3.go` — engine discovery (Report PDUs:
  unknownEngineIDs / notInTimeWindows / unknownUserNames), two-pass USM decode
  (select user by msgUserName → verify auth → decrypt), response encode via
  gosnmp `UsmSecurityParameters`. Key localization uses our engine ID so a
  manager that discovered us derives matching keys. RFC 3414 time-window check.
- Auth MD5/SHA/SHA-2, privacy DES/AES/AES-192/AES-256.
- Handler routes v3 by peeking the datagram version; v1/v2c keep the
  community-keyed path. Consumes the previously-unfed device SNMPv3 config.
- `deploy/configs/demo.yaml` + `docs/PROTOCOL_GUIDE.md` document the block.

## Linked Issue

Closes #849

## Testing Evidence

Local: full gosnmp-manager ⟷ engine round trip over UDP loopback (discovery +
all levels + both ciphers + wrong-password rejection):

```
$ go test ./internal/protocols/snmp/ -run 'TestV3|TestNewV3Engine|TestEngineID'
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp

$ go test ./...   # 35 packages
ok (0 failures); golangci-lint: 0 issues; govulncheck: no vulnerabilities
```

Wire validation on CT304 (`niac-sim`, 10.10.200.101) with net-snmp from the
Proxmox VLAN200 rig, serving a real Cisco c3750 walk over authPriv (SHA/AES):

```
$ snmpget -v3 -l authPriv -u niacadmin -a SHA -A ... -x AES -X ... 10.10.200.101 sysDescr.0
iso.3.6.1.2.1.1.1.0 = STRING: "switch demo-core-sw"

$ snmpwalk -v3 -l authPriv ... 10.10.200.101 system
iso.3.6.1.2.1.1.2.0 = OID: iso.3.6.1.4.1.9.1.1
iso.3.6.1.2.1.1.5.0 = STRING: "demo-core-sw"
... (ifDescr walk returns 41 OIDs)

# negatives: noAuthNoPriv -> "Authentication failed"; wrong priv key -> dropped
```

## Security and Release Checklist

- [x] `make lint` clean (0 issues), `make security` clean (govulncheck / gitleaks / npm audit)
- [x] No new default credentials; v3 users are operator-configured
- [x] Wrong auth/priv credentials are rejected (verified on the wire)
- [x] No schema drift; docs + example config updated
- [x] Feature branch, conventional commit, PR-based
