### PR TITLE
docs(adr): revise ADR 0008 to the N-engines-behind-one-demux model

### DIFF
--- a/docs/adr/0008-multi-vlan-segment-playback.md
+++ b/docs/adr/0008-multi-vlan-segment-playback.md
@@ -1,6 +1,6 @@
-# ADR 0008: Multi-VLAN segment playback (tagged + untagged, per-segment config)
+# ADR 0008: Multi-VLAN playback — N sim engines behind one L2 demux
 
-**Status:** Proposed (2026-07-04)
+**Status:** Proposed (revised 2026-07-04)
 
 ## Context
 
@@ -8,113 +8,118 @@ NIAC replays one config against one interface. VLAN handling is a **global
 mode**, not a first-class dimension:
 
 - Each device carries an optional `vlan:` field, and every reply echoes the
-  VLAN the request arrived on (the "reply-VLAN pattern" established in
-  niac-go #876). This makes a single device answer correctly whether it is
-  reached tagged or untagged.
-- VLAN confinement (niac-go #865) restricts a running sim to a single tagged
-  VLAN and drops untagged frames, so a demo trunk does not see rogue replies on
-  the native VLAN.
+  VLAN the request arrived on (the "reply-VLAN pattern", niac-go #876/#883).
+- VLAN confinement (#865) restricts a running sim to a single tagged VLAN and
+  drops untagged frames, so a demo trunk sees no rogue replies on the native
+  VLAN.
 
-Two limitations follow from the single-config assumption:
+Two limits follow from the single-config assumption:
 
-1. **You pick tagged _or_ untagged, not both.** Confinement is all-or-nothing
-   for one VLAN. A real bench often has an untagged management segment _and_
-   tagged VLANs on the same wire; NIAC cannot present both at once.
-2. **One flat IP namespace.** Because there is a single device table, two
-   devices cannot share an IP even if they live on different VLANs. Real
-   networks routinely reuse `10.0.0.1` across isolated VLANs.
+1. **Tagged _or_ untagged, never both.** Confinement is all-or-nothing for one
+   VLAN. A real bench often has an untagged management segment _and_ tagged
+   VLANs on the same wire.
+2. **One flat IP namespace.** A single device table means two devices cannot
+   share an IP even if they live on different VLANs. Real networks routinely
+   reuse `10.0.0.1` across isolated VLANs.
 
-The demo goal that motivates this: a NetAlly CyberScope roaming an 802.1Q trunk
-should discover **several independent "sites"** — one per VLAN — from a single
-NIAC instance, plus an untagged segment, each with its own topology and IP
-space. The owner also wants this reachable as a UI toggle (play config A
-untagged, config B on VLAN 200, config C on VLAN 300) without hand-editing YAML.
+**The behavior we want** (owner, 2026-07-04):
+
+- **Direct-attached (access cable, no tags):** NIAC serves its config untagged;
+  the tester (a NetAlly CyberScope) discovers everything in it. This is today's
+  flat behavior — unchanged.
+- **On an 802.1Q trunk (native + 200 + 300 …):** each VLAN tag is served by its
+  **own completely independent config** — its own sites, topology, and IP space.
+  Native (untagged-on-wire) → the management config; VLAN 200 → today's demo
+  config, **unchanged**; VLAN 300 → a separate config that may reuse 200's
+  addresses because the two never see each other. One NIAC, one port, N
+  independent networks a CyberScope discovers by roaming VLANs.
+
+Scope is **parity with today, per VLAN** — no new per-VLAN capability, and
+**no QinQ / stacked tags**. "Run today's sim N times, one per tag."
 
 ## Decision
 
-Introduce a **Segment** as the top-level playback unit:
+Model it as **one shared L2 I/O front-end plus N independent sim engines, one
+per VLAN tag** (untagged/native is one more engine). Not "N NIAC servers": the
+naïve reading — N copies of today's `Stack` — breaks, because a `Stack` owns its
+capture engine and N of them would each try to bind the NIC. The split is
+between shared network I/O and per-VLAN sim logic.
 
-```
-Segment = { tag: untagged | <vlan-id>, config: <device set> }
-```
+### Why it is even possible
 
-A running sim owns an ordered list of segments. The receive path **demuxes each
-ingress frame by its VLAN tag** to the matching segment, and dispatches to that
-segment's device table. Everything downstream (handlers, replies) operates
-within the selected segment.
+NIAC **synthesizes every simulated service as raw packets and binds no OS
+sockets** — verified: there is no `net.Listen*` in `internal/protocols`; the
+only real socket is one outbound `net.DialUDP` for the MapToIP proxy. So N
+engines can all "answer SNMP on 161 / DNS on 53 / DHCP on 67" because none of
+them actually owns those ports. A service that bound a real listener would break
+this on port contention; none does.
 
-### Config-first, UI second
+### Shared L2 front-end (one instance)
 
-The binding lives in YAML as a top-level `segments:` list so it is reproducible
-and CLI-testable; the Web UI toggle is a thin editor/enable layer over it, never
-a UI-only concept:
+- **Capture** on the real interface (today's `capture.Engine`, lifted out of
+  `Stack`).
+- **Ingress demux:** read the frame's 802.1Q tag; route to the engine bound to
+  that VLAN. VLAN 0 / priority-tagged → untagged. A tag with no engine is
+  **dropped** — that is confinement (#865), generalized.
+- **Egress:** one send path that stamps each outgoing frame with the **sending
+  engine's** VLAN tag.
 
-```yaml
-segments:
-  - tag: untagged
-    config: mgmt-segment.yaml      # or an inline `devices:` block
-  - tag: 200
-    config: site-evt.yaml
-  - tag: 300
-    config: site-cos.yaml
-```
+### N sim engines (one per tag)
 
-"Untagged" is simply a segment with no tag — this is how NIAC finally supports
-tagged **and** untagged simultaneously rather than choosing one.
+- Each engine is today's single-network sim — device table, protocol handlers,
+  discovery tickers, DHCP leases, neighbour/FDB caches, stats — running
+  **unchanged**, bound to exactly one VLAN (or untagged).
+- The engine **owns a fixed egress VLAN.** Consequences: a reply is tagged
+  correctly *by construction* (the request could only have reached this engine
+  on this VLAN), and device-initiated **emissions** (LLDP/CDP/babble) are tagged
+  the same way for free. This **retires the reply-VLAN bug class** (#876/#883,
+  and the IPv6 gap #884) instead of threading `pkt.VLAN` through every handler
+  forever.
+- L2/L3 identity is **engine-local:** IPs and MACs may repeat across engines;
+  ARP and FDB resolve *within* an engine, never across.
 
-### Backward compatibility
+### Config
 
-A bare top-level `devices:` config (today's format) is treated as a single
-implicit segment. Existing configs — including the current multi-site
-`demo-multisite.yaml` running on VLAN 200 — keep working unchanged; VLAN 200
-stays VLAN 200. A VLAN-300 sibling site is added by appending a second segment,
-not by rewriting the first.
-
-### Confinement generalizes
-
-VLAN confinement (#865) becomes the degenerate one-segment case of a single
-rule: **drop any ingress frame whose VLAN has no segment.** Same safety, now
-multi-tenant.
-
-### What is reused vs. new
-
-- **Reused (already built):** the reply-VLAN echo (#876) already tags every
-  reply to the segment's VLAN — the *tagging* half is free. Per-device `vlan:`
-  and confinement (#865) are the seed of the model.
-- **New:** (a) an ingress demux keyed on `pkt.VLAN` that selects a segment
-  before handler dispatch; (b) per-segment device tables so IP/topology lookups
-  are scoped to a segment instead of global; (c) the `segments:` config schema
-  and its UI editor.
+- Top-level `segments:` list, `{ tag: untagged | <vlan-id>, config }`.
+- A bare `devices:` config = one untagged engine (**backward-compatible**;
+  today's flat / direct-attach behavior). Today's VLAN-200 multi-site config
+  becomes the `tag: 200` engine, byte-for-byte unchanged.
+- Untagged is **always one engine** (the native-bound one). It is never a
+  flattened merge of the tagged VLANs — flattening would collide their reused
+  IPs.
+- Reload targets one engine or all.
 
 ## Consequences
 
 **Positive**
 
-- One NIAC instance presents multiple isolated VLAN "sites" plus an untagged
-  segment on a single trunk — the target CyberScope demo.
-- Overlapping IP spaces across VLANs become legal (per-segment namespaces).
-- Tagged and untagged environments are both first-class, addressing the
-  standing gap where NIAC handled each poorly.
+- Isolation is **structural**, not policed: an engine physically cannot see
+  another's devices, so IP/MAC reuse across VLANs is safe.
+- Existing, battle-tested handler code runs **unchanged** inside an engine.
+- Fixed-egress-VLAN **eliminates a whole bug class** (untagged replies) by
+  construction rather than by per-handler patches.
 
 **Negative / cost**
 
-- Touches the packet-ingress path and the single-config assumption baked into
-  the stack — a focused refactor, not a drop-in. Device lookups move from global
-  to per-segment; the stack holds N device tables instead of one.
-- Reload, stats, topology, and the discovery caches all become
-  segment-scoped and must be audited for the global-state assumption.
-- The Web UI grows a segment manager (list, per-segment VLAN tag, config
-  picker, enable toggle).
+- The real lift is **splitting `Stack`'s I/O ownership from its sim logic** —
+  `Stack` currently owns `capture.Engine`. This is a genuine refactor, not a
+  loop around the current struct.
+- N × discovery goroutines and timers. Fine for a handful of VLANs; cap N — do
+  not scale to 4094.
 
 **Sequencing**
 
-Land after the current UDP parity work (reflector #879, port-unreachable #878).
-This is its own workstream with its own PR series; it is not folded into a
-feature PR. The DHCP/service realism work (see the "beef up the services"
-tracking issue) is independent and can proceed in parallel.
+- Build the front-end split + engine model as its own workstream, after the
+  current UDP parity work (which has shipped).
+- **Do not patch the IPv6 reply-VLAN gap (#884) standalone** if this lands soon
+  — the engine's fixed egress VLAN subsumes it; a separate patch would be
+  throwaway.
+- No QinQ. If stacked tags are ever wanted, that is a separate ADR.
 
 ## References
 
-- niac-go #865 — VLAN confinement (drop untagged on a tagged sim)
-- niac-go #876 — reply-VLAN + source-MAC echo pattern
-- `docs/TOPOLOGY_GUIDE.md` — trunk_ports / VLAN topology declarations
+- niac-go #865 (VLAN confinement), #876 (reply-VLAN + MAC echo), #883 (DNS
+  reply-VLAN), #884 (IPv6 reply-VLAN gap — subsumed here)
+- Supersedes this ADR's prior "segments / per-segment device table" framing with
+  the sharper "N engines behind one L2 demux" model.
+- Tracking epic: #882.


### PR DESCRIPTION
## Summary

Revises **ADR 0008** (still Proposed) from the "segments / per-segment device table" framing to the sharper **"one shared L2 I/O front-end + N independent sim engines, one per VLAN tag"** model, after a design discussion with the owner.

Key decisions locked:
- **Not "N NIAC servers"** — a `Stack` owns its capture engine, so N copies would each grab the NIC. The split is shared L2 I/O vs per-VLAN sim logic.
- **Enabler:** NIAC binds no OS sockets for simulated services (verified: no `net.Listen*`; only an outbound `DialUDP` for MapToIP), so N engines can all "answer SNMP/DNS/DHCP" without port contention.
- **Engine owns a fixed egress VLAN** → replies and emissions are tagged by construction, retiring the reply-VLAN bug class (#876/#883/#884) instead of per-handler patches.
- **Untagged = one engine** (never a flattened merge of tagged VLANs).
- **Parity-with-today, no QinQ.** Today's VLAN-200 config becomes the `tag:200` engine, unchanged.
- **Sequencing:** don't patch the IPv6 gap #884 standalone — the engine model subsumes it.

## Linked Issue

Related to #882 (tracking epic; will be updated to match).

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [x] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
Docs-only (ADR revision). No code paths touched.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (n/a — docs only)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (this IS the doc)
