### PR TITLE
ci(security): add Semgrep SAST gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,10 @@ jobs:
   # area (docs-only / c-only / frontend-only). The CI Complete aggregator at
   # the bottom of this file enforces that all required jobs either passed or
   # were intentionally skipped, so branch protection can require just CI
-  # Complete (plus CodeQL/license-check from other workflows) instead of
-  # every individual job.
+  # Complete (plus "Lint PR Title" / "Lint PR Body" from their own
+  # workflows) instead of every individual job. CodeQL and License
+  # Compliance are advisory, not required contexts — the `semgrep` job in
+  # this file is the required SAST gate.
   changes:
     name: Changed paths
     runs-on: ubuntu-latest
@@ -331,6 +333,47 @@ jobs:
             jq '.runs[].results[] | {ruleId, level, severity: .properties.security_severity, message: .message.text}' trivy-results.sarif
             exit 1
           fi
+
+  # ===========================================================================
+  # Semgrep SAST — required gate (Phase 4, replaces CodeQL as the required
+  # SAST signal since CodeQL is advisory-only)
+  # ===========================================================================
+  # Blocking on ERROR severity only for now — a deliberate first step,
+  # mirroring the seed/stem rollout. WARNING/MEDIUM findings are visible in
+  # the job log but do not fail the build yet; ratchet to a stricter
+  # --severity once any WARNING backlog is triaged in a follow-up.
+  #
+  # Runs unconditionally (no path filter) — same rationale as `security`
+  # above: SAST coverage on every PR is non-negotiable, and Semgrep is fast
+  # enough (~1-2 min for this ruleset) that gating it behind path filters
+  # isn't worth the added complexity.
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install Semgrep (pinned)
+        run: pip install "semgrep==1.168.0"
+
+      - name: Run Semgrep (blocking on ERROR severity)
+        run: |
+          semgrep scan \
+            --config p/golang \
+            --config p/typescript \
+            --config p/react \
+            --config p/owasp-top-ten \
+            --severity ERROR \
+            --error \
+            --metrics=off
 
   # ===========================================================================
   # C Lint (C23 Standard - NOT C++)
@@ -823,11 +866,13 @@ jobs:
   # Every required-status-check on `main` is consolidated into this single
   # job. It fails if any upstream job actually failed; it passes if every
   # upstream either succeeded or was intentionally skipped via the path
-  # filter. Branch protection should require ONLY "CI Complete" plus the
-  # security-critical checks from other workflows (CodeQL: Analyze (go),
-  # Analyze (javascript-typescript); License Compliance Check) — not every
-  # individual job — so docs-only PRs merge cleanly when backend/frontend/c
-  # are all skipped.
+  # filter. Branch protection requires ONLY "CI Complete" (plus "Lint PR
+  # Title" / "Lint PR Body" from their own workflows) — not every individual
+  # job — so docs-only PRs merge cleanly when backend/frontend/c are all
+  # skipped. CodeQL and License Compliance are NOT required contexts: CodeQL
+  # is advisory and License Compliance reports without blocking. The
+  # `semgrep` job in this file is the required SAST gate (blocking on ERROR
+  # severity).
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
@@ -842,6 +887,7 @@ jobs:
       - backend
       - frontend
       - security
+      - semgrep
       - c-lint
       - quality
       - docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,8 +160,21 @@ jobs:
           path: internal/api/ui/
 
       - name: Install Syft (SBOM) inside container
+        env:
+          SYFT_VERSION: "1.46.0"
+          # SHA-256 of syft_1.46.0_linux_amd64.tar.gz from the upstream
+          # syft_1.46.0_checksums.txt. Rotate this together with
+          # SYFT_VERSION on upgrade. Mirrors the pinned+checksummed gitleaks
+          # install pattern in ci.yml — never pipe an installer script
+          # straight to a shell.
+          SYFT_SHA256: "d654f678b709eb53c393d38519d5ed7d2e57205529404018614cfefa0fb2b5ca"
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          set -euo pipefail
+          curl -sSfL -o syft.tar.gz \
+            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz"
+          echo "${SYFT_SHA256}  syft.tar.gz" | sha256sum -c -
+          tar -xzf syft.tar.gz syft
+          install -m 0755 syft /usr/local/bin/syft
 
       - name: Install Cosign inside container
         run: |


### PR DESCRIPTION
## Summary

Adds a required Semgrep job (`p/golang`, `p/typescript`, `p/react`, `p/owasp-top-ten`; blocking on ERROR severity) to `ci.yml`, wired into `ci-complete`'s `needs:`, replicating the seed/stem rollout. Corrects comments that implied CodeQL/License Compliance were required branch-protection contexts — they are advisory; `semgrep` is now the required SAST gate.

A fresh scan of current `origin/main` found **one ERROR finding**: `yaml.github-actions.security.gha-curl-pipe-shell` in `release.yml`'s Syft install (`curl | sh`), a leftover from the goreleaser-cross migration (#908). Fixed by pinning `SYFT_VERSION` and verifying a SHA-256 checksum before install, mirroring the existing pinned+checksummed gitleaks install pattern already in `ci.yml`. No `nosemgrep` suppressions were needed — niac has no auth/HIBP SHA-1 code or other known false positives.

## Linked Issue

Related to #915

## Testing Evidence

```text
$ semgrep scan --config p/golang --config p/typescript --config p/react --config p/owasp-top-ten --severity ERROR --error --metrics=off .
Ran 95 rules on 788 files: 0 findings.

$ make lint
0 issues. (Backend golangci-lint)
Checked 255 files in 284ms. No fixes applied. (Frontend Biome)

$ make test
37 backend packages ok, coverage 57.7%
16 frontend test files ok (Vitest)

$ actionlint .github/workflows/ci.yml .github/workflows/release.yml
Only pre-existing shellcheck info/warning findings (unchanged line content), confirmed present on origin/main before this change
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.