### PR TITLE
fix(netbios): reject invalid level-2 name encoding (closes #850)

### DIFF
--- a/internal/protocols/netbios.go
+++ b/internal/protocols/netbios.go
@@ -438,9 +438,17 @@ func (h *NetBIOSHandler) decodeNetBIOSName(data []byte) (string, byte, int) {
 	decoded := make([]byte, nbnsDecodedNameLen)
 
 	for i := range 16 {
-		high := data[1+i*2] - 'A'
-		low := data[2+i*2] - 'A'
-		decoded[i] = (high << nbnsNibbleShift) | low
+		hi := data[1+i*2]
+		lo := data[2+i*2]
+
+		// Valid NetBIOS level-2 encoding uses only 'A'..'P' (nibbles 0..15). A
+		// byte below 'A' underflows the `- 'A'` subtraction and decodes to a
+		// garbage name; reject invalid encoding instead.
+		if hi < 'A' || hi > 'A'+nbnsNibbleMask || lo < 'A' || lo > 'A'+nbnsNibbleMask {
+			return "", 0, 0
+		}
+
+		decoded[i] = ((hi - 'A') << nbnsNibbleShift) | (lo - 'A')
 	}
 
 	// Extract name (first 15 bytes, trimmed) and type (16th byte)

--- a/internal/protocols/netbios_test.go
+++ b/internal/protocols/netbios_test.go
@@ -216,6 +216,22 @@ func TestNetBIOSNamePadding(t *testing.T) {
 	}
 }
 
+// TestNetBIOSNameRejectsInvalidEncoding verifies that a level-2 encoded name
+// containing a byte outside 'A'..'P' is rejected rather than underflowing the
+// nibble subtraction into a garbage name (#850).
+func TestNetBIOSNameRejectsInvalidEncoding(t *testing.T) {
+	handler := &protocols.NetBIOSHandler{}
+
+	encoded := handler.EncodeNetBIOSName("PC", protocols.NBNameWorkstation)
+	// Corrupt an encoded nibble byte to one below 'A' (would underflow).
+	encoded[1] = 0x40
+
+	decoded, _, offset := handler.DecodeNetBIOSName(encoded)
+	if decoded != "" || offset != 0 {
+		t.Errorf("invalid encoding should be rejected, got name=%q offset=%d", decoded, offset)
+	}
+}
+
 func TestNetBIOSNameTruncation(t *testing.T) {
 	handler := &protocols.NetBIOSHandler{}
 


### PR DESCRIPTION
## Summary

Addresses the protocol-handler audit backlog (#850). The one security-relevant, attacker-adjacent item is fixed; the rest are triaged as non-issues, mooted, or accepted-low-risk with reasoning.

**Fixed:** `decodeNetBIOSName` computed each nibble as `data[i] - 'A'` with no range check — a byte below `'A'` underflowed (byte wrap) into a garbage decoded name. Valid NetBIOS level-2 encoding uses only `'A'..'P'` (nibbles 0..15); anything outside that range is now rejected at decode time.

**Triaged (no change):**
- **`GetDeviceByTTL`** — already a map lookup (`ttlDevices[ttl]`), *not* a linear scan on the hot path. Non-issue.
- **`SendICMPTimeExceeded`** slice append — mooted by the buffer-ownership fix (#863).
- **`sendDiscoveryFrame`** length field — egress-only, operator-config-driven, not attacker-triggerable.
- **DHCP DNS/NTP 4-byte alignment** (>63 servers corrupts the final address) — accepted low-risk; no realistic config approaches 63 DNS/NTP servers.

## Linked Issue

Closes #850.

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [x] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ go test ./internal/protocols/ -run NetBIOS   # ok
  - TestNetBIOSNameRejectsInvalidEncoding: a byte < 'A' is rejected (name "", offset 0)
$ make lint   # 0 issues
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (input-decode hardening; no routes)
- [x] Dependencies are pinned and justified if changed. (none)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (n/a)
