### PR TITLE
fix(ui): remove dead code + make misleading controls honest

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -32,8 +32,6 @@ import type {
   TemplateContent,
   TopologyGraph,
   UpdateProtocolDebugLevelsRequest,
-  UploadTemplateRequest,
-  UploadTemplateResponse,
   UploadUserConfigRequest,
   UploadUserConfigResponse,
   UserConfigContent,
@@ -86,8 +84,6 @@ export const updateAlerts = (payload: AlertConfig) =>
 // Files + SNMP walks
 // =====================================================================
 
-export const fetchFiles = (kind: 'pcaps' | 'walks') =>
-  request<FileEntry[]>(`/api/v1/files?kind=${kind}`);
 export const validateWalk = (filename: string) =>
   requestJson<WalkValidationResponse>('/api/v1/walk/validate', { filename }, { method: 'POST' });
 export const fixWalk = (filename: string) =>
@@ -232,14 +228,6 @@ export const fetchTemplateContent = (name: string) =>
 export const applyTemplate = (payload: UseTemplateRequest) =>
   requestJson<UseTemplateResponse>('/api/v1/templates/use', payload, { method: 'POST' });
 
-export const uploadTemplate = (payload: UploadTemplateRequest) =>
-  requestJson<UploadTemplateResponse>('/api/v1/templates', payload, { method: 'POST' });
-
-export const deleteTemplate = (name: string) =>
-  request<{ success: boolean; message: string }>(`/api/v1/templates/${encodeURIComponent(name)}`, {
-    method: 'DELETE',
-  });
-
 // =====================================================================
 // Protocol debug levels
 // =====================================================================
@@ -259,9 +247,6 @@ export const resetProtocolDebugLevels = () =>
 
 export const uploadPcap = (payload: PcapUploadRequest) =>
   requestJson<PcapUploadResponse>('/api/v1/pcap/upload', payload, { method: 'POST' });
-
-export const analyzePcap = (analysisId: string) =>
-  request<PcapAnalysisResult>(`/api/v1/pcap/analyze/${encodeURIComponent(analysisId)}`);
 
 export const fetchPcapAnalysis = (analysisId: string) =>
   request<PcapAnalysisResult>(`/api/v1/pcap/${encodeURIComponent(analysisId)}`);

--- a/ui/src/api/errors.ts
+++ b/ui/src/api/errors.ts
@@ -36,29 +36,3 @@ export class TimeoutError extends ApiError {
 export function isApiError(error: unknown): error is ApiError {
   return error instanceof ApiError;
 }
-
-export function isNetworkError(error: unknown): error is NetworkError {
-  return error instanceof NetworkError;
-}
-
-export function isTimeoutError(error: unknown): error is TimeoutError {
-  return error instanceof TimeoutError;
-}
-
-export function isAuthError(error: unknown): error is ApiError {
-  return error instanceof ApiError && (error.status === 401 || error.status === 403);
-}
-
-export function isNotFoundError(error: unknown): error is ApiError {
-  return error instanceof ApiError && error.status === 404;
-}
-
-/**
- * FIX #176: Assert a value is defined, throwing if null/undefined.
- */
-export function assertDefined<T>(value: T | null | undefined, name = 'value'): T {
-  if (value === null || value === undefined) {
-    throw new Error(`Expected ${name} to be defined`);
-  }
-  return value;
-}

--- a/ui/src/api/requestCore.ts
+++ b/ui/src/api/requestCore.ts
@@ -178,11 +178,12 @@ function parseApiError(text: string, status: number, fallback = ''): ApiError {
   return new ApiError(text || fallback || 'Request failed', status);
 }
 
-// FIX #175: Check if an error is retryable (network errors and 5xx responses).
+// FIX #175: Check if an error is retryable (network errors thrown by fetch()).
+// fetch() only ever rejects with a TypeError (network failure) or an
+// AbortError; it never rejects with a Response — 5xx responses resolve
+// normally and are handled via isRetryableStatus() on response.status below.
 function isRetryableError(error: unknown): boolean {
-  if (error instanceof TypeError) return true; // Network error
-  if (error instanceof Response && error.status >= 500) return true;
-  return false;
+  return error instanceof TypeError;
 }
 
 // FIX #175: Check if a response status is retryable.

--- a/ui/src/components/SettingsDrawer.tsx
+++ b/ui/src/components/SettingsDrawer.tsx
@@ -30,12 +30,14 @@ import {
 import type { ReactElement, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { fetchInterfaces } from '../api/client';
 import type { NetworkInterface } from '../api/types';
 import { iconSizes } from '../constants/sizes';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { type Theme, useTheme } from '../hooks/useTheme';
-import { badge, cn, drawer, layout, spacing } from '../styles/theme';
+import { cn, drawer, layout, spacing } from '../styles/theme';
+import { ConnectionStatus } from '../ui/ConnectionStatus';
 import { SimulationSection } from './settings/SimulationSection';
 
 interface SettingsDrawerProps {
@@ -151,7 +153,7 @@ export function SettingsDrawer({
             {activeTab === 'simulation' && <SimulationSection />}
             {activeTab === 'appearance' && <AppearanceSection />}
             {activeTab === 'network' && <NetworkSection />}
-            {activeTab === 'debug' && <DebugSection />}
+            {activeTab === 'debug' && <DebugSection onClose={onClose} />}
             {activeTab === 'about' && <AboutSection version={version} />}
           </div>
         </div>
@@ -347,13 +349,11 @@ function NetworkSection(): ReactElement {
           description={t('network.backendUrlDescription')}
         >
           <code className="text-xs text-brand-accent bg-brand-primary/10 px-cell py-compact rounded">
-            localhost:8080
+            {window.location.origin}
           </code>
         </SettingRow>
-        <SettingRow label={t('network.websocket')} description={t('network.websocketDescription')}>
-          <span className={cn(badge.base, badge.variant.success, badge.size.sm)}>
-            {t('network.connected')}
-          </span>
+        <SettingRow label="Connection" description={t('network.websocketDescription')}>
+          <ConnectionStatus />
         </SettingRow>
       </Section>
     </>
@@ -395,64 +395,35 @@ function InterfaceItem({ name, type, status, ip }: InterfaceItemProps): ReactEle
 // Debug Section
 // =============================================================================
 
-function DebugSection(): ReactElement {
+interface DebugSectionProps {
+  onClose: () => void;
+}
+
+function DebugSection({ onClose }: DebugSectionProps): ReactElement {
   const { t } = useTranslation('settings');
-  const [logLevel, setLogLevel] = useState<'error' | 'warn' | 'info' | 'debug'>('info');
+  const navigate = useNavigate();
 
   return (
-    <>
-      <Section title={t('debug.loggingTitle')} description={t('debug.loggingDescription')}>
-        <SettingRow label={t('debug.logLevel')} description={t('debug.logLevelDescription')}>
-          <select
-            value={logLevel}
-            onChange={(e) => setLogLevel(e.target.value as typeof logLevel)}
-            className={cn(
-              'bg-bg-elevated border border-surface-border rounded-lg px-3 py-compact-md text-sm text-text-primary',
-              'focus:outline-none focus:ring-2 focus:ring-brand-primary/50',
-            )}
-          >
-            <option value="error">{t('debug.levels.error')}</option>
-            <option value="warn">{t('debug.levels.warn')}</option>
-            <option value="info">{t('debug.levels.info')}</option>
-            <option value="debug">{t('debug.levels.debug')}</option>
-          </select>
-        </SettingRow>
-      </Section>
-
-      <Section title={t('debug.devToolsTitle')} description={t('debug.devToolsDescription')}>
-        <button
-          type="button"
-          className={cn(
-            layout.flex.between,
-            'w-full py-row px-3 bg-surface-hover rounded-lg',
-            'hover:bg-surface-hover transition-colors text-left',
-          )}
-        >
-          <div>
-            <div className="text-sm text-text-primary">{t('debug.protocolDebugLevels')}</div>
-            <div className="text-xs text-text-muted">
-              {t('debug.protocolDebugLevelsDescription')}
-            </div>
-          </div>
-          <ChevronRight className="w-4 h-4 text-text-muted" />
-        </button>
-
-        <button
-          type="button"
-          className={cn(
-            layout.flex.between,
-            'w-full py-row px-3 bg-surface-hover rounded-lg',
-            'hover:bg-surface-hover transition-colors text-left',
-          )}
-        >
-          <div>
-            <div className="text-sm text-text-primary">{t('debug.exportDiagnostics')}</div>
-            <div className="text-xs text-text-muted">{t('debug.exportDiagnosticsDescription')}</div>
-          </div>
-          <ChevronRight className="w-4 h-4 text-text-muted" />
-        </button>
-      </Section>
-    </>
+    <Section title={t('debug.devToolsTitle')} description={t('debug.devToolsDescription')}>
+      <button
+        type="button"
+        onClick={() => {
+          onClose();
+          navigate('/debug');
+        }}
+        className={cn(
+          layout.flex.between,
+          'w-full py-row px-3 bg-surface-hover rounded-lg',
+          'hover:bg-surface-hover transition-colors text-left',
+        )}
+      >
+        <div>
+          <div className="text-sm text-text-primary">{t('debug.protocolDebugLevels')}</div>
+          <div className="text-xs text-text-muted">{t('debug.protocolDebugLevelsDescription')}</div>
+        </div>
+        <ChevronRight className="w-4 h-4 text-text-muted" />
+      </button>
+    </Section>
   );
 }
 

--- a/ui/src/components/debug/ProtocolDebugLevels.tsx
+++ b/ui/src/components/debug/ProtocolDebugLevels.tsx
@@ -1,5 +1,5 @@
 import { RefreshCw, RotateCcw, Save, Settings2 } from 'lucide-react';
-import { type ChangeEvent, type FC, memo, useCallback } from 'react';
+import { type ChangeEvent, type FC, memo, useCallback, useState } from 'react';
 import type {
   DebugLevel,
   DebugProtocol,
@@ -15,6 +15,7 @@ import {
 } from '../../hooks/useProtocolDebugLevels';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
+import { ConfirmModal } from '../../ui/ConfirmModal';
 import { Tag } from '../../ui/Tag';
 import { H2, SmallText } from '../../ui/Typography';
 
@@ -215,18 +216,17 @@ export const ProtocolDebugLevels: FC = () => {
 
   const protocolsByCategory = getProtocolsByCategory();
 
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+
   const handleReset = useCallback(async () => {
-    // TODO: Replace with custom Modal component
-    if (window.confirm('Reset all protocols to default debug levels? This cannot be undone.')) {
-      await resetToDefaults();
-    }
+    setShowResetConfirm(false);
+    await resetToDefaults();
   }, [resetToDefaults]);
 
   const handleDiscard = useCallback(() => {
-    // TODO: Replace with custom Modal component
-    if (window.confirm('Discard unsaved changes?')) {
-      discardChanges();
-    }
+    setShowDiscardConfirm(false);
+    discardChanges();
   }, [discardChanges]);
 
   if (loading) {
@@ -259,7 +259,7 @@ export const ProtocolDebugLevels: FC = () => {
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={handleDiscard}
+                  onClick={() => setShowDiscardConfirm(true)}
                   disabled={saving}
                   aria-label="Discard changes"
                 >
@@ -280,7 +280,7 @@ export const ProtocolDebugLevels: FC = () => {
             <Button
               variant="outline"
               size="sm"
-              onClick={handleReset}
+              onClick={() => setShowResetConfirm(true)}
               disabled={saving}
               leftIcon={<RotateCcw className={iconSizes.md} />}
               aria-label="Reset all protocols to defaults"
@@ -378,6 +378,24 @@ export const ProtocolDebugLevels: FC = () => {
           </div>
         </div>
       </CardContent>
+
+      <ConfirmModal
+        isOpen={showResetConfirm}
+        onConfirm={handleReset}
+        onCancel={() => setShowResetConfirm(false)}
+        title="Reset All Protocols"
+        message="Reset all protocols to default debug levels? This cannot be undone."
+        confirmLabel="Reset"
+      />
+
+      <ConfirmModal
+        isOpen={showDiscardConfirm}
+        onConfirm={handleDiscard}
+        onCancel={() => setShowDiscardConfirm(false)}
+        title="Discard Changes"
+        message="Discard unsaved changes?"
+        confirmLabel="Discard"
+      />
     </Card>
   );
 };

--- a/ui/src/hooks/useEventSource.ts
+++ b/ui/src/hooks/useEventSource.ts
@@ -269,33 +269,3 @@ export function useLogStream(options: StreamHookOptions = {}): UseEventSourceRes
     ...restOptions,
   });
 }
-
-/**
- * Stats data structure from /api/v1/stream/stats
- */
-export interface StatsData {
-  type: 'stats';
-  timestamp: string;
-  data: {
-    packetsPerSecond: number;
-    bytesPerSecond: number;
-    activeConnections: number;
-    cpuUsage?: number;
-    memoryUsage?: number;
-    [key: string]: unknown;
-  };
-}
-
-/**
- * Hook for connecting to the stats stream
- */
-export function useStatsStream(options: StreamHookOptions = {}): UseEventSourceResult {
-  const { enabled = true, ...restOptions } = options;
-  const url = enabled ? `${getStreamBaseUrl()}/stats` : '';
-
-  return useEventSource({
-    url,
-    enabled,
-    ...restOptions,
-  });
-}

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -1,13 +1,4 @@
-import {
-  Activity,
-  Bot,
-  Network,
-  PlugZap,
-  SatelliteDish,
-  Server,
-  Terminal,
-  Zap,
-} from 'lucide-react';
+import { Activity, Network, PlugZap, SatelliteDish, Server, Terminal, Zap } from 'lucide-react';
 import { type FC, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { fetchSimulationStatus } from '../api/client';
@@ -16,7 +7,6 @@ import { POLL_INTERVALS } from '../constants/polling';
 import { iconSizes } from '../constants/sizes';
 import { useAppState } from '../contexts/AppContext';
 import { useApiResource } from '../hooks/useApiResource';
-import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { Tag } from '../ui/Tag';
 import { AccentLink, H2, SmallText } from '../ui/Typography';
@@ -359,21 +349,11 @@ const AutomationTimeline = memo(({ history }: { history: HistoryRecord[] | null 
           {timeline.map((event) => (
             <div
               key={event.title}
-              className="flex flex-col gap-tight rounded-lg border border-surface-border bg-bg-base/50 pad sm:flex-row sm:items-center sm:justify-between"
+              className="flex flex-col gap-tight rounded-lg border border-surface-border bg-bg-base/50 pad"
             >
-              <div>
-                <SmallText className="text-status-info">{event.time}</SmallText>
-                <p className="font-semibold text-text-primary">{event.title}</p>
-                <SmallText className="text-text-muted">{event.detail}</SmallText>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="mt-inline sm:mt-0"
-                leftIcon={<Bot className={iconSizes.md} />}
-              >
-                {t('dashboard.automation.viewDetails')}
-              </Button>
+              <SmallText className="text-status-info">{event.time}</SmallText>
+              <p className="font-semibold text-text-primary">{event.title}</p>
+              <SmallText className="text-text-muted">{event.detail}</SmallText>
             </div>
           ))}
         </div>

--- a/ui/src/pages/DebugConsolePage.tsx
+++ b/ui/src/pages/DebugConsolePage.tsx
@@ -8,6 +8,7 @@ import { iconSizes } from '../constants/sizes';
 import { useLogStream } from '../hooks/useEventSource';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
+import { ConfirmModal } from '../ui/ConfirmModal';
 import { Tag } from '../ui/Tag';
 
 // Maximum number of logs to buffer
@@ -50,6 +51,7 @@ export const DebugConsolePage: FC = () => {
   const [autoScroll, setAutoScroll] = useState(true);
   const [paused, setPaused] = useState(false);
   const [showDebugSettings, setShowDebugSettings] = useState(false);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
 
   // Handle incoming log messages
   const handleMessage = useCallback(
@@ -132,12 +134,15 @@ export const DebugConsolePage: FC = () => {
     URL.revokeObjectURL(url);
   }, [filteredLogs]);
 
-  // Clear all logs
+  // Request confirmation before clearing all buffered logs
   const handleClear = useCallback(() => {
-    // TODO: Replace with custom Modal component
-    if (window.confirm('Clear all logs? This action cannot be undone.')) {
-      setLogs([]);
-    }
+    setShowClearConfirm(true);
+  }, []);
+
+  // Clear all logs once the user confirms
+  const confirmClear = useCallback(() => {
+    setShowClearConfirm(false);
+    setLogs([]);
   }, []);
 
   // Connection status display
@@ -264,6 +269,16 @@ export const DebugConsolePage: FC = () => {
           <ProtocolDebugLevels />
         </div>
       )}
+
+      {/* Clear logs confirmation modal */}
+      <ConfirmModal
+        isOpen={showClearConfirm}
+        onConfirm={confirmClear}
+        onCancel={() => setShowClearConfirm(false)}
+        title="Clear All Logs"
+        message="Clear all logs? This action cannot be undone."
+        confirmLabel="Clear"
+      />
     </div>
   );
 };

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -113,7 +113,7 @@ export const WalkValidatorPage: FC = () => {
                 value={selectedFile}
                 onChange={(e) => setSelectedFile(e.target.value)}
                 disabled={filesLoading || files.length === 0}
-                title="Hydrated from /api/v1/files?kind=walks (the sandboxed walks directory). Use the absolute-path field to validate a walk outside this directory."
+                title="Hydrated from /api/v1/library/walks (the sandboxed walks directory). Use the absolute-path field to validate a walk outside this directory."
                 className="mt-tight w-full rounded border border-surface-border bg-bg-base/60 px-3 py-row text-sm text-text-primary focus:border-status-info focus:outline-none disabled:opacity-50"
               >
                 {filesLoading && <option>Loading…</option>}


### PR DESCRIPTION
## Summary

Correctness pass from the UI completeness audit — removes dead code and makes misleading controls honest:

- **Dead code (verified zero call sites):** `analyzePcap`, `fetchFiles`, `uploadTemplate`, `deleteTemplate`, `useStatsStream`, unused error-type guards, and an unreachable `error instanceof Response` retry branch.
- **SettingsDrawer honesty:** the dead "Protocol Debug Levels" row now routes to `/debug`; removed the no-op "Export Diagnostics" and local-state-only "Log Level"; the Connection card shows the real origin + `ConnectionStatus` component instead of a hardcoded "localhost:8080 / Connected / WebSocket" (SSE, not WebSocket).
- **Dashboard:** removed the dead "View details" button (no run-detail route exists).
- **UX:** three `window.confirm()` sites → the app's `ConfirmModal`; fixed a stale endpoint tooltip on the walk validator.

## Linked Issue

Related to #897

## Testing Evidence

```
$ npm run typecheck            # tsgo — clean
$ npx biome check src/         # Checked 251 files. No fixes applied.
$ npm run build                # vite — ✓ built
$ npm test                     # 13 files / 116 tests passed
```

## Security and Release Checklist

- [x] UI-only change; no new mutating routes, auth surfaces, or default credentials
- [x] No secrets added
- [x] No customer-facing AI or banned vocabulary
- [x] Lint + typecheck + unit tests green
