### PR TITLE
feat(dns): wildcard catch-all forward record

### DIFF
--- a/internal/protocols/dns_resolver.go
+++ b/internal/protocols/dns_resolver.go
@@ -105,7 +105,7 @@ func (h *DNSHandler) lookupHost(hostname string, set *dnsRecordSet) []dnsRecord 
 			}
 		}
 
-		return nil
+		return wildcardRecords(set.forward)
 	}
 
 	if recs, ok := h.records[hostname]; ok {
@@ -117,6 +117,20 @@ func (h *DNSHandler) lookupHost(hostname string, set *dnsRecordSet) []dnsRecord 
 		if recs, ok := h.records[fullname]; ok {
 			return recs
 		}
+	}
+
+	return wildcardRecords(h.records)
+}
+
+// dnsWildcardName is the catch-all forward record: a config record named "*"
+// resolves any otherwise-unmatched name. This lets a simulated resolver stand in
+// for "the whole internet" so a discovery tool's Internet-tier lookups succeed.
+const dnsWildcardName = "*"
+
+// wildcardRecords returns the catch-all record set, or nil if none is configured.
+func wildcardRecords(forward map[string][]dnsRecord) []dnsRecord {
+	if recs, ok := forward[dnsWildcardName]; ok {
+		return recs
 	}
 
 	return nil

--- a/internal/protocols/dns_wildcard_test.go
+++ b/internal/protocols/dns_wildcard_test.go
@@ -1,0 +1,41 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+)
+
+// TestDNSWildcardCatchAll: a "*" forward record resolves any otherwise-unmatched
+// name (so a simulated resolver can stand in for the whole internet), while exact
+// records still win and absence of a wildcard still yields no answer (NXDOMAIN).
+func TestDNSWildcardCatchAll(t *testing.T) {
+	h := &DNSHandler{
+		domain: "demo.lab",
+		records: map[string][]dnsRecord{
+			"gw.demo.lab":   {{ip: net.ParseIP("10.10.200.1")}},
+			dnsWildcardName: {{ip: net.ParseIP("8.8.8.8")}},
+		},
+	}
+
+	// Exact match wins over the wildcard.
+	if r := h.lookupHost("gw.demo.lab", nil); len(r) != 1 || !r[0].ip.Equal(net.ParseIP("10.10.200.1")) {
+		t.Errorf("exact match failed: %v", r)
+	}
+
+	// Unmatched internet name falls back to the wildcard.
+	for _, name := range []string{"www.google.com", "connectivitycheck.gstatic.com", "anything.example"} {
+		r := h.lookupHost(name, nil)
+		if len(r) != 1 || !r[0].ip.Equal(net.ParseIP("8.8.8.8")) {
+			t.Errorf("wildcard fallback for %q failed: %v", name, r)
+		}
+	}
+
+	// Without a wildcard, an unmatched name still resolves to nothing.
+	noWild := &DNSHandler{
+		domain:  "demo.lab",
+		records: map[string][]dnsRecord{"host.demo.lab": {{ip: net.ParseIP("10.0.0.9")}}},
+	}
+	if r := noWild.lookupHost("nope.example", nil); r != nil {
+		t.Errorf("expected no answer without a wildcard, got %v", r)
+	}
+}


### PR DESCRIPTION
## Summary

A forward record named `*` resolves any otherwise-unmatched name instead of returning NXDOMAIN, so a simulated DNS server can stand in for the whole internet — a discovery tool's Internet-tier DNS lookups then succeed against the isolated lab. Exact records still win; absent a wildcard, unmatched names still NXDOMAIN (unchanged).

## Linked Issue

Related to #849. No dedicated issue.

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run DNS   # ok (wildcard + exact-match precedence + NXDOMAIN)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only DNS response path)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here)
