### PR TITLE
ci(release): use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,20 +39,26 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          # PAT (not GITHUB_TOKEN) so the release PR's CI runs and the
-          # tag-push event triggers release.yml. With GITHUB_TOKEN those
-          # downstream workflows are silently skipped per GitHub's
-          # anti-recursion policy — this bit niac in Phase 2 goreleaser-cross
-          # migration testing (a GITHUB_TOKEN-authored tag never fired
-          # release.yml's `push: tags: v*` trigger). Falls back to
-          # GITHUB_TOKEN if the secret isn't set, so the workflow doesn't
-          # break if the PAT expires before being renewed (cascade is lost
-          # until renewed). Matches seed/stem.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # GitHub App installation token (not GITHUB_TOKEN) so the release
+          # PR's CI runs and the tag-push event triggers release.yml. With
+          # GITHUB_TOKEN those downstream workflows are silently skipped per
+          # GitHub's anti-recursion policy — this bit niac in Phase 2
+          # goreleaser-cross migration testing (a GITHUB_TOKEN-authored tag
+          # never fired release.yml's `push: tags: v*` trigger). App tokens
+          # are minted per-run and never expire out, unlike a PAT. Matches
+          # seed/stem.
+          token: ${{ steps.app-token.outputs.token }}
           # NOTE: do NOT pass release-type here. It is declared per-package in
           # release-please-config.json (release-type: go). Passing it as a
           # direct action input forces a mode that ignores the config-file's


### PR DESCRIPTION
## Summary

Replace the RELEASE_PLEASE_TOKEN PAT with a GitHub App installation token minted per-run via actions/create-github-app-token (org secrets APP_ID + APP_PRIVATE_KEY). App tokens don't expire out, aren't subject to the org's fine-grained-PAT lifetime policy, and still trigger the release workflow on tag push (unlike GITHUB_TOKEN). Org-level secrets make this work fleet-wide.

⚠️ DO NOT MERGE until the org secrets APP_ID and APP_PRIVATE_KEY are set (owner is creating the App). Merging before then breaks release-please (empty app-id).

## Linked Issue

Related to #919

## Testing Evidence

```text
actionlint .github/workflows/release-please.yml -> clean
create-github-app-token pinned to bcd2ba49218906704ab6c1aa796996da409d3eb1 (v3.2.0)
release-please token input now: ${{ steps.app-token.outputs.token }}; RELEASE_PLEASE_TOKEN removed
Cannot run release-please auth locally (needs the App secrets) — verified by orchestrator after secrets are set.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.