### PR TITLE
chore(license): strengthen BUSL Additional Use Grant (license-key clause)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,7 +12,10 @@ Licensed Work: NIAC (Network In A Can)
 The Licensed Work is (c) 2025-2026 Mustard Seed Networks.
 Additional Use Grant: You may make use of the Licensed Work, provided that
 you do not use the Licensed Work for a Network
-Simulation Service.
+Simulation Service. You may not move, change, disable, or circumvent the
+license key or license-validation functionality in the Licensed Work, nor
+remove or obscure any functionality of the Licensed Work that is protected
+by it.
 
                       A "Network Simulation Service" is a commercial offering
                       that allows third parties (other than your employees


### PR DESCRIPTION
## Summary

⚠️ COUNSEL REVIEW RECOMMENDED — legally operative text; do not merge without owner sign-off.

Appends a license-key-circumvention proviso to the BUSL Additional Use Grant, lifted from Elastic License 2.0 clause (ii). The existing "Network Simulation Service" competing-use restriction is preserved intact; this is additive.

## Linked Issue

Related to #911

## Testing Evidence

```text
git diff shows only the Additional Use Grant paragraph changed; no other LICENSE fields touched.
No code change — lint/test/build N/A.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.