### PR TITLE
feat(snmp): device sysName is authored, never from the walk

### DIFF
--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -185,6 +185,15 @@ func (a *Agent) LoadWalkFile(filename string) error {
 
 	loaded, skipped := 0, 0
 	for _, entry := range entries {
+		// A device's identity (sysName) is authored from its config name, not the
+		// captured device's name — otherwise every device sharing a walk collides
+		// under one name and a discovery tool merges them. sysDescr/location stay
+		// as the walk's authentic values.
+		if isAuthoredSysNameOID(entry.OID) {
+			skipped++
+
+			continue
+		}
 		if skipTopology && isSynthesizedTopologyOID(entry.OID) {
 			skipped++
 
@@ -208,6 +217,16 @@ func (a *Agent) LoadWalkFile(filename string) error {
 	}
 
 	return nil
+}
+
+// sysNameOID is SNMPv2-MIB::sysName.0 — a device's administrative identity,
+// always authored from the config rather than the capture walk.
+const sysNameOID = "1.3.6.1.2.1.1.5.0"
+
+// isAuthoredSysNameOID reports whether oid is sysName.0 (with or without the
+// leading dot walks use).
+func isAuthoredSysNameOID(oid string) bool {
+	return strings.TrimPrefix(oid, ".") == sysNameOID
 }
 
 // ownsSynthesizedTopology reports whether this device's topology is authored

--- a/internal/protocols/snmp/walk_topology_test.go
+++ b/internal/protocols/snmp/walk_topology_test.go
@@ -10,7 +10,8 @@ import (
 
 // topoWalk mixes device-content OIDs with the topology tables a capture carries
 // from its *original* neighbours (LLDP remote, CDP cache, bridge FDB).
-const topoWalk = `.1.3.6.1.2.1.2.2.1.2.1 = STRING: "GigabitEthernet1/0/1"
+const topoWalk = `.1.3.6.1.2.1.1.5.0 = STRING: "captured-device-name"
+.1.3.6.1.2.1.2.2.1.2.1 = STRING: "GigabitEthernet1/0/1"
 .1.0.8802.1.1.2.1.3.7.1.3.1 = STRING: "Gi1/0/1"
 .1.0.8802.1.1.2.1.4.1.1.9.1.1 = STRING: "foreign-lldp-neighbor"
 .1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1 = STRING: "foreign-cdp-device"
@@ -87,5 +88,30 @@ func TestLoadWalkFileStripsTopologyWhenTrunkPortsDeclared(t *testing.T) {
 	// Device content survives the strip.
 	if v, _ := trunks.HandleGet(ifDescr); v == nil {
 		t.Error("ifDescr (device content) must survive the topology strip")
+	}
+}
+
+// TestLoadWalkFileSkipsWalkSysName: the device keeps its configured identity;
+// the capture's sysName never wins (else same-walk devices collide as one node).
+func TestLoadWalkFileSkipsWalkSysName(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "t.walk")
+	if err := os.WriteFile(p, []byte(topoWalk), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dev := createTestDevice() // has a configured Name
+	agent := NewAgent(dev, 0)
+	if err := agent.LoadWalkFile(p); err != nil {
+		t.Fatalf("LoadWalkFile: %v", err)
+	}
+
+	got, _ := agent.HandleGet(".1.3.6.1.2.1.1.5.0")
+	if got == nil {
+		t.Fatal("sysName missing")
+	}
+	if s, _ := got.Value.(string); s == "captured-device-name" {
+		t.Error("walk sysName leaked; device identity must win")
+	}
+	if s, _ := got.Value.(string); s != dev.Name {
+		t.Errorf("sysName = %q, want configured name %q", s, dev.Name)
 	}
 }


### PR DESCRIPTION
## Summary
Extends "config authors identity, walk provides content" to sysName.0. A walk carries the original device name; loading it collapsed every device sharing a walk to one name (a discovery tool merged them) and neighbours synthesized from trunk_ports referenced names no device claimed. LoadWalkFile now always skips walk sysName.0 so the configured name wins; sysDescr/location stay authentic.

## Linked Issue
Related to #849

## Testing Evidence
```
go test ./internal/protocols/snmp/  -> ok (walk_replay sysDescr test still green)
golangci-lint run ./internal/protocols/snmp/ -> 0 issues
```
TestLoadWalkFileSkipsWalkSysName proves the configured name wins over the walk.

## Security and Release Checklist
- [x] lint clean
- [x] no behaviour change to sysDescr/other groups
- [x] feature branch, conventional commit, PR
