### PR TITLE
ci(typecheck): use tsgo, not unpinned npx tsc (completes #646)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         run: ../scripts/check-token-discipline.sh
 
       - name: Type check
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

Completes the tsgo adoption (#646). niac's build already uses `tsgo` (`@typescript/native-preview`) and the repo dropped the `typescript` dep, but the CI **Type check** step still ran `npx tsc --noEmit` — which `npx` auto-installs as an **unpinned JS `tsc`**, so CI typechecked with a *different, unpinned* compiler than the build. Changed it to call the pinned `typecheck` script (`tsgo --build --noEmit`).

Verified locally: `npm run typecheck` → clean (exit 0).

stem has the identical `npx tsc` CI step and should get the same fix (flagged in the commit).

## Linked Issue

Closes #646.

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ cd ui && npm run typecheck   # > tsgo --build --noEmit  → clean, exit 0
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (CI workflow only; no untrusted input in the run step)
- [x] Dependencies are pinned and justified if changed. (this removes an unpinned npx-tsc install)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (n/a)
