### PR TITLE
feat(dhcp): answer DHCPINFORM + quarantine DHCPDECLINE (completes #881)

### DIFF
--- a/internal/protocols/coverage_extra_test.go
+++ b/internal/protocols/coverage_extra_test.go
@@ -520,7 +520,7 @@ func TestDHCPBuildOptions(t *testing.T) {
 	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
 	serverIP := net.ParseIP("10.0.0.1")
 
-	opts := h.buildDHCPOptions(DHCPOffer, serverIP, mac)
+	opts := h.buildDHCPOptions(DHCPOffer, serverIP, mac, true)
 	if len(opts) == 0 {
 		t.Fatal("expected non-empty options")
 	}

--- a/internal/protocols/dhcp.go
+++ b/internal/protocols/dhcp.go
@@ -82,6 +82,7 @@ type DHCPLease struct {
 type DHCPHandler struct {
 	stack              *Stack
 	leases             map[string]*DHCPLease // Key: MAC address string
+	declined           map[string]struct{}   // pool IPs a client DHCPDECLINEd (in use); never re-offered
 	ipPool             []net.IP
 	poolStart          net.IP
 	poolEnd            net.IP
@@ -104,6 +105,7 @@ func NewDHCPHandler(stack *Stack) *DHCPHandler {
 	return &DHCPHandler{
 		stack:      stack,
 		leases:     make(map[string]*DHCPLease),
+		declined:   make(map[string]struct{}),
 		ipPool:     make([]net.IP, 0),
 		subnetMask: getDefaultSubnetMask(),
 	}
@@ -162,6 +164,7 @@ func (h *DHCPHandler) Reset() {
 	defer h.mu.Unlock()
 
 	h.leases = make(map[string]*DHCPLease)
+	h.declined = make(map[string]struct{})
 	h.ipPool = nil
 	h.poolStart = nil
 	h.poolEnd = nil
@@ -227,6 +230,10 @@ func (h *DHCPHandler) generateIPPool(start, end net.IP) ([]net.IP, error) {
 func (h *DHCPHandler) findAvailableIP() net.IP {
 	// Check each IP in pool
 	for _, ip := range h.ipPool {
+		if _, declined := h.declined[ip.String()]; declined {
+			continue // client reported this address in use (DHCPDECLINE)
+		}
+
 		inUse := false
 
 		for _, lease := range h.leases {
@@ -501,6 +508,11 @@ func (h *DHCPHandler) canGrantRequestedIP(mac net.HardwareAddr, ip net.IP) bool 
 		return staticIP.Equal(ip)
 	}
 
+	// A quarantined (DHCPDECLINEd) address is never grantable.
+	if _, declined := h.declined[ip.String()]; declined {
+		return false
+	}
+
 	// The client renewing its own current lease.
 	if existing, ok := h.leases[mac.String()]; ok && existing.IP.Equal(ip) {
 		return true
@@ -607,6 +619,57 @@ func (h *DHCPHandler) HandlePacket(pkt *Packet, ipLayer *layers.IPv4, _ *layers.
 }
 
 // dispatchDHCPMessage routes the DHCP message to the appropriate handler.
+// handleDHCPInform answers a DHCPINFORM — a client that already has an address
+// and only wants configuration options. Reply with a DHCPACK carrying options
+// but no lease (RFC 2131 §4.3.5).
+func (h *DHCPHandler) handleDHCPInform(
+	info *dhcpPacketInfo,
+	serverDevice *config.Device,
+	serialNum, debugLevel int,
+) {
+	err := h.SendDHCPInformAck(info.dhcp.Xid, info.dhcp.ClientHWAddr,
+		serverDevice.IPAddresses[0], serverDevice.MACAddress, info.vlan)
+	if err != nil {
+		if debugLevel >= 1 {
+			logging.ProtocolDebugf("DHCP", debugLevel, 1, "Failed to send Inform Ack: %v sn=%d", err, serialNum)
+		}
+
+		return
+	}
+
+	h.stack.IncrementStat("dhcp_acks")
+
+	if debugLevel >= debugLevelInfo {
+		logging.ProtocolDebugf("DHCP", debugLevel, debugLevelInfo,
+			"Sent Inform Ack to %s sn=%d", info.dhcp.ClientHWAddr, serialNum)
+	}
+}
+
+// handleDHCPDecline processes a DHCPDECLINE — the client found the address it
+// was offered already in use (via ARP). Quarantine that IP so it is never
+// offered again, and drop any lease we hold for it (RFC 2131 §4.3.3).
+func (h *DHCPHandler) handleDHCPDecline(info *dhcpPacketInfo, serialNum, debugLevel int) {
+	declinedIP := getRequestedIP(info.dhcp)
+	if declinedIP == nil {
+		return
+	}
+
+	h.mu.Lock()
+	h.declined[declinedIP.String()] = struct{}{}
+
+	for mac, lease := range h.leases {
+		if lease.IP.Equal(declinedIP) {
+			delete(h.leases, mac)
+		}
+	}
+	h.mu.Unlock()
+
+	if debugLevel >= debugLevelInfo {
+		logging.ProtocolDebugf("DHCP", debugLevel, debugLevelInfo,
+			"Declined address %s quarantined sn=%d", declinedIP, serialNum)
+	}
+}
+
 func (h *DHCPHandler) dispatchDHCPMessage(
 	info *dhcpPacketInfo,
 	serverDevice *config.Device,
@@ -629,9 +692,9 @@ func (h *DHCPHandler) dispatchDHCPMessage(
 		delete(h.leases, info.dhcp.ClientHWAddr.String())
 		h.mu.Unlock()
 	case DHCPInform:
-		if debugLevel >= DebugLevelVerbose {
-			logger.Debug("DHCP: Inform", "mac", info.dhcp.ClientHWAddr, "sn", serialNum)
-		}
+		h.handleDHCPInform(info, serverDevice, serialNum, debugLevel)
+	case DHCPDecline:
+		h.handleDHCPDecline(info, serialNum, debugLevel)
 	default:
 		if debugLevel >= DebugLevelInfo {
 			logger.Debug("DHCP: Unhandled message type", "type", info.messageType, "sn", serialNum)
@@ -679,7 +742,7 @@ func (h *DHCPHandler) SendDHCPOffer(
 	serverMAC net.HardwareAddr,
 	vlan int,
 ) error {
-	return h.sendDHCPResponse(xid, clientMAC, offeredIP, serverIP, serverMAC, DHCPOffer, vlan)
+	return h.sendDHCPResponse(xid, clientMAC, offeredIP, serverIP, serverMAC, DHCPOffer, vlan, true)
 }
 
 // SendDHCPAck sends a DHCP Ack message.
@@ -690,7 +753,20 @@ func (h *DHCPHandler) SendDHCPAck(
 	serverMAC net.HardwareAddr,
 	vlan int,
 ) error {
-	return h.sendDHCPResponse(xid, clientMAC, assignedIP, serverIP, serverMAC, DHCPAck, vlan)
+	return h.sendDHCPResponse(xid, clientMAC, assignedIP, serverIP, serverMAC, DHCPAck, vlan, true)
+}
+
+// SendDHCPInformAck answers a DHCPINFORM: a DHCPACK carrying configuration
+// parameters (mask, router, DNS, domain, …) but no address or lease — the
+// client already holds its own IP and only wants options (RFC 2131 §4.3.5).
+func (h *DHCPHandler) SendDHCPInformAck(
+	xid uint32,
+	clientMAC net.HardwareAddr,
+	serverIP net.IP,
+	serverMAC net.HardwareAddr,
+	vlan int,
+) error {
+	return h.sendDHCPResponse(xid, clientMAC, net.IPv4zero, serverIP, serverMAC, DHCPAck, vlan, false)
 }
 
 // SendDHCPNak sends a DHCPNAK rejecting a REQUEST the server cannot satisfy
@@ -705,7 +781,7 @@ func (h *DHCPHandler) SendDHCPNak(
 	serverMAC net.HardwareAddr,
 	vlan int,
 ) error {
-	return h.sendDHCPResponse(xid, clientMAC, net.IPv4zero, serverIP, serverMAC, DHCPNak, vlan)
+	return h.sendDHCPResponse(xid, clientMAC, net.IPv4zero, serverIP, serverMAC, DHCPNak, vlan, false)
 }
 
 // sendDHCPNakForRequest emits a DHCPNAK for a REQUEST the server cannot satisfy,
@@ -740,6 +816,7 @@ func (h *DHCPHandler) buildDHCPOptions(
 	msgType uint8,
 	serverIP net.IP,
 	clientMAC net.HardwareAddr,
+	withLease bool,
 ) []layers.DHCPOption {
 	// A DHCPNAK carries only the message type, the server identifier, and an
 	// optional human-readable reason — never lease parameters or an address
@@ -757,12 +834,25 @@ func (h *DHCPHandler) buildDHCPOptions(
 	options := []layers.DHCPOption{
 		{Type: layers.DHCPOptMessageType, Length: 1, Data: []byte{msgType}},
 		{Type: layers.DHCPOptServerID, Length: dhcpIPv4Len, Data: []byte(serverIP.To4())},
-		{Type: layers.DHCPOptLeaseTime, Length: dhcpIPv4Len, Data: h.encodeUint32(uint32(DefaultLeaseTime.Seconds()))},
 		{Type: layers.DHCPOptSubnetMask, Length: dhcpIPv4Len, Data: []byte(h.subnetMask.To4())},
 	}
 
+	// A DHCPACK answering a DHCPINFORM carries configuration parameters but no
+	// lease (the client already has its address); the lease-time and T1/T2
+	// timers are omitted (RFC 2131 §4.3.5).
+	if withLease {
+		options = append(options, layers.DHCPOption{
+			Type: layers.DHCPOptLeaseTime, Length: dhcpIPv4Len,
+			Data: h.encodeUint32(uint32(DefaultLeaseTime.Seconds())),
+		})
+	}
+
 	options = h.appendNetworkOptions(options)
-	options = h.appendTimingOptions(options)
+
+	if withLease {
+		options = h.appendTimingOptions(options)
+	}
+
 	options = h.appendBootOptions(options)
 	options = h.appendMiscOptions(options, clientMAC)
 
@@ -895,6 +985,7 @@ func (h *DHCPHandler) sendDHCPResponse(
 	serverMAC net.HardwareAddr,
 	msgType uint8,
 	vlan int,
+	withLease bool,
 ) error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -920,7 +1011,7 @@ func (h *DHCPHandler) sendDHCPResponse(
 		RelayAgentIP: net.IPv4zero,
 		ClientHWAddr: clientMAC,
 	}
-	dhcp.Options = h.buildDHCPOptions(msgType, serverIP, clientMAC)
+	dhcp.Options = h.buildDHCPOptions(msgType, serverIP, clientMAC, withLease)
 
 	return h.serializeAndSendDHCP(dhcp, serverIP, serverMAC, vlan)
 }

--- a/internal/protocols/dhcp.go
+++ b/internal/protocols/dhcp.go
@@ -618,7 +618,6 @@ func (h *DHCPHandler) HandlePacket(pkt *Packet, ipLayer *layers.IPv4, _ *layers.
 	h.dispatchDHCPMessage(info, serverDevice, pkt.SerialNumber, debugLevel)
 }
 
-// dispatchDHCPMessage routes the DHCP message to the appropriate handler.
 // handleDHCPInform answers a DHCPINFORM — a client that already has an address
 // and only wants configuration options. Reply with a DHCPACK carrying options
 // but no lease (RFC 2131 §4.3.5).
@@ -654,13 +653,20 @@ func (h *DHCPHandler) handleDHCPDecline(info *dhcpPacketInfo, serialNum, debugLe
 		return
 	}
 
-	h.mu.Lock()
-	h.declined[declinedIP.String()] = struct{}{}
+	mac := info.dhcp.ClientHWAddr.String()
 
-	for mac, lease := range h.leases {
-		if lease.IP.Equal(declinedIP) {
-			delete(h.leases, mac)
-		}
+	h.mu.Lock()
+	// Only a pool address is quarantined: this bounds the declined set to the
+	// pool size (a client cannot grow it with arbitrary addresses) and ignores
+	// DECLINEs for addresses this server does not manage.
+	if h.isIPInPool(declinedIP) {
+		h.declined[declinedIP.String()] = struct{}{}
+	}
+
+	// Only the declining client's own lease is dropped — a client must not be
+	// able to release (hijack) another client's lease by declining its address.
+	if lease, ok := h.leases[mac]; ok && lease.IP.Equal(declinedIP) {
+		delete(h.leases, mac)
 	}
 	h.mu.Unlock()
 

--- a/internal/protocols/dhcp_nak_test.go
+++ b/internal/protocols/dhcp_nak_test.go
@@ -90,6 +90,7 @@ func TestBuildDHCPOptionsNak(t *testing.T) {
 		DHCPNak,
 		net.ParseIP("10.20.200.2"),
 		net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		false,
 	)
 
 	present := map[layers.DHCPOpt]bool{}

--- a/internal/protocols/dhcp_realism_test.go
+++ b/internal/protocols/dhcp_realism_test.go
@@ -3,9 +3,55 @@ package protocols
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/gopacket/gopacket/layers"
 )
+
+func declineBy(h *DHCPHandler, mac net.HardwareAddr, ip net.IP) {
+	h.handleDHCPDecline(&dhcpPacketInfo{
+		dhcp: &layers.DHCPv4{
+			ClientHWAddr: mac,
+			Options: []layers.DHCPOption{
+				{Type: layers.DHCPOptMessageType, Length: 1, Data: []byte{DHCPDecline}},
+				{Type: layers.DHCPOptRequestIP, Length: 4, Data: ip.To4()},
+			},
+		},
+		messageType: DHCPDecline,
+	}, 1, 0)
+}
+
+// TestHandleDHCPDeclineIsScoped verifies a DECLINE cannot be weaponised: a
+// non-pool address is never quarantined (bounds the declined set) and a client
+// cannot delete another client's lease by declining its address (no hijack).
+func TestHandleDHCPDeclineIsScoped(t *testing.T) {
+	_, h, _ := newDHCPTestHandler(t)
+
+	poolIP := net.ParseIP("10.20.200.150")
+	nonPool := net.ParseIP("8.8.8.8")
+	attacker := net.HardwareAddr{0xde, 0xad, 0x00, 0x00, 0x00, 0x01}
+	victim := net.HardwareAddr{0xbe, 0xef, 0x00, 0x00, 0x00, 0x02}
+
+	h.leases[victim.String()] = &DHCPLease{IP: poolIP, MAC: victim, Expiry: time.Now().Add(time.Hour)}
+
+	// A non-pool DECLINE is ignored — the quarantine set can't be grown with
+	// arbitrary addresses.
+	declineBy(h, attacker, nonPool)
+	if _, quarantined := h.declined[nonPool.String()]; quarantined {
+		t.Error("a non-pool DECLINE must not be quarantined (unbounded-state guard)")
+	}
+
+	// Declining the victim's pool address quarantines the address but must NOT
+	// delete the victim's lease.
+	declineBy(h, attacker, poolIP)
+	if _, quarantined := h.declined[poolIP.String()]; !quarantined {
+		t.Error("a pool DECLINE should quarantine the address")
+	}
+
+	if _, stillLeased := h.leases[victim.String()]; !stillLeased {
+		t.Error("a client must not delete another client's lease via DECLINE (lease-hijack)")
+	}
+}
 
 // TestHandleDHCPInformAckHasNoLease verifies a DHCPINFORM gets a DHCPACK with
 // configuration options but no address or lease (RFC 2131 §4.3.5).

--- a/internal/protocols/dhcp_realism_test.go
+++ b/internal/protocols/dhcp_realism_test.go
@@ -1,0 +1,88 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket/layers"
+)
+
+// TestHandleDHCPInformAckHasNoLease verifies a DHCPINFORM gets a DHCPACK with
+// configuration options but no address or lease (RFC 2131 §4.3.5).
+func TestHandleDHCPInformAckHasNoLease(t *testing.T) {
+	stack, h, device := newDHCPTestHandler(t)
+
+	info := &dhcpPacketInfo{
+		dhcp: &layers.DHCPv4{
+			Operation:    layers.DHCPOpRequest,
+			Xid:          0xABCD,
+			ClientHWAddr: net.HardwareAddr{0xaa, 0xaa, 0xaa, 0x00, 0x00, 0x07},
+			Options: []layers.DHCPOption{
+				{Type: layers.DHCPOptMessageType, Length: 1, Data: []byte{DHCPInform}},
+			},
+		},
+		messageType: DHCPInform,
+		vlan:        200,
+	}
+	h.handleDHCPInform(info, device, 1, 0)
+
+	d := dhcpOf(t, drainDHCP(t, stack))
+
+	if mt := dhcpMsgType(d); mt != DHCPAck {
+		t.Errorf("Inform reply message type = %d, want %d (ACK)", mt, DHCPAck)
+	}
+
+	if !d.YourClientIP.Equal(net.IPv4zero) {
+		t.Errorf("Inform ACK yiaddr = %s, want 0.0.0.0 (no address assigned)", d.YourClientIP)
+	}
+
+	present := map[layers.DHCPOpt]bool{}
+	for _, o := range d.Options {
+		present[o.Type] = true
+	}
+
+	// No lease parameters (RFC 2131 §4.3.5).
+	for _, forbidden := range []layers.DHCPOpt{layers.DHCPOptLeaseTime, layers.DHCPOptT1, layers.DHCPOptT2} {
+		if present[forbidden] {
+			t.Errorf("Inform ACK must not carry lease option %v", forbidden)
+		}
+	}
+
+	// But config options are still delivered.
+	if !present[layers.DHCPOptSubnetMask] {
+		t.Error("Inform ACK should carry the subnet mask")
+	}
+}
+
+// TestHandleDHCPDeclineQuarantines verifies a DHCPDECLINE quarantines the
+// address so it is never granted again (RFC 2131 §4.3.3).
+func TestHandleDHCPDeclineQuarantines(t *testing.T) {
+	_, h, _ := newDHCPTestHandler(t)
+
+	mac := net.HardwareAddr{0xaa, 0xaa, 0xaa, 0x00, 0x00, 0x09}
+	ip := net.ParseIP("10.20.200.150")
+
+	if !h.canGrantRequestedIP(mac, ip) {
+		t.Fatal("in-pool address should be grantable before a decline")
+	}
+
+	info := &dhcpPacketInfo{
+		dhcp: &layers.DHCPv4{
+			ClientHWAddr: mac,
+			Options: []layers.DHCPOption{
+				{Type: layers.DHCPOptMessageType, Length: 1, Data: []byte{DHCPDecline}},
+				{Type: layers.DHCPOptRequestIP, Length: 4, Data: ip.To4()},
+			},
+		},
+		messageType: DHCPDecline,
+	}
+	h.handleDHCPDecline(info, 1, 0)
+
+	if h.canGrantRequestedIP(mac, ip) {
+		t.Error("a declined address must not be grantable")
+	}
+
+	if _, quarantined := h.declined[ip.String()]; !quarantined {
+		t.Error("declined address should be recorded in the quarantine set")
+	}
+}


### PR DESCRIPTION
## Summary

Completes the practical target-B DHCP realism from #881. Release already frees the lease (fixed since the issue was filed) and NAK shipped in #886; this adds the two remaining real-server behaviors a CyberScope/EtherScope may exercise:

- **DHCPINFORM → DHCPACK** with configuration options but **no address or lease** — `yiaddr` 0, lease-time/T1/T2 omitted (RFC 2131 §4.3.5). A `withLease` flag threads through `buildDHCPOptions`/`sendDHCPResponse`; `SendDHCPInformAck` wraps it.
- **DHCPDECLINE → quarantine** the address (`declined` set) so it's never offered again, and drop any lease bound to it (RFC 2131 §4.3.3). `findAvailableIP` and `canGrantRequestedIP` skip quarantined IPs.

**Deliberately not done** (deprioritized — low value; real servers rarely differ and no tester checks them): option-55 parameter-request-list honoring, Offer/Ack option split.

## Linked Issue

Closes #881.

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/... -run 'DHCP|Inform|Decline|Nak|CanGrant'   # ok
  - TestHandleDHCPInformAckHasNoLease: ACK carries options + subnet mask, no
    lease-time/T1/T2, yiaddr 0
  - TestHandleDHCPDeclineQuarantines: declined address becomes non-grantable
$ go test ./internal/protocols/...   # full suite green (Offer/Ack unaffected by the option-builder refactor)
$ make lint   # 0 issues
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (raw DHCP response path; no routes)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (RFC cites in code + PR)
