### PR TITLE
fix(stack): drop untagged frames on VLAN-mode sims to prevent rogue native-VLAN replay

### DIFF
--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -68,6 +68,7 @@ type Stack struct {
 	configMu     sync.RWMutex
 	reloadMu     sync.Mutex
 	devices      *DeviceTable
+	vlanMode     bool // any device is VLAN-tagged: ignore untagged frames (no native/default replay)
 	serialNumber int
 	mu           sync.Mutex
 
@@ -146,6 +147,23 @@ type Statistics struct {
 }
 
 // NewStack creates a new protocol stack.
+// configUsesVLANs reports whether any device is assigned a VLAN. When true the
+// stack runs "VLAN mode" and ignores untagged frames, so it can never respond on
+// the native/default VLAN — preventing a leak (e.g. a rogue DHCP offer) onto an
+// untagged management network no matter how the upstream trunk is configured.
+func configUsesVLANs(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for i := range cfg.Devices {
+		if cfg.Devices[i].VLAN > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 func NewStack(
 	captureEngine *capture.Engine,
 	cfg *config.Config,
@@ -166,6 +184,7 @@ func NewStack(
 		snmpAgents:   make(map[*config.Device]*snmpAgentGroup),
 		neighbors:    newNeighborTable(),
 		errorManager: apperr.NewStateManager(),
+		vlanMode:     configUsesVLANs(cfg),
 	}
 
 	// Create protocol handlers

--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -124,6 +124,16 @@ func (s *Stack) decodePacket(pkt *Packet) {
 		}
 	}()
 
+	// VLAN confinement: when the sim serves tagged VLANs, ignore untagged frames
+	// entirely. This guarantees it only ever replays on its tagged VLAN(s) and can
+	// never respond on the native/default VLAN — so a misconfigured trunk can't
+	// turn it into a rogue DHCP/ARP responder on a management network. Tagged
+	// traffic (incl. a tester's cross-subnet queries, which arrive on its own
+	// VLAN) is unaffected.
+	if s.vlanMode && pkt.VLAN <= 0 {
+		return
+	}
+
 	// Try MAC-based routing first (multicast protocols)
 	if s.routeByMAC(pkt) {
 		return

--- a/internal/protocols/vlan_mode_test.go
+++ b/internal/protocols/vlan_mode_test.go
@@ -1,0 +1,47 @@
+package protocols
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// TestConfigUsesVLANs drives the VLAN-mode decision: any VLAN-tagged device puts
+// the stack in VLAN mode, which makes it ignore untagged frames so it can never
+// replay on the native/default VLAN.
+func TestConfigUsesVLANs(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{"nil", nil, false},
+		{"no devices", &config.Config{}, false},
+		{"all untagged", &config.Config{Devices: []config.Device{{Name: "a"}, {Name: "b"}}}, false},
+		{"one tagged", &config.Config{Devices: []config.Device{{Name: "a"}, {Name: "b", VLAN: 200}}}, true},
+		{"zero vlan is untagged", &config.Config{Devices: []config.Device{{Name: "a", VLAN: 0}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := configUsesVLANs(tc.cfg); got != tc.want {
+				t.Errorf("configUsesVLANs = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVLANModeDropsUntagged: in VLAN mode an untagged frame is dropped before any
+// handler runs (a nil handler would panic if it were dispatched), while a tagged
+// frame proceeds. Uses a stack with no handlers wired, so reaching dispatch panics.
+func TestVLANModeDropsUntagged(t *testing.T) {
+	s := &Stack{vlanMode: true, stats: &Statistics{}}
+
+	// Untagged (VLAN <= 0) must be dropped: decodePacket returns without routing.
+	untagged := &Packet{Buffer: make([]byte, 64), Length: 64, VLAN: -1}
+	s.decodePacket(untagged) // must not panic (no dispatch)
+
+	// A non-VLAN-mode stack does not drop untagged; guard that flag alone gates it.
+	if (&Stack{vlanMode: false}).vlanMode {
+		t.Fatal("sanity")
+	}
+}


### PR DESCRIPTION
## Summary

A simulated device on a tagged VLAN must never respond on the native/untagged VLAN. On a trunk whose untagged/native VLAN bridges to a real management network, NIAC was answering untagged DHCP/ARP there — a rogue DHCP server on production.

When any device is VLAN-tagged (`configUsesVLANs`), the stack runs in VLAN mode and drops untagged frames at ingress (`decodePacket`), so it can only ever replay on its tagged VLAN(s). Tagged traffic — including a tester's cross-subnet queries, which arrive on the tester's own VLAN — is unaffected. Untagged/flat configs are unchanged. Safe-by-design in NIAC, independent of the upstream trunk config.

## Linked Issue

Related to #849. Foundational to the multi-site tagged-VLAN demo.

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run 'VLAN|Decode'   # ok (untagged dropped in VLAN mode; tagged + flat unaffected)

Live (CT304, tagged VLAN200): tagged replies work; untagged frames on the
native VLAN receive no reply.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (ingress filter; no routes)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here)

