### PR TITLE
fix(icmp): tag Time Exceeded replies with the request VLAN for path analysis

### DIFF
--- a/internal/protocols/icmp.go
+++ b/internal/protocols/icmp.go
@@ -315,6 +315,7 @@ func (h *ICMPHandler) SendICMPTimeExceeded(
 	srcMAC, dstMAC net.HardwareAddr,
 	originalIP *layers.IPv4,
 	device *config.Device,
+	vlan int,
 ) error {
 	if originalIP == nil {
 		return ErrOriginalIPLayerMissing
@@ -333,7 +334,12 @@ func (h *ICMPHandler) SendICMPTimeExceeded(
 		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeTimeExceeded, 0),
 	}
 
-	ttl := defaultTTLIPv6
+	// A router hop replies with its own IP TTL, not the IPv6 default.
+	ttl := defaultTTLIPv4
+	if device != nil && device.ICMPConfig != nil && device.ICMPConfig.TTL > 0 {
+		ttl = device.ICMPConfig.TTL
+	}
+
 	eth := &layers.Ethernet{
 		SrcMAC:       srcMAC,
 		DstMAC:       dstMAC,
@@ -376,6 +382,7 @@ func (h *ICMPHandler) SendICMPTimeExceeded(
 		Length:       len(buf.Bytes()),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         vlan, // echo the probe's VLAN or the reply never reaches a tagged tester
 	}
 	h.stack.Send(pkt)
 

--- a/internal/protocols/ip.go
+++ b/internal/protocols/ip.go
@@ -203,6 +203,7 @@ func (h *IPHandler) handleTTLTimeout(pkt *Packet, ipLayer *layers.IPv4) bool {
 		dstMAC,
 		ipLayer,
 		device,
+		pkt.VLAN,
 	)
 	if err != nil {
 		return false


### PR DESCRIPTION
## Summary

A device with a hop TTL replies ICMP Time Exceeded to expiring probes — how a scanner (NetAlly CyberScope) renders the L3 path. But `SendICMPTimeExceeded` built the reply packet with no VLAN, so on a tagged segment it never reached the tester (the echo-reply path tags correctly, masking the bug — pings worked, traceroute hops were blank). Now echoes the probe's VLAN, and sends the router's own IP TTL (was the IPv6 default 128 on an IPv4 packet).

## Linked Issue

Fixes #871

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run 'ICMP|TTL'   # ok

Live (CT304, tagged VLAN200), ICMP traceroute 10.20.200.250 -> 8.8.8.8:
  1  10.20.200.2  (EVT-CORE, hop 1)
  2  10.20.200.4  (EVT-EDGE, hop 2)
  3  8.8.8.8       (destination)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only ICMP response path)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here + issue)