### PR TITLE
feat(udp): reply ICMP port-unreachable from a closed UDP port

### DIFF
--- a/internal/protocols/icmp.go
+++ b/internal/protocols/icmp.go
@@ -543,6 +543,7 @@ func (h *ICMPHandler) SendICMPUnreachable(
 	srcMAC, dstMAC []byte,
 	code uint8,
 	originalPacket []byte,
+	vlan int,
 ) error {
 	// Build Ethernet header
 	eth := &layers.Ethernet{
@@ -600,6 +601,7 @@ func (h *ICMPHandler) SendICMPUnreachable(
 		Buffer:       buffer.Bytes(),
 		Length:       len(buffer.Bytes()),
 		SerialNumber: serialNum,
+		VLAN:         vlan, // reply on the VLAN the request arrived on (tagged or untagged)
 	}
 
 	h.stack.Send(pkt)

--- a/internal/protocols/icmp_test.go
+++ b/internal/protocols/icmp_test.go
@@ -239,7 +239,7 @@ func TestSendICMPUnreachable(t *testing.T) {
 	code := uint8(1) // Host unreachable
 	originalPacket := make([]byte, 100)
 
-	err := handler.SendICMPUnreachable(srcIP, dstIP, srcMAC, dstMAC, code, originalPacket)
+	err := handler.SendICMPUnreachable(srcIP, dstIP, srcMAC, dstMAC, code, originalPacket, 0)
 	if err != nil {
 		t.Errorf("SendICMPUnreachable failed: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestSendICMPUnreachable_LargeOriginalPacket(t *testing.T) {
 	code := uint8(3)                    // Port unreachable
 	originalPacket := make([]byte, 200) // Large packet
 
-	err := handler.SendICMPUnreachable(srcIP, dstIP, srcMAC, dstMAC, code, originalPacket)
+	err := handler.SendICMPUnreachable(srcIP, dstIP, srcMAC, dstMAC, code, originalPacket, 0)
 	if err != nil {
 		t.Errorf("SendICMPUnreachable with large packet failed: %v", err)
 	}

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -105,7 +105,46 @@ func (h *UDPHandler) HandlePacket(pkt *Packet, ipLayer *layers.IPv4, devices []*
 		if debugLevel >= DebugLevelVerbose {
 			_, _ = fmt.Fprintf(os.Stdout, "UDP packet to unhandled port %d sn=%d\n", udp.DstPort, pkt.SerialNumber)
 		}
+
+		h.sendPortUnreachable(pkt, ipLayer, udp, devices)
 	}
+}
+
+// sendPortUnreachable replies ICMP Destination Unreachable / port unreachable
+// from the addressed device — the RFC 792 behaviour of a closed UDP port. This
+// is what lets a UDP path analysis / traceroute confirm it reached the target
+// (its intermediate hops already answer via the TTL Time Exceeded path).
+func (h *UDPHandler) sendPortUnreachable(
+	pkt *Packet,
+	ipLayer *layers.IPv4,
+	udp *layers.UDP,
+	devices []*config.Device,
+) {
+	if h.stack.icmpHandler == nil || len(devices) == 0 {
+		return
+	}
+
+	device := devices[0]
+	// A device that forwards this port (MapToIP) isn't a closed port.
+	if device.MapToIP != nil || len(device.MACAddress) == 0 {
+		return
+	}
+
+	dstMAC := pkt.GetSourceMAC()
+	if dstMAC == nil {
+		return
+	}
+
+	// RFC 792 §3.2: quote the offending IP header + 8 bytes of its datagram.
+	original := append(ipLayer.LayerContents(), udp.LayerContents()...)
+
+	_ = h.stack.icmpHandler.SendICMPUnreachable(
+		ipLayer.DstIP, ipLayer.SrcIP,
+		device.MACAddress, dstMAC,
+		layers.ICMPv4CodePort,
+		original,
+		pkt.VLAN,
+	)
 }
 
 func (h *UDPHandler) handleSNMP(pkt *Packet, ipLayer *layers.IPv4, udp *layers.UDP, devices []*config.Device) {


### PR DESCRIPTION
## Summary

A closed UDP port answers ICMP Destination Unreachable / port unreachable (RFC 792), which lets a UDP-mode path analysis / traceroute confirm it reached the target (intermediate hops already answer via the TTL Time Exceeded path). The UDP handler's default case now sends it from the addressed device, on the request's VLAN and to its source MAC. `SendICMPUnreachable` gains a VLAN parameter. Beyond Java parity — Java doesn't implement this.

## Linked Issue

Fixes #877

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run 'UDP|ICMP' ; golangci-lint run --new-from-rev=origin/main ./internal/protocols/...
ok  internal/protocols
0 issues.

Wire verification PENDING: the CT304 integration tree has diverged from main
(several armed-but-unmerged PRs), so a clean end-to-end UDP-traceroute check
should be run after this + the path-analysis PRs land on a fresh main.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only ICMP reply)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here + issue)