### PR TITLE
feat(snmp): learn downstream host MACs into bridge FDB (Nearest Switch)

### DIFF
--- a/internal/protocols/snmp/constants.go
+++ b/internal/protocols/snmp/constants.go
@@ -151,6 +151,10 @@ const (
 	// FrameRateOutMultiplier is the multiplier for outgoing frame rate simulation.
 	FrameRateOutMultiplier = 80
 
+	// FDBStatusLearned is the FDB status for a dynamically learned entry
+	// (dot1dTpFdbStatus learned(3)) — a downstream host MAC seen on a port.
+	FDBStatusLearned = 3
+
 	// FDBStatusSelf is the FDB status for self entry.
 	FDBStatusSelf = 4
 

--- a/internal/protocols/snmp/mib.go
+++ b/internal/protocols/snmp/mib.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -78,6 +79,68 @@ func (m *MIB) Get(oid string) *OIDValue {
 	}
 
 	return value
+}
+
+// IndexSuffixForValue returns the trailing index of the OID under table (a
+// table-column prefix, e.g. ifDescr) whose value stringifies to want. When more
+// than one entry matches it returns the numerically largest index: a device with
+// both a real walk and trunk_ports carries the interface twice — the walk's real
+// ifIndex (Cisco convention, 10000+) and a small sequential synthesis index —
+// and the walk's is the one whose bridge port / ifName a manager renders.
+// Returns the suffix after "<table>." and true on a hit.
+func (m *MIB) IndexSuffixForValue(table, want string) (string, bool) {
+	table = strings.TrimPrefix(table, ".")
+	prefix := table + "."
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	best := ""
+	bestNum := -1
+	found := false
+
+	for oid, val := range m.entries {
+		if !strings.HasPrefix(oid, prefix) {
+			continue
+		}
+
+		v := val
+		if v.Dynamic != nil {
+			v = v.Dynamic()
+		}
+
+		if oidValueString(v) != want {
+			continue
+		}
+
+		suffix := strings.TrimPrefix(oid, prefix)
+		// Prefer the largest single-integer index; fall back to first match for
+		// non-numeric suffixes.
+		if n, err := strconv.Atoi(suffix); err == nil {
+			if n > bestNum {
+				bestNum, best = n, suffix
+			}
+		} else if !found {
+			best = suffix
+		}
+
+		found = true
+	}
+
+	return best, found
+}
+
+// oidValueString renders an OIDValue's payload as a string for comparison,
+// covering the string and []byte encodings a walk may load.
+func oidValueString(v *OIDValue) string {
+	switch t := v.Value.(type) {
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		return fmt.Sprintf("%v", v.Value)
+	}
 }
 
 // GetNext retrieves the next OID in lexicographical order.

--- a/internal/protocols/snmp/mib_if.go
+++ b/internal/protocols/snmp/mib_if.go
@@ -23,6 +23,16 @@ func (a *Agent) initializeIFMIB() {
 		return
 	}
 
+	// A capture walk carries the device's real interface table (ifIndex, names,
+	// counters). Synthesizing a second, sequential ifTable from trunk_ports on
+	// top of it duplicates interfaces under different indices — harmless when a
+	// device has one uplink, but it pollutes the interface list once downstream
+	// access ports are modelled. The walk owns IF-MIB; trunk_ports only drive the
+	// neighbour/forwarding topology (see initializeLLDPRemoteMIB, SynthesizePeerTopology).
+	if a.hasWalkContent() {
+		return
+	}
+
 	// Count interfaces from trunk_ports
 	numInterfaces := len(device.TrunkPorts)
 	if numInterfaces == 0 {

--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -1,0 +1,124 @@
+package snmp
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// PeerMACResolver returns the MAC bytes for a device name, and whether it is
+// known. The stack builds it from the full config roster — an agent alone only
+// knows its own device.
+type PeerMACResolver func(deviceName string) ([]byte, bool)
+
+// hasWalkContent reports whether this device is backed by a capture walk, which
+// then owns the IF-MIB / BRIDGE-MIB content that construction would otherwise
+// synthesize from trunk_ports.
+func (a *Agent) hasWalkContent() bool {
+	if a.device == nil {
+		return false
+	}
+
+	return a.device.SNMPConfig.WalkFile != "" || len(a.device.SNMPConfig.WalkFiles) > 0
+}
+
+// SynthesizePeerTopology fills in the bridge forwarding entries that let a
+// discovery tool answer "which switch/port is this host on" (NetAlly's Nearest
+// Switch). Construction seeds only a self FDB entry because a single agent does
+// not know its neighbours' MACs; here — after the fleet is loaded — each
+// trunk_port whose remote device resolves to a MAC becomes a learned FDB entry
+// on the port's bridge index, mapped through the walk's real ifIndex.
+//
+// Ports whose interface name is absent from the device's own walk (e.g. an
+// inter-switch uplink named for a chassis the walk doesn't model) are skipped:
+// those links already show via the CDP/LLDP neighbour tables; the FDB is for
+// attached hosts. Call after all MIB content is loaded, then Reindex.
+func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
+	if a == nil || a.device == nil || resolve == nil {
+		return
+	}
+
+	changed := false
+
+	for _, trunk := range a.device.TrunkPorts {
+		if trunk.RemoteDevice == "" || trunk.Interface == "" {
+			continue
+		}
+
+		mac, ok := resolve(trunk.RemoteDevice)
+		if !ok || len(mac) == 0 {
+			continue
+		}
+
+		bridgePort, ok := a.bridgePortForInterface(trunk.Interface)
+		if !ok {
+			continue
+		}
+
+		a.addLearnedFDBEntry(mac, bridgePort)
+		changed = true
+	}
+
+	if changed {
+		a.mib.Reindex()
+	}
+}
+
+// bridgePortForInterface resolves an interface name (e.g. "FastEthernet0/5") to
+// its bridge port number via the walk's ifTable and dot1dBasePortTable, so the
+// FDB port lines up with the real ifIndex/ifName a manager will render.
+func (a *Agent) bridgePortForInterface(name string) (int, bool) {
+	ifIndex, ok := a.mib.IndexSuffixForValue(ifDescr, name)
+	if !ok {
+		ifIndex, ok = a.mib.IndexSuffixForValue(ifName, name)
+	}
+
+	if !ok {
+		return 0, false
+	}
+
+	ifIndexNum, err := strconv.Atoi(ifIndex)
+	if err != nil {
+		return 0, false
+	}
+
+	// dot1dBasePortIfIndex maps bridge port -> ifIndex; invert it. Honour the
+	// capture's numbering where present so the port resolves to the real
+	// physical interface.
+	if port, found := a.mib.IndexSuffixForValue(dot1dBasePortIfIndex, ifIndex); found {
+		if n, convErr := strconv.Atoi(port); convErr == nil {
+			return n, true
+		}
+	}
+
+	// Captures often model only a few active bridge ports, so the interface may
+	// have no dot1dBasePort row. Add one keyed by the ifIndex (unique) mapping
+	// straight back to it, so FDB port -> dot1dBasePortIfIndex -> ifIndex ->
+	// ifName still resolves to the right interface.
+	a.mib.Set(dot1dBasePort+"."+ifIndex, &OIDValue{Type: gosnmp.Integer, Value: ifIndexNum})
+	a.mib.Set(dot1dBasePortIfIndex+"."+ifIndex, &OIDValue{Type: gosnmp.Integer, Value: ifIndexNum})
+
+	return ifIndexNum, true
+}
+
+// addLearnedFDBEntry registers a dot1dTpFdbTable learned entry: MAC seen on the
+// given bridge port.
+func (a *Agent) addLearnedFDBEntry(mac []byte, bridgePort int) {
+	idx := macBytesToOIDIndex(mac)
+
+	a.mib.Set(dot1dTpFdbAddress+"."+idx, &OIDValue{Type: gosnmp.OctetString, Value: mac})
+	a.mib.Set(dot1dTpFdbPort+"."+idx, &OIDValue{Type: gosnmp.Integer, Value: bridgePort})
+	a.mib.Set(dot1dTpFdbStatus+"."+idx, &OIDValue{Type: gosnmp.Integer, Value: FDBStatusLearned})
+}
+
+// macBytesToOIDIndex renders MAC bytes as the dotted-decimal OID index the
+// dot1dTpFdbTable is keyed by.
+func macBytesToOIDIndex(mac []byte) string {
+	parts := make([]string, len(mac))
+	for i, b := range mac {
+		parts[i] = strconv.Itoa(int(b))
+	}
+
+	return strings.Join(parts, ".")
+}

--- a/internal/protocols/snmp/peer_topology_test.go
+++ b/internal/protocols/snmp/peer_topology_test.go
@@ -1,0 +1,84 @@
+package snmp
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// TestSynthesizePeerTopologyLearnsHostOnPort verifies a downstream device's MAC
+// lands in the bridge FDB on the port resolved through the walk's ifTable and
+// dot1dBasePortTable — the chain a scanner follows for "Nearest Switch".
+func TestSynthesizePeerTopologyLearnsHostOnPort(t *testing.T) {
+	dev := createTestDevice()
+	dev.Type = "switch"
+	dev.TrunkPorts = []config.TrunkPort{
+		{Interface: "FastEthernet0/5", RemoteDevice: "PC01"},
+		{Interface: "FastEthernet0/6", RemoteDevice: "UNKNOWN-DEV"}, // MAC unresolved -> skipped
+	}
+
+	agent := NewAgent(dev, 0)
+
+	// Seed the walk-provided tables: Fa0/5 is ifIndex 10005, bridge port 5.
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("SetOID: %v", err)
+		}
+	}
+	must(agent.SetOID(ifDescr+".10005", &OIDValue{Type: gosnmp.OctetString, Value: "FastEthernet0/5"}))
+	must(agent.SetOID(dot1dBasePortIfIndex+".5", &OIDValue{Type: gosnmp.Integer, Value: 10005}))
+
+	pc1MAC, _ := net.ParseMAC("aa:bb:cc:00:00:21")
+	resolve := func(name string) ([]byte, bool) {
+		if name == "PC01" {
+			return pc1MAC, true
+		}
+		return nil, false // UNKNOWN-DEV is unresolvable
+	}
+
+	agent.SynthesizePeerTopology(resolve)
+
+	idx := macBytesToOIDIndex(pc1MAC)
+
+	port := agent.mib.Get(dot1dTpFdbPort + "." + idx)
+	if port == nil {
+		t.Fatal("no FDB port entry for PC01 — host not learned")
+	}
+	if got, ok := port.Value.(int); !ok || got != 5 {
+		t.Errorf("FDB port = %v, want bridge port 5 (Fa0/5)", port.Value)
+	}
+
+	status := agent.mib.Get(dot1dTpFdbStatus + "." + idx)
+	if status == nil || status.Value.(int) != FDBStatusLearned {
+		t.Errorf("FDB status = %v, want learned(%d)", status, FDBStatusLearned)
+	}
+
+	// The unresolvable neighbour must not produce a learned entry: only the self
+	// entry plus PC01 should carry a learned/self status under the FDB.
+	if got := learnedFDBCount(agent); got != 1 {
+		t.Errorf("learned FDB entries = %d, want exactly 1 (PC01)", got)
+	}
+}
+
+// learnedFDBCount counts dot1dTpFdbStatus entries marked learned(3).
+func learnedFDBCount(a *Agent) int {
+	n := 0
+
+	a.mib.mu.RLock()
+	defer a.mib.mu.RUnlock()
+
+	for oid, v := range a.mib.entries {
+		if strings.HasPrefix(oid, dot1dTpFdbStatus+".") {
+			if iv, ok := v.Value.(int); ok && iv == FDBStatusLearned {
+				n++
+			}
+		}
+	}
+
+	return n
+}

--- a/internal/protocols/snmp_agents.go
+++ b/internal/protocols/snmp_agents.go
@@ -62,6 +62,19 @@ func (g *snmpAgentGroup) ReindexAll() {
 	}
 }
 
+// SynthesizePeerTopologyAll fills each agent's downstream bridge FDB from the
+// resolved fleet MACs (see Agent.SynthesizePeerTopology). Every community agent
+// shares the device's topology, so all get the entries.
+func (g *snmpAgentGroup) SynthesizePeerTopologyAll(resolve snmp.PeerMACResolver) {
+	if g == nil {
+		return
+	}
+
+	for _, agent := range g.agents {
+		agent.SynthesizePeerTopology(resolve)
+	}
+}
+
 func (g *snmpAgentGroup) Communities() []string {
 	if g == nil {
 		return nil

--- a/internal/protocols/stack_snmp.go
+++ b/internal/protocols/stack_snmp.go
@@ -84,13 +84,39 @@ func (s *Stack) initSNMPAgent(device *config.Device) {
 		}
 	}
 
-	// Every MIB is now fully loaded (walk files, AddMib, topology). Build the
-	// sorted OID indexes eagerly so the first GetNext of a discovery does not
-	// trigger a large sort on the stack's single decode goroutine — which would
-	// stall SNMP responses fleet-wide when a scanner walks every device at once.
+	// Now that the MIB is loaded, fill downstream bridge FDB entries from the
+	// fleet roster (a host MAC on the access port it hangs off) so a scanner can
+	// answer "nearest switch/port" for discovered hosts.
+	group.SynthesizePeerTopologyAll(s.peerMACResolver())
+
+	// Every MIB is now fully loaded (walk files, AddMib, topology, peer FDB).
+	// Build the sorted OID indexes eagerly so the first GetNext of a discovery
+	// does not trigger a large sort on the stack's single decode goroutine —
+	// which would stall SNMP responses fleet-wide when a scanner walks every
+	// device at once.
 	group.ReindexAll()
 
 	s.snmpAgents[device] = group
+}
+
+// peerMACResolver returns a lookup from device name to MAC over the whole config
+// roster. An SNMP agent knows only its own device, so cross-device MAC
+// resolution (for FDB / neighbour synthesis) has to come from the stack.
+func (s *Stack) peerMACResolver() snmp.PeerMACResolver {
+	byName := make(map[string][]byte, len(s.config.Devices))
+
+	for i := range s.config.Devices {
+		dev := &s.config.Devices[i]
+		if len(dev.MACAddress) > 0 {
+			byName[dev.Name] = dev.MACAddress
+		}
+	}
+
+	return func(name string) ([]byte, bool) {
+		mac, ok := byName[name]
+
+		return mac, ok
+	}
 }
 
 // initSNMPv3Engine builds and attaches the device's SNMPv3 authoritative


### PR DESCRIPTION
## Summary

A NetAlly CyberScope reports each host's connected switch + port from the switch's bridge forwarding table:
`host MAC → dot1dTpFdbPort → bridge port → dot1dBasePortIfIndex → ifIndex → ifName`.
NIAC seeded only a **self** FDB entry, so discovered hosts had no Nearest Switch and switches looked portless.

- After the fleet loads, `SynthesizePeerTopology` resolves each `trunk_port`'s remote device to its MAC (via a stack-built name→MAC map — an agent alone knows only itself) and adds a **learned** FDB entry on the port's bridge index, mapped through the walk's real ifIndex. Captures model only a few bridge ports, so a missing `dot1dBasePort` row is synthesized keyed by ifIndex.
- Stop synthesizing an IF-MIB from `trunk_ports` when a walk is present: the walk owns the interface table, and a second sequential ifTable duplicated interfaces once downstream access ports were modelled. Trunk_ports now only drive neighbour/forwarding topology (consistent with #862).

Companion PR in `niac-demo-catalog` attaches end devices to access-switch ports.

## Linked Issue

Fixes #868

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/... ; golangci-lint run --new-from-rev=origin/main ./internal/protocols/...
ok  internal/protocols/snmp   (TestSynthesizePeerTopologyLearnsHostOnPort + existing)
ok  internal/protocols
0 issues.

Live (CT304, tagged VLAN200 host), COS-ACC-SW1 with attached hosts:
  FDB learned entries: 9
  COS-PC01 (02:00:0a:06:00:01): FDB port 10001 -> ifIndex 10001 -> ifName "FastEthernet0/1"
  interface list: 29 ifDescr rows, no synthesized duplicates (ifTable gate holds)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only SNMP synthesis; no auth/mutation surfaces)
- [x] Dependencies are pinned and justified if changed. (no dependency changes)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here + #868)