### PR TITLE
feat(ui): migrate device editor to react-hook-form + valibot

### DIFF
--- a/ui/src/components/device-editor/BasicSettingsSection.tsx
+++ b/ui/src/components/device-editor/BasicSettingsSection.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import type { FieldErrors } from 'react-hook-form';
 import type { Device, DeviceType } from '../../api/types';
 import { deviceTypeOptions as deviceTypes } from '../../constants/device-types';
 import { CollapsibleSection } from '../form/CollapsibleSection';
@@ -10,6 +11,8 @@ export interface BasicSettingsSectionProps {
   isExpanded: boolean;
   onToggle: () => void;
   onUpdate: <K extends keyof Device>(field: K, value: Device[K]) => void;
+  /** Inline validation errors from the editor's failed-save valibot check. */
+  errors?: FieldErrors<Device>;
 }
 
 export const BasicSettingsSection: FC<BasicSettingsSectionProps> = ({
@@ -17,6 +20,7 @@ export const BasicSettingsSection: FC<BasicSettingsSectionProps> = ({
   isExpanded,
   onToggle,
   onUpdate,
+  errors,
 }) => {
   return (
     <CollapsibleSection
@@ -31,6 +35,7 @@ export const BasicSettingsSection: FC<BasicSettingsSectionProps> = ({
           required={true}
           helpText="Unique identifier for the device"
           htmlFor="device-hostname"
+          error={errors?.hostname?.message}
         >
           <input
             id="device-hostname"
@@ -47,6 +52,7 @@ export const BasicSettingsSection: FC<BasicSettingsSectionProps> = ({
           required={true}
           helpText="Hardware address in format XX:XX:XX:XX:XX:XX"
           htmlFor="device-mac"
+          error={errors?.mac?.message}
         >
           <input
             id="device-mac"
@@ -77,6 +83,7 @@ export const BasicSettingsSection: FC<BasicSettingsSectionProps> = ({
           label="Primary IP Address"
           helpText="Main management IP address"
           htmlFor="device-primary-ip"
+          error={errors?.ip?.message}
         >
           <input
             id="device-primary-ip"

--- a/ui/src/components/device-editor/useDeviceEditor.test.tsx
+++ b/ui/src/components/device-editor/useDeviceEditor.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * useDeviceEditor.test.tsx — locks the react-hook-form migration (#730).
+ *
+ * The hook runs rhf headless: section components still call `updateField`
+ * and read `device`, while save-time validation moved from imperative
+ * presence checks to a valibot `safeParse`. These tests pin that contract:
+ * updateField flows into `device`, an invalid save is blocked with an inline
+ * field error, and a valid save reaches the API.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useDeviceEditor } from './useDeviceEditor';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ hostname: 'new' }),
+    useLocation: () => ({ pathname: '/device-config/new' }),
+  };
+});
+
+const mockCreateDevice = vi.fn();
+vi.mock('../../api/client', () => ({
+  createDevice: (...args: unknown[]) => mockCreateDevice(...args),
+  updateDevice: vi.fn(),
+  deleteDevice: vi.fn(),
+  fetchConfigDevice: () => Promise.resolve({ device: null }),
+  fetchWalkFiles: () => Promise.resolve([]),
+  fetchDeviceEditorSchema: () => Promise.resolve({ visibleSections: [] }),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }): React.ReactElement =>
+  createElement(MemoryRouter, null, children);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function render() {
+  return renderHook(() => useDeviceEditor(), { wrapper });
+}
+
+describe('useDeviceEditor', () => {
+  it('flows updateField changes into device', async () => {
+    const { result } = render();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.updateField('hostname', 'edge-01'));
+    expect(result.current.device.hostname).toBe('edge-01');
+  });
+
+  it('blocks save on an invalid MAC and surfaces an inline field error', async () => {
+    const { result } = render();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.updateField('hostname', 'edge-01'));
+    act(() => result.current.updateField('mac', 'not-a-mac'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockCreateDevice).not.toHaveBeenCalled();
+    expect(result.current.fieldErrors.mac?.message).toMatch(/six hex octets/i);
+    expect(result.current.message?.type).toBe('error');
+  });
+
+  it('blocks save when the hostname is empty', async () => {
+    const { result } = render();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.updateField('mac', '00:1A:2B:3C:4D:5E'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockCreateDevice).not.toHaveBeenCalled();
+    expect(result.current.fieldErrors.hostname?.message).toBe('Hostname is required');
+  });
+
+  it('saves a valid new device through the API', async () => {
+    mockCreateDevice.mockResolvedValueOnce({ device: { hostname: 'edge-01' } });
+    const { result } = render();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.updateField('hostname', 'edge-01'));
+    act(() => result.current.updateField('mac', '00:1A:2B:3C:4D:5E'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockCreateDevice).toHaveBeenCalledTimes(1);
+    expect(mockCreateDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: 'edge-01', mac: '00:1A:2B:3C:4D:5E' }),
+    );
+    expect(result.current.fieldErrors.hostname).toBeUndefined();
+  });
+});

--- a/ui/src/components/device-editor/useDeviceEditor.ts
+++ b/ui/src/components/device-editor/useDeviceEditor.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type FieldErrors, type Path, type PathValue, useForm } from 'react-hook-form';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import * as v from 'valibot';
 import {
   createDevice,
   deleteDevice,
@@ -10,6 +12,7 @@ import {
 } from '../../api/client';
 import type { Device, FileEntry } from '../../api/types';
 import { useApiResource } from '../../hooks/useApiResource';
+import { DeviceFormSchema } from '../../schemas/forms';
 import { getErrorMessage } from '../../utils/format';
 import type { StatusMessage } from './DeviceEditorHeader';
 
@@ -54,6 +57,10 @@ export interface UseDeviceEditorReturn {
   saving: boolean;
   deleting: boolean;
   message: StatusMessage | null;
+  // Inline, per-field validation errors surfaced next to the offending
+  // input (hostname / mac / ip). Populated on a failed save from the
+  // valibot DeviceFormSchema; cleared as the user edits the field.
+  fieldErrors: FieldErrors<Device>;
   expandedSections: Set<string>;
   showYamlPreview: boolean;
   showDeleteConfirm: boolean;
@@ -76,8 +83,16 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
   const location = useLocation();
   const isNewDevice = hostname === 'new' || location.pathname === '/device-config/new';
 
+  // react-hook-form owns the device values. Inputs use the custom
+  // `updateField` setter (not `register`), so the form runs headless:
+  // `watch()` exposes current values, `safeParse` validates on save, and
+  // `setError` drives the inline field errors. Keeping this contract means
+  // the ~14 section components stay unchanged.
+  const form = useForm<Device>({ defaultValues: createEmptyDevice() });
+  const { setValue, getValues, watch, reset, setError, clearErrors, formState } = form;
+  const device = watch();
+
   // State
-  const [device, setDevice] = useState<Device>(createEmptyDevice());
   const [originalDevice, setOriginalDevice] = useState<Device | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -133,12 +148,14 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
   // Update local state when fetched device changes
   useEffect(() => {
     if (fetchedDevice?.device) {
-      setDevice(fetchedDevice.device);
+      reset(fetchedDevice.device);
       setOriginalDevice(fetchedDevice.device);
     }
-  }, [fetchedDevice]);
+  }, [fetchedDevice, reset]);
 
-  // Check if device has been modified
+  // Check if device has been modified. Deliberately kept as a structural
+  // JSON compare (not rhf's formState.isDirty) so the unsaved-changes
+  // navigation guard behaves exactly as before the rhf migration.
   const isDirty = useMemo(() => {
     if (isNewDevice) {
       return device.hostname.trim() !== '';
@@ -163,20 +180,46 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
   }, []);
 
   // Handle form field changes
-  const updateField = useCallback(<K extends keyof Device>(field: K, value: Device[K]) => {
-    setDevice((prev) => ({ ...prev, [field]: value }));
-    setMessage(null);
-  }, []);
+  const updateField = useCallback(
+    <K extends keyof Device>(field: K, value: Device[K]) => {
+      // Bridge the ergonomic `keyof Device` public signature to rhf's
+      // `Path`/`PathValue` types — a top-level key is always a valid path,
+      // but the compiler can't prove it through the generic.
+      setValue(field as Path<Device>, value as PathValue<Device, Path<Device>>, {
+        shouldDirty: true,
+      });
+      clearErrors(field as Path<Device>);
+      setMessage(null);
+    },
+    [setValue, clearErrors],
+  );
 
   // Handle save
   const handleSave = useCallback(async () => {
-    if (!device.hostname.trim()) {
-      setMessage({ type: 'error', text: 'Hostname is required' });
-      return;
-    }
+    const current = getValues();
 
-    if (!device.mac.trim()) {
-      setMessage({ type: 'error', text: 'MAC address is required' });
+    // Format-level validation (hostname / mac / ip) before the round-trip.
+    // The Go side validates the full structure; this catches the common
+    // mistakes inline. Uses safeParse so unrelated device sections pass
+    // through untouched.
+    clearErrors();
+    const result = v.safeParse(DeviceFormSchema, current);
+    if (!result.success) {
+      // Surface the first issue per field. valibot reports pipe issues in
+      // order, so an empty hostname shows "Hostname is required" (minLength)
+      // rather than the later format message.
+      const flagged = new Set<string>();
+      for (const issue of result.issues) {
+        const key = issue.path?.[0]?.key;
+        if (typeof key === 'string' && !flagged.has(key)) {
+          flagged.add(key);
+          setError(key as Path<Device>, { message: issue.message });
+        }
+      }
+      setMessage({
+        type: 'error',
+        text: result.issues[0]?.message ?? 'Please fix the highlighted fields',
+      });
       return;
     }
 
@@ -185,11 +228,11 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
 
     try {
       if (isNewDevice) {
-        await createDevice(device);
+        await createDevice(current);
         setMessage({ type: 'success', text: 'Device created successfully' });
         // Navigate to the new device's edit page
         setTimeout(() => {
-          navigate(`/device-config/${encodeURIComponent(device.hostname)}`);
+          navigate(`/device-config/${encodeURIComponent(current.hostname)}`);
         }, 500);
       } else {
         if (!hostname) {
@@ -197,13 +240,13 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
           setSaving(false);
           return;
         }
-        await updateDevice(hostname, device);
+        await updateDevice(hostname, current);
         setMessage({ type: 'success', text: 'Device updated successfully' });
-        setOriginalDevice(device);
+        setOriginalDevice(current);
         // If hostname changed, navigate to new URL
-        if (device.hostname !== hostname) {
+        if (current.hostname !== hostname) {
           setTimeout(() => {
-            navigate(`/device-config/${encodeURIComponent(device.hostname)}`);
+            navigate(`/device-config/${encodeURIComponent(current.hostname)}`);
           }, 500);
         }
       }
@@ -212,7 +255,7 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     } finally {
       setSaving(false);
     }
-  }, [device, hostname, isNewDevice, navigate]);
+  }, [getValues, clearErrors, setError, hostname, isNewDevice, navigate]);
 
   // Handle delete
   const handleDelete = useCallback(async () => {
@@ -235,10 +278,10 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     if (isNewDevice) {
       navigate('/device-config');
     } else if (originalDevice) {
-      setDevice(originalDevice);
+      reset(originalDevice);
       setMessage(null);
     }
-  }, [isNewDevice, originalDevice, navigate]);
+  }, [isNewDevice, originalDevice, navigate, reset]);
 
   return {
     hostname,
@@ -254,6 +297,7 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     saving,
     deleting,
     message,
+    fieldErrors: formState.errors,
     expandedSections,
     showYamlPreview,
     showDeleteConfirm,

--- a/ui/src/components/form/FormField.tsx
+++ b/ui/src/components/form/FormField.tsx
@@ -9,6 +9,8 @@ export interface FormFieldProps {
   required?: boolean;
   className?: string;
   htmlFor?: string;
+  /** Inline validation error rendered below the field, in the error color. */
+  error?: string;
 }
 
 export const FormField: FC<FormFieldProps> = ({
@@ -18,6 +20,7 @@ export const FormField: FC<FormFieldProps> = ({
   required,
   className = '',
   htmlFor,
+  error,
 }) => (
   <div className={className}>
     {htmlFor ? (
@@ -51,5 +54,10 @@ export const FormField: FC<FormFieldProps> = ({
       </div>
     )}
     {children}
+    {error && (
+      <p className="mt-1 text-xs text-status-error" role="alert">
+        {error}
+      </p>
+    )}
   </div>
 );

--- a/ui/src/pages/DeviceEditorPage.tsx
+++ b/ui/src/pages/DeviceEditorPage.tsx
@@ -35,6 +35,7 @@ export const DeviceEditorPage: FC = () => {
     saving,
     deleting,
     message,
+    fieldErrors,
     expandedSections,
     showYamlPreview,
     showDeleteConfirm,
@@ -95,6 +96,7 @@ export const DeviceEditorPage: FC = () => {
           isExpanded={expandedSections.has('basic')}
           onToggle={() => toggleSection('basic')}
           onUpdate={updateField}
+          errors={fieldErrors}
         />
       )}
 

--- a/ui/src/schemas/forms.test.ts
+++ b/ui/src/schemas/forms.test.ts
@@ -1,0 +1,87 @@
+/**
+ * forms.test.ts — pins the DeviceFormSchema validation the device editor
+ * relies on (#730). These cases lock the format rules that mirror the Go
+ * `validate:"mac"` / `validate:"ip"` tags and guarantee the schema ignores
+ * the many other device sections so it can be run against a whole Device.
+ */
+
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+import { DeviceFormSchema } from './forms';
+
+/** First validation message for a given top-level field, or undefined. */
+function errorFor(input: unknown, field: string): string | undefined {
+  const result = v.safeParse(DeviceFormSchema, input);
+  if (result.success) return undefined;
+  const issue = result.issues.find((i) => i.path?.[0]?.key === field);
+  return issue?.message;
+}
+
+describe('DeviceFormSchema', () => {
+  it('accepts a valid device (hostname + MAC + IPv4)', () => {
+    const result = v.safeParse(DeviceFormSchema, {
+      hostname: 'core-switch-01',
+      mac: '00:1A:2B:3C:4D:5E',
+      ip: '10.0.0.1',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('treats an empty primary IP as valid (no management IP)', () => {
+    expect(
+      v.safeParse(DeviceFormSchema, { hostname: 'sw1', mac: '00:1A:2B:3C:4D:5E', ip: '' }).success,
+    ).toBe(true);
+  });
+
+  it('treats an omitted primary IP as valid', () => {
+    expect(
+      v.safeParse(DeviceFormSchema, { hostname: 'sw1', mac: '00:1A:2B:3C:4D:5E' }).success,
+    ).toBe(true);
+  });
+
+  it('ignores the other device sections (runs against a whole Device)', () => {
+    const result = v.safeParse(DeviceFormSchema, {
+      hostname: 'sw1',
+      mac: '00:1A:2B:3C:4D:5E',
+      type: 'switch',
+      ips: ['10.0.0.2'],
+      snmpAgent: { community: 'public' },
+      interfaceDetails: [{ name: 'Gi0/1' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts hyphen-separated MAC addresses', () => {
+    expect(
+      v.safeParse(DeviceFormSchema, { hostname: 'sw1', mac: '00-1A-2B-3C-4D-5E' }).success,
+    ).toBe(true);
+  });
+
+  it('requires a hostname', () => {
+    expect(errorFor({ hostname: '', mac: '00:1A:2B:3C:4D:5E' }, 'hostname')).toBe(
+      'Hostname is required',
+    );
+  });
+
+  it('rejects a hostname that does not start with a letter', () => {
+    expect(errorFor({ hostname: '1router', mac: '00:1A:2B:3C:4D:5E' }, 'hostname')).toMatch(
+      /must start with a letter/i,
+    );
+  });
+
+  it('requires a MAC address', () => {
+    expect(errorFor({ hostname: 'sw1', mac: '' }, 'mac')).toBe('MAC address is required');
+  });
+
+  it('rejects a malformed MAC address', () => {
+    expect(errorFor({ hostname: 'sw1', mac: 'ZZ:ZZ:ZZ:ZZ:ZZ:ZZ' }, 'mac')).toMatch(
+      /six hex octets/i,
+    );
+  });
+
+  it('rejects a malformed primary IP', () => {
+    expect(errorFor({ hostname: 'sw1', mac: '00:1A:2B:3C:4D:5E', ip: '999.1.1.1' }, 'ip')).toMatch(
+      /valid IPv4/i,
+    );
+  });
+});

--- a/ui/src/schemas/forms.ts
+++ b/ui/src/schemas/forms.ts
@@ -10,6 +10,12 @@ import * as v from 'valibot';
 // Hostname source-of-truth regex (mirrors the Go-side validation).
 const HOSTNAME_REGEX = /^[a-zA-Z][a-zA-Z0-9._-]{0,252}$/;
 
+// MAC + IPv4 regexes mirror the Go `validate:"mac"` / `validate:"ip"` tags on
+// converter.Device (internal/converter/types.go). Kept here so the device
+// editor can surface format errors inline before the round-trip to the server.
+const MAC_REGEX = /^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$/;
+const IPV4_REGEX = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+
 /**
  * Clone-device form: a single field for the new hostname. The Go side
  * also validates; this layer is for inline UI errors before submit.
@@ -71,3 +77,41 @@ export const ErrorInjectionSchema = v.object({
 });
 
 export type ErrorInjectionFormFields = v.InferOutput<typeof ErrorInjectionSchema>;
+
+/**
+ * Device editor: the two always-required identity fields plus the optional
+ * primary IP. The device object carries many more (per-protocol) sections, but
+ * only these need format-level validation before save — the Go side validates
+ * the full structure. `safeParse` against this schema replaces the editor's old
+ * presence-only checks (`if (!device.hostname.trim())`) and drives inline field
+ * errors. Extra keys on the parsed object are ignored by `v.object`, so it can
+ * be run against a whole `Device` without stripping the other sections (the
+ * caller keeps using the untouched device for the actual save).
+ */
+export const DeviceFormSchema = v.object({
+  hostname: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Hostname is required'),
+    v.maxLength(253, 'Hostname is too long (max 253 chars)'),
+    v.regex(
+      HOSTNAME_REGEX,
+      'Hostname must start with a letter and contain only alphanumeric, dots, hyphens, or underscores',
+    ),
+  ),
+  mac: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'MAC address is required'),
+    v.regex(MAC_REGEX, 'MAC must be six hex octets, e.g. 00:1A:2B:3C:4D:5E'),
+  ),
+  ip: v.optional(
+    v.pipe(
+      v.string(),
+      // Primary IP is optional; an empty string means "no management IP".
+      v.check((s) => s === '' || IPV4_REGEX.test(s), 'Primary IP must be a valid IPv4 address'),
+    ),
+  ),
+});
+
+export type DeviceFormFields = v.InferOutput<typeof DeviceFormSchema>;


### PR DESCRIPTION
## Summary

Migrates the device editor's `useDeviceEditor` hook to react-hook-form (run headless) plus a valibot `DeviceFormSchema`. This replaces the old presence-only checks (`if (!device.hostname.trim())`) with format-level hostname/MAC/IP validation that mirrors the Go `validate:"mac"`/`validate:"ip"` tags, surfaced as inline field errors via a new optional `FormField.error` prop.

The ~14 section components are unchanged: the hook keeps its `updateField`/`device` public contract (`setValue`/`watch` back the values), and `isDirty` stays a structural `JSON.stringify` compare so the unsaved-changes navigation guard behaves byte-for-byte as before.

## Linked Issue

Closes #730

## Testing Evidence

```
$ npm run typecheck            # tsgo --build --noEmit
(clean, no errors)

$ npx vitest run src/schemas/forms.test.ts src/components/device-editor/useDeviceEditor.test.tsx
 Test Files  2 passed (2)
      Tests  14 passed (14)

$ npm run build                # vite
✓ built

$ npx biome check <changed files>
Checked 7 files. No fixes applied.
```

Also verified in the combined integration branch (all four UI PRs merged): tsgo typecheck + biome (255 files) + 136 vitest tests + vite build + `go build ./...` all green.

## Security and Release Checklist

- [x] UI-only change; no new mutating routes, auth surfaces, or default credentials
- [x] No secrets added
- [x] No customer-facing AI or banned vocabulary
- [x] Lint + typecheck + unit tests green
