### PR TITLE
fix(tcp): reply to the request's VLAN + source MAC, SYN-ACK for path probes

### DIFF
--- a/internal/protocols/ftp.go
+++ b/internal/protocols/ftp.go
@@ -49,7 +49,12 @@ func NewFTPHandler(stack *Stack) *FTPHandler {
 }
 
 // HandleRequest processes an FTP request.
-func (h *FTPHandler) HandleRequest(_ *Packet, ipLayer *layers.IPv4, tcpLayer *layers.TCP, devices []*config.Device) {
+func (h *FTPHandler) HandleRequest(
+	reqPkt *Packet,
+	ipLayer *layers.IPv4,
+	tcpLayer *layers.TCP,
+	devices []*config.Device,
+) {
 	debugLevel := h.stack.GetDebugLevel()
 
 	// Parse FTP command
@@ -75,7 +80,7 @@ func (h *FTPHandler) HandleRequest(_ *Packet, ipLayer *layers.IPv4, tcpLayer *la
 	}
 
 	// Send response
-	h.sendResponse(ipLayer, tcpLayer, []byte(response), devices)
+	h.sendResponse(ipLayer, tcpLayer, []byte(response), devices, reqPkt)
 }
 
 // sendResponse sends an FTP response.
@@ -84,6 +89,7 @@ func (h *FTPHandler) sendResponse(
 	tcpLayer *layers.TCP,
 	response []byte,
 	devices []*config.Device,
+	reqPkt *Packet,
 ) {
 	debugLevel := h.stack.GetDebugLevel()
 
@@ -96,17 +102,13 @@ func (h *FTPHandler) sendResponse(
 		return
 	}
 
-	// Get source MAC
-	srcDevices := h.stack.GetDevices().GetByIP(ipLayer.SrcIP)
+	// Reply to the requester's own frame source MAC and VLAN.
+	vlan := reqPktVLAN(reqPkt)
 
-	var srcMAC []byte
-
-	if len(srcDevices) > 0 && len(srcDevices[0].MACAddress) > 0 {
-		srcMAC = srcDevices[0].MACAddress
-	} else {
-		// Fallback - would need to get from original packet
+	srcMAC := requestSourceMAC(reqPkt)
+	if srcMAC == nil {
 		if debugLevel >= DebugLevelInfo {
-			_, _ = fmt.Fprintf(os.Stdout, "Cannot send FTP response: no MAC for %s\n", ipLayer.SrcIP)
+			_, _ = fmt.Fprintf(os.Stdout, "Cannot send FTP response: no source MAC for %s\n", ipLayer.SrcIP)
 		}
 
 		return
@@ -177,6 +179,7 @@ func (h *FTPHandler) sendResponse(
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         vlan, // reply on the VLAN the request arrived on (tagged or untagged)
 	}
 
 	h.stack.Send(responsePkt)
@@ -454,7 +457,7 @@ func selectIPv4Address(devices []*config.Device) net.IP {
 }
 
 // SendWelcome sends FTP welcome banner when connection is established.
-func (h *FTPHandler) SendWelcome(ipLayer *layers.IPv4, tcpLayer *layers.TCP, devices []*config.Device) {
+func (h *FTPHandler) SendWelcome(reqPkt *Packet, ipLayer *layers.IPv4, tcpLayer *layers.TCP, devices []*config.Device) {
 	debugLevel := h.stack.GetDebugLevel()
 
 	// Only send welcome on new connections (SYN+ACK)
@@ -484,7 +487,7 @@ func (h *FTPHandler) SendWelcome(ipLayer *layers.IPv4, tcpLayer *layers.TCP, dev
 	// Small delay to let connection establish
 	go func() {
 		time.Sleep(ftpConnectionDelayMs * time.Millisecond)
-		h.sendResponse(ipLayer, tcpLayer, []byte(welcome), devices)
+		h.sendResponse(ipLayer, tcpLayer, []byte(welcome), devices, reqPkt)
 	}()
 
 	if debugLevel >= DebugLevelInfo {

--- a/internal/protocols/healthcheck.go
+++ b/internal/protocols/healthcheck.go
@@ -3,6 +3,7 @@ package protocols
 import (
 	"encoding/binary"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -135,7 +136,7 @@ func NewHealthCheckHandler(stack *Stack) *HealthCheckHandler {
 
 // HandleTCPConnect handles TCP SYN for health check ports (returns SYN-ACK to indicate service is up).
 func (h *HealthCheckHandler) HandleTCPConnect(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -154,12 +155,12 @@ func (h *HealthCheckHandler) HandleTCPConnect(
 	}
 
 	// Send SYN-ACK to indicate service is available
-	h.sendSYNACK(ipLayer, tcpLayer, devices)
+	h.sendSYNACK(ipLayer, tcpLayer, devices, reqPkt)
 }
 
 // HandleLDAPRequest handles LDAP bind/search requests.
 func (h *HealthCheckHandler) HandleLDAPRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -178,13 +179,13 @@ func (h *HealthCheckHandler) HandleLDAPRequest(
 	// Parse LDAP message and send appropriate response
 	response := h.generateLDAPResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleRTSPRequest handles RTSP OPTIONS/DESCRIBE requests.
 func (h *HealthCheckHandler) HandleRTSPRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -202,13 +203,13 @@ func (h *HealthCheckHandler) HandleRTSPRequest(
 
 	response := h.generateRTSPResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleMySQLRequest handles MySQL connection handshake.
 func (h *HealthCheckHandler) HandleMySQLRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -228,13 +229,13 @@ func (h *HealthCheckHandler) HandleMySQLRequest(
 	// If we have payload (after handshake), send greeting
 	if len(tcpLayer.Payload) > 0 {
 		response := h.generateMySQLGreeting(devices)
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandlePostgresRequest handles PostgreSQL connection handshake.
 func (h *HealthCheckHandler) HandlePostgresRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -253,13 +254,13 @@ func (h *HealthCheckHandler) HandlePostgresRequest(
 	// Check if this is SSL request or startup message
 	response := h.generatePostgresResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleMSSQLRequest handles MS SQL Server connection.
 func (h *HealthCheckHandler) HandleMSSQLRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -277,13 +278,13 @@ func (h *HealthCheckHandler) HandleMSSQLRequest(
 
 	response := h.generateMSSQLResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleModbusRequest handles Modbus TCP requests.
 func (h *HealthCheckHandler) HandleModbusRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -301,13 +302,13 @@ func (h *HealthCheckHandler) HandleModbusRequest(
 
 	response := h.generateModbusResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleDICOMRequest handles DICOM association requests.
 func (h *HealthCheckHandler) HandleDICOMRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -325,13 +326,13 @@ func (h *HealthCheckHandler) HandleDICOMRequest(
 
 	response := h.generateDICOMResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleHL7Request handles HL7 MLLP messages.
 func (h *HealthCheckHandler) HandleHL7Request(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -349,13 +350,13 @@ func (h *HealthCheckHandler) HandleHL7Request(
 
 	response := h.generateHL7Response(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleOPCUARequest handles OPC UA connection requests.
 func (h *HealthCheckHandler) HandleOPCUARequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -373,13 +374,13 @@ func (h *HealthCheckHandler) HandleOPCUARequest(
 
 	response := h.generateOPCUAResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // HandleSMBRequest handles SMB/CIFS connection requests.
 func (h *HealthCheckHandler) HandleSMBRequest(
-	_ *Packet,
+	reqPkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -397,12 +398,17 @@ func (h *HealthCheckHandler) HandleSMBRequest(
 
 	response := h.generateSMBResponse(tcpLayer.Payload, devices)
 	if response != nil {
-		h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+		h.sendTCPResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 	}
 }
 
 // sendSYNACK sends a TCP SYN-ACK response.
-func (h *HealthCheckHandler) sendSYNACK(ipLayer *layers.IPv4, tcpLayer *layers.TCP, devices []*config.Device) {
+func (h *HealthCheckHandler) sendSYNACK(
+	ipLayer *layers.IPv4,
+	tcpLayer *layers.TCP,
+	devices []*config.Device,
+	reqPkt *Packet,
+) {
 	debugLevel := h.stack.GetDebugLevel()
 
 	if len(devices) == 0 {
@@ -414,16 +420,14 @@ func (h *HealthCheckHandler) sendSYNACK(ipLayer *layers.IPv4, tcpLayer *layers.T
 		return
 	}
 
-	// Get source MAC
-	srcDevices := h.stack.GetDevices().GetByIP(ipLayer.SrcIP)
+	// Reply to the requester's own MAC (from the request frame), not a modelled
+	// device — a real tester is not in our device table. Reply on its VLAN.
+	vlan := reqPktVLAN(reqPkt)
 
-	var srcMAC []byte
-
-	if len(srcDevices) > 0 && len(srcDevices[0].MACAddress) > 0 {
-		srcMAC = srcDevices[0].MACAddress
-	} else {
+	srcMAC := requestSourceMAC(reqPkt)
+	if srcMAC == nil {
 		if debugLevel >= DebugLevelInfo {
-			_, _ = fmt.Fprintf(os.Stdout, "Cannot send SYN-ACK: no MAC for %s\n", ipLayer.SrcIP)
+			_, _ = fmt.Fprintf(os.Stdout, "Cannot send SYN-ACK: no source MAC for %s\n", ipLayer.SrcIP)
 		}
 
 		return
@@ -484,6 +488,7 @@ func (h *HealthCheckHandler) sendSYNACK(ipLayer *layers.IPv4, tcpLayer *layers.T
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         vlan, // reply on the VLAN the request arrived on (tagged or untagged)
 	}
 
 	h.stack.Send(pkt)
@@ -494,12 +499,34 @@ func (h *HealthCheckHandler) sendSYNACK(ipLayer *layers.IPv4, tcpLayer *layers.T
 	}
 }
 
+// reqPktVLAN returns the request packet's VLAN, or 0 (untagged) if absent, so a
+// reply is sent on the VLAN the request arrived on.
+func reqPktVLAN(pkt *Packet) int {
+	if pkt == nil {
+		return 0
+	}
+
+	return pkt.VLAN
+}
+
+// requestSourceMAC returns the request frame's source MAC — the correct reply
+// destination even when the requester (a real tester) is not a modelled device,
+// unlike a device-table lookup by IP.
+func requestSourceMAC(pkt *Packet) net.HardwareAddr {
+	if pkt == nil {
+		return nil
+	}
+
+	return pkt.GetSourceMAC()
+}
+
 // sendTCPResponse sends a TCP response with payload.
 func (h *HealthCheckHandler) sendTCPResponse(
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	payload []byte,
 	devices []*config.Device,
+	reqPkt *Packet,
 ) {
 	debugLevel := h.stack.GetDebugLevel()
 
@@ -512,13 +539,10 @@ func (h *HealthCheckHandler) sendTCPResponse(
 		return
 	}
 
-	srcDevices := h.stack.GetDevices().GetByIP(ipLayer.SrcIP)
+	vlan := reqPktVLAN(reqPkt)
 
-	var srcMAC []byte
-
-	if len(srcDevices) > 0 && len(srcDevices[0].MACAddress) > 0 {
-		srcMAC = srcDevices[0].MACAddress
-	} else {
+	srcMAC := requestSourceMAC(reqPkt)
+	if srcMAC == nil {
 		return
 	}
 
@@ -576,6 +600,7 @@ func (h *HealthCheckHandler) sendTCPResponse(
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         vlan, // reply on the VLAN the request arrived on (tagged or untagged)
 	}
 
 	h.stack.Send(pkt)

--- a/internal/protocols/http.go
+++ b/internal/protocols/http.go
@@ -70,7 +70,12 @@ func NewHTTPHandler(stack *Stack) *HTTPHandler {
 }
 
 // HandleRequest processes an HTTP request.
-func (h *HTTPHandler) HandleRequest(_ *Packet, ipLayer *layers.IPv4, tcpLayer *layers.TCP, devices []*config.Device) {
+func (h *HTTPHandler) HandleRequest(
+	reqPkt *Packet,
+	ipLayer *layers.IPv4,
+	tcpLayer *layers.TCP,
+	devices []*config.Device,
+) {
 	debugLevel := h.stack.GetDebugLevel()
 
 	// Parse HTTP request
@@ -95,8 +100,8 @@ func (h *HTTPHandler) HandleRequest(_ *Packet, ipLayer *layers.IPv4, tcpLayer *l
 	// Generate response
 	response := h.generateResponse(request, devices)
 
-	// Send response
-	h.sendResponse(ipLayer, tcpLayer, response, devices)
+	// Send response on the VLAN + to the MAC the request arrived on.
+	h.sendResponse(ipLayer, tcpLayer, response, devices, reqPkt)
 }
 
 // HTTPRequest represents a parsed HTTP request.
@@ -370,6 +375,7 @@ func (h *HTTPHandler) sendResponse(
 	tcpLayer *layers.TCP,
 	response []byte,
 	devices []*config.Device,
+	reqPkt *Packet,
 ) {
 	debugLevel := h.stack.GetDebugLevel()
 
@@ -382,17 +388,14 @@ func (h *HTTPHandler) sendResponse(
 		return
 	}
 
-	// Get source MAC (lookup by source IP)
-	srcDevices := h.stack.GetDevices().GetByIP(ipLayer.SrcIP)
+	// Reply to the requester's own frame source MAC and VLAN — a real tester is
+	// not a modelled device, so a device-table lookup by IP would fail.
+	vlan := reqPktVLAN(reqPkt)
 
-	var srcMAC []byte
-
-	if len(srcDevices) > 0 && len(srcDevices[0].MACAddress) > 0 {
-		srcMAC = srcDevices[0].MACAddress
-	} else {
-		// Cannot find source MAC - skip sending
+	srcMAC := requestSourceMAC(reqPkt)
+	if srcMAC == nil {
 		if debugLevel >= DebugLevelInfo {
-			_, _ = fmt.Fprintf(os.Stdout, "Cannot send HTTP response: no MAC for %s\n", ipLayer.SrcIP)
+			_, _ = fmt.Fprintf(os.Stdout, "Cannot send HTTP response: no source MAC for %s\n", ipLayer.SrcIP)
 		}
 
 		return
@@ -463,6 +466,7 @@ func (h *HTTPHandler) sendResponse(
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         vlan, // reply on the VLAN the request arrived on (tagged or untagged)
 	}
 
 	h.stack.Send(responsePkt)

--- a/internal/protocols/tcp.go
+++ b/internal/protocols/tcp.go
@@ -134,7 +134,13 @@ func (h *TCPHandler) routeToHandler(
 
 	switch tcp.DstPort {
 	case TCPPortHTTP:
-		h.handleHTTP(pkt, ipLayer, tcp, devices, hasPayload)
+		// A bare SYN (TCP path analysis / port probe) gets a SYN-ACK so the hop
+		// completes; a SYN with payload is a real HTTP request.
+		if isSYNOnly {
+			h.stack.healthCheckHandler.HandleTCPConnect(pkt, ipLayer, tcp, devices, TCPPortHTTP)
+		} else {
+			h.handleHTTP(pkt, ipLayer, tcp, devices, hasPayload)
+		}
 	case TCPPortHTTPS:
 		h.handleHealthCheckPort(pkt, ipLayer, tcp, devices, TCPPortHTTPS, isSYNOnly, nil)
 	case TCPPortFTP:
@@ -172,7 +178,7 @@ func (h *TCPHandler) routeToHandler(
 		h.stack.iperf3Handler.HandleIPerf3Request(pkt, ipLayer, tcp, devices)
 	default:
 		if isSYNOnly {
-			h.sendRST(ipLayer, tcp, devices)
+			h.sendRST(ipLayer, tcp, devices, pkt.VLAN)
 		}
 	}
 }
@@ -236,7 +242,7 @@ func (h *TCPHandler) handleHealthCheckPort(
 }
 
 // sendRST sends a TCP RST packet.
-func (h *TCPHandler) sendRST(ipLayer *layers.IPv4, tcp *layers.TCP, devices []*config.Device) {
+func (h *TCPHandler) sendRST(ipLayer *layers.IPv4, tcp *layers.TCP, devices []*config.Device, vlan int) {
 	debugLevel := h.stack.GetDebugLevel()
 
 	device := h.findDeviceWithIP(devices, ipLayer.DstIP)
@@ -249,7 +255,7 @@ func (h *TCPHandler) sendRST(ipLayer *layers.IPv4, tcp *layers.TCP, devices []*c
 		return
 	}
 
-	h.sendRSTPacket(device, dstMAC, ipLayer, tcp, debugLevel)
+	h.sendRSTPacket(device, dstMAC, ipLayer, tcp, debugLevel, vlan)
 }
 
 // findDeviceWithIP finds a device that has the specified IP address and MAC.
@@ -309,6 +315,7 @@ func (h *TCPHandler) sendRSTPacket(
 	ipLayer *layers.IPv4,
 	tcp *layers.TCP,
 	debugLevel int,
+	vlan int,
 ) {
 	eth := &layers.Ethernet{
 		SrcMAC:       device.MACAddress,
@@ -347,7 +354,7 @@ func (h *TCPHandler) sendRSTPacket(
 		return
 	}
 
-	h.sendSerializedPacket(buffer.Bytes(), device, ipReply, tcpReply, debugLevel)
+	h.sendSerializedPacket(buffer.Bytes(), device, ipReply, tcpReply, debugLevel, vlan)
 }
 
 // sendSerializedPacket sends a serialized packet and logs the result.
@@ -357,6 +364,7 @@ func (h *TCPHandler) sendSerializedPacket(
 	ipReply *layers.IPv4,
 	tcpReply *layers.TCP,
 	debugLevel int,
+	vlan int,
 ) {
 	h.stack.mu.Lock()
 	h.stack.serialNumber++
@@ -368,6 +376,7 @@ func (h *TCPHandler) sendSerializedPacket(
 		Length:       len(data),
 		SerialNumber: serialNum,
 		Device:       device,
+		VLAN:         vlan, // reply on the VLAN the request arrived on (tagged or untagged)
 	}
 
 	h.stack.Send(pkt)


### PR DESCRIPTION
## Summary

TCP-family replies (HTTP, FTP, health-check services, RST, SYN-ACK) were unreachable from a real tester on a tagged segment, for two reasons:

1. **Destination MAC** was resolved with `GetByIP(request.SrcIP)` — a device-table lookup that fails for a tester (a CyberScope) which isn't a modelled device, so replies were silently dropped. Now uses the request frame's own source MAC (as the IPv6 path already did).
2. **No VLAN** on the reply packet, so on a tagged trunk it never returned. Now echoes the request's VLAN — which also makes an untagged direct-attach reply work (untagged request → VLAN 0).

Plus: a bare SYN to an open port (TCP path analysis / port probe) got no reply (`handleHTTP` only acts on a payload). A SYN-only on port 80 now routes to the SYN-ACK path so the hop completes; closed ports already RST.

## Linked Issue

Fixes #875

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ ; golangci-lint run --new-from-rev=origin/main ./internal/protocols/...
ok  internal/protocols
0 issues.

Live (CT304, tagged VLAN200 tester -> faked 8.8.8.8):
  HTTP GET -> INET-R1 page (by IP and via DNS-wildcard hostname google.com)
  traceroute -T -p 80 -> 10.20.200.2 -> 10.20.200.4 -> 8.8.8.8   (path completes)
  TCP to closed port -> RST (connection refused)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only reply path; TCP/HTTP/FTP responses)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here + issue)