### PR TITLE
feat(protocols): tag CDP/LLDP/FDP/EDP advertisements onto the device VLAN

### DIFF
--- a/internal/protocols/discovery_helpers.go
+++ b/internal/protocols/discovery_helpers.go
@@ -128,6 +128,7 @@ func sendDiscoveryFrame(dstMACString string, device *config.Device, payload []by
 		Length:       len(frame),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         device.VLAN, // advertise on the device's access VLAN
 	}
 
 	stack.Send(pkt)

--- a/internal/protocols/edp.go
+++ b/internal/protocols/edp.go
@@ -329,6 +329,7 @@ func (h *EDPHandler) sendFrame(device *config.Device, edpPayload []byte) {
 		Length:       len(frame),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         device.VLAN, // advertise on the device's access VLAN
 	}
 
 	h.stack.Send(pkt)

--- a/internal/protocols/lldp.go
+++ b/internal/protocols/lldp.go
@@ -559,6 +559,7 @@ func (h *LLDPHandler) sendFrame(device *config.Device, lldpPayload []byte) error
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         device.VLAN, // advertise on the device's access VLAN
 	}
 
 	h.stack.Send(pkt)


### PR DESCRIPTION
## Summary

Proactive CDP/LLDP/FDP/EDP advertisements were emitted untagged, so a device
on a non-native VLAN advertised on the wrong VLAN and a trunk-attached tester
scanning that VLAN would never hear it. Sets `pkt.VLAN = device.VLAN` on the
advertisement packets so the central `sendPacket` splice (from #859) tags them:

- CDP + FDP via the shared `sendDiscoveryFrame`
- LLDP and EDP in their own `sendFrame`

`insertDot1Q` handles the 802.3/LLC discovery frames correctly — it inserts the
tag ahead of the length field and preserves it. `device.VLAN == 0` (WAN/native)
stays untagged.

Completes multi-VLAN behaviour started in #859: both reactive replies and
proactive L2 discovery frames now ride the correct VLAN, so a CyberScope tagging
into each of VLANs 200/210/220/230 both hears live discovery frames and gets
SNMP/ICMP answers there.

## Linked Issue

Related to #849

## Testing Evidence

```
$ go build ./internal/protocols/ && go test ./internal/protocols/
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols

$ golangci-lint run ./internal/protocols/
0 issues.
```

Uses the same tag-splice path unit-tested in #859 (`TestInsertDot1Q*`,
including an 802.3 already-tagged/short-frame no-op case). End-to-end per-VLAN
advertisement visibility is validated on the wire during the multi-VLAN lab
deployment (needs the trunk).

## Security and Release Checklist

- [x] `make lint` clean on touched package (0 issues)
- [x] No new external input trust; VLAN bounded in insertDot1Q
- [x] No default creds / no new exposure
- [x] Feature branch, conventional commit, PR-based
