### PR TITLE
feat(protocols): tag reactive replies onto the request's VLAN

### DIFF
--- a/internal/protocols/arp.go
+++ b/internal/protocols/arp.go
@@ -107,7 +107,7 @@ func (h *ARPHandler) handleARPRequest(pkt *Packet, arp *layers.ARP) {
 		return
 	}
 
-	h.sendARPReplies(devices, targetIP, sourceMAC, sourceIP)
+	h.sendARPReplies(devices, targetIP, sourceMAC, sourceIP, pkt.VLAN)
 }
 
 // logARPRequest logs an ARP request at verbose debug level.
@@ -131,7 +131,7 @@ func (h *ARPHandler) logDebug(msg string, args ...any) {
 
 // sendARPReplies sends ARP replies for all matching devices.
 func (h *ARPHandler) sendARPReplies(
-	devices []*config.Device, targetIP net.IP, sourceMAC net.HardwareAddr, sourceIP net.IP,
+	devices []*config.Device, targetIP net.IP, sourceMAC net.HardwareAddr, sourceIP net.IP, vlan int,
 ) {
 	for _, device := range devices {
 		if len(device.MACAddress) == 0 {
@@ -139,6 +139,7 @@ func (h *ARPHandler) sendARPReplies(
 		}
 		reply := h.buildARPReply(device.MACAddress, targetIP, sourceMAC, sourceIP)
 		if reply != nil {
+			reply.VLAN = vlan // answer on the VLAN the request arrived on
 			h.stack.Send(reply)
 			h.stack.IncrementStat("arp_replies")
 			h.logDebug(

--- a/internal/protocols/coverage_extra_test.go
+++ b/internal/protocols/coverage_extra_test.go
@@ -647,13 +647,13 @@ func TestDHCPSendDHCPResponse(t *testing.T) {
 	serverMAC := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
 
 	// SendDHCPOffer goes through sendDHCPResponse -> serializeAndSendDHCP
-	err := h.SendDHCPOffer(1234, mac, net.ParseIP("10.0.0.10"), serverIP, serverMAC)
+	err := h.SendDHCPOffer(1234, mac, net.ParseIP("10.0.0.10"), serverIP, serverMAC, 0)
 	if err == nil {
 		t.Log("SendDHCPOffer succeeded (queued)")
 	}
 
 	// SendDHCPAck
-	err = h.SendDHCPAck(1234, mac, net.ParseIP("10.0.0.10"), serverIP, serverMAC)
+	err = h.SendDHCPAck(1234, mac, net.ParseIP("10.0.0.10"), serverIP, serverMAC, 0)
 	if err == nil {
 		t.Log("SendDHCPAck succeeded (queued)")
 	}

--- a/internal/protocols/dhcp.go
+++ b/internal/protocols/dhcp.go
@@ -377,6 +377,7 @@ type dhcpPacketInfo struct {
 	dhcp        *layers.DHCPv4
 	messageType uint8
 	hostname    string
+	vlan        int // VLAN the request arrived on; replies echo it
 }
 
 // parseDHCPPacket parses a DHCP packet and extracts relevant information.
@@ -393,7 +394,7 @@ func (h *DHCPHandler) parseDHCPPacket(pkt *Packet) *dhcpPacketInfo {
 		return nil
 	}
 
-	info := &dhcpPacketInfo{dhcp: dhcp}
+	info := &dhcpPacketInfo{dhcp: dhcp, vlan: pkt.VLAN}
 
 	// Extract message type and hostname from options
 	for _, opt := range dhcp.Options {
@@ -465,6 +466,7 @@ func (h *DHCPHandler) handleDHCPDiscover(
 		lease.IP,
 		serverDevice.IPAddresses[0],
 		serverDevice.MACAddress,
+		info.vlan,
 	)
 	if offerErr != nil {
 		if debugLevel >= 1 {
@@ -512,6 +514,7 @@ func (h *DHCPHandler) handleDHCPRequest(
 		lease.IP,
 		serverDevice.IPAddresses[0],
 		serverDevice.MACAddress,
+		info.vlan,
 	)
 	if ackErr != nil {
 		if debugLevel >= 1 {
@@ -638,8 +641,9 @@ func (h *DHCPHandler) SendDHCPOffer(
 	clientMAC net.HardwareAddr,
 	offeredIP, serverIP net.IP,
 	serverMAC net.HardwareAddr,
+	vlan int,
 ) error {
-	return h.sendDHCPResponse(xid, clientMAC, offeredIP, serverIP, serverMAC, DHCPOffer)
+	return h.sendDHCPResponse(xid, clientMAC, offeredIP, serverIP, serverMAC, DHCPOffer, vlan)
 }
 
 // SendDHCPAck sends a DHCP Ack message.
@@ -648,8 +652,9 @@ func (h *DHCPHandler) SendDHCPAck(
 	clientMAC net.HardwareAddr,
 	assignedIP, serverIP net.IP,
 	serverMAC net.HardwareAddr,
+	vlan int,
 ) error {
-	return h.sendDHCPResponse(xid, clientMAC, assignedIP, serverIP, serverMAC, DHCPAck)
+	return h.sendDHCPResponse(xid, clientMAC, assignedIP, serverIP, serverMAC, DHCPAck, vlan)
 }
 
 // buildDHCPOptions constructs the DHCP options for a response.
@@ -799,6 +804,7 @@ func (h *DHCPHandler) sendDHCPResponse(
 	assignedIP, serverIP net.IP,
 	serverMAC net.HardwareAddr,
 	msgType uint8,
+	vlan int,
 ) error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -820,7 +826,7 @@ func (h *DHCPHandler) sendDHCPResponse(
 	}
 	dhcp.Options = h.buildDHCPOptions(msgType, serverIP, clientMAC)
 
-	return h.serializeAndSendDHCP(dhcp, serverIP, serverMAC)
+	return h.serializeAndSendDHCP(dhcp, serverIP, serverMAC, vlan)
 }
 
 // serializeAndSendDHCP serializes and sends a DHCP packet.
@@ -828,6 +834,7 @@ func (h *DHCPHandler) serializeAndSendDHCP(
 	dhcp *layers.DHCPv4,
 	serverIP net.IP,
 	serverMAC net.HardwareAddr,
+	vlan int,
 ) error {
 	udp := &layers.UDP{SrcPort: dhcpServerPort, DstPort: dhcpClientPort}
 	ip := &layers.IPv4{
@@ -848,7 +855,7 @@ func (h *DHCPHandler) serializeAndSendDHCP(
 		return fmt.Errorf("failed to serialize DHCP response: %w", err)
 	}
 
-	return h.stack.SendRawPacket(buf.Bytes())
+	return h.stack.SendRawPacketVLAN(buf.Bytes(), vlan)
 }
 
 // encodeUint32 encodes a uint32 as big-endian bytes.

--- a/internal/protocols/dns_nbstat.go
+++ b/internal/protocols/dns_nbstat.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (h *DNSHandler) handleNBSTATQuery(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	udpLayer *layers.UDP,
 	serverDevice *config.Device,
@@ -43,6 +43,7 @@ func (h *DNSHandler) handleNBSTATQuery(
 		payload,
 		[]byte(serverDevice.MACAddress),
 		[]byte(dstMAC),
+		reqPkt.VLAN,
 	)
 }
 

--- a/internal/protocols/export_test.go
+++ b/internal/protocols/export_test.go
@@ -392,7 +392,7 @@ func (h *ICMPHandler) SendEchoReply(
 	payload []byte,
 	device *config.Device,
 ) error {
-	return h.sendEchoReply(srcMAC, dstMAC, srcIP, dstIP, id, seq, payload, device)
+	return h.sendEchoReply(srcMAC, dstMAC, srcIP, dstIP, id, seq, payload, device, 0)
 }
 
 // ---- ICMPv6Handler exports ----

--- a/internal/protocols/icmp.go
+++ b/internal/protocols/icmp.go
@@ -444,6 +444,7 @@ func (h *ICMPHandler) handleEchoRequest(
 			icmp.Seq,
 			icmp.Payload,
 			device,
+			pkt.VLAN,
 		)
 		if err != nil {
 			if debugLevel >= DebugLevelInfo {
@@ -467,6 +468,7 @@ func (h *ICMPHandler) sendEchoReply(
 	id, seq uint16,
 	payload []byte,
 	device *config.Device,
+	vlan int,
 ) error {
 	// Get TTL from config, or use default
 	ttl := defaultTTLIPv4
@@ -527,6 +529,7 @@ func (h *ICMPHandler) sendEchoReply(
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         vlan, // reply on the VLAN the echo request arrived on
 	}
 
 	h.stack.Send(pkt)

--- a/internal/protocols/netbios.go
+++ b/internal/protocols/netbios.go
@@ -261,7 +261,7 @@ func getFirstIPv4(ips []net.IP) net.IP {
 
 // sendNameQueryResponse sends a NetBIOS name query response.
 func (h *NetBIOSHandler) sendNameQueryResponse(
-	_ *Packet,
+	reqPkt *Packet,
 	transactionID uint16,
 	name string,
 	nameType byte,
@@ -339,6 +339,7 @@ func (h *NetBIOSHandler) sendNameQueryResponse(
 		buf.Bytes(),
 		srcMAC,
 		dstMAC,
+		reqPkt.VLAN,
 	)
 }
 

--- a/internal/protocols/protocols_bench_test.go
+++ b/internal/protocols/protocols_bench_test.go
@@ -283,7 +283,7 @@ func BenchmarkDHCPOfferGeneration(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		_ = handler.SendDHCPOffer(0x12345678, clientMAC, offeredIP, serverIP, serverMAC)
+		_ = handler.SendDHCPOffer(0x12345678, clientMAC, offeredIP, serverIP, serverMAC, 0)
 	}
 }
 
@@ -306,7 +306,7 @@ func BenchmarkDHCPAckGeneration(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		_ = handler.SendDHCPAck(0x12345678, clientMAC, assignedIP, serverIP, serverMAC)
+		_ = handler.SendDHCPAck(0x12345678, clientMAC, assignedIP, serverIP, serverMAC, 0)
 	}
 }
 
@@ -354,9 +354,9 @@ func BenchmarkDHCPFullCycle(b *testing.B) {
 		lease, _ := handler.AllocateLease(clientMAC, nil, "test-host")
 		if lease != nil {
 			// Send OFFER
-			_ = handler.SendDHCPOffer(uint32(i), clientMAC, lease.IP, serverIP, serverMAC)
+			_ = handler.SendDHCPOffer(uint32(i), clientMAC, lease.IP, serverIP, serverMAC, 0)
 			// Send ACK (REQUEST/ACK)
-			_ = handler.SendDHCPAck(uint32(i), clientMAC, lease.IP, serverIP, serverMAC)
+			_ = handler.SendDHCPAck(uint32(i), clientMAC, lease.IP, serverIP, serverMAC, 0)
 		}
 	}
 }

--- a/internal/protocols/snmp.go
+++ b/internal/protocols/snmp.go
@@ -155,6 +155,7 @@ func (h *SNMPHandler) sendResponse(
 		uint16(udp.DstPort), uint16(udp.SrcPort),
 		payload,
 		[]byte(srcMAC), []byte(dstMAC),
+		pkt.VLAN,
 	)
 	if err != nil && h.stack.GetProtocolDebugLevel(logging.ProtocolSNMP) >= 1 {
 		_, _ = fmt.Fprintf(os.Stdout,

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -274,8 +274,15 @@ func (s *Stack) Send(pkt *Packet) {
 	}
 }
 
-// SendRawPacket queues raw bytes as a packet for sending.
+// SendRawPacket queues raw bytes as a packet for sending (untagged).
 func (s *Stack) SendRawPacket(data []byte) error {
+	return s.SendRawPacketVLAN(data, 0)
+}
+
+// SendRawPacketVLAN queues raw bytes as a packet, tagging it onto vlan (1..4094)
+// so the reply lands on the same VLAN the request arrived on. vlan <= 0 sends
+// untagged.
+func (s *Stack) SendRawPacketVLAN(data []byte, vlan int) error {
 	s.mu.Lock()
 	s.serialNumber++
 	serialNum := s.serialNumber
@@ -285,6 +292,7 @@ func (s *Stack) SendRawPacket(data []byte) error {
 		Buffer:       data,
 		Length:       len(data),
 		SerialNumber: serialNum,
+		VLAN:         vlan,
 	}
 
 	s.Send(pkt)

--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -289,7 +289,15 @@ func (s *Stack) sendPacket(pkt *Packet) {
 		pkt.Length = len(pkt.Buffer)
 	}
 
-	err := s.capture.SendPacket(pkt.Buffer[:pkt.Length])
+	// Tag replies onto the VLAN their request arrived on, so a trunk-attached
+	// tester (e.g. a CyberScope tagging into VLAN 210) accepts them. Untagged
+	// requests carry VLAN <= 0 and insertDot1Q leaves the frame unchanged.
+	frame := pkt.Buffer[:pkt.Length]
+	if pkt.VLAN > 0 {
+		frame = insertDot1Q(frame, pkt.VLAN)
+	}
+
+	err := s.capture.SendPacket(frame)
 	if err != nil {
 		if s.debugConfig.GetGlobal() >= DebugLevelInfo {
 			_, _ = fmt.Fprintf(os.Stdout, "Error sending packet sn=%d: %v\n", pkt.SerialNumber, err)

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -170,6 +170,7 @@ func (h *UDPHandler) proxyToMap(device *config.Device, ipLayer *layers.IPv4, udp
 			buf[:n],
 			[]byte(srcMAC),
 			[]byte(dstMAC),
+			pkt.VLAN,
 		)
 	}()
 }
@@ -180,6 +181,7 @@ func (h *UDPHandler) SendUDP(
 	srcPort, dstPort uint16,
 	payload []byte,
 	srcMAC, dstMAC []byte,
+	vlan int,
 ) error {
 	// Build Ethernet header
 	eth := &layers.Ethernet{
@@ -233,6 +235,7 @@ func (h *UDPHandler) SendUDP(
 		Buffer:       buffer.Bytes(),
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
+		VLAN:         vlan, // reply on the VLAN the request arrived on
 	}
 
 	h.stack.Send(pkt)

--- a/internal/protocols/vlan.go
+++ b/internal/protocols/vlan.go
@@ -1,0 +1,37 @@
+package protocols
+
+import "encoding/binary"
+
+// 802.1Q VLAN tag constants.
+const (
+	ethMACsLen      = 12     // dst MAC (6) + src MAC (6)
+	ethHeaderLen    = 14     // MACs + EtherType
+	dot1qTPID       = 0x8100 // 802.1Q Tag Protocol Identifier
+	dot1qTagLen     = 4      // TPID (2) + TCI (2)
+	vlanIDMax       = 4094   // valid VLAN IDs are 1..4094
+	dot1qVLANIDMask = 0x0FFF // low 12 bits of the TCI carry the VLAN ID
+)
+
+// insertDot1Q returns frame with an 802.1Q VLAN tag inserted after the source
+// MAC (priority 0, DEI 0). It is a no-op when the frame is too short, the VLAN
+// ID is out of range (valid 1..4094), or the frame already carries a tag — so it
+// is safe to call unconditionally on any reply frame. The input slice is never
+// mutated.
+func insertDot1Q(frame []byte, vlanID int) []byte {
+	if len(frame) < ethHeaderLen || vlanID <= 0 || vlanID > vlanIDMax {
+		return frame
+	}
+	if binary.BigEndian.Uint16(frame[ethMACsLen:]) == dot1qTPID {
+		return frame // already tagged; do not double-tag
+	}
+
+	tci := uint16(vlanID) & dot1qVLANIDMask
+
+	tagged := make([]byte, len(frame)+dot1qTagLen)
+	copy(tagged, frame[:ethMACsLen])
+	binary.BigEndian.PutUint16(tagged[ethMACsLen:], dot1qTPID)
+	binary.BigEndian.PutUint16(tagged[ethMACsLen+2:], tci)
+	copy(tagged[ethMACsLen+dot1qTagLen:], frame[ethMACsLen:])
+
+	return tagged
+}

--- a/internal/protocols/vlan_test.go
+++ b/internal/protocols/vlan_test.go
@@ -1,0 +1,80 @@
+package protocols
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+// untaggedFrame builds a minimal Ethernet+ARP frame (EtherType 0x0806).
+func untaggedFrame(t *testing.T) []byte {
+	t.Helper()
+	eth := &layers.Ethernet{
+		SrcMAC:       []byte{0x02, 0, 0, 0, 0, 0x01},
+		DstMAC:       []byte{0x02, 0, 0, 0, 0, 0x02},
+		EthernetType: layers.EthernetTypeARP,
+	}
+	arp := &layers.ARP{
+		AddrType: layers.LinkTypeEthernet, Protocol: layers.EthernetTypeIPv4,
+		HwAddressSize: 6, ProtAddressSize: 4, Operation: layers.ARPReply,
+		SourceHwAddress: []byte{0x02, 0, 0, 0, 0, 0x01}, SourceProtAddress: []byte{10, 0, 0, 1},
+		DstHwAddress: []byte{0x02, 0, 0, 0, 0, 0x02}, DstProtAddress: []byte{10, 0, 0, 2},
+	}
+	buf := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, eth, arp); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestInsertDot1QTagsFrame(t *testing.T) {
+	frame := untaggedFrame(t)
+	tagged := insertDot1Q(frame, 210)
+
+	if len(tagged) != len(frame)+4 {
+		t.Fatalf("tagged len = %d, want %d", len(tagged), len(frame)+4)
+	}
+	// MACs preserved.
+	if !bytes.Equal(tagged[:12], frame[:12]) {
+		t.Error("MAC header not preserved")
+	}
+	// Decode and confirm the tag round-trips with the right VLAN + inner type.
+	pkt := gopacket.NewPacket(tagged, layers.LayerTypeEthernet, gopacket.Default)
+	dot1q, ok := pkt.Layer(layers.LayerTypeDot1Q).(*layers.Dot1Q)
+	if !ok {
+		t.Fatal("no Dot1Q layer after insert")
+	}
+	if dot1q.VLANIdentifier != 210 {
+		t.Errorf("VLAN = %d, want 210", dot1q.VLANIdentifier)
+	}
+	if dot1q.Type != layers.EthernetTypeARP {
+		t.Errorf("inner type = %v, want ARP", dot1q.Type)
+	}
+	if pkt.Layer(layers.LayerTypeARP) == nil {
+		t.Error("ARP payload lost after tagging")
+	}
+}
+
+func TestInsertDot1QNoOps(t *testing.T) {
+	frame := untaggedFrame(t)
+	cases := []struct {
+		name string
+		vlan int
+		in   []byte
+	}{
+		{"vlan zero", 0, frame},
+		{"vlan too big", 5000, frame},
+		{"frame too short", 210, frame[:8]},
+		{"already tagged", 210, insertDot1Q(frame, 100)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := insertDot1Q(tc.in, tc.vlan)
+			if len(out) != len(tc.in) {
+				t.Errorf("expected no-op, len changed %d -> %d", len(tc.in), len(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

NIAC parses incoming 802.1Q tags but built every reactive reply untagged
(only gratuitous ARP was tagged, by device VLAN). A trunk-attached tester —
e.g. a NetAlly CyberScope tagging into VLAN 210/220/230 to discover each
subnet — will not accept untagged replies, so multi-VLAN discovery only
worked on the native VLAN.

This echoes the VLAN a request arrived on back onto its reply:

- `insertDot1Q()` splices an 802.1Q tag into a serialized frame (no-op when
  the frame is too short, the VLAN is out of range, or it is already tagged).
- `sendPacket()` splices centrally when `pkt.VLAN > 0` — one transmit
  chokepoint tags every reply queued with a VLAN.
- Reply builders copy the request VLAN onto the reply packet: ARP, ICMP echo,
  all UDP replies (SNMP/DNS/NetBIOS/generic via `SendUDP`), and DHCP
  OFFER/ACK (via new `SendRawPacketVLAN` + `dhcpPacketInfo.vlan`).

No routing/forwarding is added — each simulated device simply answers on the
VLAN it was asked on, which is what a trunk-attached discovery tool needs.
Untagged requests carry `VLAN <= 0`, so `insertDot1Q` leaves them unchanged;
native-VLAN / access-port behaviour is unaffected.

Unblocks the multi-VLAN NIAC demo topology that mirrors the GNS3 CyberScope
lab (per-site VLANs 200/210/220/230 on one trunk).

## Linked Issue

Related to #849

## Testing Evidence

```
$ go test ./internal/protocols/
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols

$ golangci-lint run ./internal/protocols/
0 issues.
```

`TestInsertDot1QTagsFrame` decodes the tagged frame back with gopacket and
asserts VLAN 210 + preserved inner EtherType/payload (wire-format correct per
an independent decoder). `TestInsertDot1QNoOps` covers the no-op guards.
End-to-end tag echo (tester on a tagged VLAN) is validated on the wire during
the multi-VLAN lab deployment, where the trunk exists — CT304's current port
is an access port that strips tags, so it cannot exercise the tagged path.

## Security and Release Checklist

- [x] `make lint` clean on touched package (0 issues)
- [x] No new external input trust; VLAN ID bounded to 1..4094 before use
- [x] No default creds / no new network exposure
- [x] Feature branch, conventional commit, PR-based
