### PR TITLE
fix(dhcp): NAK a REQUEST the server cannot satisfy instead of silence

### DIFF
--- a/internal/protocols/dhcp.go
+++ b/internal/protocols/dhcp.go
@@ -40,6 +40,9 @@ const (
 // DefaultLeaseTime is the DHCP lease duration (24 hours).
 const DefaultLeaseTime = 24 * time.Hour
 
+// dhcpNakReason is the human-readable message (option 56) carried in a DHCPNAK.
+const dhcpNakReason = "requested address not available"
+
 // DHCP encoding constants.
 const (
 	dhcpMaxByte          = 255    // max byte value for subnet mask octets / max DHCP option length
@@ -484,6 +487,29 @@ func (h *DHCPHandler) handleDHCPDiscover(
 	}
 }
 
+// canGrantRequestedIP reports whether the server can lease exactly ip to mac.
+// It decides ACK vs NAK for a DHCPREQUEST: a request for any other address (a
+// wrong subnet, or one already held by a different client) must be NAKed, not
+// silently ACKed for a substitute. Takes the read lock; the pool/lease helpers
+// it calls assume the caller holds it.
+func (h *DHCPHandler) canGrantRequestedIP(mac net.HardwareAddr, ip net.IP) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	// A statically-bound client may only have its static address.
+	if staticIP := h.matchStaticLease(mac); staticIP != nil {
+		return staticIP.Equal(ip)
+	}
+
+	// The client renewing its own current lease.
+	if existing, ok := h.leases[mac.String()]; ok && existing.IP.Equal(ip) {
+		return true
+	}
+
+	// A pool address the client may claim (in range and not held by another).
+	return h.isIPInPool(ip) && !h.isIPLeased(ip)
+}
+
 // handleDHCPRequest handles a DHCP Request message.
 func (h *DHCPHandler) handleDHCPRequest(
 	info *dhcpPacketInfo,
@@ -499,11 +525,21 @@ func (h *DHCPHandler) handleDHCPRequest(
 
 	requestedIP := getRequestedIP(info.dhcp)
 
+	// A REQUEST names the address the client intends to use. If we cannot lease
+	// exactly that address, reject with a NAK — a real server never substitutes
+	// a different address in the REQUEST phase, and silence just makes the
+	// client wait out a timeout.
+	if requestedIP != nil && !h.canGrantRequestedIP(info.dhcp.ClientHWAddr, requestedIP) {
+		h.sendDHCPNakForRequest(info, serverDevice, requestedIP, serialNum, debugLevel)
+
+		return
+	}
+
 	lease, err := h.allocateLease(info.dhcp.ClientHWAddr, requestedIP, info.hostname)
 	if err != nil {
-		if debugLevel >= 1 {
-			logging.ProtocolDebugf("DHCP", debugLevel, 1, "Failed to confirm lease: %v sn=%d", err, serialNum)
-		}
+		// Cannot fulfil an otherwise-valid request (e.g. pool exhausted); NAK
+		// rather than go silent so the client restarts instead of timing out.
+		h.sendDHCPNakForRequest(info, serverDevice, requestedIP, serialNum, debugLevel)
 
 		return
 	}
@@ -657,6 +693,47 @@ func (h *DHCPHandler) SendDHCPAck(
 	return h.sendDHCPResponse(xid, clientMAC, assignedIP, serverIP, serverMAC, DHCPAck, vlan)
 }
 
+// SendDHCPNak sends a DHCPNAK rejecting a REQUEST the server cannot satisfy
+// (a wrong-subnet or unavailable requested address). Without it, such a request
+// gets silence and the client waits out a timeout — a real server tells the
+// client to restart. Broadcast on the request VLAN with no address or lease
+// options (RFC 2131 §4.3.2).
+func (h *DHCPHandler) SendDHCPNak(
+	xid uint32,
+	clientMAC net.HardwareAddr,
+	serverIP net.IP,
+	serverMAC net.HardwareAddr,
+	vlan int,
+) error {
+	return h.sendDHCPResponse(xid, clientMAC, net.IPv4zero, serverIP, serverMAC, DHCPNak, vlan)
+}
+
+// sendDHCPNakForRequest emits a DHCPNAK for a REQUEST the server cannot satisfy,
+// on the request's VLAN, and records the stat.
+func (h *DHCPHandler) sendDHCPNakForRequest(
+	info *dhcpPacketInfo,
+	serverDevice *config.Device,
+	requestedIP net.IP,
+	serialNum, debugLevel int,
+) {
+	nakErr := h.SendDHCPNak(info.dhcp.Xid, info.dhcp.ClientHWAddr,
+		serverDevice.IPAddresses[0], serverDevice.MACAddress, info.vlan)
+	if nakErr != nil {
+		if debugLevel >= 1 {
+			logging.ProtocolDebugf("DHCP", debugLevel, 1, "Failed to send Nak: %v sn=%d", nakErr, serialNum)
+		}
+
+		return
+	}
+
+	h.stack.IncrementStat("dhcp_naks")
+
+	if debugLevel >= debugLevelInfo {
+		logging.ProtocolDebugf("DHCP", debugLevel, debugLevelInfo,
+			"Sent Nak (requested %s) to %s sn=%d", requestedIP, info.dhcp.ClientHWAddr, serialNum)
+	}
+}
+
 // buildDHCPOptions constructs the DHCP options for a response.
 // Caller must hold h.mu (at least RLock).
 func (h *DHCPHandler) buildDHCPOptions(
@@ -664,6 +741,19 @@ func (h *DHCPHandler) buildDHCPOptions(
 	serverIP net.IP,
 	clientMAC net.HardwareAddr,
 ) []layers.DHCPOption {
+	// A DHCPNAK carries only the message type, the server identifier, and an
+	// optional human-readable reason — never lease parameters or an address
+	// (RFC 2131 §4.3.2). Returning the full option set would let a client
+	// mistake the rejection for a usable lease.
+	if msgType == DHCPNak {
+		return []layers.DHCPOption{
+			{Type: layers.DHCPOptMessageType, Length: 1, Data: []byte{msgType}},
+			{Type: layers.DHCPOptServerID, Length: dhcpIPv4Len, Data: []byte(serverIP.To4())},
+			{Type: layers.DHCPOptMessage, Length: safeconv.Uint8(len(dhcpNakReason)), Data: []byte(dhcpNakReason)},
+			{Type: layers.DHCPOptEnd},
+		}
+	}
+
 	options := []layers.DHCPOption{
 		{Type: layers.DHCPOptMessageType, Length: 1, Data: []byte{msgType}},
 		{Type: layers.DHCPOptServerID, Length: dhcpIPv4Len, Data: []byte(serverIP.To4())},
@@ -809,6 +899,12 @@ func (h *DHCPHandler) sendDHCPResponse(
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
+	// A NAK never conveys an address; yiaddr must be zero (RFC 2131 §4.3.2).
+	yourIP := assignedIP
+	if msgType == DHCPNak {
+		yourIP = net.IPv4zero
+	}
+
 	dhcp := &layers.DHCPv4{
 		Operation:    layers.DHCPOpReply,
 		HardwareType: layers.LinkTypeEthernet,
@@ -819,7 +915,7 @@ func (h *DHCPHandler) sendDHCPResponse(
 		Secs:         0,
 		Flags:        dhcpBroadcastFlag,
 		ClientIP:     net.IPv4zero,
-		YourClientIP: assignedIP,
+		YourClientIP: yourIP,
 		NextServerIP: net.IPv4zero,
 		RelayAgentIP: net.IPv4zero,
 		ClientHWAddr: clientMAC,

--- a/internal/protocols/dhcp_nak_test.go
+++ b/internal/protocols/dhcp_nak_test.go
@@ -1,0 +1,186 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+func drainDHCP(t *testing.T, stack *Stack) *Packet {
+	t.Helper()
+
+	select {
+	case pkt := <-stack.sendQueue:
+		return pkt
+	default:
+		t.Fatal("no DHCP packet queued")
+
+		return nil
+	}
+}
+
+func dhcpOf(t *testing.T, pkt *Packet) *layers.DHCPv4 {
+	t.Helper()
+
+	p := gopacket.NewPacket(pkt.Buffer, layers.LayerTypeEthernet, gopacket.Default)
+
+	d, ok := p.Layer(layers.LayerTypeDHCPv4).(*layers.DHCPv4)
+	if !ok {
+		t.Fatal("packet has no DHCPv4 layer")
+	}
+
+	return d
+}
+
+func dhcpMsgType(d *layers.DHCPv4) byte {
+	for _, o := range d.Options {
+		if o.Type == layers.DHCPOptMessageType && len(o.Data) > 0 {
+			return o.Data[0]
+		}
+	}
+
+	return 0
+}
+
+func newDHCPTestHandler(t *testing.T) (*Stack, *DHCPHandler, *config.Device) {
+	t.Helper()
+
+	stack := newTestStackInternal(t)
+	h := NewDHCPHandler(stack)
+	h.SetPool(net.ParseIP("10.20.200.100"), net.ParseIP("10.20.200.199"))
+	h.SetServerConfig(net.ParseIP("10.20.200.2"), net.ParseIP("10.20.200.1"), nil, "demo.lab")
+	h.subnetMask = net.ParseIP("255.255.255.0")
+
+	device := &config.Device{
+		Name:        "dhcp-server",
+		MACAddress:  net.HardwareAddr{0x02, 0x00, 0x14, 0x03, 0x00, 0x01},
+		IPAddresses: []net.IP{net.ParseIP("10.20.200.2")},
+	}
+
+	return stack, h, device
+}
+
+func dhcpRequest(clientMAC net.HardwareAddr, requestedIP net.IP, vlan int) *dhcpPacketInfo {
+	return &dhcpPacketInfo{
+		dhcp: &layers.DHCPv4{
+			Operation:    layers.DHCPOpRequest,
+			Xid:          0x12345678,
+			ClientHWAddr: clientMAC,
+			Options: []layers.DHCPOption{
+				{Type: layers.DHCPOptMessageType, Length: 1, Data: []byte{DHCPRequest}},
+				{Type: layers.DHCPOptRequestIP, Length: 4, Data: requestedIP.To4()},
+			},
+		},
+		messageType: DHCPRequest,
+		vlan:        vlan,
+	}
+}
+
+// TestBuildDHCPOptionsNak verifies a NAK carries only message-type, server-id,
+// and a message — never lease parameters or a subnet mask (RFC 2131 §4.3.2).
+func TestBuildDHCPOptionsNak(t *testing.T) {
+	stack := newTestStackInternal(t)
+	h := NewDHCPHandler(stack)
+
+	opts := h.buildDHCPOptions(
+		DHCPNak,
+		net.ParseIP("10.20.200.2"),
+		net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+	)
+
+	present := map[layers.DHCPOpt]bool{}
+	for _, o := range opts {
+		present[o.Type] = true
+	}
+
+	if !present[layers.DHCPOptServerID] {
+		t.Error("NAK must carry the server identifier")
+	}
+
+	for _, forbidden := range []layers.DHCPOpt{
+		layers.DHCPOptSubnetMask, layers.DHCPOptRouter, layers.DHCPOptDNS, layers.DHCPOptLeaseTime,
+	} {
+		if present[forbidden] {
+			t.Errorf("NAK must not carry option %v", forbidden)
+		}
+	}
+}
+
+// TestSendDHCPNakWireShape verifies the NAK is broadcast on the request VLAN
+// with a zero yiaddr and message-type NAK.
+func TestSendDHCPNakWireShape(t *testing.T) {
+	stack := newTestStackInternal(t)
+	h := NewDHCPHandler(stack)
+
+	err := h.SendDHCPNak(0x12345678,
+		net.HardwareAddr{0xaa, 0xaa, 0xaa, 0x00, 0x00, 0x01},
+		net.ParseIP("10.20.200.2"),
+		net.HardwareAddr{0x02, 0x00, 0x14, 0x03, 0x00, 0x01},
+		200)
+	if err != nil {
+		t.Fatalf("SendDHCPNak: %v", err)
+	}
+
+	pkt := drainDHCP(t, stack)
+	if pkt.VLAN != 200 {
+		t.Errorf("NAK VLAN = %d, want 200", pkt.VLAN)
+	}
+
+	d := dhcpOf(t, pkt)
+	if mt := dhcpMsgType(d); mt != DHCPNak {
+		t.Errorf("message type = %d, want %d (NAK)", mt, DHCPNak)
+	}
+
+	if !d.YourClientIP.Equal(net.IPv4zero) {
+		t.Errorf("NAK yiaddr = %s, want 0.0.0.0", d.YourClientIP)
+	}
+}
+
+// TestHandleDHCPRequestNakOnWrongSubnet is the core regression: a REQUEST for an
+// address outside the pool is NAKed, not silently ACKed for a substitute.
+func TestHandleDHCPRequestNakOnWrongSubnet(t *testing.T) {
+	stack, h, device := newDHCPTestHandler(t)
+
+	info := dhcpRequest(net.HardwareAddr{0xaa, 0xaa, 0xaa, 0x00, 0x00, 0x01}, net.ParseIP("10.99.99.99"), 200)
+	h.handleDHCPRequest(info, device, 1, 0)
+
+	d := dhcpOf(t, drainDHCP(t, stack))
+	if mt := dhcpMsgType(d); mt != DHCPNak {
+		t.Errorf("wrong-subnet REQUEST got message type %d, want %d (NAK)", mt, DHCPNak)
+	}
+}
+
+// TestHandleDHCPRequestAckOnValidRequest verifies a REQUEST for an in-pool free
+// address still ACKs (the fix must not NAK legitimate requests).
+func TestHandleDHCPRequestAckOnValidRequest(t *testing.T) {
+	stack, h, device := newDHCPTestHandler(t)
+
+	info := dhcpRequest(net.HardwareAddr{0xaa, 0xaa, 0xaa, 0x00, 0x00, 0x02}, net.ParseIP("10.20.200.150"), 200)
+	h.handleDHCPRequest(info, device, 1, 0)
+
+	d := dhcpOf(t, drainDHCP(t, stack))
+	if mt := dhcpMsgType(d); mt != DHCPAck {
+		t.Errorf("valid REQUEST got message type %d, want %d (ACK)", mt, DHCPAck)
+	}
+
+	if !d.YourClientIP.Equal(net.ParseIP("10.20.200.150")) {
+		t.Errorf("ACK yiaddr = %s, want the requested 10.20.200.150", d.YourClientIP)
+	}
+}
+
+func TestCanGrantRequestedIP(t *testing.T) {
+	_, h, _ := newDHCPTestHandler(t)
+	mac := net.HardwareAddr{0xaa, 0xaa, 0xaa, 0x00, 0x00, 0x03}
+
+	if h.canGrantRequestedIP(mac, net.ParseIP("10.20.200.150")) != true {
+		t.Error("in-pool free address should be grantable")
+	}
+
+	if h.canGrantRequestedIP(mac, net.ParseIP("10.99.99.99")) != false {
+		t.Error("out-of-pool address must not be grantable")
+	}
+}


### PR DESCRIPTION
## Summary

Target (A) from #881 — **demo-correct DHCP**. A `DHCPREQUEST` names the address the client intends to use. The server used to, for a wrong-subnet or unavailable requested IP, **silently substitute a different pool address and ACK it** — which a real server never does in the REQUEST phase — and on allocate failure it went **silent**, leaving the client to time out. A CyberScope doing an INIT-REBOOT / cached-lease / renewal request would see a wrong ACK or dead air.

Now: if the server cannot lease *exactly* the requested address (`canGrantRequestedIP`), it broadcasts a **DHCPNAK** on the request VLAN with a zero `yiaddr` and no lease options (RFC 2131 §4.3.2). Legitimate in-pool / static / renewal requests still ACK the requested address.

Adds `SendDHCPNak`, the NAK-only option set in `buildDHCPOptions`, and `canGrantRequestedIP`.

## Linked Issue

Related to #881 (target A). The remaining items (Inform-ACK, Release-frees/reaping, Decline, option-55, Offer/Ack split) are target B, deferred.

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run 'DHCP|Nak|CanGrant' -count=1   # ok
  - TestBuildDHCPOptionsNak: NAK carries only message-type/server-id/message, never mask/router/dns/lease
  - TestSendDHCPNakWireShape: broadcast on the request VLAN, yiaddr 0, message-type NAK
  - TestHandleDHCPRequestNakOnWrongSubnet: out-of-pool REQUEST -> NAK (not a substitute ACK)
  - TestHandleDHCPRequestAckOnValidRequest: in-pool REQUEST -> ACK for the requested address
  - TestCanGrantRequestedIP: in-pool grantable, out-of-pool not
$ make lint   # 0 issues
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (raw DHCP response path; no routes)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (documented here + RFC cite in code)
