### PR TITLE
fix(build): make quality gates fail honestly, dedupe vars.mk

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'Node.js version'
     required: false
-    default: '26.2.0'
+    default: '26.3.0'
   working-directory:
     description: 'Working directory for npm'
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,9 @@ jobs:
       - name: Install libpcap-dev
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 
-      - name: Download dependencies
-        run: go mod download
-
       - name: Verify dependencies
+        # ./.github/actions/setup-go already runs `go mod download`; this
+        # step only needs the extra verification setup-go doesn't do.
         run: go mod verify
 
       - name: Run golangci-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,11 +627,22 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '1'
-        # make build-backend injects the same VERSION/COMMIT/BUILD_TIME/
-        # UI_BUILD_HASH ldflags via mk/vars.mk + the root Makefile's LDFLAGS
-        # (Universal Build Contract) — overriding BINARY_NAME here instead of
-        # duplicating the ldflags computation inline.
-        run: make build-backend BINARY_NAME=niac-${{ matrix.os }}-${{ matrix.arch }}
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # UI build hash matches Makefile recipe; mandatory per CLAUDE.md
+          # Universal Build Contract.
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          echo "UI_BUILD_HASH=${UI_BUILD_HASH}"
+
+          go build -trimpath -buildvcs=false \
+            -ldflags="-s -w \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.Version=${VERSION} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.Commit=${COMMIT} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
+            -o niac-${{ matrix.os }}-${{ matrix.arch }} ./cmd/niac
 
       - name: Verify binary
         run: ./niac-${{ matrix.os }}-${{ matrix.arch }} --help || ./niac-${{ matrix.os }}-${{ matrix.arch }} version || echo "Binary runs"
@@ -682,11 +693,18 @@ jobs:
         run: npm ci
 
       - name: Build backend
-        # make build-backend injects the identical ldflags via mk/vars.mk +
-        # the root Makefile's LDFLAGS (Universal Build Contract) instead of
-        # duplicating the VERSION/COMMIT/BUILD_TIME/UI_BUILD_HASH computation
-        # inline. Output name (./niac) matches BINARY_NAME's default.
-        run: make build-backend
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          go build -trimpath -buildvcs=false \
+            -ldflags="-s -w \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.Version=${VERSION} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.Commit=${COMMIT} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
+            -o niac ./cmd/niac
 
       - name: Install Playwright browsers
         working-directory: ui
@@ -781,11 +799,18 @@ jobs:
           path: internal/api/ui/
 
       - name: Build backend
-        # make build-backend injects the identical ldflags via mk/vars.mk +
-        # the root Makefile's LDFLAGS (Universal Build Contract) instead of
-        # duplicating the VERSION/COMMIT/BUILD_TIME/UI_BUILD_HASH computation
-        # inline. Output name (./niac) matches BINARY_NAME's default.
-        run: make build-backend
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          go build -trimpath -buildvcs=false \
+            -ldflags="-s -w \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.Version=${VERSION} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.Commit=${COMMIT} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.BuildTime=${BUILD_TIME} \
+              -X github.com/MustardSeedNetworks/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
+            -o niac ./cmd/niac
 
       - name: Start server
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,9 +275,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 
       - name: Run govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-          govulncheck ./...
+        # make security-backend installs govulncheck if missing and runs the
+        # scan; using the target here keeps the version-string behavior in
+        # sync with `make security` / `make verify` locally instead of
+        # duplicating the invocation.
+        run: make security-backend
 
       - name: Run gosec
         uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
@@ -293,11 +295,16 @@ jobs:
       - name: Set up Node.js
         uses: ./.github/actions/setup-node
 
-      - name: Run npm audit
+      - name: Install npm dependencies
         working-directory: ui
-        run: |
-          npm ci
-          npm audit --audit-level=high || true
+        run: npm ci
+
+      - name: Run npm audit
+        # Was `npm audit --audit-level=high || true` — the `|| true` silently
+        # discarded npm audit's exit code, so this step reported green
+        # regardless of findings. make security-frontend propagates the
+        # real exit code (see mk/security.mk).
+        run: make security-frontend
 
       # gitleaks-action requires a paid licence for organization repos. Use the
       # MIT-licensed gitleaks CLI directly instead — same engine, same config.
@@ -615,22 +622,11 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '1'
-        run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
-          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          # UI build hash matches Makefile recipe; mandatory per CLAUDE.md
-          # Universal Build Contract.
-          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
-          echo "UI_BUILD_HASH=${UI_BUILD_HASH}"
-
-          go build -trimpath -buildvcs=false \
-            -ldflags="-s -w \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.Version=${VERSION} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.Commit=${COMMIT} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.BuildTime=${BUILD_TIME} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
-            -o niac-${{ matrix.os }}-${{ matrix.arch }} ./cmd/niac
+        # make build-backend injects the same VERSION/COMMIT/BUILD_TIME/
+        # UI_BUILD_HASH ldflags via mk/vars.mk + the root Makefile's LDFLAGS
+        # (Universal Build Contract) — overriding BINARY_NAME here instead of
+        # duplicating the ldflags computation inline.
+        run: make build-backend BINARY_NAME=niac-${{ matrix.os }}-${{ matrix.arch }}
 
       - name: Verify binary
         run: ./niac-${{ matrix.os }}-${{ matrix.arch }} --help || ./niac-${{ matrix.os }}-${{ matrix.arch }} version || echo "Binary runs"
@@ -681,18 +677,11 @@ jobs:
         run: npm ci
 
       - name: Build backend
-        run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
-          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
-          go build -trimpath -buildvcs=false \
-            -ldflags="-s -w \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.Version=${VERSION} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.Commit=${COMMIT} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.BuildTime=${BUILD_TIME} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
-            -o niac ./cmd/niac
+        # make build-backend injects the identical ldflags via mk/vars.mk +
+        # the root Makefile's LDFLAGS (Universal Build Contract) instead of
+        # duplicating the VERSION/COMMIT/BUILD_TIME/UI_BUILD_HASH computation
+        # inline. Output name (./niac) matches BINARY_NAME's default.
+        run: make build-backend
 
       - name: Install Playwright browsers
         working-directory: ui
@@ -787,18 +776,11 @@ jobs:
           path: internal/api/ui/
 
       - name: Build backend
-        run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
-          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          UI_BUILD_HASH=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
-          go build -trimpath -buildvcs=false \
-            -ldflags="-s -w \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.Version=${VERSION} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.Commit=${COMMIT} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.BuildTime=${BUILD_TIME} \
-              -X github.com/MustardSeedNetworks/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
-            -o niac ./cmd/niac
+        # make build-backend injects the identical ldflags via mk/vars.mk +
+        # the root Makefile's LDFLAGS (Universal Build Contract) instead of
+        # duplicating the VERSION/COMMIT/BUILD_TIME/UI_BUILD_HASH computation
+        # inline. Output name (./niac) matches BINARY_NAME's default.
+        run: make build-backend
 
       - name: Start server
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.1
+          version: v2.12.2
           args: --timeout=5m
 
       - name: Verify niac.schema.json is up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,12 @@ jobs:
     runs-on: ubuntu-latest
     # Always runs — security checks are non-negotiable on every PR.
     permissions:
+      # Job-level `permissions:` REPLACES the workflow-level block entirely
+      # (they don't merge) — `actions: read` from the top-level block was
+      # silently dropped here, which broke the codeql-action/upload-sarif
+      # step below ("Resource not accessible by integration") and skipped
+      # every step after it (npm audit, gitleaks, Trivy) on 2026-07-04.
+      actions: read
       contents: read
       # github/codeql-action/upload-sarif@v4 requires security-events: write
       # to push results to the Security tab (regressed from a default-on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,10 @@ jobs:
 
       - name: Upload gosec results
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
-        if: always()
+        # Code scanning requires a public repo or Advanced Security (same
+        # gate as codeql.yml); gosec enforcement stays blocking via the
+        # golangci-lint gosec linter in the backend job.
+        if: always() && github.event.repository.visibility == 'public'
         with:
           sarif_file: gosec-results.sarif
 
@@ -345,7 +348,10 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy results
-        if: always() && hashFiles('trivy-results.sarif') != ''
+        # Code scanning requires a public repo or Advanced Security (same
+        # gate as codeql.yml); the "Fail on CRITICAL/HIGH findings" step
+        # below still blocks on the SARIF content regardless of visibility.
+        if: always() && hashFiles('trivy-results.sarif') != '' && github.event.repository.visibility == 'public'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "26.2.0"
+          node-version: "26.3.0"
           cache: npm
           cache-dependency-path: ui/package-lock.json
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "26.2.0"
+          node-version: "26.3.0"
           cache: npm
           cache-dependency-path: ui/package-lock.json
 

--- a/Makefile
+++ b/Makefile
@@ -20,57 +20,30 @@
 #
 # REQUIREMENTS
 # ------------
-#   - Go 1.25.5+ (with CGO for libpcap)
+#   - Go 1.26.4+ (with CGO for libpcap)
 #   - Node.js 26.3.0 and npm 11.17.0
 #   - libpcap-dev (Linux) or libpcap (macOS via Homebrew)
 #
 # =============================================================================
 
 # =============================================================================
-# Version and Build Information
+# Shared Variables (single source of truth)
 # =============================================================================
+# VERSION/COMMIT/BUILD_TIME, platform/arch detection, and ANSI color codes
+# all live in mk/vars.mk. Include it first so every other mk/*.mk file (and
+# the targets below) can rely on it.
 
-# Version information (can be overridden)
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+include mk/vars.mk
 
-# Platform detection
-UNAME := $(shell uname -s)
-ifeq ($(UNAME),Darwin)
-    PLATFORM := darwin
+# Platform pretty name for display — not in vars.mk since it's presentation
+# only, derived from vars.mk's PLATFORM.
+ifeq ($(PLATFORM),darwin)
     PLATFORM_PRETTY := macOS
-else ifeq ($(UNAME),Linux)
-    PLATFORM := linux
+else ifeq ($(PLATFORM),linux)
     PLATFORM_PRETTY := Linux
 else
-    PLATFORM := unknown
     PLATFORM_PRETTY := Unknown
 endif
-
-# Architecture detection
-ARCH := $(shell uname -m)
-ifeq ($(ARCH),x86_64)
-    GOARCH := amd64
-else ifeq ($(ARCH),arm64)
-    GOARCH := arm64
-else ifeq ($(ARCH),aarch64)
-    GOARCH := arm64
-endif
-
-# =============================================================================
-# ANSI Color Codes
-# =============================================================================
-
-BOLD := \033[1m
-RESET := \033[0m
-RED := \033[31m
-GREEN := \033[32m
-YELLOW := \033[33m
-BLUE := \033[34m
-MAGENTA := \033[35m
-CYAN := \033[36m
-WHITE := \033[37m
 
 # =============================================================================
 # Display Helpers
@@ -137,20 +110,19 @@ endef
 BINARY_NAME=niac
 CONVERTER_NAME=niac-convert
 
-# Version package path for ldflags injection
-VERSION_PKG=github.com/MustardSeedNetworks/niac-go/internal/version
+# VERSION_PKG comes from mk/vars.mk (single source of truth).
 
 # Go build flags for reproducible builds
 GO_BUILD_FLAGS := -trimpath -buildvcs=false
 GOFLAGS=$(GO_BUILD_FLAGS)
 
-# Directories — defined BEFORE UI_BUILD_HASH because that variable
-# uses `:=` (immediate evaluation) and references EMBED_DIR. Defining
-# EMBED_DIR after UI_BUILD_HASH meant the hash always evaluated
-# against an empty path and the embedded /__version endpoint reported
-# uiBuildHash="" in the make-built binary. GitHub release workflows set
-# uiBuildHash through their own ldflags.
-UI_DIR := ui
+# Directories — UI_DIR comes from mk/vars.mk. UI_DIST/EMBED_DIR defined
+# BEFORE UI_BUILD_HASH because that variable uses `:=` (immediate
+# evaluation) and references EMBED_DIR. Defining EMBED_DIR after
+# UI_BUILD_HASH meant the hash always evaluated against an empty path and
+# the embedded /__version endpoint reported uiBuildHash="" in the
+# make-built binary. GitHub release workflows set uiBuildHash through
+# their own ldflags.
 UI_DIST := $(UI_DIR)/dist
 EMBED_DIR := internal/api/ui
 

--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -40,7 +40,7 @@ tools: tools-go tools-frontend ## Install all development tools
 tools-go: ## Install Go development tools
 	@printf "$(BOLD)📦 Installing Go development tools...$(RESET)\n"
 	@echo "Installing golangci-lint..."
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 	@echo "Installing govulncheck..."
 	@go install golang.org/x/vuln/cmd/govulncheck@latest
 	@echo "Installing gosec..."

--- a/mk/lint.mk
+++ b/mk/lint.mk
@@ -49,7 +49,10 @@ lint-backend-quiet:
 	$$GOLANGCI_LINT cache clean >/dev/null 2>&1; \
 	LINTER_COUNT=$$(grep -c "^    - " .golangci.yml 2>/dev/null || echo "30+"); \
 	printf "   Running $$LINTER_COUNT linters (cache cleared)...\n"; \
-	$$GOLANGCI_LINT run --timeout=5m 2>&1 | head -20 || true
+	OUTPUT=$$($$GOLANGCI_LINT run --timeout=5m 2>&1); \
+	STATUS=$$?; \
+	echo "$$OUTPUT" | head -20; \
+	exit $$STATUS
 
 lint-frontend: ## Run frontend linter (Biome)
 	@printf "$(BOLD)🔍 Running frontend linter (Biome)...$(RESET)\n"
@@ -58,8 +61,11 @@ lint-frontend: ## Run frontend linter (Biome)
 
 lint-frontend-quiet:
 	@FILE_COUNT=$$(find $(UI_DIR)/src -name "*.ts" -o -name "*.tsx" 2>/dev/null | wc -l | tr -d ' '); \
-	printf "   Checking $$FILE_COUNT files...\n"
-	@cd $(UI_DIR) && npx @biomejs/biome check src/ 2>&1 | tail -5 || true
+	printf "   Checking $$FILE_COUNT files...\n"; \
+	OUTPUT=$$(cd $(UI_DIR) && npx @biomejs/biome check src/ 2>&1); \
+	STATUS=$$?; \
+	echo "$$OUTPUT" | tail -20; \
+	exit $$STATUS
 
 lint-md: ## Lint markdown files with markdownlint
 	@printf "$(BOLD)🔍 Linting markdown files...$(RESET)\n"

--- a/mk/lint.mk
+++ b/mk/lint.mk
@@ -34,7 +34,7 @@ lint-backend: ## Run Go linter
 	@GOLANGCI_LINT="$$(go env GOPATH)/bin/golangci-lint"; \
 	if [ ! -f "$$GOLANGCI_LINT" ]; then \
 		printf "📦 Installing golangci-lint v2...\n"; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2; \
 	fi; \
 	$$GOLANGCI_LINT cache clean && \
 	$$GOLANGCI_LINT run --timeout=5m
@@ -44,7 +44,7 @@ lint-backend-quiet:
 	@GOLANGCI_LINT="$$(go env GOPATH)/bin/golangci-lint"; \
 	if [ ! -f "$$GOLANGCI_LINT" ]; then \
 		printf "   Installing golangci-lint v2...\n"; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2; \
 	fi; \
 	$$GOLANGCI_LINT cache clean >/dev/null 2>&1; \
 	LINTER_COUNT=$$(grep -c "^    - " .golangci.yml 2>/dev/null || echo "30+"); \
@@ -99,7 +99,7 @@ fix-backend: ## Auto-fix Go linting issues
 	@GOLANGCI_LINT="$$(go env GOPATH)/bin/golangci-lint"; \
 	if [ ! -f "$$GOLANGCI_LINT" ]; then \
 		printf "📦 Installing golangci-lint v2...\n"; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2; \
 	fi; \
 	$$GOLANGCI_LINT run --fix
 	@gofmt -w -s .
@@ -108,7 +108,7 @@ fix-backend: ## Auto-fix Go linting issues
 fix-backend-quiet:
 	@GOLANGCI_LINT="$$(go env GOPATH)/bin/golangci-lint"; \
 	if [ ! -f "$$GOLANGCI_LINT" ]; then \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2; \
 	fi; \
 	$$GOLANGCI_LINT run --fix 2>&1 | grep -E "^[0-9]+ issues" || printf "   No issues found\n"
 	@gofmt -w -s .

--- a/mk/security.mk
+++ b/mk/security.mk
@@ -49,7 +49,14 @@ security-backend-quiet:
 		go install golang.org/x/vuln/cmd/govulncheck@latest; \
 	fi
 	@printf "   Scanning Go dependencies...\n"
-	@govulncheck ./... 2>&1 | grep -E "(Vulnerability|No vulnerabilities)" | head -5 || printf "   No vulnerabilities found\n"
+	@OUTPUT=$$(govulncheck ./... 2>&1); \
+	STATUS=$$?; \
+	echo "$$OUTPUT" | grep -E "(Vulnerability|No vulnerabilities)" | head -5 || printf "   No vulnerabilities found\n"; \
+	if [ $$STATUS -ne 0 ]; then \
+		echo ""; \
+		echo "$$OUTPUT" | tail -60; \
+		exit $$STATUS; \
+	fi
 
 security-frontend: ## Run frontend security scan (npm audit)
 	@printf "$(BOLD)🔒 Running npm audit...$(RESET)\n"
@@ -58,7 +65,14 @@ security-frontend: ## Run frontend security scan (npm audit)
 
 security-frontend-quiet:
 	@printf "   Auditing npm packages...\n"
-	@cd $(UI_DIR) && npm audit --audit-level=high 2>&1 | grep -E "(found|vulnerabilities)" | head -3 || printf "   No vulnerabilities found\n"
+	@OUTPUT=$$(cd $(UI_DIR) && npm audit --audit-level=high 2>&1); \
+	STATUS=$$?; \
+	echo "$$OUTPUT" | grep -E "(found|vulnerabilities)" | head -3 || printf "   No vulnerabilities found\n"; \
+	if [ $$STATUS -ne 0 ]; then \
+		echo ""; \
+		echo "$$OUTPUT" | tail -60; \
+		exit $$STATUS; \
+	fi
 
 security-secrets: ## Scan for secrets in codebase (gitleaks)
 	@printf "$(BOLD)🔒 Running gitleaks...$(RESET)\n"
@@ -83,9 +97,16 @@ security-secrets-quiet:
 	fi; \
 	printf "   Scanning for secrets...\n"; \
 	if [ -f .gitleaks.toml ]; then \
-		$$GITLEAKS detect --source . --config .gitleaks.toml 2>&1 | grep -E "(leaks found|no leaks)" || printf "   No secrets found\n"; \
+		OUTPUT=$$($$GITLEAKS detect --source . --config .gitleaks.toml 2>&1); \
 	else \
-		$$GITLEAKS detect --source . 2>&1 | grep -E "(leaks found|no leaks)" || printf "   No secrets found\n"; \
+		OUTPUT=$$($$GITLEAKS detect --source . 2>&1); \
+	fi; \
+	STATUS=$$?; \
+	echo "$$OUTPUT" | grep -E "(leaks found|no leaks)" || printf "   No secrets found\n"; \
+	if [ $$STATUS -ne 0 ]; then \
+		echo ""; \
+		echo "$$OUTPUT" | tail -60; \
+		exit $$STATUS; \
 	fi
 
 security-trivy: ## Run Trivy vulnerability scan

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -69,7 +69,14 @@ test-backend-quiet:
 	@PKGS=$$(go list ./... | grep -v '/ui$$'); \
 	PKG_COUNT=$$(echo "$$PKGS" | wc -l | tr -d ' '); \
 	printf "   Testing $$PKG_COUNT packages...\n"; \
-	go test -race -coverprofile=coverage.out $$PKGS 2>&1 | grep -E "^(ok|FAIL|---)" || true
+	OUTPUT=$$(go test -race -coverprofile=coverage.out $$PKGS 2>&1); \
+	STATUS=$$?; \
+	echo "$$OUTPUT" | grep -E "^(ok|FAIL|---)"; \
+	if [ $$STATUS -ne 0 ]; then \
+		echo ""; \
+		echo "$$OUTPUT" | grep -v -E "^(ok|FAIL|---)" | tail -60; \
+		exit $$STATUS; \
+	fi
 	@if [ -f coverage.out ]; then \
 		COV=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}'); \
 		printf "   📊 Coverage: %s\n" "$$COV"; \
@@ -88,8 +95,15 @@ test-frontend: ## Run frontend tests with progress
 
 test-frontend-quiet:
 	@STORY_COUNT=$$(find $(UI_DIR)/src -name "*.test.ts" -o -name "*.test.tsx" 2>/dev/null | wc -l | tr -d ' '); \
-	printf "   Running $$STORY_COUNT test files...\n"
-	@cd $(UI_DIR) && npm test 2>&1 | grep -E "(PASS|FAIL|Tests:)" || true
+	printf "   Running $$STORY_COUNT test files...\n"; \
+	OUTPUT=$$(cd $(UI_DIR) && npm test 2>&1); \
+	STATUS=$$?; \
+	echo "$$OUTPUT" | grep -E "(PASS|FAIL|Tests:)"; \
+	if [ $$STATUS -ne 0 ]; then \
+		echo ""; \
+		echo "$$OUTPUT" | tail -60; \
+		exit $$STATUS; \
+	fi
 
 # =============================================================================
 # E2E Tests


### PR DESCRIPTION
## Summary

Make the quality gates honest and fix a live CI security-coverage bug. All seven `-quiet` wrappers in mk/lint.mk / mk/test.mk / mk/security.mk swallowed exit codes via `| grep ... || true` / `|| printf` (latent — the current tree is genuinely clean, but the gates could not fail). This PR propagates real exit codes, wires `include mk/vars.mk` as the single variable source (duplicated root-Makefile blocks deleted, stale Go header fixed), and fixes the live bug: the CI security job's job-level `permissions:` block replaced the workflow-level one and dropped `actions: read`, breaking the gosec SARIF upload and skipping npm audit + gitleaks + Trivy for the run (root cause of both 2026-07-04 CI failures). Also hardens CI `npm audit` from `|| true` to a real gate via `make security-frontend`, converts the govulncheck step to `make security-backend` (checks, not builds), removes a redundant `go mod download`, and bumps golangci-lint v2.12.1→v2.12.2 + Node 26.2.0→26.3.0 (setup-node composite, dead-code.yml, license-check.yml). CI build steps intentionally stay raw `go build` per owner policy: CI owns multi-arch builds; make is local-only (three earlier conversions reverted, byte-identical restore verified against origin/main).

## Linked Issue

Fixes #904

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [x] Security hardening

## Risk

- [x] Medium

## Testing Evidence

```text
Injected-failure proof (wrapper honesty):
  injected failing Go test (t.Fatal) -> make test: exit 2 (make: *** Error), was exit 0 before
  injected unused-var lint violation -> make lint: exit 2, was exit 0 before
  both injections removed before commit.

Final gates (honest wrappers, all exit 0):
  make lint       -> golangci-lint 0 issues (v2.12.2 verified 0 new findings); Biome clean
  make fmt-check  -> clean
  make test       -> 37 Go packages ok @ 57.5% coverage; 16 Vitest files pass
  make security   -> govulncheck clean; npm audit --audit-level=high exit 0; gitleaks no leaks

ldflags contract:
  make version / make build && ./niac --version -> real Version/Commit/BuildTime (not "unknown")
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.

6. **`fix(ci): skip SARIF uploads on private repo (code scanning unavailable)`** — with actions:read restored, the Security Scanning job progressed to its real wall: codeql-action/upload-sarif fails with "Advanced Security must be enabled for this repository to use code scanning" on this private free-plan repo (same failure existed on main). Both SARIF upload steps now gate on `github.event.repository.visibility == 'public'`, mirroring codeql.yml. Not continue-on-error — steps skip where they cannot work. Enforcement unaffected: gosec stays blocking via golangci-lint's gosec linter; the "Fail on CRITICAL/HIGH findings" step still blocks on Trivy's SARIF regardless of visibility. This lets npm audit/gitleaks/Trivy actually execute in that job for the first time in a while.
