### PR TITLE
feat(udp): reflect NetAlly UDP performance probes back to the tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the lab.
 
 - **Configurable topology** — declare devices, interfaces, VLANs, and neighbours in YAML; load templates or generate interactively
 - **Multi-IP per device** — each simulated endpoint can carry multiple v4/v6 addresses
-- **Protocol coverage** — ARP, ICMPv4/v6, DHCPv4/v6, DNS, LLDP, CDP, SNMP (v1/v2c/v3, walks + traps), TCP, UDP, HTTP, iperf3
+- **Protocol coverage** — ARP, ICMPv4/v6, DHCPv4/v6, DNS, LLDP, CDP, SNMP (v1/v2c/v3, walks + traps), TCP, UDP (incl. NetAlly reflector), HTTP, iperf3
 - **Per-protocol debug levels** — turn verbose logging on/off at the protocol layer without restarting
 - **PCAP analysis** — `niac analyze-pcap` summarises captures by protocol; `niac analyze-walk` extracts topology from SNMP walks
 - **Error injection** — inject latency, loss, jitter, or protocol-specific faults on a running simulation

--- a/docs/PROTOCOL_GUIDE.md
+++ b/docs/PROTOCOL_GUIDE.md
@@ -436,6 +436,41 @@ TCP is automatically used by application protocols (HTTP, FTP) that require it. 
 
 UDP is automatically used by application protocols (DNS, DHCP, SNMP) that require it. No explicit configuration needed.
 
+#### UDP Reflector
+
+A device can act as a **NetAlly-style UDP reflector** — the endpoint a
+performance/TrueSpeed tester bounces probes off to measure round-trip latency,
+jitter, and DiffServ handling. When a UDP packet arrives whose payload carries a
+reflector signature (`DATA:OT` or `PROBEOT`, 5 bytes into the payload), the
+device echoes it back to the sender with source/destination MAC and IP swapped,
+the ToS byte wiggled, and the reply optionally delayed. UDP ports are left
+unswapped to match the niac-java reflector; the tester matches replies by
+signature, not the 4-tuple. Replies inherit the request's VLAN tag.
+
+##### Configuration
+
+```yaml
+devices:
+  - name: reflector
+    mac: "bb:bb:bb:00:00:02"
+    ips: ["10.20.200.100"]
+    reflector:
+      latency_ms: 10   # delay before reflecting (0 = immediate)
+      jitter_ms: 2     # random +/- delay around latency
+      dscp: false      # false: wiggle IP-precedence bit (0x01); true: wiggle DSCP bottom-2 bits (0x03)
+```
+
+##### Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `latency_ms` | integer | One-way delay before the reflected packet is sent, in milliseconds. `0` reflects immediately. |
+| `jitter_ms` | integer | Randomises the delay by +/- this many milliseconds, floored at zero. |
+| `dscp` | boolean | Selects which ToS bits are toggled: `false` (default) flips the IP-precedence bit, `true` flips the bottom two DSCP bits. |
+
+The presence of the `reflector:` block enables the reflector — there is no
+separate enable flag.
+
 ## Application Protocols
 
 ### DHCP (DHCPv4)

--- a/docs/schemas/niac.schema.json
+++ b/docs/schemas/niac.schema.json
@@ -298,6 +298,9 @@
         "iperf3": {
           "$ref": "#/$defs/IPerf3Config"
         },
+        "reflector": {
+          "$ref": "#/$defs/ReflectorConfig"
+        },
         "interfaces": {
           "items": {
             "$ref": "#/$defs/Interface"
@@ -1083,6 +1086,21 @@
             "type": "string"
           },
           "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ReflectorConfig": {
+      "properties": {
+        "latency_ms": {
+          "type": "integer"
+        },
+        "jitter_ms": {
+          "type": "integer"
+        },
+        "dscp": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -50,6 +50,7 @@ const (
 	defaultIperfPort        = 5201    // default iperf port
 	defaultIperfDuration    = 1000    // default iperf duration ms
 	defaultBandwidthMbps    = 100     // default bandwidth in Mbps
+	maxReflectorDelayMs     = 60000   // max reflector latency/jitter (60s)
 )
 
 // SchemaProperty represents a JSON Schema property definition.
@@ -217,6 +218,7 @@ func buildProtocolSchemaProperties() map[string]*SchemaProperty {
 		"ttl":            buildTTLConfigSchema(&maxTTL),
 		"os_fingerprint": buildOSFingerprintSchema(),
 		"iperf3":         buildIPerf3Schema(&maxPort),
+		"reflector":      buildReflectorSchema(),
 	}
 }
 

--- a/internal/api/schema_network.go
+++ b/internal/api/schema_network.go
@@ -400,3 +400,36 @@ func buildIPerf3Schema(maxPort *float64) *SchemaProperty {
 		},
 	}
 }
+
+// buildReflectorSchema creates the JSON Schema for the NetAlly UDP reflector.
+func buildReflectorSchema() *SchemaProperty {
+	return &SchemaProperty{
+		Type:        "object",
+		Title:       "UDP Reflector",
+		Description: "NetAlly-style UDP reflector endpoint for performance/TrueSpeed tests",
+		Properties: map[string]*SchemaProperty{
+			"latency_ms": {
+				Type:        "integer",
+				Title:       "Latency (ms)",
+				Description: "Delay before reflecting a probe",
+				Default:     0,
+				Minimum:     floatPtr(0),
+				Maximum:     floatPtr(maxReflectorDelayMs),
+			},
+			"jitter_ms": {
+				Type:        "integer",
+				Title:       "Jitter (ms)",
+				Description: "Random +/- delay around latency",
+				Default:     0,
+				Minimum:     floatPtr(0),
+				Maximum:     floatPtr(maxReflectorDelayMs),
+			},
+			"dscp": {
+				Type:        "boolean",
+				Title:       "DSCP wiggle",
+				Description: "Toggle the DSCP bottom-2 bits instead of the IP-precedence bit",
+				Default:     false,
+			},
+		},
+	}
+}

--- a/internal/api/schema_test.go
+++ b/internal/api/schema_test.go
@@ -130,7 +130,7 @@ func TestBuildProtocolSchemaProperties(t *testing.T) {
 		"snmpAgent", "lldp", "cdp", "edp", "fdp", "stp",
 		"dhcp", "dns", "http", "ftp", "netbios",
 		"icmp", "icmpv6", "dhcpv6", "traffic", "ttl",
-		"os_fingerprint", "iperf3",
+		"os_fingerprint", "iperf3", "reflector",
 	}
 
 	for _, proto := range expectedProtocols {

--- a/internal/config/reflector_test.go
+++ b/internal/config/reflector_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+)
+
+func TestParseReflectorConfig(t *testing.T) {
+	if got := parseReflectorConfig(nil); got != nil {
+		t.Errorf("nil YAML reflector = %+v, want nil", got)
+	}
+
+	got := parseReflectorConfig(&converter.ReflectorConfig{
+		LatencyMs: 25,
+		JitterMs:  5,
+		DSCP:      true,
+	})
+	if got == nil {
+		t.Fatal("parseReflectorConfig returned nil for a populated config")
+	}
+
+	if got.LatencyMs != 25 || got.JitterMs != 5 || !got.DSCP {
+		t.Errorf("parsed reflector = %+v, want {LatencyMs:25 JitterMs:5 DSCP:true}", got)
+	}
+}
+
+// TestConvertYAMLDeviceReflector proves the reflector block wires through the
+// full YAML -> domain device conversion.
+func TestConvertYAMLDeviceReflector(t *testing.T) {
+	yamlDevice := converter.Device{
+		Name:      "reflector",
+		MAC:       "bb:bb:bb:00:00:02",
+		IPs:       []string{"10.20.200.100"},
+		Reflector: &converter.ReflectorConfig{LatencyMs: 10, JitterMs: 2},
+	}
+
+	device, err := convertYAMLDevice(yamlDevice, "")
+	if err != nil {
+		t.Fatalf("convertYAMLDevice: %v", err)
+	}
+
+	if device.ReflectorConfig == nil {
+		t.Fatal("device.ReflectorConfig is nil; reflector block did not convert")
+	}
+
+	if device.ReflectorConfig.LatencyMs != 10 || device.ReflectorConfig.JitterMs != 2 {
+		t.Errorf("converted reflector = %+v, want {LatencyMs:10 JitterMs:2}", device.ReflectorConfig)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -172,6 +172,7 @@ type Device struct {
 	TrafficConfig       *TrafficConfig       // Traffic pattern configuration (v1.6.0)
 	OSFingerprintConfig *OSFingerprintConfig // OS fingerprinting configuration (v1.24.0)
 	IPerf3              *IPerf3Config        // iPerf3 server emulation configuration (v1.25.0)
+	ReflectorConfig     *ReflectorConfig     // NetAlly UDP reflector endpoint (v0.94.0)
 	PortChannels        []PortChannel        // Port-channel/LAG configuration (v1.23.0)
 	TrunkPorts          []TrunkPort          // Trunk port configuration (v1.23.0)
 	Properties          map[string]string
@@ -202,6 +203,15 @@ type IPerf3Config struct {
 	PacketLossPercent float64 // Simulated packet loss percentage
 	UploadMbps        float64 // Simulated upload bandwidth
 	DownloadMbps      float64 // Simulated download bandwidth
+}
+
+// ReflectorConfig holds NetAlly UDP reflector settings for a device. A device
+// with this set echoes signed reflector probes back to the sender (see
+// UDPHandler reflect path). Presence enables the reflector.
+type ReflectorConfig struct {
+	LatencyMs int  // Delay before reflecting, in milliseconds (0 = immediate)
+	JitterMs  int  // Random +/- delay around LatencyMs, in milliseconds
+	DSCP      bool // true: toggle DSCP bottom-2 bits (0x03); false: IP-precedence bit (0x01)
 }
 
 // DHCPConfig holds DHCP server configuration for a device.

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -410,5 +410,8 @@ func parseDeviceProtocolConfigs(device *Device, yamlDevice *converter.Device) er
 	// Handle iPerf3 configuration
 	device.IPerf3 = parseIPerf3Config(yamlDevice.IPerf3)
 
+	// Handle UDP reflector configuration
+	device.ReflectorConfig = parseReflectorConfig(yamlDevice.Reflector)
+
 	return nil
 }

--- a/internal/config/yaml_protocols.go
+++ b/internal/config/yaml_protocols.go
@@ -59,6 +59,20 @@ func parseOSFingerprintConfig(yamlOSFP *converter.OSFingerprintConfig) *OSFinger
 	return osFP
 }
 
+// parseReflectorConfig parses NetAlly UDP reflector configuration from YAML.
+// A non-nil result enables the reflector on the device.
+func parseReflectorConfig(yamlReflector *converter.ReflectorConfig) *ReflectorConfig {
+	if yamlReflector == nil {
+		return nil
+	}
+
+	return &ReflectorConfig{
+		LatencyMs: yamlReflector.LatencyMs,
+		JitterMs:  yamlReflector.JitterMs,
+		DSCP:      yamlReflector.DSCP,
+	}
+}
+
 // parseIPerf3Config parses iPerf3 server emulation configuration from YAML.
 func parseIPerf3Config(yamlIPerf3 *converter.IPerf3Config) *IPerf3Config {
 	if yamlIPerf3 == nil {

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -85,6 +85,7 @@ type Device struct {
 	Traffic       *TrafficConfig       `yaml:"traffic,omitempty"`        // v1.6.0
 	OSFingerprint *OSFingerprintConfig `yaml:"os_fingerprint,omitempty"` // v1.24.0
 	IPerf3        *IPerf3Config        `yaml:"iperf3,omitempty"`         // v1.25.0
+	Reflector     *ReflectorConfig     `yaml:"reflector,omitempty"`      // v0.94.0 — NetAlly UDP reflector endpoint
 	Interfaces    []Interface          `yaml:"interfaces,omitempty"`     // Device interface metadata
 	TrunkPorts    []TrunkPort          `yaml:"trunk_ports,omitempty"`    // v1.23.0 — topology link declarations
 	PortChannels  []PortChannel        `yaml:"port_channels,omitempty"`  // v1.23.0 — LAG bundling
@@ -137,6 +138,26 @@ type IPerf3Config struct {
 	PacketLossPercent float64 `yaml:"packet_loss_percent,omitempty"`
 	UploadMbps        float64 `yaml:"upload_mbps,omitempty"`
 	DownloadMbps      float64 `yaml:"download_mbps,omitempty"`
+}
+
+// ReflectorConfig represents a NetAlly-style UDP reflector endpoint. When
+// present, the device echoes signed reflector probes (TrueSpeed / performance
+// tests) back to the sender with source/destination swapped, matching the
+// niac-java Reflector() section. The presence of this block enables the
+// reflector; there is no separate enable flag (Java sets isReflector on the
+// section being parsed).
+type ReflectorConfig struct {
+	// LatencyMs delays the reflected packet by this many milliseconds,
+	// simulating one-way path latency (Java Latency()). 0 = reflect
+	// immediately.
+	LatencyMs int `yaml:"latency_ms,omitempty" validate:"omitempty,gte=0,lte=60000"`
+	// JitterMs randomises the delay by +/- this many milliseconds around
+	// LatencyMs (Java Jitter()). 0 = no jitter.
+	JitterMs int `yaml:"jitter_ms,omitempty" validate:"omitempty,gte=0,lte=60000"`
+	// DSCP selects which ToS bits are toggled on the reflected packet:
+	// true wiggles the bottom two DSCP bits (0x03, Java Dscp), false
+	// wiggles the IP-precedence bit (0x01, Java IpPrecedence — the default).
+	DSCP bool `yaml:"dscp,omitempty"`
 }
 
 // OSFingerprintConfig represents OS fingerprinting configuration for device simulation.

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -36,6 +36,27 @@ const (
 	udpIPv4TTL     = 64 // IPv4 default TTL
 )
 
+// NetAlly UDP reflector constants. The reflector echoes probes whose payload
+// carries one of the signatures below, starting at reflectorSigOffset bytes
+// into the UDP payload (matching niac-java Udp.reflect: signatureIdx =
+// udpDataIdx + 5).
+const (
+	reflectorSigOffset = 5 // Signature starts 5 bytes into the UDP payload
+
+	// reflectorWiggleIPPrec toggles the IP-precedence bit; reflectorWiggleDSCP
+	// toggles the bottom two DSCP bits. The reflected packet's ToS is XORed
+	// with one of these so the tester can confirm the round trip preserved (or
+	// deliberately altered) DiffServ marking.
+	reflectorWiggleIPPrec = 0x01
+	reflectorWiggleDSCP   = 0x03
+
+	// reflectorSigData and reflectorSigProbe are the 8-byte magic strings that
+	// mark a reflector probe. A payload matching either at reflectorSigOffset is
+	// echoed back.
+	reflectorSigData  = "DATA:OT\x00"
+	reflectorSigProbe = "PROBEOT\x00"
+)
+
 // UDPHandler handles UDP packets.
 type UDPHandler struct {
 	stack *Stack
@@ -102,6 +123,13 @@ func (h *UDPHandler) HandlePacket(pkt *Packet, ipLayer *layers.IPv4, devices []*
 		// NetBIOS Datagram Service
 		h.stack.netbiosHandler.HandleDatagramService(pkt, packet, udp, devices)
 	default:
+		// A NetAlly reflector probe arrives on an arbitrary UDP port and is
+		// identified by its payload signature, not the port — so reflection
+		// is attempted here rather than via a fixed case.
+		if h.tryReflect(pkt, ipLayer, udp, devices) {
+			return
+		}
+
 		if debugLevel >= DebugLevelVerbose {
 			_, _ = fmt.Fprintf(os.Stdout, "UDP packet to unhandled port %d sn=%d\n", udp.DstPort, pkt.SerialNumber)
 		}
@@ -175,13 +203,26 @@ func (h *UDPHandler) proxyToMap(device *config.Device, ipLayer *layers.IPv4, udp
 	}()
 }
 
-// SendUDP sends a UDP packet.
+// SendUDP sends a UDP packet with a default (zero) ToS byte.
 func (h *UDPHandler) SendUDP(
 	srcIP, dstIP []byte,
 	srcPort, dstPort uint16,
 	payload []byte,
 	srcMAC, dstMAC []byte,
 	vlan int,
+) error {
+	return h.sendUDPWithTOS(srcIP, dstIP, srcPort, dstPort, payload, srcMAC, dstMAC, vlan, 0)
+}
+
+// sendUDPWithTOS sends a UDP packet, stamping the IPv4 ToS byte. tos lets the
+// reflector path preserve/alter DiffServ marking; other callers pass 0.
+func (h *UDPHandler) sendUDPWithTOS(
+	srcIP, dstIP []byte,
+	srcPort, dstPort uint16,
+	payload []byte,
+	srcMAC, dstMAC []byte,
+	vlan int,
+	tos uint8,
 ) error {
 	// Build Ethernet header
 	eth := &layers.Ethernet{
@@ -194,6 +235,7 @@ func (h *UDPHandler) SendUDP(
 	ipLayer := &layers.IPv4{
 		Version:  udpIPv4Version,
 		IHL:      udpIPv4IHL,
+		TOS:      tos,
 		TTL:      udpIPv4TTL,
 		Protocol: layers.IPProtocolUDP,
 		SrcIP:    srcIP,
@@ -246,6 +288,128 @@ func (h *UDPHandler) SendUDP(
 	}
 
 	return nil
+}
+
+// tryReflect echoes a NetAlly reflector probe back to its sender. It returns
+// true when the packet was a reflector probe destined for a reflector-enabled
+// device (and was reflected), false otherwise so the caller can fall through to
+// normal unhandled-port logging.
+//
+// A reflected packet swaps source/destination MAC and IP but — matching
+// niac-java Udp.reflect — leaves the UDP ports untouched; the tester matches
+// the reply by its payload signature, not the 4-tuple. The IPv4 ToS byte is
+// wiggled so the round trip's DiffServ handling is observable, and the reply is
+// delayed by the device's configured latency +/- jitter.
+func (h *UDPHandler) tryReflect(pkt *Packet, ipLayer *layers.IPv4, udp *layers.UDP, devices []*config.Device) bool {
+	device := reflectorForIP(devices, ipLayer.DstIP)
+	if device == nil {
+		return false
+	}
+
+	if !reflectorSignatureMatch(udp.Payload) {
+		return false
+	}
+
+	srcMAC := []byte(device.MACAddress)
+	dstMAC := pkt.GetSourceMAC()
+
+	if len(srcMAC) == 0 || len(dstMAC) == 0 {
+		return false
+	}
+
+	srcIP := ipLayer.DstIP.To4() // reflector answers as itself
+	dstIP := ipLayer.SrcIP.To4() // back to the tester
+
+	if srcIP == nil || dstIP == nil {
+		return false
+	}
+
+	tos := wiggleTOS(ipLayer.TOS, device.ReflectorConfig.DSCP)
+
+	// Own the payload bytes: the capture buffer is reused, and reflection may
+	// be deferred onto a timer goroutine.
+	payload := append([]byte(nil), udp.Payload...)
+	srcPort := uint16(udp.SrcPort)
+	dstPort := uint16(udp.DstPort)
+	vlan := pkt.VLAN
+
+	send := func() {
+		_ = h.sendUDPWithTOS(srcIP, dstIP, srcPort, dstPort, payload, srcMAC, dstMAC, vlan, tos)
+	}
+
+	if delay := reflectorDelay(device.ReflectorConfig); delay > 0 {
+		time.AfterFunc(delay, send)
+	} else {
+		send()
+	}
+
+	if h.stack.GetDebugLevel() >= DebugLevelVerbose {
+		_, _ = fmt.Fprintf(os.Stdout, "Reflected UDP probe %s:%d -> %s (sn=%d)\n",
+			ipLayer.SrcIP, udp.SrcPort, ipLayer.DstIP, pkt.SerialNumber)
+	}
+
+	return true
+}
+
+// reflectorForIP returns the first reflector-enabled device that owns ip, or
+// nil if none does.
+func reflectorForIP(devices []*config.Device, ip net.IP) *config.Device {
+	for _, device := range devices {
+		if device.ReflectorConfig == nil {
+			continue
+		}
+
+		for _, deviceIP := range device.IPAddresses {
+			if deviceIP.Equal(ip) {
+				return device
+			}
+		}
+	}
+
+	return nil
+}
+
+// reflectorSignatureMatch reports whether payload carries a reflector signature
+// at reflectorSigOffset.
+func reflectorSignatureMatch(payload []byte) bool {
+	for _, sig := range []string{reflectorSigData, reflectorSigProbe} {
+		if len(payload) >= reflectorSigOffset+len(sig) &&
+			string(payload[reflectorSigOffset:reflectorSigOffset+len(sig)]) == sig {
+			return true
+		}
+	}
+
+	return false
+}
+
+// wiggleTOS toggles the IP-precedence bit (or the bottom two DSCP bits when
+// dscp is set) of a ToS byte, matching niac-java's reflector wiggle.
+func wiggleTOS(tos uint8, dscp bool) uint8 {
+	wiggle := uint8(reflectorWiggleIPPrec)
+	if dscp {
+		wiggle = reflectorWiggleDSCP
+	}
+
+	return tos ^ wiggle
+}
+
+// reflectorDelay returns the send delay for a reflected packet: the configured
+// latency, randomised by +/- jitter, floored at zero.
+func reflectorDelay(cfg *config.ReflectorConfig) time.Duration {
+	if cfg.LatencyMs <= 0 && cfg.JitterMs <= 0 {
+		return 0
+	}
+
+	ms := cfg.LatencyMs
+	if cfg.JitterMs > 0 {
+		ms += getSimRand().IntN(2*cfg.JitterMs+1) - cfg.JitterMs
+	}
+
+	if ms < 0 {
+		ms = 0
+	}
+
+	return time.Duration(ms) * time.Millisecond
 }
 
 // HandlePacketV6 processes a UDP packet over IPv6.

--- a/internal/protocols/udp_reflector_test.go
+++ b/internal/protocols/udp_reflector_test.go
@@ -1,0 +1,256 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// buildReflectorProbe serialises a UDP reflector probe from tester -> reflector
+// and returns a Packet (whose Buffer carries the Ethernet header so
+// GetSourceMAC works), plus the parsed IPv4/UDP layers tryReflect consumes.
+func buildReflectorProbe(
+	t *testing.T,
+	testerMAC, reflMAC net.HardwareAddr,
+	testerIP, reflIP net.IP,
+	tos uint8,
+	vlan int,
+	payload []byte,
+) (*Packet, *layers.IPv4, *layers.UDP) {
+	t.Helper()
+
+	eth := &layers.Ethernet{SrcMAC: testerMAC, DstMAC: reflMAC, EthernetType: layers.EthernetTypeIPv4}
+	ip := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TOS:      tos,
+		TTL:      64,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    testerIP.To4(),
+		DstIP:    reflIP.To4(),
+	}
+	udp := &layers.UDP{SrcPort: 45000, DstPort: 3842}
+
+	if err := udp.SetNetworkLayerForChecksum(ip); err != nil {
+		t.Fatalf("SetNetworkLayerForChecksum: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+
+	if err := gopacket.SerializeLayers(buf, opts, eth, ip, udp, gopacket.Payload(payload)); err != nil {
+		t.Fatalf("SerializeLayers: %v", err)
+	}
+
+	pkt := &Packet{Buffer: buf.Bytes(), Length: len(buf.Bytes()), SerialNumber: 1, VLAN: vlan}
+	// Re-decode the UDP layer so udp.Payload is populated as it is at runtime.
+	udp.Payload = payload
+
+	return pkt, ip, udp
+}
+
+// reflectorProbePayload returns a payload with sig at reflectorSigOffset.
+func reflectorProbePayload(sig string) []byte {
+	p := make([]byte, reflectorSigOffset+len(sig))
+	copy(p[reflectorSigOffset:], sig)
+
+	return p
+}
+
+func TestReflectorSignatureMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    bool
+	}{
+		{"data signature", reflectorProbePayload("DATA:OT\x00"), true},
+		{"probe signature", reflectorProbePayload("PROBEOT\x00"), true},
+		{"wrong signature", reflectorProbePayload("NOPE:XX\x00"), false},
+		{"signature at wrong offset", append([]byte("DATA:OT\x00"), 0, 0), false},
+		{"too short", []byte("DATA"), false},
+		{"empty", nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reflectorSignatureMatch(tc.payload); got != tc.want {
+				t.Errorf("reflectorSignatureMatch = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWiggleTOS(t *testing.T) {
+	if got := wiggleTOS(0x00, false); got != reflectorWiggleIPPrec {
+		t.Errorf("IP-precedence wiggle of 0x00 = %#x, want %#x", got, reflectorWiggleIPPrec)
+	}
+
+	if got := wiggleTOS(0x00, true); got != reflectorWiggleDSCP {
+		t.Errorf("DSCP wiggle of 0x00 = %#x, want %#x", got, reflectorWiggleDSCP)
+	}
+
+	// XOR is its own inverse: wiggling twice restores the original.
+	if got := wiggleTOS(wiggleTOS(0xB8, true), true); got != 0xB8 {
+		t.Errorf("double DSCP wiggle = %#x, want 0xB8", got)
+	}
+}
+
+func TestReflectorDelay(t *testing.T) {
+	if d := reflectorDelay(&config.ReflectorConfig{}); d != 0 {
+		t.Errorf("zero config delay = %v, want 0", d)
+	}
+
+	// Jitter alone stays within [0, jitter].
+	for range 100 {
+		d := reflectorDelay(&config.ReflectorConfig{JitterMs: 10}).Milliseconds()
+		if d < 0 || d > 10 {
+			t.Fatalf("jitter-only delay %d out of [0,10]", d)
+		}
+	}
+
+	// Latency + jitter stays within [latency-jitter, latency+jitter], floored at 0.
+	for range 100 {
+		d := reflectorDelay(&config.ReflectorConfig{LatencyMs: 50, JitterMs: 5}).Milliseconds()
+		if d < 45 || d > 55 {
+			t.Fatalf("latency+jitter delay %d out of [45,55]", d)
+		}
+	}
+}
+
+func TestTryReflect(t *testing.T) {
+	stack := newTestStackInternal(t)
+	handler := NewUDPHandler(stack)
+
+	testerMAC := net.HardwareAddr{0xAA, 0xAA, 0xAA, 0x00, 0x00, 0x01}
+	reflMAC := net.HardwareAddr{0xBB, 0xBB, 0xBB, 0x00, 0x00, 0x02}
+	testerIP := net.ParseIP("10.20.200.250")
+	reflIP := net.ParseIP("10.20.200.100")
+
+	device := &config.Device{
+		Name:            "reflector",
+		MACAddress:      reflMAC,
+		IPAddresses:     []net.IP{reflIP},
+		ReflectorConfig: &config.ReflectorConfig{}, // immediate, IP-precedence wiggle
+	}
+	devices := []*config.Device{device}
+
+	const probeTOS = 0x00
+
+	pkt, ip, udp := buildReflectorProbe(
+		t,
+		testerMAC,
+		reflMAC,
+		testerIP,
+		reflIP,
+		probeTOS,
+		200,
+		reflectorProbePayload("DATA:OT\x00"),
+	)
+
+	if !handler.tryReflect(pkt, ip, udp, devices) {
+		t.Fatal("tryReflect returned false for a valid probe")
+	}
+
+	var reply *Packet
+	select {
+	case reply = <-stack.sendQueue:
+	default:
+		t.Fatal("no reflected packet was queued")
+	}
+
+	if reply.VLAN != 200 {
+		t.Errorf("reflected VLAN = %d, want 200 (echo request VLAN)", reply.VLAN)
+	}
+
+	// Decode the reflected frame and assert the swap.
+	got := gopacket.NewPacket(reply.Buffer, layers.LayerTypeEthernet, gopacket.Default)
+
+	ethOut, _ := got.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+	if ethOut == nil {
+		t.Fatal("reflected packet missing Ethernet layer")
+	}
+
+	if ethOut.SrcMAC.String() != reflMAC.String() || ethOut.DstMAC.String() != testerMAC.String() {
+		t.Errorf("reflected MACs src=%s dst=%s, want src=%s dst=%s",
+			ethOut.SrcMAC, ethOut.DstMAC, reflMAC, testerMAC)
+	}
+
+	ipOut, _ := got.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+	if ipOut == nil {
+		t.Fatal("reflected packet missing IPv4 layer")
+	}
+
+	if !ipOut.SrcIP.Equal(reflIP) || !ipOut.DstIP.Equal(testerIP) {
+		t.Errorf("reflected IPs src=%s dst=%s, want src=%s dst=%s",
+			ipOut.SrcIP, ipOut.DstIP, reflIP, testerIP)
+	}
+
+	if ipOut.TOS != reflectorWiggleIPPrec {
+		t.Errorf("reflected TOS = %#x, want %#x (wiggled from 0x00)", ipOut.TOS, reflectorWiggleIPPrec)
+	}
+
+	udpOut, _ := got.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	if udpOut == nil {
+		t.Fatal("reflected packet missing UDP layer")
+	}
+
+	// Ports are intentionally NOT swapped, matching niac-java.
+	if udpOut.SrcPort != udp.SrcPort || udpOut.DstPort != udp.DstPort {
+		t.Errorf("reflected ports src=%d dst=%d, want src=%d dst=%d (unswapped)",
+			udpOut.SrcPort, udpOut.DstPort, udp.SrcPort, udp.DstPort)
+	}
+}
+
+func TestTryReflectSkips(t *testing.T) {
+	stack := newTestStackInternal(t)
+	handler := NewUDPHandler(stack)
+
+	reflMAC := net.HardwareAddr{0xBB, 0xBB, 0xBB, 0x00, 0x00, 0x02}
+	reflIP := net.ParseIP("10.20.200.100")
+	testerMAC := net.HardwareAddr{0xAA, 0xAA, 0xAA, 0x00, 0x00, 0x01}
+	testerIP := net.ParseIP("10.20.200.250")
+
+	reflector := &config.Device{
+		Name: "reflector", MACAddress: reflMAC, IPAddresses: []net.IP{reflIP},
+		ReflectorConfig: &config.ReflectorConfig{},
+	}
+	plain := &config.Device{
+		Name: "plain", MACAddress: reflMAC, IPAddresses: []net.IP{reflIP},
+	}
+
+	t.Run("no reflector device", func(t *testing.T) {
+		pkt, ip, udp := buildReflectorProbe(
+			t,
+			testerMAC,
+			reflMAC,
+			testerIP,
+			reflIP,
+			0,
+			0,
+			reflectorProbePayload("DATA:OT\x00"),
+		)
+		if handler.tryReflect(pkt, ip, udp, []*config.Device{plain}) {
+			t.Error("reflected for a non-reflector device")
+		}
+	})
+
+	t.Run("no signature", func(t *testing.T) {
+		pkt, ip, udp := buildReflectorProbe(
+			t,
+			testerMAC,
+			reflMAC,
+			testerIP,
+			reflIP,
+			0,
+			0,
+			[]byte("just some udp payload"),
+		)
+		if handler.tryReflect(pkt, ip, udp, []*config.Device{reflector}) {
+			t.Error("reflected a non-probe payload")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds NetAlly-style **UDP reflector** mode — the last Java feature niac-go lacked (`Udp.reflect`). A device with a `reflector:` block echoes signed reflector probes (`DATA:OT` / `PROBEOT`, 5 bytes into the payload) back to the sender: source/destination MAC and IP swapped, IPv4 ToS wiggled (IP-precedence bit, or DSCP bottom-2 when `dscp: true`), reply delayed by `latency_ms` +/- `jitter_ms`. UDP ports are **intentionally left unswapped** (the tester matches replies by signature, not the 4-tuple) and the request VLAN is echoed — matching niac-java and the reply-VLAN pattern. This is the endpoint a NetAlly performance/TrueSpeed tester bounces probes off.

Touches: `ReflectorConfig` in converter/config/parser, the UDP reflect path (`tryReflect` + ToS-aware sender), API/UI schema, regenerated JSON schema, PROTOCOL_GUIDE + README docs, and unit tests. Reuses the repo's `simRand` (crypto/rand) for jitter so gosec stays green.

## Linked Issue

Related to #849. Java parity: `Udp.reflect` (Reflector section) — the last Java feature Go lacked.

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/... ./internal/config/... ./internal/api/... ./internal/converter/...   # ok
$ make lint     # 0 issues (Backend + Frontend)
$ make fmt-check # all formatting checks passed

Unit tests assert: signature match at offset 5, ToS wiggle (XOR self-inverse),
jitter bounds, full reflect (MAC+IP swapped, ports unswapped, VLAN echoed, ToS
wiggled), and skip paths (non-reflector device / non-probe payload). YAML ->
domain round-trip proves the reflector block reaches device.ReflectorConfig.
```

Wire verification on CT304 (tagged VLAN200) is a follow-up alongside #878.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only UDP response path; no routes)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (PROTOCOL_GUIDE + README + generated schema)

