### PR TITLE
fix(sanitize): correct numeric-walk identity scrub and stop OID corruption

### DIFF
--- a/cmd/niac/sanitize.go
+++ b/cmd/niac/sanitize.go
@@ -365,80 +365,116 @@ func updateMappingStatistics(mapping *SanitizationMapping, initialIPs, initialHo
 	mapping.Statistics.HostnamesTransformed += len(mapping.Hostnames) - initialHostnames
 }
 
+// Precompiled patterns for sanitizeLine. Compiling once (rather than per line)
+// matters: walks run to hundreds of thousands of lines each.
+var (
+	stringValueRe   = regexp.MustCompile(`= STRING:.*`)
+	stringCaptureRe = regexp.MustCompile(`= STRING: (.+)`)
+	ipValueRe       = regexp.MustCompile(`IpAddress: (\d+\.\d+\.\d+\.\d+)`)
+	dnsLocalRe      = regexp.MustCompile(`\.local\b`)
+	dnsTLDRe        = regexp.MustCompile(`\.(com|net|org)\b`)
+
+	// ipIndexedOIDRe matches the standard IPv4 table columns whose row index ends
+	// in a dotted-quad IP address. Only OIDs matching this have their trailing
+	// four arcs rewritten as an IP; applying that to an arbitrary OID whose last
+	// arcs merely look like octets corrupts the MIB structure.
+	//   .4.20.1 ipAddrTable      · .4.21.1 ipRouteTable
+	//   .4.22.1 ipNetToMediaTable · .3.1.1 atTable (legacy)
+	ipIndexedOIDRe = regexp.MustCompile(`^\.1\.3\.6\.1\.2\.1\.(?:4\.2[012]\.1|3\.1\.1)\.`)
+)
+
+// sysGroupPrefix is the numeric OID root of the SNMPv2-MIB system group.
+const sysGroupPrefix = ".1.3.6.1.2.1.1."
+
+// ipv4OctetCount is the number of trailing OID arcs that form a dotted-quad index.
+const ipv4OctetCount = 4
+
 func sanitizeLine(line string, mapping *SanitizationMapping, domain, location, contact, community string) string {
-	// 1. System contact
-	if strings.Contains(line, "sysContact") {
-		line = regexp.MustCompile(`= STRING:.*`).ReplaceAllString(line, fmt.Sprintf("= STRING: %s", contact))
-	}
-
-	// 2. System location
-	if strings.Contains(line, "sysLocation") {
-		line = regexp.MustCompile(`= STRING:.*`).
-			ReplaceAllString(line, fmt.Sprintf("= STRING: NiAC-Go - %s - Network Operations", location))
-	}
-
-	// 3. System name (hostname)
-	if strings.Contains(line, "sysName") {
-		// Extract original hostname
-		re := regexp.MustCompile(`= STRING: (.+)`)
-		if matches := re.FindStringSubmatch(line); len(matches) > 1 {
-			original := strings.TrimSpace(matches[1])
-			sanitized := sanitizeHostname(original, mapping)
-			line = re.ReplaceAllString(line, fmt.Sprintf("= STRING: %s", sanitized))
+	// 1-3. System-group identity scalars. Match both numeric walks
+	// (.1.3.6.1.2.1.1.<n>.0, i.e. snmpwalk -On) and symbolic walks (MIB name).
+	isContact := isSystemScalar(line, "4", "sysContact")
+	switch {
+	case isContact:
+		line = stringValueRe.ReplaceAllString(line, "= STRING: "+contact)
+	case isSystemScalar(line, "6", "sysLocation"):
+		line = stringValueRe.ReplaceAllString(line, "= STRING: NiAC-Go - "+location+" - Network Operations")
+	case isSystemScalar(line, "5", "sysName"):
+		if matches := stringCaptureRe.FindStringSubmatch(line); len(matches) > 1 {
+			hostname := sanitizeHostname(strings.TrimSpace(matches[1]), mapping)
+			line = stringValueRe.ReplaceAllString(line, "= STRING: "+hostname)
 		}
 	}
 
-	// 4. SNMP community strings
+	// 4. SNMP community strings (symbolic MIB objects only; numeric community
+	// columns are enterprise-specific and not represented by a fixed OID).
 	if strings.Contains(line, "snmpCommunity") || strings.Contains(line, "community") {
-		line = regexp.MustCompile(`= STRING:.*`).ReplaceAllString(line, fmt.Sprintf("= STRING: %s", community))
+		line = stringValueRe.ReplaceAllString(line, "= STRING: "+community)
 	}
 
-	// 5. IP addresses in IpAddress values
-	ipValueRe := regexp.MustCompile(`IpAddress: (\d+\.\d+\.\d+\.\d+)`)
+	// 5. IP addresses in IpAddress values.
 	line = ipValueRe.ReplaceAllStringFunc(line, func(match string) string {
 		ip := ipValueRe.FindStringSubmatch(match)[1]
-		// Skip special IPs
 		if isSpecialIP(ip) {
 			return match
 		}
-		sanitized := sanitizeIP(ip, mapping)
-		return fmt.Sprintf("IpAddress: %s", sanitized)
+		return "IpAddress: " + sanitizeIP(ip, mapping)
 	})
 
-	// 6. IP addresses in OIDs (e.g., .1.3.6.1.2.1.3.1.1.3.2.1.10.250.0.45)
-	// This is trickier - need to identify IP octets in OID
-	oidIPRe := regexp.MustCompile(`\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?:\s|=|$)`)
-	line = oidIPRe.ReplaceAllStringFunc(line, func(match string) string {
-		parts := oidIPRe.FindStringSubmatch(match)
-		if len(parts) < ipRegexParts {
-			return match
-		}
+	// 6. IP addresses embedded as the row index of a standard IPv4 table column.
+	line = rewriteOIDIndexIP(line, mapping)
 
-		// Check if these look like IP octets
-		o1, o2, o3, o4 := parts[1], parts[2], parts[3], parts[4]
-		if !looksLikeIPOctet(o1) || !looksLikeIPOctet(o2) || !looksLikeIPOctet(o3) || !looksLikeIPOctet(o4) {
-			return match
-		}
-
-		ip := fmt.Sprintf("%s.%s.%s.%s", o1, o2, o3, o4)
-		if isSpecialIP(ip) {
-			return match
-		}
-
-		sanitized := sanitizeIP(ip, mapping)
-		octets := strings.Split(sanitized, ".")
-		suffix := match[len(match)-1:] // Preserve trailing character
-		return fmt.Sprintf(".%s.%s.%s.%s%s", octets[0], octets[1], octets[2], octets[3], suffix)
-	})
-
-	// 7. DNS domains (but skip email addresses in contact strings)
-	if domain != "" && !strings.Contains(line, "sysContact") {
-		// Replace common domain patterns
-		line = regexp.MustCompile(`\.local\b`).ReplaceAllString(line, ".niac-go.local")
-		line = regexp.MustCompile(`\.(com|net|org)\b`).ReplaceAllString(line, "."+domain)
+	// 7. DNS domains (but skip email addresses in contact strings).
+	if domain != "" && !isContact {
+		line = dnsLocalRe.ReplaceAllString(line, ".niac-go.local")
+		line = dnsTLDRe.ReplaceAllString(line, "."+domain)
 	}
 
 	return line
+}
+
+// isSystemScalar reports whether line is the given system-group scalar, in either
+// numeric (.1.3.6.1.2.1.1.<arc>.0) or symbolic (MIB object name) walk format.
+func isSystemScalar(line, arc, symbolic string) bool {
+	return strings.HasPrefix(line, sysGroupPrefix+arc+".0 ") || strings.Contains(line, symbolic)
+}
+
+// rewriteOIDIndexIP rewrites the trailing dotted-quad IP index of a standard
+// IPv4-indexed table column and leaves every other OID untouched, so structural
+// arcs that merely look like octets are never disturbed. Only the OID field is
+// considered; the value field is handled by the IpAddress pass.
+func rewriteOIDIndexIP(line string, mapping *SanitizationMapping) string {
+	sep := strings.Index(line, " = ")
+	if sep < 0 {
+		return line
+	}
+	oid := line[:sep]
+	if !hasIPIndexedPrefix(oid) {
+		return line
+	}
+
+	arcs := strings.Split(oid, ".")
+	if len(arcs) < ipv4OctetCount {
+		return line
+	}
+	index := arcs[len(arcs)-ipv4OctetCount:]
+	for _, arc := range index {
+		if !looksLikeIPOctet(arc) {
+			return line
+		}
+	}
+
+	ip := strings.Join(index, ".")
+	if isSpecialIP(ip) {
+		return line
+	}
+
+	copy(arcs[len(arcs)-ipv4OctetCount:], strings.Split(sanitizeIP(ip, mapping), "."))
+	return strings.Join(arcs, ".") + line[sep:]
+}
+
+// hasIPIndexedPrefix reports whether oid sits under a known IPv4-indexed table column.
+func hasIPIndexedPrefix(oid string) bool {
+	return ipIndexedOIDRe.MatchString(oid)
 }
 
 func sanitizeIP(ip string, mapping *SanitizationMapping) string {

--- a/cmd/niac/sanitize_numeric_test.go
+++ b/cmd/niac/sanitize_numeric_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Real device SNMP walks in the corpus are numeric (snmpwalk -On), not symbolic
+// MIB names. These tests lock the sanitizer's behavior on numeric input:
+//   - system-group identity scalars must be scrubbed by numeric OID, and
+//   - the IP-in-OID rewrite must only touch genuine IP-indexed table columns,
+//     never the trailing arcs of an arbitrary structural OID.
+
+func sanitizeLineDefaults(line string) string {
+	return sanitizeLine(line, newSanitizationMapping(), "niac-go.com", "DC-WEST", "netadmin@niac-go.com", "public")
+}
+
+func TestSanitizeLineNumericSystemContact(t *testing.T) {
+	line := `.1.3.6.1.2.1.1.4.0 = STRING: "Operational Services"`
+	got := sanitizeLineDefaults(line)
+	if strings.Contains(got, "Operational Services") {
+		t.Errorf("numeric sysContact not scrubbed: %q", got)
+	}
+	if !strings.Contains(got, "netadmin@niac-go.com") {
+		t.Errorf("numeric sysContact not replaced with contact: %q", got)
+	}
+}
+
+func TestSanitizeLineNumericSystemLocation(t *testing.T) {
+	line := `.1.3.6.1.2.1.1.6.0 = STRING: "GS2 - London"`
+	got := sanitizeLineDefaults(line)
+	if strings.Contains(got, "London") {
+		t.Errorf("numeric sysLocation not scrubbed: %q", got)
+	}
+	if !strings.Contains(got, "NiAC-Go") {
+		t.Errorf("numeric sysLocation not branded: %q", got)
+	}
+}
+
+func TestSanitizeLineNumericSystemName(t *testing.T) {
+	line := `.1.3.6.1.2.1.1.5.0 = STRING: "GS2620b01"`
+	got := sanitizeLineDefaults(line)
+	if strings.Contains(got, "GS2620b01") {
+		t.Errorf("numeric sysName not scrubbed: %q", got)
+	}
+	if !strings.Contains(got, "niac-") {
+		t.Errorf("numeric sysName not replaced with branded hostname: %q", got)
+	}
+}
+
+// TestSanitizeLineDoesNotCorruptStructuralOID is the core regression guard: a
+// non-IP-indexed OID whose last four arcs happen to be <=255 must be returned
+// byte-for-byte unchanged. The old greedy regex rewrote these into 10.100.x.x,
+// relocating real MIB nodes and destroying the system group.
+func TestSanitizeLineDoesNotCorruptStructuralOID(t *testing.T) {
+	structural := []string{
+		`.1.3.6.1.2.1.2.2.1.1.10 = INTEGER: 10`,           // ifIndex, trailing .2.1.1.10
+		`.1.3.6.1.2.1.1.9.1.2.1 = OID: .1.3.6.1.6.3.1`,    // sysORID, trailing .9.1.2.1
+		`.1.3.6.1.2.1.1.3.0 = Timeticks: (498147033) 57d`, // sysUpTime
+		`.1.3.6.1.4.1.12356.101.1.6200.0 = INTEGER: 1`,    // enterprise scalar
+	}
+	for _, line := range structural {
+		if got := sanitizeLineDefaults(line); got != line {
+			t.Errorf("structural OID corrupted:\n in:  %q\n out: %q", line, got)
+		}
+	}
+}
+
+// TestSanitizeLineRewritesIPIndexedColumns guards the intended behavior: genuine
+// IPv4-indexed table columns keep having their trailing IP index rewritten.
+func TestSanitizeLineRewritesIPIndexedColumns(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string
+		wantNot string // original IP must be gone from the OID index
+	}{
+		{
+			name:    "ipAddrTable",
+			line:    `.1.3.6.1.2.1.4.20.1.1.203.0.113.5 = IpAddress: 203.0.113.5`,
+			wantNot: ".203.0.113.5 ",
+		},
+		{
+			name:    "ipNetToMediaTable ifIndex+IP",
+			line:    `.1.3.6.1.2.1.4.22.1.3.5.203.0.113.9 = IpAddress: 203.0.113.9`,
+			wantNot: ".203.0.113.9 ",
+		},
+		{
+			name:    "ipRouteTable dest IP",
+			line:    `.1.3.6.1.2.1.4.21.1.1.203.0.113.0 = IpAddress: 203.0.113.0`,
+			wantNot: ".203.0.113.0 ",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeLineDefaults(tc.line)
+			if strings.Contains(got, tc.wantNot) {
+				t.Errorf("IP index not rewritten in %s: %q", tc.name, got)
+			}
+			if !strings.Contains(got, "= IpAddress: 10.") {
+				t.Errorf("IpAddress value not rewritten to lab range in %s: %q", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestSanitizeLineIPIndexPreservesIfIndex ensures only the IP portion of a
+// multi-part index is rewritten, not the leading ifIndex arc.
+func TestSanitizeLineIPIndexPreservesIfIndex(t *testing.T) {
+	line := `.1.3.6.1.2.1.4.22.1.3.5.203.0.113.9 = IpAddress: 203.0.113.9`
+	got := sanitizeLineDefaults(line)
+	if !strings.HasPrefix(got, ".1.3.6.1.2.1.4.22.1.3.5.10.") {
+		t.Errorf("ifIndex arc (.5) not preserved before rewritten IP: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

The `niac sanitize` command was written and tested against symbolic (`snmpwalk -Os`) output, but the walk corpus is numeric (`-On`). On numeric walks the identity scrubs never fired (real `sysContact`/`sysName`/`sysLocation` leaked) and an unanchored trailing-quad regex rewrote the last four arcs of *any* octet-looking OID, relocating real MIB nodes and destroying the system group (e.g. `.1.3.6.1.2.1.1.9.1.2.1` → `.1.3.6.1.2.1.1.10.100.0.179`).

Fix: match system scalars by numeric OID as well as symbolic name, and restrict the IP-index rewrite to the standard IPv4-indexed table columns (ipAddrTable, ipRouteTable, ipNetToMediaTable, atTable), operating on the OID field only. Regexes are precompiled once instead of per line.

## Linked Issue

Fixes #855

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

Unit tests (new numeric-format + structural-OID corruption guard, plus existing symbolic tests) and lint:

```text
$ go test ./cmd/niac/
ok  	github.com/MustardSeedNetworks/niac-go/cmd/niac	0.133s

$ golangci-lint run ./cmd/niac/
0 issues.
```

End-to-end on the real corrupted walk (raw GS2 Firewall, 621,564 lines):

```text
corrupt system-group OIDs (.1.3.6.1.2.1.1.10.*)   : 0
identity leaks (London / Operational Services)    : 0
ipAddrTable values outside 10.0.0.0/8 (real leaks): 0   (specials 0.0.0.0/127.0.0.1/multicast/broadcast preserved)
system group intact: sysContact→netadmin@niac-go.com, sysName→niac-core-dev-06, sysLocation→NiAC-Go - DC-WEST - Network Operations
```

Known residual (out of scope, tracked separately): one Fortinet enterprise OID (`.12356.101.13.2.1.1.11.1`) still carries the unit name; the tool intentionally scrubs only standard system scalars.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.