### PR TITLE
feat(ui): add License page surfacing tier + features

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -271,5 +271,31 @@
       "errorInvalidFile": "Please select a YAML file (.yaml or .yml)",
       "errorReadFailed": "Failed to read file"
     }
+  },
+  "license": {
+    "label": "License",
+    "title": "License & Features",
+    "description": "See your active license tier, the features it unlocks, and how to activate or upgrade.",
+    "loading": "Checking license…",
+    "loadError": "Could not load license status.",
+    "retry": "Retry",
+    "devMode": "Development build — license enforcement is off, so every feature is available and no upgrade prompts are shown.",
+    "currentTier": "Current tier",
+    "tier": "Tier",
+    "activation": "Activation",
+    "activated": "Activated",
+    "notActivated": "Not activated",
+    "trial": "Trial",
+    "trialDaysRemaining": "{{days}} days remaining",
+    "features": "Included features",
+    "noFeatures": "No feature flags are reported for this tier.",
+    "manage": "Manage your license",
+    "manageHint": "NIAC validates licenses offline — there is no phone-home. Activate, start a trial, or deactivate with the niac license CLI on the host running the daemon.",
+    "cmd": {
+      "status": "Status",
+      "activate": "Activate",
+      "trial": "Trial",
+      "deactivate": "Deactivate"
+    }
   }
 }

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -271,5 +271,31 @@
       "errorInvalidFile": "Seleccione un archivo YAML (.yaml o .yml)",
       "errorReadFailed": "Error al leer el archivo"
     }
+  },
+  "license": {
+    "label": "Licencia",
+    "title": "Licencia y funciones",
+    "description": "Consulte su nivel de licencia activo, las funciones que desbloquea y cómo activar o actualizar.",
+    "loading": "Verificando licencia…",
+    "loadError": "No se pudo cargar el estado de la licencia.",
+    "retry": "Reintentar",
+    "devMode": "Compilación de desarrollo: la aplicación de licencia está desactivada, por lo que todas las funciones están disponibles y no se muestran avisos de actualización.",
+    "currentTier": "Nivel actual",
+    "tier": "Nivel",
+    "activation": "Activación",
+    "activated": "Activada",
+    "notActivated": "Sin activar",
+    "trial": "Prueba",
+    "trialDaysRemaining": "{{days}} días restantes",
+    "features": "Funciones incluidas",
+    "noFeatures": "No se reportan indicadores de funciones para este nivel.",
+    "manage": "Administrar su licencia",
+    "manageHint": "NIAC valida las licencias sin conexión, sin comunicación externa. Active, inicie una prueba o desactive con la CLI niac license en el host que ejecuta el daemon.",
+    "cmd": {
+      "status": "Estado",
+      "activate": "Activar",
+      "trial": "Prueba",
+      "deactivate": "Desactivar"
+    }
   }
 }

--- a/ui/src/navGroups.ts
+++ b/ui/src/navGroups.ts
@@ -3,6 +3,7 @@ import {
   Database,
   FileBox,
   GitCompare,
+  KeyRound,
   Network,
   PlugZap,
   Server,
@@ -41,6 +42,7 @@ export function useNavGroups(): SidebarNavGroup[] {
         items: [
           { path: '/', label: t('dashboard.label'), icon: Activity },
           { path: '/runtime', label: t('runtime.label'), icon: PlugZap },
+          { path: '/license', label: t('license.label'), icon: KeyRound },
         ],
       },
       {

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -4,6 +4,7 @@ import {
   Database,
   FileBox,
   GitCompare,
+  KeyRound,
   Network,
   PlugZap,
   Server,
@@ -62,6 +63,9 @@ const LibraryWalksPage = lazy(() =>
 const LibraryPcapsPage = lazy(() =>
   import('./pages/LibraryFilesPage').then((m) => ({ default: m.LibraryPcapsPage })),
 );
+const LicensePage = lazy(() =>
+  import('./pages/LicensePage').then((m) => ({ default: m.LicensePage })),
+);
 
 /**
  * PageConfig is one entry in the application's route table, resolved
@@ -97,7 +101,8 @@ type PageI18nKey =
   | 'configDiff'
   | 'walkValidator'
   | 'libraryWalks'
-  | 'libraryPcaps';
+  | 'libraryPcaps'
+  | 'license';
 
 /**
  * PageDef is the static, language-agnostic definition stored in
@@ -449,6 +454,26 @@ const staticPages: PageDef[] = [
           The Packets and Traffic pages will reuse this listing for their PCAP pickers — the unified
           library means a PCAP added here is visible everywhere the daemon needs to pick one without
           extra plumbing.
+        </p>
+      </>
+    ),
+  },
+  {
+    path: '/license',
+    i18nKey: 'license',
+    icon: KeyRound,
+    component: LicensePage,
+    help: (
+      <>
+        <p>
+          Shows the active license tier and the features it unlocks, mirroring{' '}
+          <code>niac license status</code>.
+        </p>
+        <p>
+          NIAC validates licenses <strong>offline</strong> — there is no phone-home. Activation,
+          trials, and deactivation are local operations, so this page is read-only and lists the{' '}
+          <code>niac license</code> commands to run on the host instead of doing it over the
+          network.
         </p>
       </>
     ),

--- a/ui/src/pages/LicensePage.tsx
+++ b/ui/src/pages/LicensePage.tsx
@@ -1,0 +1,136 @@
+/**
+ * LicensePage — surfaces the active license tier, the features it unlocks,
+ * and how to activate or upgrade.
+ *
+ * NIAC validates licenses offline (no phone-home): activation, trial, and
+ * deactivation are local `niac license` CLI operations that write the license
+ * file the daemon reads. This page is therefore a read-only view of
+ * GET /api/v1/license (via useLicense) plus the commands to run — it gives the
+ * CLI's `niac license status` a home in the UI and makes the Free/Pro tier
+ * visible instead of invisible.
+ */
+import { Check, KeyRound, RefreshCw } from 'lucide-react';
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { iconSizes } from '../constants/sizes';
+import { useLicense } from '../contexts/LicenseContext';
+import { Alert } from '../ui/Alert';
+import { Button } from '../ui/Button';
+import { Card, CardContent, CardHeader, CardRow } from '../ui/Card';
+
+export const LicensePage: FC = () => {
+  const { t } = useTranslation('pages');
+  const { status, loading, error, refresh } = useLicense();
+
+  // Offline license operations — the command strings are kept verbatim.
+  const commands = [
+    { label: t('license.cmd.status'), cmd: 'niac license status' },
+    { label: t('license.cmd.activate'), cmd: 'niac license activate -k <KEY>' },
+    { label: t('license.cmd.trial'), cmd: 'niac license trial' },
+    { label: t('license.cmd.deactivate'), cmd: 'niac license deactivate' },
+  ];
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent>
+          <p className="text-text-secondary">{t('license.loading')}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !status) {
+    return (
+      <Alert status="error">
+        <div className="flex items-center justify-between gap-comfortable">
+          <span>{error ?? t('license.loadError')}</span>
+          <Button variant="outline" onClick={() => void refresh()}>
+            <RefreshCw className={iconSizes.md} />
+            {t('license.retry')}
+          </Button>
+        </div>
+      </Alert>
+    );
+  }
+
+  const tierStatus = status.isActivated ? 'success' : 'warning';
+
+  return (
+    <div className="stack-xl">
+      {!status.licenseEnforced && <Alert status="info">{t('license.devMode')}</Alert>}
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-compact">
+            <KeyRound className={`${iconSizes.lg} text-text-secondary`} />
+            <h2 className="text-lg font-semibold text-text-primary">{t('license.currentTier')}</h2>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <CardRow label={t('license.tier')} value={status.tier} status={tierStatus} />
+          <CardRow
+            label={t('license.activation')}
+            value={status.isActivated ? t('license.activated') : t('license.notActivated')}
+            status={tierStatus}
+          />
+          {status.isTrialMode && (
+            <CardRow
+              label={t('license.trial')}
+              value={t('license.trialDaysRemaining', { days: status.trialDaysRemaining })}
+              status="info"
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-text-primary">{t('license.features')}</h2>
+        </CardHeader>
+        <CardContent>
+          {status.features.length === 0 ? (
+            <p className="text-text-secondary">{t('license.noFeatures')}</p>
+          ) : (
+            <ul className="grid gap-compact sm:grid-cols-2">
+              {status.features.map((feature) => (
+                <li
+                  key={feature}
+                  className="flex items-center gap-compact text-sm text-text-secondary"
+                >
+                  <Check className={`${iconSizes.md} text-status-success`} />
+                  <code className="text-text-primary">{feature}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-text-primary">{t('license.manage')}</h2>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-comfortable">
+            <p className="text-sm text-text-secondary">{t('license.manageHint')}</p>
+            <div className="flex flex-col gap-compact">
+              {commands.map(({ label, cmd }) => (
+                <div key={cmd} className="flex items-center gap-comfortable">
+                  <span className="w-24 shrink-0 text-xs uppercase tracking-wide text-text-muted">
+                    {label}
+                  </span>
+                  <code className="flex-1 rounded bg-surface-raised px-cell py-compact text-sm text-text-primary">
+                    {cmd}
+                  </code>
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default LicensePage;


### PR DESCRIPTION
## Summary

Adds a read-only License page at `/license` (Overview nav) surfacing the active tier, activation/trial status, and feature list via `useLicense()`. Previously the Free/Pro tier was invisible everywhere despite `GET /api/v1/license` being fetched at boot. NIAC validates licenses offline (no phone-home), so activation/trial/deactivation remain CLI operations — the page mirrors `niac license status` and documents the offline `niac license` commands. Registered in `pageRegistry` + `navGroups`; `en`/`es` locale keys added.

## Linked Issue

Related to #897

## Testing Evidence

```
$ npm run typecheck            # tsgo — clean
$ npx vitest run src/i18n/i18n.parity.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)    # en/es license.* key parity + term preservation
$ npm run build                # vite — ✓ built
$ npx biome check src/pages/LicensePage.tsx src/pageRegistry.tsx src/navGroups.ts
Checked 3 files. No fixes applied.
```

## Security and Release Checklist

- [x] Read-only page; no new mutating routes, auth surfaces, or default credentials
- [x] No secrets added
- [x] No customer-facing AI or banned vocabulary
- [x] Lint + typecheck + unit tests green
