### PR TITLE
fix(snmp): learned FDB port must be an in-range bridge port

### DIFF
--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -40,6 +40,7 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 	}
 
 	changed := false
+	maxPort := 0
 
 	for _, trunk := range a.device.TrunkPorts {
 		if trunk.RemoteDevice == "" || trunk.Interface == "" {
@@ -57,17 +58,29 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 		}
 
 		a.addLearnedFDBEntry(mac, bridgePort)
+
+		if bridgePort > maxPort {
+			maxPort = bridgePort
+		}
+
 		changed = true
 	}
 
 	if changed {
+		// A learned FDB port must be a valid bridge port: managers reject entries
+		// whose port exceeds dot1dBaseNumPorts. Captures model only a few ports,
+		// so raise the count to cover the ports we just wired.
+		a.raiseBaseNumPorts(maxPort)
 		a.mib.Reindex()
 	}
 }
 
 // bridgePortForInterface resolves an interface name (e.g. "FastEthernet0/5") to
-// its bridge port number via the walk's ifTable and dot1dBasePortTable, so the
-// FDB port lines up with the real ifIndex/ifName a manager will render.
+// its bridge port number, preferring the walk's own dot1dBasePortTable so the
+// port lines up with the real ifIndex/ifName a manager renders. When the capture
+// doesn't model that port, it derives the physical port number from the name and
+// adds the dot1dBasePort row — a small, in-range port, not the ifIndex (which a
+// manager would reject as out of range).
 func (a *Agent) bridgePortForInterface(name string) (int, bool) {
 	ifIndex, ok := a.mib.IndexSuffixForValue(ifDescr, name)
 	if !ok {
@@ -78,28 +91,60 @@ func (a *Agent) bridgePortForInterface(name string) (int, bool) {
 		return 0, false
 	}
 
-	ifIndexNum, err := strconv.Atoi(ifIndex)
-	if err != nil {
-		return 0, false
-	}
-
-	// dot1dBasePortIfIndex maps bridge port -> ifIndex; invert it. Honour the
-	// capture's numbering where present so the port resolves to the real
-	// physical interface.
+	// Honour the capture's numbering where the port is modelled.
 	if port, found := a.mib.IndexSuffixForValue(dot1dBasePortIfIndex, ifIndex); found {
 		if n, convErr := strconv.Atoi(port); convErr == nil {
 			return n, true
 		}
 	}
 
-	// Captures often model only a few active bridge ports, so the interface may
-	// have no dot1dBasePort row. Add one keyed by the ifIndex (unique) mapping
-	// straight back to it, so FDB port -> dot1dBasePortIfIndex -> ifIndex ->
-	// ifName still resolves to the right interface.
-	a.mib.Set(dot1dBasePort+"."+ifIndex, &OIDValue{Type: gosnmp.Integer, Value: ifIndexNum})
-	a.mib.Set(dot1dBasePortIfIndex+"."+ifIndex, &OIDValue{Type: gosnmp.Integer, Value: ifIndexNum})
+	// Otherwise use the interface's physical port number as the bridge port
+	// (matches the capture's convention, e.g. Fa0/5 -> port 5) and add the row.
+	port := physicalPortNumber(name)
+	if port <= 0 {
+		return 0, false
+	}
 
-	return ifIndexNum, true
+	ifIndexNum, err := strconv.Atoi(ifIndex)
+	if err != nil {
+		return 0, false
+	}
+
+	portStr := strconv.Itoa(port)
+	a.mib.Set(dot1dBasePort+"."+portStr, &OIDValue{Type: gosnmp.Integer, Value: port})
+	a.mib.Set(dot1dBasePortIfIndex+"."+portStr, &OIDValue{Type: gosnmp.Integer, Value: ifIndexNum})
+
+	return port, true
+}
+
+// physicalPortNumber extracts the trailing port number of a Cisco-style
+// interface name ("FastEthernet0/5" -> 5, "GigabitEthernet1/0/24" -> 24).
+func physicalPortNumber(name string) int {
+	slash := strings.LastIndex(name, "/")
+	if slash < 0 || slash == len(name)-1 {
+		return 0
+	}
+
+	n, err := strconv.Atoi(name[slash+1:])
+	if err != nil {
+		return 0
+	}
+
+	return n
+}
+
+// raiseBaseNumPorts ensures dot1dBaseNumPorts is at least n.
+func (a *Agent) raiseBaseNumPorts(n int) {
+	cur := 0
+	if v := a.mib.Get(dot1dBaseNumPorts); v != nil {
+		if iv, ok := v.Value.(int); ok {
+			cur = iv
+		}
+	}
+
+	if n > cur {
+		a.mib.Set(dot1dBaseNumPorts, &OIDValue{Type: gosnmp.Integer, Value: n})
+	}
 }
 
 // addLearnedFDBEntry registers a dot1dTpFdbTable learned entry: MAC seen on the

--- a/internal/protocols/snmp/peer_topology_test.go
+++ b/internal/protocols/snmp/peer_topology_test.go
@@ -65,6 +65,43 @@ func TestSynthesizePeerTopologyLearnsHostOnPort(t *testing.T) {
 	}
 }
 
+// TestSynthesizePeerTopologyDerivesPortWhenWalkSparse covers the case a real
+// capture models few bridge ports: the port is derived from the interface name
+// (Fa0/7 -> 7), a dot1dBasePort row is added, and dot1dBaseNumPorts is raised so
+// the learned FDB port stays in range (managers reject out-of-range ports).
+func TestSynthesizePeerTopologyDerivesPortWhenWalkSparse(t *testing.T) {
+	dev := createTestDevice()
+	dev.Type = "switch"
+	dev.SNMPConfig.WalkFile = "x.walk" // walk-backed: no synthesized ifTable
+	dev.TrunkPorts = []config.TrunkPort{{Interface: "FastEthernet0/7", RemoteDevice: "PC07"}}
+
+	agent := NewAgent(dev, 0)
+
+	// Walk provides ifDescr and a small NumPorts, but no dot1dBasePort for Fa0/7.
+	fa7 := &OIDValue{Type: gosnmp.OctetString, Value: "FastEthernet0/7"}
+	if err := agent.SetOID(ifDescr+".10007", fa7); err != nil {
+		t.Fatalf("SetOID: %v", err)
+	}
+	if err := agent.SetOID(dot1dBaseNumPorts, &OIDValue{Type: gosnmp.Integer, Value: 5}); err != nil {
+		t.Fatalf("SetOID: %v", err)
+	}
+
+	mac, _ := net.ParseMAC("aa:bb:cc:00:00:77")
+	agent.SynthesizePeerTopology(func(string) ([]byte, bool) { return mac, true })
+
+	port := agent.mib.Get(dot1dTpFdbPort + "." + macBytesToOIDIndex(mac))
+	if port == nil || port.Value.(int) != 7 {
+		t.Fatalf("FDB port = %v, want physical port 7", port)
+	}
+	// dot1dBasePort row added and NumPorts raised to cover it.
+	if e := agent.mib.Get(dot1dBasePortIfIndex + ".7"); e == nil || e.Value.(int) != 10007 {
+		t.Errorf("dot1dBasePortIfIndex.7 = %v, want 10007", e)
+	}
+	if e := agent.mib.Get(dot1dBaseNumPorts); e == nil || e.Value.(int) < 7 {
+		t.Errorf("dot1dBaseNumPorts = %v, want >= 7", e)
+	}
+}
+
 // learnedFDBCount counts dot1dTpFdbStatus entries marked learned(3).
 func learnedFDBCount(a *Agent) int {
 	n := 0


### PR DESCRIPTION
## Summary

Follow-up to #869. The Nearest-Switch FDB synthesis keyed each learned entry to the interface's **ifIndex** (e.g. 10001) as the bridge port. Bridge ports are small (`dot1dBaseNumPorts` is often single digits), so a manager rejects an out-of-range port — hosts still resolved to no switch on the CyberScope even though the FDB was populated.

Now derive the **physical port number** from the interface name (`Fa0/5` → 5, matching the capture's `dot1dBasePort` convention), add the `dot1dBasePort` row, and raise `dot1dBaseNumPorts` to cover it.

## Linked Issue

Related to #868

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/snmp/ -run PeerTopology ; golangci-lint run --new-from-rev=origin/main ./internal/protocols/snmp/...
ok  internal/protocols/snmp   (adds TestSynthesizePeerTopologyDerivesPortWhenWalkSparse)
0 issues.

Live (CT304, tagged VLAN200), COS-ACC-SW1:
  dot1dBaseNumPorts: 5 -> 15
  PC01 (02:00:0a:06:00:01): FDB port 1 -> ifIndex 10001 -> ifName "FastEthernet0/1"
  FDB ports now small/in-range (1..5 for PCs, 11/13/15 for APs)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only SNMP synthesis)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here)