### PR TITLE
ci(governance): exempt release-please PRs from PR-body template

### DIFF
--- a/.github/workflows/pr-body-lint.yml
+++ b/.github/workflows/pr-body-lint.yml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR body
-        if: github.event_name == 'pull_request'
+        # release-please PRs carry an auto-generated changelog body, not the human
+        # change-PR template (no single linked issue, no code delta to test).
+        # Validating them against it is a category error; their integrity is
+        # ensured by release-please itself + the CI Complete gate. Skip them.
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary

release-please PRs carry an auto-generated changelog body, which fails the required Lint PR Body check (missing the human-PR headings + single linked issue), permanently blocking releases under enforce_admins. Exempt `release-please--*` branches from the human-template validation — branch-based since the release-PR author varies by token.

## Linked Issue

Related to #917

## Testing Evidence

```text
actionlint .github/workflows/pr-body-lint.yml -> clean
The Validate-PR-body step now has: if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')
Job still reports success for release PRs (only-applicable step skipped, nothing fails).
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.
