### PR TITLE
fix(dns): reply on the request VLAN so tagged testers resolve names

### DIFF
--- a/internal/protocols/coverage_extra_test.go
+++ b/internal/protocols/coverage_extra_test.go
@@ -420,7 +420,7 @@ func TestDNSSendDNSResponse(t *testing.T) {
 		net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2"),
 		net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
 		net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
-		12345)
+		12345, 0)
 	// Expect error because stack has no capture engine
 	if err == nil {
 		t.Log("SendDNSResponse succeeded (stack queued packet)")
@@ -440,7 +440,7 @@ func TestDNSSendDNSResponseV6(t *testing.T) {
 		net.ParseIP("fd00::1"), net.ParseIP("fd00::2"),
 		net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
 		net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
-		12345)
+		12345, 0)
 	if err == nil {
 		t.Log("SendDNSResponseV6 succeeded")
 	}

--- a/internal/protocols/dns_handler.go
+++ b/internal/protocols/dns_handler.go
@@ -41,7 +41,7 @@ func (h *DNSHandler) HandleQuery(
 	response := h.buildDNSResponse(dns, serverDevice, debugLevel, pkt.SerialNumber)
 	srcMAC := h.extractSourceMAC(packet)
 	h.sendAndLogResponse(response, serverIP, ipLayer.SrcIP, serverDevice.MACAddress, srcMAC,
-		udpLayer.SrcPort, debugLevel, pkt.SerialNumber)
+		udpLayer.SrcPort, pkt.VLAN, debugLevel, pkt.SerialNumber)
 }
 
 // parseDNSLayer extracts and validates the DNS layer from a packet.
@@ -185,10 +185,11 @@ func (h *DNSHandler) sendAndLogResponse(
 	srcIP, dstIP net.IP,
 	srcMAC, dstMAC net.HardwareAddr,
 	dstPort layers.UDPPort,
+	vlan int,
 	debugLevel int,
 	serial int,
 ) {
-	err := h.SendDNSResponse(response, srcIP, dstIP, srcMAC, dstMAC, dstPort)
+	err := h.SendDNSResponse(response, srcIP, dstIP, srcMAC, dstMAC, dstPort, vlan)
 	if err != nil {
 		if debugLevel >= DebugLevelInfo {
 			_, _ = fmt.Fprintf(os.Stdout, "DNS: Failed to send response: %v sn=%d\n", err, serial)
@@ -203,12 +204,15 @@ func (h *DNSHandler) sendAndLogResponse(
 	}
 }
 
-// SendDNSResponse sends a DNS response.
+// SendDNSResponse sends a DNS response on the request's VLAN. A tagged request
+// (a tester on an 802.1Q trunk) must get a tagged reply, or the frame is dropped
+// before it reaches the sender — the same reply-VLAN rule the other handlers use.
 func (h *DNSHandler) SendDNSResponse(
 	response *layers.DNS,
 	srcIP, dstIP net.IP,
 	srcMAC, dstMAC net.HardwareAddr,
 	dstPort layers.UDPPort,
+	vlan int,
 ) error {
 	// Build UDP layer
 	udp := &layers.UDP{
@@ -246,16 +250,17 @@ func (h *DNSHandler) SendDNSResponse(
 		return fmt.Errorf("failed to serialize DNS response: %w", err)
 	}
 
-	// Send packet
-	return h.stack.SendRawPacket(buf.Bytes())
+	// Reply on the VLAN the query arrived on (0 = untagged).
+	return h.stack.SendRawPacketVLAN(buf.Bytes(), vlan)
 }
 
-// SendDNSResponseV6 sends a DNS response over IPv6.
+// SendDNSResponseV6 sends a DNS response over IPv6 on the request's VLAN.
 func (h *DNSHandler) SendDNSResponseV6(
 	response *layers.DNS,
 	srcIP, dstIP net.IP,
 	srcMAC, dstMAC net.HardwareAddr,
 	dstPort layers.UDPPort,
+	vlan int,
 ) error {
 	udp := &layers.UDP{
 		SrcPort: dnsPort,
@@ -291,7 +296,8 @@ func (h *DNSHandler) SendDNSResponseV6(
 		return fmt.Errorf("failed to serialize DNS/IPv6 response: %w", err)
 	}
 
-	return h.stack.SendRawPacket(buf.Bytes())
+	// Reply on the VLAN the query arrived on (0 = untagged).
+	return h.stack.SendRawPacketVLAN(buf.Bytes(), vlan)
 }
 
 // HandleQueryV6 processes a DNS query over IPv6.
@@ -328,7 +334,7 @@ func (h *DNSHandler) HandleQueryV6(
 	}
 
 	h.sendAndLogResponseV6(response, serverIP, ipv6.SrcIP, serverDevice.MACAddress, dstMAC,
-		udpLayer.SrcPort, debugLevel, pkt.SerialNumber)
+		udpLayer.SrcPort, pkt.VLAN, debugLevel, pkt.SerialNumber)
 }
 
 // handleNBSTATIfPresentV6 checks for and handles NBSTAT queries over IPv6.
@@ -419,10 +425,11 @@ func (h *DNSHandler) sendAndLogResponseV6(
 	srcIP, dstIP net.IP,
 	srcMAC, dstMAC net.HardwareAddr,
 	dstPort layers.UDPPort,
+	vlan int,
 	debugLevel int,
 	serial int,
 ) {
-	err := h.SendDNSResponseV6(response, srcIP, dstIP, srcMAC, dstMAC, dstPort)
+	err := h.SendDNSResponseV6(response, srcIP, dstIP, srcMAC, dstMAC, dstPort, vlan)
 	if err != nil && debugLevel >= DebugLevelInfo {
 		_, _ = fmt.Fprintf(os.Stdout, "DNS/IPv6: Failed to send response: %v sn=%d\n", err, serial)
 	}

--- a/internal/protocols/dns_vlan_test.go
+++ b/internal/protocols/dns_vlan_test.go
@@ -1,0 +1,39 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket/layers"
+)
+
+// TestSendDNSResponseEchoesVLAN verifies a DNS reply is queued on the request's
+// VLAN. A tester on an 802.1Q trunk sends tagged queries; an untagged reply is
+// dropped before it reaches the sender (the pre-#876 bug, which had never been
+// applied to the DNS handler — DNS used SendRawPacket, not SendRawPacketVLAN).
+func TestSendDNSResponseEchoesVLAN(t *testing.T) {
+	for _, vlan := range []int{0, 200} {
+		stack := newTestStackInternal(t)
+		h := NewDNSHandler(stack)
+
+		response := &layers.DNS{ID: 1, QR: true, AA: true, ResponseCode: layers.DNSResponseCodeNoErr}
+
+		err := h.SendDNSResponse(response,
+			net.ParseIP("10.20.200.2"), net.ParseIP("10.20.200.250"),
+			net.HardwareAddr{0x02, 0x00, 0x14, 0x03, 0x00, 0x01},
+			net.HardwareAddr{0xaa, 0xaa, 0xaa, 0x00, 0x00, 0x01},
+			45000, vlan)
+		if err != nil {
+			t.Fatalf("SendDNSResponse(vlan=%d): %v", vlan, err)
+		}
+
+		select {
+		case pkt := <-stack.sendQueue:
+			if pkt.VLAN != vlan {
+				t.Errorf("DNS reply VLAN = %d, want %d (must echo the request VLAN)", pkt.VLAN, vlan)
+			}
+		default:
+			t.Fatalf("no DNS reply queued for vlan=%d", vlan)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

DNS was the one query handler still sending replies via `SendRawPacket` (untagged) instead of `SendRawPacketVLAN(pkt.VLAN)`. On an 802.1Q trunk, a tester's tagged query got an **untagged** reply, which is dropped before it reaches the sender — so DNS (and thus a CyberScope Internet AutoTest's name resolution) was dark on the tagged demo, **even for exact-match records**. SNMP, TCP, HTTP, and DHCP already echo the request VLAN (#876); this applies the same reply-VLAN rule to DNS v4 and v6, threading `pkt.VLAN` through `sendAndLogResponse` → `SendDNSResponse` → `SendRawPacketVLAN`.

Found live: on the CT304 tagged-VLAN200 demo, `snmpget` to the DNS server worked but `dig` (exact record and wildcard alike) timed out. Root cause was the untagged reply, not the config.

## Linked Issue

Related to #849. Same class as #876 (reply-VLAN), never applied to DNS.

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run 'DNS|SendDNS'   # ok
  TestSendDNSResponseEchoesVLAN asserts the reply is queued on the request
  VLAN (0 and 200); regression guard for the untagged-reply bug.
$ make lint   # 0 issues

Live (CT304, tagged VLAN200) after deploy: dig @10.20.200.2 gw.demo.lab and a
wildcard name both resolve (were timing out before).
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (read-only DNS response path; no routes)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here)
