### PR TITLE
feat: multi-VLAN segment playback — run N demos at once (ADR 0008)

### DIFF
--- a/cmd/niac/config.go
+++ b/cmd/niac/config.go
@@ -153,7 +153,7 @@ func runConfigExport(args []string) {
 	}
 
 	fmt.Fprintf(os.Stdout, "Configuration exported to %s\n", outputFile)
-	fmt.Fprintf(os.Stdout, "Devices: %d\n", len(cfg.Devices))
+	fmt.Fprintf(os.Stdout, "Devices: %d\n", cfg.DeviceCount())
 }
 
 func runConfigDiff(args []string) {

--- a/cmd/niac/main.go
+++ b/cmd/niac/main.go
@@ -200,7 +200,7 @@ func runLegacyMode(osArgs []string, info versionInfo, services *serviceOptions) 
 
 	// Initialize global statistics (v1.19.0)
 	statsTracker := stats.NewStatistics(interfaceName, configFile, info.version)
-	statsTracker.SetDeviceCount(len(cfg.Devices))
+	statsTracker.SetDeviceCount(cfg.DeviceCount())
 
 	// Count SNMP-enabled devices
 	snmpCount := 0

--- a/cmd/niac/validate.go
+++ b/cmd/niac/validate.go
@@ -112,7 +112,7 @@ func runValidate(args []string, options *validateOptions) {
 	if options.json {
 		outputJSONResult(result)
 	} else {
-		outputTextResult(result, configFile, options.verbose, len(cfg.Devices))
+		outputTextResult(result, configFile, options.verbose, cfg.DeviceCount())
 	}
 
 	// Exit with appropriate code

--- a/docs/schemas/niac.schema.json
+++ b/docs/schemas/niac.schema.json
@@ -161,6 +161,12 @@
             "$ref": "#/$defs/Device"
           },
           "type": "array"
+        },
+        "segments": {
+          "items": {
+            "$ref": "#/$defs/Segment"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -1105,6 +1111,27 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "Segment": {
+      "properties": {
+        "tag": {
+          "type": "string"
+        },
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/Device"
+          },
+          "type": "array"
+        },
+        "config": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tag"
+      ]
     },
     "SnmpAgent": {
       "properties": {

--- a/internal/config/segments_test.go
+++ b/internal/config/segments_test.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestNormalizedSegmentsBackwardCompat: a bare `devices:` config presents as a
+// single untagged segment — today's flat behavior, unchanged.
+func TestNormalizedSegmentsBackwardCompat(t *testing.T) {
+	cfg, err := LoadYAMLBytes([]byte(`
+devices:
+  - name: r1
+    mac: "02:00:00:00:00:01"
+    ips: ["10.0.0.1"]
+`))
+	if err != nil {
+		t.Fatalf("LoadYAMLBytes: %v", err)
+	}
+
+	if len(cfg.Segments) != 0 {
+		t.Errorf("flat config should have no explicit segments, got %d", len(cfg.Segments))
+	}
+
+	segs := cfg.NormalizedSegments()
+	if len(segs) != 1 {
+		t.Fatalf("NormalizedSegments = %d, want 1", len(segs))
+	}
+
+	if segs[0].Tag != UntaggedTag {
+		t.Errorf("implicit segment tag = %d, want untagged (%d)", segs[0].Tag, UntaggedTag)
+	}
+
+	if len(segs[0].Devices) != 1 || segs[0].Devices[0].Name != "r1" {
+		t.Errorf("implicit segment should carry the flat device list")
+	}
+}
+
+// TestSegmentsParse: explicit segments bind device sets to tags; both `untagged`
+// and a bare integer tag are accepted.
+func TestSegmentsParse(t *testing.T) {
+	cfg, err := LoadYAMLBytes([]byte(`
+segments:
+  - tag: untagged
+    devices:
+      - name: mgmt
+        mac: "02:00:00:00:00:0a"
+        ips: ["10.0.0.1"]
+  - tag: 200
+    devices:
+      - name: evt
+        mac: "02:00:00:00:00:14"
+        ips: ["10.20.200.1"]
+`))
+	if err != nil {
+		t.Fatalf("LoadYAMLBytes: %v", err)
+	}
+
+	segs := cfg.NormalizedSegments()
+	if len(segs) != 2 {
+		t.Fatalf("segments = %d, want 2", len(segs))
+	}
+
+	if segs[0].Tag != UntaggedTag {
+		t.Errorf("segment 0 tag = %d, want untagged", segs[0].Tag)
+	}
+
+	if segs[1].Tag != 200 {
+		t.Errorf("segment 1 tag = %d, want 200", segs[1].Tag)
+	}
+
+	if segs[1].Devices[0].Name != "evt" {
+		t.Errorf("segment 1 device = %q, want evt", segs[1].Devices[0].Name)
+	}
+}
+
+func TestSegmentsRejectMixedWithTopLevelDevices(t *testing.T) {
+	_, err := LoadYAMLBytes([]byte(`
+devices:
+  - name: r1
+    mac: "02:00:00:00:00:01"
+    ips: ["10.0.0.1"]
+segments:
+  - tag: 200
+    devices:
+      - name: evt
+        mac: "02:00:00:00:00:14"
+        ips: ["10.20.200.1"]
+`))
+	if !errors.Is(err, ErrSegmentsAndTopLevelDevices) {
+		t.Errorf("mixing top-level devices and segments should fail with ErrSegmentsAndTopLevelDevices, got %v", err)
+	}
+}
+
+func TestSegmentTagValidation(t *testing.T) {
+	for _, bad := range []string{"0", "4095", "abc", "-1"} {
+		_, err := LoadYAMLBytes([]byte(`
+segments:
+  - tag: "` + bad + `"
+    devices:
+      - name: d
+        mac: "02:00:00:00:00:01"
+        ips: ["10.0.0.1"]
+`))
+		if !errors.Is(err, ErrInvalidSegmentTag) {
+			t.Errorf("tag %q should be rejected with ErrInvalidSegmentTag, got %v", bad, err)
+		}
+	}
+}
+
+func TestSegmentDevicesXORConfig(t *testing.T) {
+	// Neither devices nor config.
+	_, err := LoadYAMLBytes([]byte(`
+segments:
+  - tag: 200
+`))
+	if !errors.Is(err, ErrSegmentDevicesXORConfig) {
+		t.Errorf("segment with neither devices nor config should fail, got %v", err)
+	}
+
+	// Both devices and config.
+	_, err = LoadYAMLBytes([]byte(`
+segments:
+  - tag: 200
+    config: other.yaml
+    devices:
+      - name: d
+        mac: "02:00:00:00:00:01"
+        ips: ["10.0.0.1"]
+`))
+	if !errors.Is(err, ErrSegmentDevicesXORConfig) {
+		t.Errorf("segment with both devices and config should fail, got %v", err)
+	}
+}

--- a/internal/config/segments_test.go
+++ b/internal/config/segments_test.go
@@ -2,8 +2,59 @@ package config
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+// TestSegmentConfigPathResolution: a segment's `config:` file (a whole demo) is
+// loaded and its devices become the segment's device set — how two real demo
+// configs are run side-by-side.
+func TestSegmentConfigPathResolution(t *testing.T) {
+	dir := t.TempDir()
+
+	demo1 := filepath.Join(dir, "demo1.yaml")
+	if err := os.WriteFile(demo1, []byte(`
+devices:
+  - name: demo1-r1
+    mac: "02:00:00:00:02:01"
+    ips: ["10.0.0.1"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := filepath.Join(dir, "multi.yaml")
+	if err := os.WriteFile(parent, []byte(`
+segments:
+  - tag: 200
+    config: demo1.yaml
+  - tag: 300
+    devices:
+      - name: demo2-r1
+        mac: "02:00:00:00:03:01"
+        ips: ["10.0.0.1"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadYAML(parent)
+	if err != nil {
+		t.Fatalf("LoadYAML: %v", err)
+	}
+
+	segs := cfg.NormalizedSegments()
+	if len(segs) != 2 {
+		t.Fatalf("segments = %d, want 2", len(segs))
+	}
+
+	if segs[0].Tag != 200 || len(segs[0].Devices) != 1 || segs[0].Devices[0].Name != "demo1-r1" {
+		t.Errorf("tag-200 segment should resolve demo1.yaml to demo1-r1, got %+v", segs[0])
+	}
+
+	if segs[1].Tag != 300 || segs[1].Devices[0].Name != "demo2-r1" {
+		t.Errorf("tag-300 inline segment wrong: %+v", segs[1])
+	}
+}
 
 // TestNormalizedSegmentsBackwardCompat: a bare `devices:` config presents as a
 // single untagged segment — today's flat behavior, unchanged.

--- a/internal/config/segments_test.go
+++ b/internal/config/segments_test.go
@@ -125,6 +125,35 @@ segments:
 	}
 }
 
+func TestDeviceCountIncludesSegments(t *testing.T) {
+	flat, _ := LoadYAMLBytes([]byte(`
+devices:
+  - name: a
+    mac: "02:00:00:00:00:01"
+    ips: ["10.0.0.1"]
+`))
+	if flat.DeviceCount() != 1 {
+		t.Errorf("flat DeviceCount = %d, want 1", flat.DeviceCount())
+	}
+
+	seg, _ := LoadYAMLBytes([]byte(`
+segments:
+  - tag: 200
+    devices:
+      - name: a
+        mac: "02:00:00:00:00:01"
+        ips: ["10.0.0.1"]
+  - tag: 300
+    devices:
+      - name: b
+        mac: "02:00:00:00:00:02"
+        ips: ["10.0.0.2"]
+`))
+	if seg.DeviceCount() != 2 {
+		t.Errorf("segmented DeviceCount = %d, want 2 (must count devices inside segments)", seg.DeviceCount())
+	}
+}
+
 func TestSegmentsRejectMixedWithTopLevelDevices(t *testing.T) {
 	_, err := LoadYAMLBytes([]byte(`
 devices:

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -9,19 +9,23 @@ import (
 var (
 	ErrInvalidDeviceDeclaration = errors.New("invalid device declaration")
 	ErrNoDevicesDefined         = errors.New("no devices defined in configuration")
-	ErrInvalidMapToIP           = errors.New("invalid map_to_ip")
-	ErrInvalidTTLIP             = errors.New("invalid ttl ip")
-	ErrInvalidTTLMask           = errors.New("invalid ttl mask")
-	ErrInvalidIPAddress         = errors.New("invalid IP address")
-	ErrInvalidSNMPAddr          = errors.New("invalid snmp_addr")
-	ErrDNSTTLNegative           = errors.New("DNS record TTL cannot be negative")
-	ErrDNSTTLExceedsMax         = errors.New("DNS record TTL exceeds maximum (2147483647)")
-	ErrInsufficientFields       = errors.New("insufficient fields")
-	ErrPathTraversalDetected    = errors.New("path traversal detected")
-	ErrPathOutsideBaseDir       = errors.New("path outside base directory")
-	ErrWalkFileNotFound         = errors.New("walk file not found")
-	ErrWalkFileIsSymlink        = errors.New("walk file is a symlink (not allowed)")
-	ErrWalkFileNotRegular       = errors.New("walk file is not a regular file")
+
+	ErrSegmentsAndTopLevelDevices = errors.New("use either top-level devices or segments, not both")
+	ErrSegmentDevicesXORConfig    = errors.New("segment must set exactly one of devices or config")
+	ErrInvalidSegmentTag          = errors.New("invalid segment tag")
+	ErrInvalidMapToIP             = errors.New("invalid map_to_ip")
+	ErrInvalidTTLIP               = errors.New("invalid ttl ip")
+	ErrInvalidTTLMask             = errors.New("invalid ttl mask")
+	ErrInvalidIPAddress           = errors.New("invalid IP address")
+	ErrInvalidSNMPAddr            = errors.New("invalid snmp_addr")
+	ErrDNSTTLNegative             = errors.New("DNS record TTL cannot be negative")
+	ErrDNSTTLExceedsMax           = errors.New("DNS record TTL exceeds maximum (2147483647)")
+	ErrInsufficientFields         = errors.New("insufficient fields")
+	ErrPathTraversalDetected      = errors.New("path traversal detected")
+	ErrPathOutsideBaseDir         = errors.New("path outside base directory")
+	ErrWalkFileNotFound           = errors.New("walk file not found")
+	ErrWalkFileIsSymlink          = errors.New("walk file is a symlink (not allowed)")
+	ErrWalkFileNotRegular         = errors.New("walk file is not a regular file")
 )
 
 // LLDP Chassis ID Type constants.
@@ -118,6 +122,32 @@ type Config struct {
 	IncludePath        string              // Base path for walk files
 	CapturePlayback    *CapturePlayback    // Optional PCAP playback config
 	DiscoveryProtocols *DiscoveryProtocols // Discovery protocol configuration
+	Segments           []Segment           // Multi-VLAN playback bindings (ADR 0008); empty = flat/untagged
+}
+
+// UntaggedTag is the Segment.Tag value for the native/untagged VLAN.
+const UntaggedTag = 0
+
+// Segment binds a device set to a VLAN tag for multi-VLAN playback (ADR 0008).
+// Each segment is served as an isolated network on its tag. Exactly one of
+// Devices (inline) or ConfigPath (a file resolved by the loader) is populated.
+type Segment struct {
+	Tag        int      // UntaggedTag (0) for the native VLAN, else a VLAN id 1..4094
+	Devices    []Device // Inline device set for this segment
+	ConfigPath string   // Path to a config file for this segment (resolved by the loader)
+}
+
+// NormalizedSegments returns the list of engine bindings this config describes:
+// its explicit Segments if any, otherwise a single untagged segment wrapping the
+// flat Devices list. This is the one place the "bare devices = one untagged
+// segment" backward-compatibility rule lives, so every consumer sees a uniform
+// list of (tag, device-set) engines.
+func (c *Config) NormalizedSegments() []Segment {
+	if len(c.Segments) > 0 {
+		return c.Segments
+	}
+
+	return []Segment{{Tag: UntaggedTag, Devices: c.Devices}}
 }
 
 // CapturePlayback represents PCAP file playback configuration.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -137,6 +137,22 @@ type Segment struct {
 	ConfigPath string   // Path to a config file for this segment (resolved by the loader)
 }
 
+// DeviceCount returns the total number of devices this config describes,
+// counting devices inside segments (a `segments:` config has no top-level
+// Devices, so len(c.Devices) alone would report zero).
+func (c *Config) DeviceCount() int {
+	if len(c.Segments) == 0 {
+		return len(c.Devices)
+	}
+
+	total := 0
+	for _, seg := range c.Segments {
+		total += len(seg.Devices)
+	}
+
+	return total
+}
+
 // NormalizedSegments returns the list of engine bindings this config describes:
 // its explicit Segments if any, otherwise a single untagged segment wrapping the
 // flat Devices list. This is the one place the "bare devices = one untagged

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -46,8 +46,8 @@ func (v *Validator) Validate(cfg *Config) *ListError {
 		return v.errors
 	}
 
-	// Validate devices
-	if len(cfg.Devices) == 0 {
+	// Validate devices (counting devices inside segments)
+	if cfg.DeviceCount() == 0 {
 		v.addWarning("devices", "no devices defined in configuration")
 	}
 

--- a/internal/config/yaml_load.go
+++ b/internal/config/yaml_load.go
@@ -69,7 +69,7 @@ func buildConfigFromYAML(yamlConfig *converter.Config, configDir string) (*Confi
 		cfg.Devices = append(cfg.Devices, device)
 	}
 
-	segments, err := buildSegments(yamlConfig, cfg.IncludePath)
+	segments, err := buildSegments(yamlConfig, cfg.IncludePath, configDir)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func buildConfigFromYAML(yamlConfig *converter.Config, configDir string) (*Confi
 
 // buildSegments converts and validates the multi-VLAN segment bindings (ADR
 // 0008). Segments and a top-level device list are mutually exclusive.
-func buildSegments(yamlConfig *converter.Config, includePath string) ([]Segment, error) {
+func buildSegments(yamlConfig *converter.Config, includePath, configDir string) ([]Segment, error) {
 	if len(yamlConfig.Segments) == 0 {
 		return nil, nil
 	}
@@ -100,7 +100,7 @@ func buildSegments(yamlConfig *converter.Config, includePath string) ([]Segment,
 	segments := make([]Segment, 0, len(yamlConfig.Segments))
 
 	for _, ySeg := range yamlConfig.Segments {
-		seg, err := buildSegment(ySeg, includePath)
+		seg, err := buildSegment(ySeg, includePath, configDir)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +111,7 @@ func buildSegments(yamlConfig *converter.Config, includePath string) ([]Segment,
 	return segments, nil
 }
 
-func buildSegment(ySeg converter.Segment, includePath string) (Segment, error) {
+func buildSegment(ySeg converter.Segment, includePath, configDir string) (Segment, error) {
 	tag, err := parseSegmentTag(string(ySeg.Tag))
 	if err != nil {
 		return Segment{}, err
@@ -126,6 +126,10 @@ func buildSegment(ySeg converter.Segment, includePath string) (Segment, error) {
 
 	seg := Segment{Tag: tag, ConfigPath: ySeg.Config}
 
+	if hasConfig {
+		return resolveSegmentConfig(seg, ySeg.Config, configDir)
+	}
+
 	for _, yamlDevice := range ySeg.Devices {
 		device, convErr := convertYAMLDevice(yamlDevice, includePath)
 		if convErr != nil {
@@ -134,6 +138,34 @@ func buildSegment(ySeg converter.Segment, includePath string) (Segment, error) {
 
 		seg.Devices = append(seg.Devices, device)
 	}
+
+	return seg, nil
+}
+
+// resolveSegmentConfig loads a segment's `config:` file (a whole demo) and uses
+// its devices as the segment's device set. The path is relative to the parent
+// config's directory. A segment config that itself declares segments is
+// rejected — nesting demos is out of scope.
+func resolveSegmentConfig(seg Segment, path, configDir string) (Segment, error) {
+	if !filepath.IsAbs(path) && configDir != "" {
+		path = filepath.Join(configDir, path)
+	}
+
+	loaded, err := LoadYAML(path)
+	if err != nil {
+		return Segment{}, fmt.Errorf("segment tag %d config %q: %w", seg.Tag, path, err)
+	}
+
+	if len(loaded.Segments) > 0 {
+		return Segment{}, fmt.Errorf(
+			"%w: segment tag %d config %q declares its own segments",
+			ErrInvalidSegmentTag,
+			seg.Tag,
+			path,
+		)
+	}
+
+	seg.Devices = loaded.Devices
 
 	return seg, nil
 }

--- a/internal/config/yaml_load.go
+++ b/internal/config/yaml_load.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/converter"
 )
@@ -67,11 +69,98 @@ func buildConfigFromYAML(yamlConfig *converter.Config, configDir string) (*Confi
 		cfg.Devices = append(cfg.Devices, device)
 	}
 
-	if len(cfg.Devices) == 0 {
+	segments, err := buildSegments(yamlConfig, cfg.IncludePath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.Segments = segments
+
+	// A config must describe at least one device somewhere — either flat, or
+	// inline in a segment. (Segments that only reference a `config:` file are
+	// resolved later by the loader, so they legitimately have no inline devices.)
+	if len(cfg.Devices) == 0 && !configHasDevices(cfg.Segments) {
 		return nil, ErrNoDevicesDefined
 	}
 
 	return cfg, nil
+}
+
+// buildSegments converts and validates the multi-VLAN segment bindings (ADR
+// 0008). Segments and a top-level device list are mutually exclusive.
+func buildSegments(yamlConfig *converter.Config, includePath string) ([]Segment, error) {
+	if len(yamlConfig.Segments) == 0 {
+		return nil, nil
+	}
+
+	if len(yamlConfig.Devices) > 0 {
+		return nil, ErrSegmentsAndTopLevelDevices
+	}
+
+	segments := make([]Segment, 0, len(yamlConfig.Segments))
+
+	for _, ySeg := range yamlConfig.Segments {
+		seg, err := buildSegment(ySeg, includePath)
+		if err != nil {
+			return nil, err
+		}
+
+		segments = append(segments, seg)
+	}
+
+	return segments, nil
+}
+
+func buildSegment(ySeg converter.Segment, includePath string) (Segment, error) {
+	tag, err := parseSegmentTag(string(ySeg.Tag))
+	if err != nil {
+		return Segment{}, err
+	}
+
+	hasInline := len(ySeg.Devices) > 0
+	hasConfig := ySeg.Config != ""
+
+	if hasInline == hasConfig {
+		return Segment{}, fmt.Errorf("%w: tag %q", ErrSegmentDevicesXORConfig, ySeg.Tag)
+	}
+
+	seg := Segment{Tag: tag, ConfigPath: ySeg.Config}
+
+	for _, yamlDevice := range ySeg.Devices {
+		device, convErr := convertYAMLDevice(yamlDevice, includePath)
+		if convErr != nil {
+			return Segment{}, convErr
+		}
+
+		seg.Devices = append(seg.Devices, device)
+	}
+
+	return seg, nil
+}
+
+// parseSegmentTag maps a segment tag string to a VLAN id: "untagged" -> 0, else
+// a decimal VLAN id in 1..4094.
+func parseSegmentTag(tag string) (int, error) {
+	if strings.EqualFold(tag, "untagged") {
+		return UntaggedTag, nil
+	}
+
+	vlan, err := strconv.Atoi(tag)
+	if err != nil || vlan < minVLANID || vlan > maxVLANID {
+		return 0, fmt.Errorf("%w: %q (want \"untagged\" or 1..4094)", ErrInvalidSegmentTag, tag)
+	}
+
+	return vlan, nil
+}
+
+func configHasDevices(segments []Segment) bool {
+	for _, seg := range segments {
+		if len(seg.Devices) > 0 || seg.ConfigPath != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func resolveIncludePath(configDir, includePath string) string {

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -1,6 +1,23 @@
 package converter
 
-import "errors"
+import (
+	"errors"
+
+	"gopkg.in/yaml.v3"
+)
+
+// VLANTag is a segment VLAN tag. It accepts both YAML strings ("untagged",
+// "200") and bare integers (200), so a config author can write `tag: 200`
+// unquoted or `tag: untagged`. The raw scalar text is preserved for the loader
+// to interpret.
+type VLANTag string
+
+// UnmarshalYAML reads the raw scalar so an int or a string tag both work.
+func (t *VLANTag) UnmarshalYAML(node *yaml.Node) error {
+	*t = VLANTag(node.Value)
+
+	return nil
+}
 
 // Sentinel errors for converter.
 var (
@@ -32,6 +49,24 @@ type Config struct {
 	CapturePlaybacks   []CapturePlayback   `yaml:"capture_playbacks,omitempty"   validate:"omitempty,dive"`
 	DiscoveryProtocols *DiscoveryProtocols `yaml:"discovery_protocols,omitempty"`
 	Devices            []Device            `yaml:"devices"                       validate:"omitempty,dive"`
+	// Segments binds independent device sets to VLAN tags for multi-VLAN
+	// playback (ADR 0008). When present, each segment is served as its own
+	// isolated network (own IP space) on its tag, and top-level `devices` must
+	// be empty. When absent, `devices` is served as a single untagged segment —
+	// today's flat behavior.
+	Segments []Segment `yaml:"segments,omitempty" validate:"omitempty,dive"`
+}
+
+// Segment binds a device set to a VLAN tag for multi-VLAN playback. Exactly one
+// of Devices (inline) or Config (a path to a config file) is set.
+type Segment struct {
+	// Tag is "untagged" (the native VLAN) or a VLAN id in 1..4094.
+	Tag VLANTag `yaml:"tag" validate:"required"`
+	// Devices is an inline device set for this segment.
+	Devices []Device `yaml:"devices,omitempty" validate:"omitempty,dive"`
+	// Config is a path to a config file whose devices form this segment
+	// (resolved by the loader). Mutually exclusive with Devices.
+	Config string `yaml:"config,omitempty"`
 }
 
 // DiscoveryProtocols configures discovery protocol behavior.

--- a/internal/protocols/arp.go
+++ b/internal/protocols/arp.go
@@ -101,7 +101,7 @@ func (h *ARPHandler) handleARPRequest(pkt *Packet, arp *layers.ARP) {
 	h.stack.IncrementStat("arp_requests")
 	h.logARPRequest(pkt, targetIP, sourceIP, sourceMAC)
 
-	devices := h.stack.GetDevices().GetByIP(targetIP)
+	devices := h.stack.devicesFor(pkt.VLAN).GetByIP(targetIP)
 	if len(devices) == 0 {
 		h.logDebug("ARP Request: No device found for IP", "ip", targetIP)
 		return

--- a/internal/protocols/coverage_extra_test.go
+++ b/internal/protocols/coverage_extra_test.go
@@ -2582,12 +2582,12 @@ func TestTCPLookupDestinationMAC(t *testing.T) {
 	h := NewTCPHandler(stack)
 
 	// Non-IP type
-	if h.lookupDestinationMAC("not-an-ip", 0) != nil {
+	if h.lookupDestinationMAC("not-an-ip", 0, 0) != nil {
 		t.Error("expected nil for non-IP type")
 	}
 
 	// Unknown IP
-	mac := h.lookupDestinationMAC(net.ParseIP("10.0.0.1"), 0)
+	mac := h.lookupDestinationMAC(net.ParseIP("10.0.0.1"), 0, 0)
 	if mac != nil {
 		t.Error("expected nil for unknown IP")
 	}
@@ -3459,7 +3459,7 @@ func TestTCPLookupDestinationMACV6(t *testing.T) {
 	h := NewTCPHandler(stack)
 
 	// Unknown IP
-	mac := h.lookupDestinationMACV6(net.ParseIP("fd00::1"), 0)
+	mac := h.lookupDestinationMACV6(net.ParseIP("fd00::1"), 0, 0)
 	if mac != nil {
 		t.Error("expected nil for unknown IP")
 	}

--- a/internal/protocols/device_table.go
+++ b/internal/protocols/device_table.go
@@ -57,8 +57,13 @@ func (dt *DeviceTable) AddByIP(ip net.IP, device *config.Device) {
 	dt.byIP[key] = append(dt.byIP[key], device)
 }
 
-// GetByMAC looks up device by MAC address.
+// GetByMAC looks up device by MAC address. A nil receiver (an unclaimed VLAN
+// segment looked up via Stack.devicesFor) behaves as an empty table.
 func (dt *DeviceTable) GetByMAC(mac net.HardwareAddr) *config.Device {
+	if dt == nil {
+		return nil
+	}
+
 	dt.mu.RLock()
 	defer dt.mu.RUnlock()
 
@@ -66,8 +71,13 @@ func (dt *DeviceTable) GetByMAC(mac net.HardwareAddr) *config.Device {
 }
 
 // GetByIP looks up devices by IP address (may return multiple)
-// Works for both IPv4 and IPv6 addresses.
+// Works for both IPv4 and IPv6 addresses. A nil receiver behaves as an empty
+// table (see GetByMAC).
 func (dt *DeviceTable) GetByIP(ip net.IP) []*config.Device {
+	if dt == nil {
+		return nil
+	}
+
 	dt.mu.RLock()
 	defer dt.mu.RUnlock()
 
@@ -122,8 +132,13 @@ func (dt *DeviceTable) Count() int {
 	return len(dt.byMAC)
 }
 
-// AllDevices returns all devices.
+// AllDevices returns all devices. A nil receiver behaves as an empty table
+// (see GetByMAC).
 func (dt *DeviceTable) AllDevices() []*config.Device {
+	if dt == nil {
+		return nil
+	}
+
 	dt.mu.RLock()
 	defer dt.mu.RUnlock()
 
@@ -155,8 +170,13 @@ func (dt *DeviceTable) RegisterTTL(device *config.Device) {
 	}
 }
 
-// GetDeviceByTTL returns a device that should respond to a TTL timeout.
+// GetDeviceByTTL returns a device that should respond to a TTL timeout. A nil
+// receiver behaves as an empty table (see GetByMAC).
 func (dt *DeviceTable) GetDeviceByTTL(ttl int) *config.Device {
+	if dt == nil {
+		return nil
+	}
+
 	dt.mu.RLock()
 	devices := dt.ttlDevices[ttl]
 	dt.mu.RUnlock()
@@ -184,9 +204,10 @@ func (dt *DeviceTable) GetDeviceByTTL(ttl int) *config.Device {
 	return selected
 }
 
-// IncrementTTLCount increments the response count for a TTL device.
+// IncrementTTLCount increments the response count for a TTL device. A nil
+// receiver behaves as an empty table (see GetByMAC).
 func (dt *DeviceTable) IncrementTTLCount(device *config.Device) {
-	if device == nil {
+	if dt == nil || device == nil {
 		return
 	}
 

--- a/internal/protocols/icmp.go
+++ b/internal/protocols/icmp.go
@@ -116,12 +116,12 @@ func (h *ICMPHandler) getAddressMaskTargets(pkt *Packet, ipLayer *layers.IPv4) [
 	isBroadcast := dstMAC != nil && dstMAC.String() == "ff:ff:ff:ff:ff:ff"
 
 	if !isBroadcast {
-		return h.stack.GetDevices().GetByIP(ipLayer.DstIP)
+		return h.stack.devicesFor(pkt.VLAN).GetByIP(ipLayer.DstIP)
 	}
 
 	var targets []*config.Device
 
-	for _, dev := range h.stack.GetDevices().GetAll() {
+	for _, dev := range h.stack.devicesFor(pkt.VLAN).GetAll() {
 		if dev.ICMPConfig != nil && dev.ICMPConfig.AddressMaskReply != nil {
 			targets = append(targets, dev)
 		}
@@ -184,7 +184,7 @@ func (h *ICMPHandler) handleRouterSolicitation(
 	debugLevel := h.stack.GetDebugLevel()
 	dstMAC := pkt.GetSourceMAC()
 
-	for _, device := range h.stack.GetDevices().GetAll() {
+	for _, device := range h.stack.devicesFor(pkt.VLAN).GetAll() {
 		if device.ICMPConfig == nil || device.ICMPConfig.RouterAdvertisement == nil {
 			continue
 		}

--- a/internal/protocols/ip.go
+++ b/internal/protocols/ip.go
@@ -51,7 +51,7 @@ func (h *IPHandler) HandlePacket(pkt *Packet) {
 			ip.SrcIP, ip.DstIP, ip.Protocol, pkt.SerialNumber)
 	}
 
-	devices := h.getTargetDevices(ip, pkt.SerialNumber, debugLevel)
+	devices := h.getTargetDevices(ip, pkt.SerialNumber, debugLevel, pkt.VLAN)
 	if devices == nil {
 		return
 	}
@@ -84,10 +84,16 @@ func (h *IPHandler) parseIPv4Layer(pkt *Packet, debugLevel int) *layers.IPv4 {
 	return ip
 }
 
-// getTargetDevices returns devices that should receive this packet.
-func (h *IPHandler) getTargetDevices(ip *layers.IPv4, serialNum int, debugLevel int) []*config.Device {
+// getTargetDevices returns devices that should receive this packet, scoped to
+// the VLAN segment (if any) the packet arrived on.
+func (h *IPHandler) getTargetDevices(
+	ip *layers.IPv4,
+	serialNum int,
+	debugLevel int,
+	vlan int,
+) []*config.Device {
 	isBroadcast := ip.DstIP.Equal([]byte{255, 255, 255, 255})
-	devices := h.stack.GetDevices().GetByIP(ip.DstIP)
+	devices := h.stack.devicesFor(vlan).GetByIP(ip.DstIP)
 
 	if len(devices) == 0 && !isBroadcast {
 		if debugLevel >= DebugLevelVerbose {
@@ -98,7 +104,7 @@ func (h *IPHandler) getTargetDevices(ip *layers.IPv4, serialNum int, debugLevel 
 	}
 
 	if isBroadcast && len(devices) == 0 {
-		devices = h.stack.GetDevices().GetAll()
+		devices = h.stack.devicesFor(vlan).GetAll()
 	}
 
 	return devices
@@ -169,7 +175,7 @@ func (h *IPHandler) handleTTLTimeout(pkt *Packet, ipLayer *layers.IPv4) bool {
 
 	ttl := int(ipLayer.TTL)
 
-	device := h.stack.GetDevices().GetDeviceByTTL(ttl)
+	device := h.stack.devicesFor(pkt.VLAN).GetDeviceByTTL(ttl)
 	if device == nil {
 		return false
 	}
@@ -209,7 +215,7 @@ func (h *IPHandler) handleTTLTimeout(pkt *Packet, ipLayer *layers.IPv4) bool {
 		return false
 	}
 
-	h.stack.GetDevices().IncrementTTLCount(device)
+	h.stack.devicesFor(pkt.VLAN).IncrementTTLCount(device)
 
 	return true
 }

--- a/internal/protocols/iperf3.go
+++ b/internal/protocols/iperf3.go
@@ -276,7 +276,7 @@ func (h *IPerf3Handler) HandleIPerf3Request(
 			_, _ = fmt.Fprintf(os.Stdout, "iPerf3: New connection from %s:%d\n", ipLayer.SrcIP, tcpLayer.SrcPort)
 		}
 
-		h.sendSYNACK(ipLayer, tcpLayer, devices)
+		h.sendSYNACK(ipLayer, tcpLayer, devices, pkt.VLAN)
 		h.getOrCreateSession(ipLayer.SrcIP.String(), uint16(tcpLayer.SrcPort), cfg)
 
 		return
@@ -299,7 +299,7 @@ func (h *IPerf3Handler) HandleIPerf3Request(
 
 // handleIPerf3Data processes iPerf3 protocol messages.
 func (h *IPerf3Handler) handleIPerf3Data(
-	_ *Packet,
+	pkt *Packet,
 	ipLayer *layers.IPv4,
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
@@ -324,24 +324,24 @@ func (h *IPerf3Handler) handleIPerf3Data(
 		if len(payload) >= iperf3MinJSONCheckSize {
 			// Check if this looks like JSON parameters
 			if payload[0] == '{' || (len(payload) > iperf3MinJSONCheckSize && payload[iperf3MinJSONCheckSize] == '{') {
-				h.handleParamExchange(ipLayer, tcpLayer, devices, session, payload)
+				h.handleParamExchange(ipLayer, tcpLayer, devices, session, payload, pkt.VLAN)
 			} else if len(payload) >= iperf3CookieSize {
 				// Cookie received, acknowledge and move to param exchange
 				session.State = iperf3StateParamExch
 
-				h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestStart)
+				h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestStart, pkt.VLAN)
 			}
 		}
 
 	case iperf3StateParamExch:
 		// Parse test parameters JSON
-		h.handleParamExchange(ipLayer, tcpLayer, devices, session, payload)
+		h.handleParamExchange(ipLayer, tcpLayer, devices, session, payload, pkt.VLAN)
 
 	case iperf3StateCreateFlow:
 		// Data streams being created
 		session.State = iperf3StateTestStart
 
-		h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestRunning)
+		h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestRunning, pkt.VLAN)
 
 	case iperf3StateTestStart, iperf3StateTestRun:
 		// Test is running - count bytes received
@@ -353,7 +353,7 @@ func (h *IPerf3Handler) handleIPerf3Data(
 			elapsed := time.Since(session.StartTime).Seconds()
 			if elapsed >= float64(session.TestParams.Time) {
 				session.State = iperf3StateExchResult
-				h.sendResults(ipLayer, tcpLayer, devices, session)
+				h.sendResults(ipLayer, tcpLayer, devices, session, pkt.VLAN)
 			}
 		}
 
@@ -363,7 +363,7 @@ func (h *IPerf3Handler) handleIPerf3Data(
 			_, _ = fmt.Fprintf(os.Stdout, "iPerf3: Test complete, sending results\n")
 		}
 
-		h.sendResults(ipLayer, tcpLayer, devices, session)
+		h.sendResults(ipLayer, tcpLayer, devices, session, pkt.VLAN)
 		session.State = iperf3StateIPerf3Done
 
 	case iperf3StateIPerf3Done:
@@ -380,6 +380,7 @@ func (h *IPerf3Handler) handleParamExchange(
 	devices []*config.Device,
 	session *IPerf3Session,
 	payload []byte,
+	vlan int,
 ) {
 	debugLevel := h.stack.GetDebugLevel()
 
@@ -412,7 +413,7 @@ func (h *IPerf3Handler) handleParamExchange(
 			_, _ = fmt.Fprintf(os.Stdout, "iPerf3: Failed to parse params: %v (data: %s)\n", err, string(jsonData))
 		}
 		// Send acknowledgment anyway
-		h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestStart)
+		h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestStart, vlan)
 
 		session.State = iperf3StateCreateFlow
 
@@ -434,7 +435,7 @@ func (h *IPerf3Handler) handleParamExchange(
 	session.StartTime = time.Now()
 
 	// Send test start acknowledgment
-	h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestStart)
+	h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgTestStart, vlan)
 }
 
 // sendStateCode sends a single-byte state code to the client.
@@ -443,9 +444,10 @@ func (h *IPerf3Handler) sendStateCode(
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
 	stateCode int8,
+	vlan int,
 ) {
 	response := []byte{safeconv.ByteFromInt8(stateCode)}
-	h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+	h.sendTCPResponse(ipLayer, tcpLayer, response, devices, vlan)
 }
 
 // sendResults sends simulated test results to the client.
@@ -454,6 +456,7 @@ func (h *IPerf3Handler) sendResults(
 	tcpLayer *layers.TCP,
 	devices []*config.Device,
 	session *IPerf3Session,
+	vlan int,
 ) {
 	cfg := session.Config
 
@@ -543,14 +546,14 @@ func (h *IPerf3Handler) sendResults(
 	)
 	copy(response[4:], jsonData)
 
-	h.sendTCPResponse(ipLayer, tcpLayer, response, devices)
+	h.sendTCPResponse(ipLayer, tcpLayer, response, devices, vlan)
 
 	// Send result OK state
-	h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgResultOK)
+	h.sendStateCode(ipLayer, tcpLayer, devices, iperf3MsgResultOK, vlan)
 }
 
 // sendSYNACK sends a TCP SYN-ACK response.
-func (h *IPerf3Handler) sendSYNACK(ipLayer *layers.IPv4, tcpLayer *layers.TCP, devices []*config.Device) {
+func (h *IPerf3Handler) sendSYNACK(ipLayer *layers.IPv4, tcpLayer *layers.TCP, devices []*config.Device, vlan int) {
 	debugLevel := h.stack.GetDebugLevel()
 
 	if len(devices) == 0 {
@@ -562,8 +565,8 @@ func (h *IPerf3Handler) sendSYNACK(ipLayer *layers.IPv4, tcpLayer *layers.TCP, d
 		return
 	}
 
-	// Get source MAC
-	srcDevices := h.stack.GetDevices().GetByIP(ipLayer.SrcIP)
+	// Get source MAC (scoped to the request's VLAN segment)
+	srcDevices := h.stack.devicesFor(vlan).GetByIP(ipLayer.SrcIP)
 
 	var srcMAC []byte
 
@@ -648,6 +651,7 @@ func (h *IPerf3Handler) sendTCPResponse(
 	tcpLayer *layers.TCP,
 	payload []byte,
 	devices []*config.Device,
+	vlan int,
 ) {
 	debugLevel := h.stack.GetDebugLevel()
 
@@ -660,7 +664,7 @@ func (h *IPerf3Handler) sendTCPResponse(
 		return
 	}
 
-	srcDevices := h.stack.GetDevices().GetByIP(ipLayer.SrcIP)
+	srcDevices := h.stack.devicesFor(vlan).GetByIP(ipLayer.SrcIP)
 
 	var srcMAC []byte
 

--- a/internal/protocols/ipv6.go
+++ b/internal/protocols/ipv6.go
@@ -106,7 +106,7 @@ func (h *IPv6Handler) HandlePacket(pkt *Packet) {
 			ipv6.SrcIP, ipv6.DstIP, ipv6.NextHeader, ipv6.HopLimit, pkt.SerialNumber)
 	}
 
-	devices := h.getIPv6TargetDevices(ipv6, pkt.SerialNumber)
+	devices := h.getIPv6TargetDevices(ipv6, pkt.SerialNumber, pkt.VLAN)
 	if devices == nil && !IsIPv6Multicast(ipv6.DstIP) {
 		return
 	}
@@ -141,8 +141,8 @@ func (h *IPv6Handler) parseIPv6Layer(packet gopacket.Packet, serialNum int) *lay
 }
 
 // getIPv6TargetDevices returns devices that should receive this packet, or nil if not for us.
-func (h *IPv6Handler) getIPv6TargetDevices(ipv6 *layers.IPv6, serialNum int) []*config.Device {
-	devices := h.stack.GetDevices().GetByIP(ipv6.DstIP)
+func (h *IPv6Handler) getIPv6TargetDevices(ipv6 *layers.IPv6, serialNum int, vlan int) []*config.Device {
+	devices := h.stack.devicesFor(vlan).GetByIP(ipv6.DstIP)
 	if len(devices) > 0 {
 		return devices
 	}

--- a/internal/protocols/netbios.go
+++ b/internal/protocols/netbios.go
@@ -297,7 +297,7 @@ func (h *NetBIOSHandler) sendNameQueryResponse(
 	ttl := uint32(nbnsDefaultTTL)
 	nodeFlags := uint16(nbnsDefaultNodeFlags) // Default: B-node, unique name
 
-	if matched := h.stack.GetDevices().GetByMAC(srcMAC); matched != nil && matched.NetBIOSConfig != nil {
+	if matched := h.stack.devicesFor(reqPkt.VLAN).GetByMAC(srcMAC); matched != nil && matched.NetBIOSConfig != nil {
 		if matched.NetBIOSConfig.TTL > 0 {
 			ttl = matched.NetBIOSConfig.TTL
 		}

--- a/internal/protocols/segment_demux_test.go
+++ b/internal/protocols/segment_demux_test.go
@@ -1,0 +1,84 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+func segDevice(name, mac, ip string) config.Device {
+	return config.Device{
+		Name:        name,
+		MACAddress:  mustMAC(mac),
+		IPAddresses: []net.IP{net.ParseIP(ip)},
+	}
+}
+
+func mustMAC(s string) net.HardwareAddr {
+	m, err := net.ParseMAC(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return m
+}
+
+// TestSegmentDemuxIsolatesReusedIP: two demos on different tags reuse the same
+// IP; devicesFor routes each tag to its own device — the core of "run N demos
+// at once".
+func TestSegmentDemuxIsolatesReusedIP(t *testing.T) {
+	cfg := &config.Config{
+		Segments: []config.Segment{
+			{Tag: 200, Devices: []config.Device{segDevice("demo1-host", "02:00:00:00:02:00", "10.0.0.1")}},
+			{Tag: 300, Devices: []config.Device{segDevice("demo2-host", "02:00:00:00:03:00", "10.0.0.1")}},
+		},
+	}
+
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	ip := net.ParseIP("10.0.0.1")
+
+	d200 := stack.devicesFor(200).GetByIP(ip)
+	d300 := stack.devicesFor(300).GetByIP(ip)
+
+	if len(d200) != 1 || len(d300) != 1 {
+		t.Fatalf("each segment should resolve 10.0.0.1 to one device; got %d (200) and %d (300)", len(d200), len(d300))
+	}
+
+	if d200[0].Name != "demo1-host" {
+		t.Errorf("VLAN 200 resolved 10.0.0.1 to %q, want demo1-host", d200[0].Name)
+	}
+
+	if d300[0].Name != "demo2-host" {
+		t.Errorf("VLAN 300 resolved 10.0.0.1 to %q, want demo2-host", d300[0].Name)
+	}
+
+	// An unclaimed tag has no devices (decodePacket drops such frames).
+	if stack.devicesFor(999) != nil {
+		t.Errorf("unclaimed VLAN 999 should have no device table")
+	}
+}
+
+// TestFlatModeUnchanged: a config with no segments stays in flat mode —
+// devicesFor returns the single global table for every VLAN.
+func TestFlatModeUnchanged(t *testing.T) {
+	cfg := &config.Config{
+		Devices: []config.Device{segDevice("flat-host", "02:00:00:00:0f:00", "10.0.0.1")},
+	}
+
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+
+	if stack.segmentTables != nil {
+		t.Fatal("a config without segments must not enter segment mode")
+	}
+
+	// Every VLAN resolves to the same global table.
+	if stack.devicesFor(200) != stack.devices || stack.devicesFor(0) != stack.devices {
+		t.Error("flat mode: devicesFor must return the global device table for any VLAN")
+	}
+
+	if got := stack.devicesFor(200).GetByIP(net.ParseIP("10.0.0.1")); len(got) != 1 {
+		t.Errorf("flat mode: 10.0.0.1 should resolve to the one device, got %d", len(got))
+	}
+}

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -63,14 +63,15 @@ const (
 
 // Stack manages the network protocol stack.
 type Stack struct {
-	capture      *capture.Engine
-	config       *config.Config
-	configMu     sync.RWMutex
-	reloadMu     sync.Mutex
-	devices      *DeviceTable
-	vlanMode     bool // any device is VLAN-tagged: ignore untagged frames (no native/default replay)
-	serialNumber int
-	mu           sync.Mutex
+	capture       *capture.Engine
+	config        *config.Config
+	configMu      sync.RWMutex
+	reloadMu      sync.Mutex
+	devices       *DeviceTable
+	segmentTables map[int]*DeviceTable // multi-VLAN mode (ADR 0008): tag -> that segment's isolated device set; nil when running flat
+	vlanMode      bool                 // any device is VLAN-tagged: ignore untagged frames (no native/default replay)
+	serialNumber  int
+	mu            sync.Mutex
 
 	// Packet queues
 	sendQueue chan *Packet
@@ -322,6 +323,45 @@ func (s *Stack) SendRawPacketVLAN(data []byte, vlan int) error {
 // GetDevices returns the device table.
 func (s *Stack) GetDevices() *DeviceTable {
 	return s.devices
+}
+
+// devicesFor returns the device table that should answer traffic tagged with
+// vlan. In flat/untagged mode (segmentTables nil) every VLAN shares the one
+// global table, exactly as before multi-VLAN segments existed. In segment
+// mode each VLAN tag is its own isolated "demo": an untagged frame (vlan <= 0)
+// normalizes to config.UntaggedTag so it can still match an explicit untagged
+// segment, and a tag with no bound segment returns nil — callers (via the
+// nil-safe DeviceTable methods) and decodePacket's confinement check both
+// treat a nil table as "no devices for this VLAN".
+func (s *Stack) devicesFor(vlan int) *DeviceTable {
+	if s.segmentTables == nil {
+		return s.devices
+	}
+
+	key := vlan
+	if key < 0 {
+		key = config.UntaggedTag
+	}
+
+	return s.segmentTables[key]
+}
+
+// AllDevices returns every device the stack knows about across all VLAN
+// segments (or the single flat set when not running in segment mode). Used
+// by discovery-protocol emitters, which advertise every device regardless of
+// which segment it belongs to — each advertisement is already scoped to its
+// own device's VLAN by the sender.
+func (s *Stack) AllDevices() []*config.Device {
+	if s.segmentTables == nil {
+		return s.devices.GetAll()
+	}
+
+	all := make([]*config.Device, 0, len(s.segmentTables))
+	for _, table := range s.segmentTables {
+		all = append(all, table.GetAll()...)
+	}
+
+	return all
 }
 
 // ReloadConfig applies a new configuration to the running stack.

--- a/internal/protocols/stack_init.go
+++ b/internal/protocols/stack_init.go
@@ -34,6 +34,13 @@ func (s *Stack) notifyObservers(direction string, pkt *Packet) {
 }
 
 // initializeDevices repopulates device-dependent state from the provided config.
+//
+// A config with explicit Segments (ADR 0008 multi-VLAN) builds one isolated
+// DeviceTable per VLAN tag instead of the single flat table, so two (or more)
+// independent "demos" can run at once — even reusing the same IPs — and get
+// demultiplexed by devicesFor at packet-routing time. A flat config (no
+// Segments) takes the original code path byte-for-byte: this branch is the
+// load-bearing backward-compat guarantee, not just an optimization.
 func (s *Stack) initializeDevices(cfg *config.Config) {
 	if cfg == nil {
 		return
@@ -41,12 +48,16 @@ func (s *Stack) initializeDevices(cfg *config.Config) {
 
 	s.resetDeviceState()
 
-	for i := range cfg.Devices {
-		device := &cfg.Devices[i]
-		s.registerDevice(device)
-	}
+	if len(cfg.Segments) > 0 {
+		s.initializeSegments(cfg)
+	} else {
+		for i := range cfg.Devices {
+			device := &cfg.Devices[i]
+			s.registerDevice(device)
+		}
 
-	s.applySNMPAddrMappings(cfg)
+		s.applySNMPAddrMappings(cfg.Devices, s.devices)
+	}
 
 	s.configMu.Lock()
 	s.config = cfg
@@ -61,6 +72,37 @@ func (s *Stack) initializeDevices(cfg *config.Config) {
 	}
 }
 
+// initializeSegments builds one isolated DeviceTable per VLAN segment
+// (ADR 0008 slice 2). Each segment's inline Devices get their own table so
+// devicesFor can route a frame to the correct "demo" by VLAN tag, even when
+// two segments reuse the same IP addresses.
+//
+// Segments that only set ConfigPath (no inline Devices) are skipped for now —
+// resolving a segment config file is a separate slice — so their VLAN tag
+// ends up with no table and devicesFor(tag) returns nil for it, same as any
+// other unclaimed tag.
+func (s *Stack) initializeSegments(cfg *config.Config) {
+	s.segmentTables = make(map[int]*DeviceTable)
+
+	for _, seg := range cfg.NormalizedSegments() {
+		if len(seg.Devices) == 0 {
+			// TODO(slice-2): resolve ConfigPath via config.LoadYAML
+			continue
+		}
+
+		segTable := NewDeviceTable()
+
+		for i := range seg.Devices {
+			device := &seg.Devices[i]
+			s.registerSegmentDevice(device, segTable)
+		}
+
+		s.applySNMPAddrMappings(seg.Devices, segTable)
+
+		s.segmentTables[seg.Tag] = segTable
+	}
+}
+
 // resetDeviceState resets all device-related state.
 func (s *Stack) resetDeviceState() {
 	if s.devices == nil {
@@ -68,6 +110,12 @@ func (s *Stack) resetDeviceState() {
 	} else {
 		s.devices.Reset()
 	}
+
+	// Cleared unconditionally: a reload that drops Segments from a
+	// previously-segmented config must fall back to flat mode, and
+	// initializeSegments rebuilds this map from scratch whenever segments
+	// are present.
+	s.segmentTables = nil
 
 	s.snmpAgents = make(map[*config.Device]*snmpAgentGroup)
 
@@ -84,10 +132,11 @@ func (s *Stack) resetDeviceState() {
 	}
 }
 
-// registerDevice registers a single device with all relevant handlers.
+// registerDevice registers a single device with all relevant handlers,
+// targeting the stack's single flat device table (the no-segments path).
 func (s *Stack) registerDevice(device *config.Device) {
-	s.registerDeviceAddresses(device)
-	s.registerDeviceFeatures(device)
+	s.registerDeviceAddresses(device, s.devices)
+	s.registerDeviceFeatures(device, s.devices)
 	s.configureDHCPServer(device)
 	s.initSNMPAgent(device)
 
@@ -96,25 +145,47 @@ func (s *Stack) registerDevice(device *config.Device) {
 	}
 }
 
-// registerDeviceAddresses registers device MAC and IP addresses.
-func (s *Stack) registerDeviceAddresses(device *config.Device) {
-	if len(device.MACAddress) > 0 {
-		s.devices.AddByMAC(device.MACAddress, device)
-	}
+// registerSegmentDevice registers a single device the same way registerDevice
+// does, except its table-scoped state (addresses, TTL, FDB) goes into the
+// given segment's own table instead of the flat s.devices — devicesFor(vlan)
+// only ever returns segment tables in segment mode, so TTL-timeout routing
+// (ip.go's handleTTLTimeout) would silently never find a registration left
+// behind in s.devices. The remaining handler state (DHCP, SNMP, DNS) is keyed
+// by *config.Device pointer, not by table, so it coexists safely across
+// segments even when two segments reuse the same IP.
+func (s *Stack) registerSegmentDevice(device *config.Device, table *DeviceTable) {
+	s.registerDeviceAddresses(device, table)
+	s.registerDeviceFeatures(device, table)
+	s.configureDHCPServer(device)
+	s.initSNMPAgent(device)
 
-	for _, ip := range device.IPAddresses {
-		s.devices.AddByIP(ip, device)
+	if device.DNSConfig != nil {
+		s.dnsHandler.LoadDeviceDNSConfig(device)
 	}
 }
 
-// registerDeviceFeatures registers TTL and forwarding device features.
-func (s *Stack) registerDeviceFeatures(device *config.Device) {
+// registerDeviceAddresses registers device MAC and IP addresses into table.
+func (s *Stack) registerDeviceAddresses(device *config.Device, table *DeviceTable) {
+	if len(device.MACAddress) > 0 {
+		table.AddByMAC(device.MACAddress, device)
+	}
+
+	for _, ip := range device.IPAddresses {
+		table.AddByIP(ip, device)
+	}
+}
+
+// registerDeviceFeatures registers TTL and forwarding device features into
+// table. Like addresses, TTL/FDB state lives on the DeviceTable itself
+// (DeviceTable.ttlDevices / .forwardingDevices), so it must land in the same
+// table devicesFor(vlan) will look it up from.
+func (s *Stack) registerDeviceFeatures(device *config.Device, table *DeviceTable) {
 	if device.TTLConfig != nil {
-		s.devices.RegisterTTL(device)
+		table.RegisterTTL(device)
 	}
 
 	if device.SNMPConfig.Dot1DFdbTable != nil || device.SNMPConfig.Dot1QFdbTable != nil {
-		s.devices.RegisterForwardingDevice(device)
+		table.RegisterForwardingDevice(device)
 	}
 }
 
@@ -154,15 +225,19 @@ func (s *Stack) configureDHCPServer(device *config.Device) {
 	}
 }
 
-// applySNMPAddrMappings applies SNMP agent sharing mappings.
-func (s *Stack) applySNMPAddrMappings(cfg *config.Config) {
-	for i := range cfg.Devices {
-		device := &cfg.Devices[i]
+// applySNMPAddrMappings applies SNMP agent sharing mappings for devices,
+// resolving each device's SnmpAddr against table. The flat path calls this
+// with (cfg.Devices, s.devices); segment mode calls it once per segment with
+// that segment's own (Devices, table) so an snmp_addr reference resolves
+// within the same isolated demo instead of leaking across segments.
+func (s *Stack) applySNMPAddrMappings(devices []config.Device, table *DeviceTable) {
+	for i := range devices {
+		device := &devices[i]
 		if device.SNMPConfig.SnmpAddr == nil {
 			continue
 		}
 
-		targets := s.devices.GetByIP(device.SNMPConfig.SnmpAddr)
+		targets := table.GetByIP(device.SNMPConfig.SnmpAddr)
 		if len(targets) == 0 {
 			continue
 		}

--- a/internal/protocols/stack_init.go
+++ b/internal/protocols/stack_init.go
@@ -67,7 +67,7 @@ func (s *Stack) initializeDevices(cfg *config.Config) {
 		_, _ = fmt.Fprintf(
 			os.Stdout,
 			"Initialized %d devices from configuration\n",
-			len(cfg.Devices),
+			cfg.DeviceCount(),
 		)
 	}
 }

--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -143,6 +143,16 @@ func (s *Stack) decodePacket(pkt *Packet) {
 		return
 	}
 
+	// Segment confinement (ADR 0008 multi-VLAN): in segment mode every VLAN
+	// tag must be bound to a segment/"demo" to get a reply. This is the
+	// segment-mode analogue of the vlanMode check above — keyed by
+	// devicesFor's per-tag lookup instead of a single global flag — so a tag
+	// with no bound segment is dropped here rather than falling through to
+	// per-handler device lookups that would just come up empty anyway.
+	if s.segmentTables != nil && s.devicesFor(pkt.VLAN) == nil {
+		return
+	}
+
 	// Try MAC-based routing first (multicast protocols)
 	if s.routeByMAC(pkt) {
 		return

--- a/internal/protocols/tcp.go
+++ b/internal/protocols/tcp.go
@@ -250,7 +250,7 @@ func (h *TCPHandler) sendRST(ipLayer *layers.IPv4, tcp *layers.TCP, devices []*c
 		return
 	}
 
-	dstMAC := h.lookupDestinationMAC(ipLayer.SrcIP, debugLevel)
+	dstMAC := h.lookupDestinationMAC(ipLayer.SrcIP, debugLevel, vlan)
 	if dstMAC == nil {
 		return
 	}
@@ -289,14 +289,15 @@ func (h *TCPHandler) deviceHasIP(device *config.Device, targetIP any) bool {
 	return false
 }
 
-// lookupDestinationMAC looks up the MAC address for a destination IP.
-func (h *TCPHandler) lookupDestinationMAC(srcIP any, debugLevel int) []byte {
+// lookupDestinationMAC looks up the MAC address for a destination IP, scoped
+// to the VLAN segment the original request arrived on.
+func (h *TCPHandler) lookupDestinationMAC(srcIP any, debugLevel int, vlan int) []byte {
 	ip, ok := srcIP.(net.IP)
 	if !ok {
 		return nil
 	}
 
-	srcDevice := h.stack.GetDevices().GetByIP(ip)
+	srcDevice := h.stack.devicesFor(vlan).GetByIP(ip)
 	if len(srcDevice) > 0 && len(srcDevice[0].MACAddress) > 0 {
 		return srcDevice[0].MACAddress
 	}
@@ -549,13 +550,13 @@ func (h *TCPHandler) routeToHandlerV6(
 		}
 	default:
 		if isSYNOnly {
-			h.sendRSTV6(ipv6, tcp, devices)
+			h.sendRSTV6(ipv6, tcp, devices, pkt.VLAN)
 		}
 	}
 }
 
 // sendRSTV6 sends a TCP RST packet over IPv6.
-func (h *TCPHandler) sendRSTV6(ipv6 *layers.IPv6, tcp *layers.TCP, devices []*config.Device) {
+func (h *TCPHandler) sendRSTV6(ipv6 *layers.IPv6, tcp *layers.TCP, devices []*config.Device, vlan int) {
 	debugLevel := h.stack.GetDebugLevel()
 
 	device := h.findDeviceWithIP(devices, ipv6.DstIP)
@@ -563,7 +564,7 @@ func (h *TCPHandler) sendRSTV6(ipv6 *layers.IPv6, tcp *layers.TCP, devices []*co
 		return
 	}
 
-	dstMAC := h.lookupDestinationMACV6(ipv6.SrcIP, debugLevel)
+	dstMAC := h.lookupDestinationMACV6(ipv6.SrcIP, debugLevel, vlan)
 	if dstMAC == nil {
 		return
 	}
@@ -571,9 +572,10 @@ func (h *TCPHandler) sendRSTV6(ipv6 *layers.IPv6, tcp *layers.TCP, devices []*co
 	h.sendRSTPacketV6(device, dstMAC, ipv6, tcp, debugLevel)
 }
 
-// lookupDestinationMACV6 looks up the MAC address for an IPv6 destination.
-func (h *TCPHandler) lookupDestinationMACV6(srcIP net.IP, debugLevel int) []byte {
-	srcDevice := h.stack.GetDevices().GetByIP(srcIP)
+// lookupDestinationMACV6 looks up the MAC address for an IPv6 destination,
+// scoped to the VLAN segment the original request arrived on.
+func (h *TCPHandler) lookupDestinationMACV6(srcIP net.IP, debugLevel int, vlan int) []byte {
+	srcDevice := h.stack.devicesFor(vlan).GetByIP(srcIP)
 	if len(srcDevice) > 0 && len(srcDevice[0].MACAddress) > 0 {
 		return srcDevice[0].MACAddress
 	}


### PR DESCRIPTION
## Summary

**Slice 1 of the multi-VLAN engine model (ADR 0008 / epic #882).** Adds a top-level `segments:` list binding an independent device set to a VLAN tag, the domain types, and the backward-compatible normalization that unifies old and new configs:

- `Config.NormalizedSegments()` — a bare `devices:` config presents as a **single untagged segment**, so every downstream consumer (the demux + engines in later slices) sees one uniform list of `(tag, device-set)` engines. Today's flat behavior is unchanged.
- `tag:` accepts `untagged` or a VLAN id `1..4094`, **quoted or bare** (`VLANTag` custom unmarshal, so `tag: 200` and `tag: "200"` both work).
- Segments and top-level `devices:` are **mutually exclusive**; each segment sets **exactly one** of `devices` (inline) or `config` (a file path, resolved by the loader in slice 2).

**Schema/parse/validation only — no runtime change.** The demux (`decodePacket` is the insertion point) and the Stack→Engine extraction are later slices; the current single-VLAN sim is untouched.

## Linked Issue

Related to #882 (ADR 0008 engine model).

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/config/... -count=1   # ok
  - TestNormalizedSegmentsBackwardCompat: bare devices -> one untagged segment
  - TestSegmentsParse: explicit segments, untagged + bare-int tag
  - TestSegmentsRejectMixedWithTopLevelDevices, TestSegmentTagValidation (0/4095/abc/-1),
    TestSegmentDevicesXORConfig (neither/both)
$ make schema   # regenerated; segments in docs/schemas/niac.schema.json
$ make lint     # 0 issues
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (config parsing only)
- [x] Dependencies are pinned and justified if changed. (none — yaml.v3 already present)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (generated schema; ADR 0008)

