### PR TITLE
feat(ui): localize TierGate upgrade tooltip via react-i18next

### DIFF
--- a/ui/src/components/ui/TierGate.test.tsx
+++ b/ui/src/components/ui/TierGate.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * TierGate.test.tsx — locks the license-gate behavior plus the #713
+ * i18n wiring: when the active license lacks the feature the wrapper
+ * renders the locked overlay with the *localized* upgrade tooltip;
+ * when it has the feature (or is still loading) it renders children
+ * untouched. The Spanish case proves the tooltip is resolved through
+ * i18next and interpolated, not a hardcoded English string.
+ */
+
+import { render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { I18nextProvider } from 'react-i18next';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../i18n';
+import { TierGate } from './TierGate';
+
+// TierGate reads the license through useLicense(); mock the context so
+// the test controls hasFeature/loading without a provider or network.
+const mockLicense = {
+  hasFeature: vi.fn<(feature: string) => boolean>(),
+  loading: false,
+};
+vi.mock('../../contexts/LicenseContext', () => ({
+  useLicense: () => mockLicense,
+}));
+
+function renderGate(node: ReactElement): ReturnType<typeof render> {
+  return render(<I18nextProvider i18n={i18n}>{node}</I18nextProvider>);
+}
+
+describe('TierGate', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+    mockLicense.loading = false;
+    mockLicense.hasFeature = vi.fn<(feature: string) => boolean>(() => false);
+  });
+
+  afterAll(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('locks the child and shows the localized upgrade tooltip when unlicensed', () => {
+    renderGate(
+      <TierGate feature="capture.export">
+        <button type="button">Export</button>
+      </TierGate>,
+    );
+
+    // Child stays visible so the user sees what they're missing.
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument();
+
+    const locked = screen.getByTestId('tier-gate-locked');
+    expect(locked).toHaveAttribute('data-feature', 'capture.export');
+
+    // Tooltip text and the overlay title both carry the localized hint.
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Requires the Pro tier');
+    expect(locked.querySelector('[title]')).toHaveAttribute('title', 'Requires the Pro tier');
+  });
+
+  it('interpolates a custom requiredTier into the tooltip', () => {
+    renderGate(
+      <TierGate feature="capture.export" requiredTier="Enterprise">
+        <button type="button">Export</button>
+      </TierGate>,
+    );
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Requires the Enterprise tier');
+  });
+
+  it('localizes the tooltip when the active language is Spanish', async () => {
+    await i18n.changeLanguage('es');
+    renderGate(
+      <TierGate feature="capture.export">
+        <button type="button">Exportar</button>
+      </TierGate>,
+    );
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Requiere el nivel Pro');
+  });
+
+  it('honors an explicit message over the localized default', () => {
+    renderGate(
+      <TierGate feature="capture.export" message="Ask your admin to enable this">
+        <button type="button">Export</button>
+      </TierGate>,
+    );
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Ask your admin to enable this');
+    expect(tooltip).not.toHaveTextContent('Requires the Pro tier');
+  });
+
+  it('renders children untouched when the feature is licensed', () => {
+    mockLicense.hasFeature = vi.fn<(feature: string) => boolean>(() => true);
+    renderGate(
+      <TierGate feature="capture.export">
+        <button type="button">Export</button>
+      </TierGate>,
+    );
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument();
+    expect(screen.queryByTestId('tier-gate-locked')).not.toBeInTheDocument();
+  });
+
+  it('renders children untouched while the license is still loading', () => {
+    mockLicense.loading = true;
+    mockLicense.hasFeature = vi.fn<(feature: string) => boolean>(() => false);
+    renderGate(
+      <TierGate feature="capture.export">
+        <button type="button">Export</button>
+      </TierGate>,
+    );
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument();
+    expect(screen.queryByTestId('tier-gate-locked')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/TierGate.tsx
+++ b/ui/src/components/ui/TierGate.tsx
@@ -17,6 +17,7 @@
  */
 
 import type { ReactElement, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLicense } from '../../contexts/LicenseContext';
 
 interface TierGateProps {
@@ -25,10 +26,8 @@ interface TierGateProps {
   /** Tier name shown in the tooltip (e.g. "Pro"). */
   requiredTier?: string;
   /**
-   * Custom tooltip. Defaults to a hard-coded English string today;
-   * once NIAC's UI wires up react-i18next, switch the default to
-   * `t('errors:license.tierGateTooltip', { tier })` (the locale
-   * keys are already in `internal/i18n/locales/{en,es}/errors.json`).
+   * Custom tooltip. Defaults to the localized
+   * `t('errors:license.tierGateTooltip', { tier })`.
    */
   message?: string;
 }
@@ -40,6 +39,7 @@ export function TierGate({
   message,
 }: TierGateProps): ReactElement {
   const { hasFeature, loading } = useLicense();
+  const { t } = useTranslation('errors');
 
   // Always render children while loading so layouts don't shift;
   // gate visually only after we know they lack the feature.
@@ -47,7 +47,7 @@ export function TierGate({
     return <>{children}</>;
   }
 
-  const hint = message ?? `Requires the ${requiredTier} tier`;
+  const hint = message ?? t('license.tierGateTooltip', { tier: requiredTier });
 
   // CSS-only hover (`group` + `group-hover:`) keeps the tooltip tied
   // to the wrapper without JS event handlers — that lets the outer


### PR DESCRIPTION
## Summary

Wires `TierGate` to react-i18next so its upgrade tooltip is localized instead of a hard-coded English string. `TierGate` now calls `useTranslation('errors')` and defaults the hint to `t('license.tierGateTooltip', { tier: requiredTier })` (the `en`/`es` keys already shipped). Drops the stale TODO on the `message` prop.

## Linked Issue

Closes #713

## Testing Evidence

```
$ npx vitest run src/components/ui/TierGate.test.tsx
 Test Files  1 passed (1)
      Tests  6 passed (6)     # incl. the Spanish path proving i18next resolution

$ npm run typecheck            # tsgo — clean
$ npm run build                # vite — ✓ built
$ npx biome check src/components/ui/TierGate.tsx src/components/ui/TierGate.test.tsx
Checked 2 files. No fixes applied.
```

Meets all four #713 acceptance criteria: locale flip (test), tsc clean, vite build clean, no gating regression.

## Security and Release Checklist

- [x] UI-only change; no new mutating routes, auth surfaces, or default credentials
- [x] No secrets added
- [x] No customer-facing AI or banned vocabulary
- [x] Lint + typecheck + unit tests green
