### PR TITLE
fix(sanitize): scrub device identity echoed outside the system group

### DIFF
--- a/cmd/niac/sanitize.go
+++ b/cmd/niac/sanitize.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -320,7 +321,14 @@ func processSanitizeFile(
 	return nil
 }
 
-// writeAndFinalize processes all lines and finalizes the output file.
+// maxWalkLineBytes bounds a single scanned walk line. Hex-string values can be
+// large, so this is well above bufio's 64KiB default while still capping memory.
+const maxWalkLineBytes = 8 << 20 // 8 MiB
+
+// writeAndFinalize processes all lines and finalizes the output file. It is a
+// two-pass operation: pass one collects identity strings (hostname, contact)
+// that vendor/entity OIDs echo outside the system group; pass two applies the
+// per-line rules and scrubs those echoes globally.
 func writeAndFinalize(
 	input *os.File,
 	output *os.File,
@@ -328,18 +336,33 @@ func writeAndFinalize(
 	domain, location, contact, community string,
 ) error {
 	scanner := bufio.NewScanner(input)
-	writer := bufio.NewWriter(output)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxWalkLineBytes)
 
+	var lines []string
 	for scanner.Scan() {
-		line := scanner.Text()
-		sanitized := sanitizeLine(line, mapping, domain, location, contact, community)
-		if _, err := fmt.Fprintln(writer, sanitized); err != nil {
-			return fmt.Errorf("failed to write line: %w", err)
-		}
+		lines = append(lines, scanner.Text())
 	}
-
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("scanner error: %w", err)
+	}
+
+	subs := collectIdentitySubs(lines, mapping, contact)
+
+	writer := bufio.NewWriter(output)
+	for _, line := range lines {
+		var out string
+		if isIdentityScalar(line) {
+			// The scalar rules already replace this line's value; scrubbing it
+			// again would double-sanitize the just-written hostname.
+			out = sanitizeLine(line, mapping, domain, location, contact, community)
+		} else {
+			// Scrub echoed identity before the per-line DNS rewrite so a full
+			// FQDN still matches, then apply IP/DNS rules.
+			out = sanitizeLine(applyIdentitySubs(line, subs), mapping, domain, location, contact, community)
+		}
+		if _, err := fmt.Fprintln(writer, out); err != nil {
+			return fmt.Errorf("failed to write line: %w", err)
+		}
 	}
 
 	if err := writer.Flush(); err != nil {
@@ -399,9 +422,10 @@ func sanitizeLine(line string, mapping *SanitizationMapping, domain, location, c
 	case isSystemScalar(line, "6", "sysLocation"):
 		line = stringValueRe.ReplaceAllString(line, "= STRING: NiAC-Go - "+location+" - Network Operations")
 	case isSystemScalar(line, "5", "sysName"):
-		if matches := stringCaptureRe.FindStringSubmatch(line); len(matches) > 1 {
-			hostname := sanitizeHostname(strings.TrimSpace(matches[1]), mapping)
-			line = stringValueRe.ReplaceAllString(line, "= STRING: "+hostname)
+		// Use the unquoted value so the scalar and the global echo scrub
+		// (collectIdentitySubs) sanitize the identical hostname string.
+		if v, ok := scalarStringValue(line); ok {
+			line = stringValueRe.ReplaceAllString(line, "= STRING: "+sanitizeHostname(v, mapping))
 		}
 	}
 
@@ -475,6 +499,92 @@ func rewriteOIDIndexIP(line string, mapping *SanitizationMapping) string {
 // hasIPIndexedPrefix reports whether oid sits under a known IPv4-indexed table column.
 func hasIPIndexedPrefix(oid string) bool {
 	return ipIndexedOIDRe.MatchString(oid)
+}
+
+// minIdentityScrubLen is the shortest identity value eligible for global scrubbing.
+// Shorter values risk matching legitimate substrings elsewhere in the walk.
+const minIdentityScrubLen = 5
+
+// identitySub is a literal find/replace for an echoed identity string.
+type identitySub struct {
+	from string
+	to   string
+}
+
+// isIdentityScalar reports whether line is one of the system-group identity
+// scalars whose value the per-line rules already replace.
+func isIdentityScalar(line string) bool {
+	return isSystemScalar(line, "4", "sysContact") ||
+		isSystemScalar(line, "5", "sysName") ||
+		isSystemScalar(line, "6", "sysLocation")
+}
+
+// collectIdentitySubs scans a walk for the sysName and sysContact scalar values
+// and returns literal substitutions (original -> sanitized) for the distinctive
+// ones. Real devices echo these strings in vendor OIDs, entPhysicalName, and
+// CDP/LLDP neighbor tables, which the per-line scalar rules never reach. The
+// substitutions are ordered longest-first so overlapping values replace fully.
+func collectIdentitySubs(lines []string, mapping *SanitizationMapping, contact string) []identitySub {
+	seen := make(map[string]struct{})
+	var subs []identitySub
+
+	add := func(orig, repl string) {
+		if !isDistinctiveIdentifier(orig) || orig == repl {
+			return
+		}
+		if _, dup := seen[orig]; dup {
+			return
+		}
+		seen[orig] = struct{}{}
+		subs = append(subs, identitySub{from: orig, to: repl})
+	}
+
+	for _, line := range lines {
+		switch {
+		case isSystemScalar(line, "5", "sysName"):
+			if v, ok := scalarStringValue(line); ok {
+				add(v, sanitizeHostname(v, mapping))
+			}
+		case isSystemScalar(line, "4", "sysContact"):
+			if v, ok := scalarStringValue(line); ok {
+				add(v, contact)
+			}
+		}
+	}
+
+	sort.SliceStable(subs, func(i, j int) bool { return len(subs[i].from) > len(subs[j].from) })
+	return subs
+}
+
+// applyIdentitySubs replaces every occurrence of each collected identity string.
+func applyIdentitySubs(line string, subs []identitySub) string {
+	for _, sub := range subs {
+		if strings.Contains(line, sub.from) {
+			line = strings.ReplaceAll(line, sub.from, sub.to)
+		}
+	}
+	return line
+}
+
+// scalarStringValue extracts and unquotes the STRING value of a walk line.
+func scalarStringValue(line string) (string, bool) {
+	matches := stringCaptureRe.FindStringSubmatch(line)
+	if len(matches) <= 1 {
+		return "", false
+	}
+	value := strings.TrimSpace(matches[1])
+	value = strings.TrimSuffix(strings.TrimPrefix(value, `"`), `"`)
+	return value, value != ""
+}
+
+// isDistinctiveIdentifier reports whether s is specific enough to blanket-replace:
+// long enough and containing a character typical of a hostname or contact
+// (digit, dot, hyphen, underscore, or @), which excludes plain dictionary words.
+func isDistinctiveIdentifier(s string) bool {
+	if len(s) < minIdentityScrubLen {
+		return false
+	}
+	return strings.ContainsAny(s, "0123456789.-_@")
 }
 
 func sanitizeIP(ip string, mapping *SanitizationMapping) string {

--- a/cmd/niac/sanitize_numeric_test.go
+++ b/cmd/niac/sanitize_numeric_test.go
@@ -112,3 +112,60 @@ func TestSanitizeLineIPIndexPreservesIfIndex(t *testing.T) {
 		t.Errorf("ifIndex arc (.5) not preserved before rewritten IP: %q", got)
 	}
 }
+
+// Real device hostnames/contacts are echoed outside the system group (vendor
+// OIDs, entPhysicalName, CDP/LLDP neighbor tables), where the per-line scalar
+// rules never reach. collectIdentitySubs + applyIdentitySubs form a second pass
+// that scrubs those echoes globally.
+
+func TestCollectAndApplyIdentitySubsScrubsEchoedHostname(t *testing.T) {
+	lines := []string{
+		`.1.3.6.1.2.1.1.5.0 = STRING: "COS_Lab_R00.fnet.eng"`,              // sysName
+		`.1.3.6.1.4.1.9.9.23.1.2.1.1.6.1 = STRING: "COS_Lab_R00.fnet.eng"`, // CDP neighbor echo
+	}
+	subs := collectIdentitySubs(lines, newSanitizationMapping(), "netadmin@niac-go.com")
+	got := applyIdentitySubs(lines[1], subs)
+	if strings.Contains(got, "COS_Lab_R00.fnet.eng") {
+		t.Errorf("echoed hostname not scrubbed: %q", got)
+	}
+	if !strings.Contains(got, "niac-") {
+		t.Errorf("echo not replaced with sanitized hostname: %q", got)
+	}
+}
+
+func TestCollectAndApplyIdentitySubsScrubsEchoedContact(t *testing.T) {
+	lines := []string{
+		`.1.3.6.1.2.1.1.4.0 = STRING: "netops@ucdenver.pvt"`,
+		`.1.3.6.1.4.1.9.2.1.61.0 = STRING: "escalate: netops@ucdenver.pvt"`,
+	}
+	subs := collectIdentitySubs(lines, newSanitizationMapping(), "netadmin@niac-go.com")
+	got := applyIdentitySubs(lines[1], subs)
+	if strings.Contains(got, "netops@ucdenver.pvt") {
+		t.Errorf("echoed contact not scrubbed: %q", got)
+	}
+}
+
+// TestCollectIdentitySubsSkipsGenericNames guards against over-scrubbing: a plain
+// dictionary sysName with no digit/./-/_ is not distinctive enough to blanket-
+// replace across the file (it could be a substring of legitimate model strings).
+func TestCollectIdentitySubsSkipsGenericNames(t *testing.T) {
+	lines := []string{`.1.3.6.1.2.1.1.5.0 = STRING: "Switch"`}
+	subs := collectIdentitySubs(lines, newSanitizationMapping(), "c@example.test")
+	for _, s := range subs {
+		if s.from == "Switch" {
+			t.Errorf("generic name %q should not become a global substitution", s.from)
+		}
+	}
+}
+
+// TestApplyIdentitySubsLongestFirst ensures overlapping identifiers replace fully
+// (an FQDN before its bare-host prefix).
+func TestApplyIdentitySubsLongestFirst(t *testing.T) {
+	subs := collectIdentitySubs([]string{
+		`.1.3.6.1.2.1.1.5.0 = STRING: "sw1.corp.example"`,
+	}, newSanitizationMapping(), "c@example.test")
+	got := applyIdentitySubs(`x = STRING: "sw1.corp.example neighbor"`, subs)
+	if strings.Contains(got, "sw1.corp.example") {
+		t.Errorf("FQDN not fully scrubbed: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

The sanitizer's per-line rules only rewrite the system-group identity scalars, but real devices echo their `sysName` (often an FQDN exposing the org domain, e.g. `ucdenver.pvt`) and `sysContact` in vendor OIDs, `entPhysicalName`, and CDP/LLDP neighbor tables. Across the corpus, **262/506 walks still leaked their real hostname**.

Adds a second pass per file: collect distinctive identity strings (sysName → sanitized hostname, sysContact → contact) and replace every occurrence globally, longest-first. Guard: value must contain a digit/`.`/`-`/`_`/`@` and be ≥5 chars, so generic words aren't blanket-replaced. `sysName` now sanitizes the unquoted value so the scalar and its echoes resolve to the same hostname. Scanner buffer raised to 8 MiB for long hex-string lines.

## Linked Issue

Fixes #856

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./cmd/niac/
ok  github.com/MustardSeedNetworks/niac-go/cmd/niac

$ golangci-lint run ./cmd/niac/
0 issues.
```

End-to-end on the real GS2 Firewall walk (unit name echoed in a Fortinet enterprise OID):

```text
before: .1.3.6.1.4.1.12356.101.13.2.1.1.11.1 = STRING: "GS2620b01"
after:  .1.3.6.1.4.1.12356.101.13.2.1.1.11.1 = STRING: "niac-core-dev-67"
sysName scalar:                               = STRING: niac-core-dev-67   (same name)
GS2620b01 leaks: 0 · corrupt OIDs: 0 · sysObjectID preserved
```

Follow-up: the sanitized corpus in niac-demo-catalog will be re-regenerated with this fix (combined with the pending naming-scheme reorg).

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.