### PR TITLE
fix(stack): received packets must not alias the reused capture buffer

### DIFF
--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -55,7 +56,15 @@ func (s *Stack) receiveAndQueuePacket(buffer []byte) {
 }
 
 // parseReceivedPacket parses received data into a Packet, updating stats.
+//
+// The incoming slice aliases a capture buffer that ReadPacket reuses on the
+// next read. The returned Packet is queued onto a channel and decoded by a
+// separate goroutine, so it must own its bytes; otherwise the next read
+// corrupts still-in-flight packets — a data race that torn-reads every
+// handler's header parsing. Clone at this ownership boundary.
 func (s *Stack) parseReceivedPacket(data []byte) *Packet {
+	data = bytes.Clone(data)
+
 	s.mu.Lock()
 	s.serialNumber++
 	serialNum := s.serialNumber

--- a/internal/protocols/stack_threads_test.go
+++ b/internal/protocols/stack_threads_test.go
@@ -1,0 +1,34 @@
+package protocols
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestParseReceivedPacketOwnsBuffer verifies a received packet does not alias
+// the reusable capture buffer. ReadPacket hands back a slice of a buffer that
+// the receive loop overwrites on the next read; the packet is decoded on
+// another goroutine, so it must own its bytes or in-flight packets get
+// corrupted (a data race across every handler).
+func TestParseReceivedPacketOwnsBuffer(t *testing.T) {
+	s := &Stack{stats: &Statistics{}}
+
+	// A recognizable "first packet" living in a reusable buffer.
+	shared := bytes.Repeat([]byte{0xAB}, 64)
+	snapshot := bytes.Clone(shared)
+
+	pkt := s.parseReceivedPacket(shared)
+	if pkt == nil {
+		t.Fatal("parseReceivedPacket returned nil")
+	}
+
+	// Simulate the receive loop reading the next packet into the same buffer.
+	for i := range shared {
+		shared[i] = 0xCD
+	}
+
+	if !bytes.Equal(pkt.Buffer, snapshot) {
+		t.Errorf("packet buffer was corrupted by a subsequent read: got %x…, want %x…",
+			pkt.Buffer[:4], snapshot[:4])
+	}
+}


### PR DESCRIPTION
## Summary

`receiveThread` reuses a single capture buffer; `parseReceivedPacket` stored `buffer[:n]` without copying. The packet is queued onto a channel and decoded on a separate goroutine, so under a burst (a CyberScope sweeping ARP+ICMP+SNMP at once) the receive loop laps the decode goroutine and overwrites still-in-flight packets — a data race that torn-reads every handler's header parsing and drops packets en masse. Clone at the ownership boundary in `parseReceivedPacket`.

Re-applies the lost #851 fix (commit d5f0e14 was never merged to main), rebased onto current main.

## Linked Issue

Related to #849. No dedicated issue.

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run ParseReceivedPacketOwnsBuffer   # ok
$ go test -race ./internal/protocols/                                # ok

Live (CT304): burst SNMP success went from ~0% to ~70%+; niac-java (no
buffer reuse) never exhibited this.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only receive path; no routes)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here)
