### PR TITLE
feat(snmp): authored trunk_ports topology wins over walk neighbour tables

### DIFF
--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -176,27 +176,65 @@ func (a *Agent) LoadWalkFile(filename string) error {
 		return fmt.Errorf("%w: %w", ErrFailedToParseWalkFile, err)
 	}
 
-	// Add all entries to MIB
+	// When a device declares topology links (trunk_ports), NIAC synthesizes the
+	// neighbour/forwarding tables from them (see initializeNeighborMIBs, run at
+	// construction). A capture walk carries the *original* device's neighbours,
+	// which are foreign to this lab — so skip those tables on load and let the
+	// authored topology win. Without trunk_ports the walk's data stands.
+	skipTopology := a.ownsSynthesizedTopology()
+
+	loaded, skipped := 0, 0
 	for _, entry := range entries {
+		if skipTopology && isSynthesizedTopologyOID(entry.OID) {
+			skipped++
+
+			continue
+		}
 		a.mib.Set(entry.OID, &OIDValue{
 			Type:  entry.Type,
 			Value: entry.Value,
 		})
+		loaded++
 	}
 
 	if a.debugLevel >= 1 {
 		a.logger.Debug(
 			"Loaded OIDs from walk file",
-			"count",
-			len(entries),
-			"filename",
-			filename,
-			"device",
-			a.device.Name,
+			"count", loaded,
+			"skipped_topology", skipped,
+			"filename", filename,
+			"device", a.device.Name,
 		)
 	}
 
 	return nil
+}
+
+// ownsSynthesizedTopology reports whether this device's topology is authored
+// via trunk_ports (in which case walk topology tables are skipped).
+func (a *Agent) ownsSynthesizedTopology() bool {
+	return a.device != nil && len(a.device.TrunkPorts) > 0
+}
+
+// isSynthesizedTopologyOID reports whether oid falls under a MIB subtree that
+// trunk_ports synthesis owns — LLDP remote systems, CDP cache, and the bridge
+// forwarding DB — and so must not be loaded from a capture walk. Handles the
+// optional leading dot in walk OIDs.
+func isSynthesizedTopologyOID(oid string) bool {
+	prefixes := []string{
+		lldpRemoteSystemsData, // 1.0.8802.1.1.2.1.4 — LLDP-MIB neighbours
+		cdpCache,              // 1.3.6.1.4.1.9.9.23.1.2 — CDP cache neighbours
+		dot1dTpFdbTable,       // 1.3.6.1.2.1.17.4.3 — bridge MAC→port
+	}
+
+	trimmed := strings.TrimPrefix(oid, ".")
+	for _, prefix := range prefixes {
+		if trimmed == prefix || strings.HasPrefix(trimmed, prefix+".") {
+			return true
+		}
+	}
+
+	return false
 }
 
 // HandleGet processes an SNMP GET request.

--- a/internal/protocols/snmp/walk_topology_test.go
+++ b/internal/protocols/snmp/walk_topology_test.go
@@ -1,0 +1,91 @@
+package snmp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// topoWalk mixes device-content OIDs with the topology tables a capture carries
+// from its *original* neighbours (LLDP remote, CDP cache, bridge FDB).
+const topoWalk = `.1.3.6.1.2.1.2.2.1.2.1 = STRING: "GigabitEthernet1/0/1"
+.1.0.8802.1.1.2.1.3.7.1.3.1 = STRING: "Gi1/0/1"
+.1.0.8802.1.1.2.1.4.1.1.9.1.1 = STRING: "foreign-lldp-neighbor"
+.1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1 = STRING: "foreign-cdp-device"
+.1.3.6.1.2.1.17.4.3.1.2.1.2.3.4.5.6 = INTEGER: 5
+`
+
+func TestIsSynthesizedTopologyOID(t *testing.T) {
+	strip := []string{
+		"1.0.8802.1.1.2.1.4",                  // lldpRemoteSystemsData root
+		".1.0.8802.1.1.2.1.4.1.1.9.1.1",       // lldpRemTable entry (leading dot)
+		".1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1",   // cdpCacheTable entry
+		".1.3.6.1.2.1.17.4.3.1.2.1.2.3.4.5.6", // dot1dTpFdbTable entry
+	}
+	keep := []string{
+		".1.3.6.1.2.1.2.2.1.2.1",      // ifDescr (device content)
+		".1.0.8802.1.1.2.1.3.7.1.3.1", // LLDP *local* port — not a neighbour
+		".1.3.6.1.2.1.1.5.0",          // sysName
+	}
+	for _, oid := range strip {
+		if !isSynthesizedTopologyOID(oid) {
+			t.Errorf("%s should be a synthesized-topology OID", oid)
+		}
+	}
+	for _, oid := range keep {
+		if isSynthesizedTopologyOID(oid) {
+			t.Errorf("%s should NOT be stripped", oid)
+		}
+	}
+}
+
+// TestLoadWalkFileStripsTopologyWhenTrunkPortsDeclared: a device that authors
+// its links (trunk_ports) drops the walk's foreign neighbour/FDB tables so the
+// synthesized topology wins; device content survives either way.
+func TestLoadWalkFileStripsTopologyWhenTrunkPortsDeclared(t *testing.T) {
+	load := func(withTrunks bool) *Agent {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "t.walk")
+		if err := os.WriteFile(p, []byte(topoWalk), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		dev := createTestDevice()
+		if withTrunks {
+			dev.TrunkPorts = []config.TrunkPort{
+				{Interface: "Gi1/0/1", RemoteDevice: "core-01", RemoteInterface: "Gi1/0/24"},
+			}
+		}
+		a := NewAgent(dev, 0)
+		if err := a.LoadWalkFile(p); err != nil {
+			t.Fatalf("LoadWalkFile: %v", err)
+		}
+		return a
+	}
+
+	const (
+		lldpRem = ".1.0.8802.1.1.2.1.4.1.1.9.1.1"
+		cdpCch  = ".1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1"
+		ifDescr = ".1.3.6.1.2.1.2.2.1.2.1"
+	)
+
+	// Without trunk_ports: walk topology data is kept (backward compatible).
+	noTrunks := load(false)
+	if v, _ := noTrunks.HandleGet(lldpRem); v == nil {
+		t.Error("without trunk_ports, the walk LLDP neighbour should be loaded")
+	}
+
+	// With trunk_ports: foreign topology tables are skipped.
+	trunks := load(true)
+	if v, _ := trunks.HandleGet(lldpRem); v != nil {
+		t.Errorf("with trunk_ports, walk LLDP neighbour must be skipped, got %v", v.Value)
+	}
+	if v, _ := trunks.HandleGet(cdpCch); v != nil {
+		t.Errorf("with trunk_ports, walk CDP cache must be skipped, got %v", v.Value)
+	}
+	// Device content survives the strip.
+	if v, _ := trunks.HandleGet(ifDescr); v == nil {
+		t.Error("ifDescr (device content) must survive the topology strip")
+	}
+}


### PR DESCRIPTION
## Summary

`walk = device content, trunk_ports = topology` — the load-bearing half.

A capture walk carries the original device's LLDP-remote / CDP-cache / bridge-FDB
tables (foreign neighbours a discovery tool would draw as phantom links). NIAC
already synthesizes those tables from a device's declared `trunk_ports`
(`initializeNeighborMIBs`), but `LoadWalkFile` ran afterwards and overwrote them.

Now, when a device declares `trunk_ports`, `LoadWalkFile` skips the walk's
synthesized-topology subtrees — `lldpRemoteSystemsData` (1.0.8802.1.1.2.1.4),
`cdpCache` (9.9.23.1.2), `dot1dTpFdbTable` (1.3.6.1.2.1.17.4.3) — so authored
topology wins. Device content (ifTable, entity, system, LLDP *local* data) is
untouched; devices without `trunk_ports` keep walk data as before.

## Linked Issue

Related to #849

## Testing Evidence

```
$ go test ./internal/protocols/snmp/ -run Topology
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp

$ golangci-lint run ./internal/protocols/snmp/
0 issues.
```

`TestIsSynthesizedTopologyOID` covers the prefix match (incl. LLDP local kept).
`TestLoadWalkFileStripsTopologyWhenTrunkPortsDeclared` proves: no trunk_ports →
walk neighbours kept; with trunk_ports → LLDP/CDP neighbours skipped, ifDescr
survives.

## Security and Release Checklist

- [x] `make lint` clean on touched package (0 issues)
- [x] No behaviour change for configs without trunk_ports (backward compatible)
- [x] No new external input / creds
- [x] Feature branch, conventional commit, PR-based
