### PR TITLE
fix(snmp): derive FDB bridge ports by inferred offset (no Gi/Fa collision)

### DIFF
--- a/internal/protocols/snmp/mib.go
+++ b/internal/protocols/snmp/mib.go
@@ -130,6 +130,44 @@ func (m *MIB) IndexSuffixForValue(table, want string) (string, bool) {
 	return best, found
 }
 
+// SampleIntEntry returns one entry under table (a table-column prefix) whose
+// suffix and value are both integers: its numeric suffix and integer value. Used
+// to infer a table's index convention — e.g. dot1dBasePortIfIndex is linear
+// (ifIndex = bridgePort + constant), so one sample gives the offset for ports the
+// capture didn't model. Returns ok=false if the table has no such entry.
+func (m *MIB) SampleIntEntry(table string) (int, int, bool) {
+	table = strings.TrimPrefix(table, ".")
+	prefix := table + "."
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for oid, val := range m.entries {
+		if !strings.HasPrefix(oid, prefix) {
+			continue
+		}
+
+		s, err := strconv.Atoi(strings.TrimPrefix(oid, prefix))
+		if err != nil {
+			continue
+		}
+
+		v := val
+		if v.Dynamic != nil {
+			v = v.Dynamic()
+		}
+
+		iv, err2 := strconv.Atoi(oidValueString(v))
+		if err2 != nil {
+			continue
+		}
+
+		return s, iv, true
+	}
+
+	return 0, 0, false
+}
+
 // oidValueString renders an OIDValue's payload as a string for comparison,
 // covering the string and []byte encodings a walk may load.
 func oidValueString(v *OIDValue) string {

--- a/internal/protocols/snmp/mib_bridge.go
+++ b/internal/protocols/snmp/mib_bridge.go
@@ -19,6 +19,15 @@ func (a *Agent) initializeBridgeMIB() {
 		return
 	}
 
+	// A capture walk carries the real BRIDGE-MIB (dot1dBaseNumPorts, the
+	// dot1dBasePort→ifIndex map, STP). Synthesizing a sequential one from
+	// trunk_ports on top would give ports a bogus offset-0 ifIndex mapping and
+	// mislead the downstream FDB port derivation. The walk owns BRIDGE-MIB;
+	// trunk_ports only drive neighbour/forwarding topology (see #862).
+	if a.hasWalkContent() {
+		return
+	}
+
 	numPorts := len(device.TrunkPorts)
 	if numPorts == 0 {
 		numPorts = 1

--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -42,6 +42,10 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 	changed := false
 	maxPort := 0
 
+	// Infer the capture's bridgePort→ifIndex offset once, up front, from its own
+	// table. Sampling per-port would drift as we add rows below.
+	offset, hasOffset := a.basePortOffset()
+
 	for _, trunk := range a.device.TrunkPorts {
 		if trunk.RemoteDevice == "" || trunk.Interface == "" {
 			continue
@@ -52,7 +56,7 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 			continue
 		}
 
-		bridgePort, ok := a.bridgePortForInterface(trunk.Interface)
+		bridgePort, ok := a.bridgePortForInterface(trunk.Interface, offset, hasOffset)
 		if !ok {
 			continue
 		}
@@ -81,7 +85,7 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 // doesn't model that port, it derives the physical port number from the name and
 // adds the dot1dBasePort row — a small, in-range port, not the ifIndex (which a
 // manager would reject as out of range).
-func (a *Agent) bridgePortForInterface(name string) (int, bool) {
+func (a *Agent) bridgePortForInterface(name string, offset int, hasOffset bool) (int, bool) {
 	ifIndex, ok := a.mib.IndexSuffixForValue(ifDescr, name)
 	if !ok {
 		ifIndex, ok = a.mib.IndexSuffixForValue(ifName, name)
@@ -98,16 +102,20 @@ func (a *Agent) bridgePortForInterface(name string) (int, bool) {
 		}
 	}
 
-	// Otherwise use the interface's physical port number as the bridge port
-	// (matches the capture's convention, e.g. Fa0/5 -> port 5) and add the row.
-	port := physicalPortNumber(name)
-	if port <= 0 {
-		return 0, false
-	}
-
 	ifIndexNum, err := strconv.Atoi(ifIndex)
 	if err != nil {
 		return 0, false
+	}
+
+	// The capture models only a few bridge ports, so derive one. dot1dBasePortIfIndex
+	// is linear (ifIndex = bridgePort + offset), so apply the offset inferred from
+	// the capture. This keeps distinct interface types distinct — Fa0/1 and Gi0/1
+	// have different ifIndex, so different bridge ports — unlike naming the port by
+	// the trailing number, which would collide them. Add the row so
+	// FDB port -> dot1dBasePortIfIndex -> ifIndex -> ifName resolves.
+	port := ifIndexNum
+	if hasOffset && ifIndexNum-offset > 0 {
+		port = ifIndexNum - offset
 	}
 
 	portStr := strconv.Itoa(port)
@@ -117,20 +125,15 @@ func (a *Agent) bridgePortForInterface(name string) (int, bool) {
 	return port, true
 }
 
-// physicalPortNumber extracts the trailing port number of a Cisco-style
-// interface name ("FastEthernet0/5" -> 5, "GigabitEthernet1/0/24" -> 24).
-func physicalPortNumber(name string) int {
-	slash := strings.LastIndex(name, "/")
-	if slash < 0 || slash == len(name)-1 {
-		return 0
+// basePortOffset infers the capture's linear bridgePort→ifIndex offset (ifIndex =
+// bridgePort + offset) from a sampled dot1dBasePortIfIndex row.
+func (a *Agent) basePortOffset() (int, bool) {
+	p, i, ok := a.mib.SampleIntEntry(dot1dBasePortIfIndex)
+	if !ok {
+		return 0, false
 	}
 
-	n, err := strconv.Atoi(name[slash+1:])
-	if err != nil {
-		return 0
-	}
-
-	return n
+	return i - p, true
 }
 
 // raiseBaseNumPorts ensures dot1dBaseNumPorts is at least n.

--- a/internal/protocols/snmp/peer_topology_test.go
+++ b/internal/protocols/snmp/peer_topology_test.go
@@ -77,12 +77,16 @@ func TestSynthesizePeerTopologyDerivesPortWhenWalkSparse(t *testing.T) {
 
 	agent := NewAgent(dev, 0)
 
-	// Walk provides ifDescr and a small NumPorts, but no dot1dBasePort for Fa0/7.
+	// Walk provides ifDescr, a small NumPorts, and a sample bridge-port row
+	// (port 2 -> ifIndex 10002, i.e. offset 10000), but no row for Fa0/7.
 	fa7 := &OIDValue{Type: gosnmp.OctetString, Value: "FastEthernet0/7"}
 	if err := agent.SetOID(ifDescr+".10007", fa7); err != nil {
 		t.Fatalf("SetOID: %v", err)
 	}
 	if err := agent.SetOID(dot1dBaseNumPorts, &OIDValue{Type: gosnmp.Integer, Value: 5}); err != nil {
+		t.Fatalf("SetOID: %v", err)
+	}
+	if err := agent.SetOID(dot1dBasePortIfIndex+".2", &OIDValue{Type: gosnmp.Integer, Value: 10002}); err != nil {
 		t.Fatalf("SetOID: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #870, whose `physicalPortNumber` heuristic collided interface types: `GigabitEthernet0/1` and `FastEthernet0/1` both yield 1, so an uplink and a host would share a bridge port. `dot1dBasePortIfIndex` is linear (ifIndex = bridgePort + offset); infer the offset once from a sampled row (parsing string- or int-typed walk values) and apply it. Prefer the largest matching ifIndex so a walk's real index beats sequential synthesis. Also stop synthesizing BRIDGE-MIB from trunk_ports when a walk is present (its offset-0 map would corrupt the inference; the walk owns BRIDGE-MIB/IF-MIB per #862).

## Linked Issue

Fixes #873

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/snmp/ ; golangci-lint run --new-from-rev=origin/main ./internal/protocols/...
ok  internal/protocols/snmp
0 issues.

Live (CT304), COS-ACC-SW1 FDB: Fa0/1..5 -> ports 1..5, Gi0/1 uplink -> port 101 — no collision.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only SNMP synthesis)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here)