### PR TITLE
fix(ui): data-safety guards (FTP password, walk auto-fix confirm, unsaved-changes guard)

### DIFF
--- a/internal/i18n/locales/en/devices.json
+++ b/internal/i18n/locales/en/devices.json
@@ -55,7 +55,13 @@
     "trunkPorts": "Trunk Ports",
     "portChannels": "Port Channels",
     "saveSuccess": "Device saved",
-    "saveFailed": "Failed to save device"
+    "saveFailed": "Failed to save device",
+    "unsavedNavigation": {
+      "title": "Leave without saving?",
+      "message": "This device has unsaved changes. If you leave now, those changes will be lost.",
+      "confirmLabel": "Leave",
+      "cancelLabel": "Stay"
+    }
   },
   "running": {
     "noDevicesRunning": "No devices are currently running",

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -224,7 +224,9 @@
     "description": "Compare two {{format}} network configs side-by-side and merge changes between them.",
     "originalFileTitle": "Original File",
     "modifiedFileTitle": "Modified File",
-    "readyToCompareTitle": "Ready to Compare"
+    "readyToCompareTitle": "Ready to Compare",
+    "undecidedBlocksWarning": "{{count}} block(s) are still undecided. They will keep the original (left) content until you choose Left, Both, or Right.",
+    "resolveAllBeforePreview": "Resolve all blocks (Left, Both, or Right) before previewing or exporting the merge."
   },
   "walkValidator": {
     "label": "{{protocol}} Walks",
@@ -232,7 +234,9 @@
     "description": "Validate and auto-fix {{protocol}} walk files used by the simulated {{protocol}} agents.",
     "pageTitle": "SNMP Walks",
     "noWalksFound": "No walks found",
-    "pastePathLabel": "Or paste an absolute path"
+    "pastePathLabel": "Or paste an absolute path",
+    "autoFixConfirmTitle": "Auto-fix walk file?",
+    "autoFixConfirmMessage": "This rewrites \"{{file}}\" in place. A .bak backup of the original is created alongside it before any changes are written."
   },
   "walkAnalyzer": {
     "label": "Walk Analyzer",

--- a/internal/i18n/locales/es/devices.json
+++ b/internal/i18n/locales/es/devices.json
@@ -55,7 +55,13 @@
     "trunkPorts": "Puertos troncales",
     "portChannels": "Canales de puertos",
     "saveSuccess": "Dispositivo guardado",
-    "saveFailed": "Error al guardar el dispositivo"
+    "saveFailed": "Error al guardar el dispositivo",
+    "unsavedNavigation": {
+      "title": "¿Salir sin guardar?",
+      "message": "Este dispositivo tiene cambios sin guardar. Si sale ahora, esos cambios se perderán.",
+      "confirmLabel": "Salir",
+      "cancelLabel": "Quedarse"
+    }
   },
   "running": {
     "noDevicesRunning": "No hay dispositivos en ejecución actualmente",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -224,7 +224,9 @@
     "description": "Compare dos configuraciones de red {{format}} en paralelo y fusione los cambios entre ellas.",
     "originalFileTitle": "Archivo original",
     "modifiedFileTitle": "Archivo modificado",
-    "readyToCompareTitle": "Listo para comparar"
+    "readyToCompareTitle": "Listo para comparar",
+    "undecidedBlocksWarning": "{{count}} bloque(s) siguen sin decidir. Conservarán el contenido original (izquierda) hasta que elija Izquierda, Ambos o Derecha.",
+    "resolveAllBeforePreview": "Resuelva todos los bloques (Izquierda, Ambos o Derecha) antes de previsualizar o exportar la fusión."
   },
   "walkValidator": {
     "label": "Recorridos {{protocol}}",
@@ -232,7 +234,9 @@
     "description": "Valide y corrija automáticamente los archivos de recorrido {{protocol}} utilizados por los agentes {{protocol}} simulados.",
     "pageTitle": "Recorridos SNMP",
     "noWalksFound": "No se encontraron recorridos",
-    "pastePathLabel": "O pegue una ruta absoluta"
+    "pastePathLabel": "O pegue una ruta absoluta",
+    "autoFixConfirmTitle": "¿Corregir automáticamente el archivo de recorrido?",
+    "autoFixConfirmMessage": "Esto reescribe \"{{file}}\" en su lugar. Se crea una copia de seguridad .bak del original antes de escribir cualquier cambio."
   },
   "walkAnalyzer": {
     "label": "Analizador de recorridos",

--- a/ui/src/components/config/MergeControls.test.tsx
+++ b/ui/src/components/config/MergeControls.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * MergeControls.test.tsx
+ *
+ * Data-safety regression test: a "modified" diff block left undecided
+ * (no Left/Both/Right choice) silently keeps the original (left) content
+ * in generateMergedContent. Previously nothing surfaced that risk, and
+ * "Preview Merged" was reachable with undecided blocks still pending.
+ * This pins:
+ *   1. A visible warning appears while any block is undecided.
+ *   2. "Preview Merged" is disabled until every block has a decision.
+ *   3. Once all blocks are decided, the warning disappears and Preview
+ *      is enabled.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '../../i18n';
+import type { DiffBlock, MergeDecision } from '../config/diff-viewer/types';
+import { MergeControls } from './MergeControls';
+
+const modifiedBlock: DiffBlock = {
+  id: 'block-1',
+  type: 'modified',
+  startLine: 1,
+  leftLines: [{ lineNumber: 1, content: 'left', type: 'modified' }],
+  rightLines: [{ lineNumber: 1, content: 'right', type: 'modified' }],
+};
+
+const baseProps = {
+  onAcceptAllLeft: vi.fn(),
+  onAcceptAllRight: vi.fn(),
+  onReset: vi.fn(),
+  onExport: vi.fn(),
+  onPreview: vi.fn(),
+};
+
+describe('MergeControls — undecided block safety', () => {
+  it('warns and disables Preview when a modified block has no decision', () => {
+    render(
+      <MergeControls {...baseProps} diffBlocks={[modifiedBlock]} mergeDecisions={new Map()} />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/undecided/i);
+    expect(screen.getByRole('button', { name: /preview merged/i })).toBeDisabled();
+  });
+
+  it('clears the warning and enables Preview once the block is decided', () => {
+    const decisions = new Map<string, MergeDecision>([
+      ['block-1', { blockId: 'block-1', choice: 'left' }],
+    ]);
+    render(
+      <MergeControls {...baseProps} diffBlocks={[modifiedBlock]} mergeDecisions={decisions} />,
+    );
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('button', { name: /preview merged/i })).toBeEnabled();
+  });
+});

--- a/ui/src/components/config/MergeControls.tsx
+++ b/ui/src/components/config/MergeControls.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { type FC, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
@@ -47,6 +48,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
   leftLabel = 'Original',
   rightLabel = 'Modified',
 }) => {
+  const { t } = useTranslation('pages');
   // Confirm modal states
   const [showAcceptLeftConfirm, setShowAcceptLeftConfirm] = useState(false);
   const [showAcceptRightConfirm, setShowAcceptRightConfirm] = useState(false);
@@ -153,6 +155,24 @@ export const MergeControls: FC<MergeControlsProps> = ({
           </div>
         )}
 
+        {/* Undecided-blocks warning — a "modified" block with no Left/Both/
+            Right decision silently keeps the original (left) content in
+            the preview, export, and server-side merge. Surface that risk
+            explicitly instead of letting it happen quietly. */}
+        {stats.totalChanges > 0 && !stats.isComplete && (
+          <div
+            className="flex items-start gap-compact rounded-lg border border-status-warning/30 bg-status-warning/10 pad-sm text-sm text-status-warning"
+            role="alert"
+          >
+            <AlertCircle className={`${iconSizes.md} mt-0.5 flex-shrink-0`} />
+            <span>
+              {t('configDiff.undecidedBlocksWarning', {
+                count: stats.totalChanges - stats.decisionsCount,
+              })}
+            </span>
+          </div>
+        )}
+
         {/* Decision breakdown */}
         {stats.decisionsCount > 0 && (
           <div className="flex items-center gap-comfortable flex-wrap">
@@ -210,7 +230,7 @@ export const MergeControls: FC<MergeControlsProps> = ({
         <div className="flex flex-wrap gap-default pt-2 border-t border-surface-border">
           <Button
             tone="violet"
-            disabled={disabled || stats.totalChanges === 0}
+            disabled={disabled || stats.totalChanges === 0 || !stats.isComplete}
             onClick={onPreview}
             leftIcon={<FileCheck className={iconSizes.md} />}
           >
@@ -250,8 +270,8 @@ export const MergeControls: FC<MergeControlsProps> = ({
           {stats.totalChanges === 0
             ? 'Upload two YAML config files to start comparing and merging.'
             : stats.isComplete
-              ? 'All changes resolved. You can now export the merged configuration.'
-              : 'Click the merge buttons on each changed block to decide how to merge.'}
+              ? 'All changes resolved. You can now preview and export the merged configuration.'
+              : t('configDiff.resolveAllBeforePreview')}
         </SmallText>
       </CardContent>
 

--- a/ui/src/components/device-editor/FTPSection.test.tsx
+++ b/ui/src/components/device-editor/FTPSection.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * FTPSection.test.tsx
+ *
+ * Data-safety regression test: the per-user FTP password field must render
+ * as a masked `type="password"` input, never plaintext `type="text"`. It
+ * previously rendered as plaintext, exposing configured FTP credentials to
+ * shoulder-surfing and browser autofill/history in the same way a login
+ * password field would be.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Device } from '../../api/types';
+import { FtpSection } from './FTPSection';
+
+const baseDevice: Device = {
+  hostname: 'edge-01',
+  mac: '00:1A:2B:3C:4D:5E',
+  type: 'server',
+  ftp: {
+    enabled: true,
+    systemType: 'UNIX Type: L8',
+    users: [{ username: 'anonymous', password: 'hunter2', homeDir: '/' }],
+  },
+};
+
+describe('FtpSection', () => {
+  it('renders the FTP user password field as a masked password input', () => {
+    render(
+      <FtpSection device={baseDevice} isExpanded={true} onToggle={vi.fn()} onUpdate={vi.fn()} />,
+    );
+
+    const passwordInput = screen.getByPlaceholderText('Password') as HTMLInputElement;
+    expect(passwordInput.type).toBe('password');
+    expect(passwordInput.autocomplete).toBe('new-password');
+  });
+
+  it('does not render the password value as plaintext', () => {
+    render(
+      <FtpSection device={baseDevice} isExpanded={true} onToggle={vi.fn()} onUpdate={vi.fn()} />,
+    );
+
+    expect(screen.queryByDisplayValue('hunter2')).not.toBeNull();
+    expect(screen.getByPlaceholderText('Password')).toHaveAttribute('type', 'password');
+  });
+});

--- a/ui/src/components/device-editor/FTPSection.tsx
+++ b/ui/src/components/device-editor/FTPSection.tsx
@@ -113,7 +113,8 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                   className="flex-1 rounded-lg border border-surface-border bg-bg-base/60 pad-xs text-sm text-text-primary placeholder:text-text-muted focus:border-brand-accent focus:outline-none"
                 />
                 <input
-                  type="text"
+                  type="password"
+                  autoComplete="new-password"
                   value={user.password || ''}
                   onChange={(e) => {
                     const users = [...(device.ftp?.users || [])];

--- a/ui/src/components/device-editor/useDeviceEditor.ts
+++ b/ui/src/components/device-editor/useDeviceEditor.ts
@@ -16,6 +16,7 @@ import { useApiResource } from '../../hooks/useApiResource';
 import { DeviceFormSchema } from '../../schemas/forms';
 import { getErrorMessage } from '../../utils/format';
 import type { StatusMessage } from './DeviceEditorHeader';
+import { useUnsavedChangesGuard } from './useUnsavedChangesGuard';
 
 /**
  * Create an empty device with default values
@@ -76,6 +77,16 @@ export interface UseDeviceEditorReturn {
   handleSave: () => Promise<void>;
   handleDelete: () => Promise<void>;
   handleDiscard: () => void;
+
+  // Unsaved-changes navigation guard (#920 — the editor previously lost
+  // edits silently on navigate-away). requestNavigateBack replaces a bare
+  // `navigate('/device-config')` for the "Back" button; pendingLeavePath /
+  // confirmLeave / cancelLeave drive the confirmation modal rendered by
+  // DeviceEditorPage.
+  requestNavigateBack: () => void;
+  pendingLeavePath: string | null;
+  confirmLeave: () => void;
+  cancelLeave: () => void;
 }
 
 export const useDeviceEditor = (): UseDeviceEditorReturn => {
@@ -284,6 +295,17 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     }
   }, [isNewDevice, originalDevice, navigate, reset]);
 
+  const {
+    pendingPath: pendingLeavePath,
+    requestNavigate: requestNavigateBackTo,
+    confirmNavigate: confirmLeave,
+    cancelNavigate: cancelLeave,
+  } = useUnsavedChangesGuard(isDirty, navigate);
+  const requestNavigateBack = useCallback(
+    () => requestNavigateBackTo('/device-config'),
+    [requestNavigateBackTo],
+  );
+
   return {
     hostname,
     isNewDevice,
@@ -311,5 +333,9 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     handleSave,
     handleDelete,
     handleDiscard,
+    requestNavigateBack,
+    pendingLeavePath,
+    confirmLeave,
+    cancelLeave,
   };
 };

--- a/ui/src/components/device-editor/useUnsavedChangesGuard.test.tsx
+++ b/ui/src/components/device-editor/useUnsavedChangesGuard.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * useUnsavedChangesGuard.test.tsx
+ *
+ * Data-safety regression test: the device editor previously had no
+ * unsaved-changes guard at all — navigating away (in-app link click, the
+ * editor's own Back button, or closing/refreshing the tab) silently
+ * discarded edits. This pins the three escape hatches:
+ *   1. requestNavigate() — used by the editor's "Back" button — queues a
+ *      confirmation instead of navigating immediately while dirty, and
+ *      navigates straight through when clean.
+ *   2. An in-app `<a href>` click is intercepted while dirty and only
+ *      proceeds after confirmNavigate(); cancelNavigate() discards the
+ *      pending navigation and never calls the navigate callback.
+ *   3. beforeunload is guarded (preventDefault + returnValue set) while
+ *      dirty, and left alone when clean.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useUnsavedChangesGuard } from './useUnsavedChangesGuard';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useUnsavedChangesGuard', () => {
+  it('navigates immediately via requestNavigate when not dirty', () => {
+    const navigate = vi.fn();
+    const { result } = renderHook(() => useUnsavedChangesGuard(false, navigate));
+
+    act(() => result.current.requestNavigate('/device-config'));
+
+    expect(navigate).toHaveBeenCalledWith('/device-config');
+    expect(result.current.pendingPath).toBeNull();
+  });
+
+  it('queues a confirmation via requestNavigate when dirty, and only navigates on confirm', () => {
+    const navigate = vi.fn();
+    const { result } = renderHook(() => useUnsavedChangesGuard(true, navigate));
+
+    act(() => result.current.requestNavigate('/device-config'));
+    expect(navigate).not.toHaveBeenCalled();
+    expect(result.current.pendingPath).toBe('/device-config');
+
+    act(() => result.current.confirmNavigate());
+    expect(navigate).toHaveBeenCalledWith('/device-config');
+    expect(result.current.pendingPath).toBeNull();
+  });
+
+  it('cancelNavigate discards the pending navigation without calling navigate', () => {
+    const navigate = vi.fn();
+    const { result } = renderHook(() => useUnsavedChangesGuard(true, navigate));
+
+    act(() => result.current.requestNavigate('/device-config'));
+    act(() => result.current.cancelNavigate());
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(result.current.pendingPath).toBeNull();
+  });
+
+  it('intercepts an in-app link click while dirty and proceeds only on confirm', () => {
+    const navigate = vi.fn();
+    const { result } = renderHook(() => useUnsavedChangesGuard(true, navigate));
+
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', '/device-config');
+    document.body.appendChild(anchor);
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    act(() => {
+      anchor.dispatchEvent(clickEvent);
+    });
+
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(result.current.pendingPath).toBe('/device-config');
+
+    act(() => result.current.confirmNavigate());
+    expect(navigate).toHaveBeenCalledWith('/device-config');
+
+    document.body.removeChild(anchor);
+  });
+
+  it('does not intercept an in-app link click when not dirty', () => {
+    const navigate = vi.fn();
+    const { result } = renderHook(() => useUnsavedChangesGuard(false, navigate));
+
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', '/device-config');
+    document.body.appendChild(anchor);
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    act(() => {
+      anchor.dispatchEvent(clickEvent);
+    });
+
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(result.current.pendingPath).toBeNull();
+
+    document.body.removeChild(anchor);
+  });
+
+  it('guards beforeunload while dirty', () => {
+    renderHook(() => useUnsavedChangesGuard(true, vi.fn()));
+
+    const event = new Event('beforeunload', { cancelable: true }) as BeforeUnloadEvent;
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('does not guard beforeunload when clean', () => {
+    renderHook(() => useUnsavedChangesGuard(false, vi.fn()));
+
+    const event = new Event('beforeunload', { cancelable: true }) as BeforeUnloadEvent;
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/device-editor/useUnsavedChangesGuard.ts
+++ b/ui/src/components/device-editor/useUnsavedChangesGuard.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UnsavedChangesGuard {
+  /** Path awaiting confirmation, or null when no navigation is pending. */
+  pendingPath: string | null;
+  /** Navigate now if there are no unsaved changes; otherwise queue a confirmation. */
+  requestNavigate: (path: string) => void;
+  /** User confirmed leaving — discard the guard and navigate to the pending path. */
+  confirmNavigate: () => void;
+  /** User cancelled — stay on the page, no navigation happens. */
+  cancelNavigate: () => void;
+}
+
+/**
+ * Guards navigation away from a dirty form.
+ *
+ * Two escape hatches are covered:
+ * - Same-tab navigation: a document-level capture-phase click listener
+ *   intercepts clicks on internal `<a>` elements (the app's Sidebar/NavLink
+ *   render anchors) while `isDirty` is true, so clicking away from the
+ *   editor mid-edit surfaces a confirmation instead of silently discarding
+ *   the in-progress changes. `requestNavigate` covers the editor's own
+ *   "Back" button, which isn't an anchor.
+ * - Cross-document navigation: tab close, refresh, and address-bar
+ *   navigation are guarded by the standard `beforeunload` prompt, which the
+ *   browser (not this code) renders.
+ *
+ * Deliberately does not depend on `useBlocker` — the app boots a plain
+ * `BrowserRouter` (see ui/src/main.tsx), and `useBlocker` only works under
+ * a data router (`createBrowserRouter`). Converting the whole app to a data
+ * router is out of scope for this fix.
+ */
+export const useUnsavedChangesGuard = (
+  isDirty: boolean,
+  navigate: (path: string) => void,
+): UnsavedChangesGuard => {
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+  const [pendingPath, setPendingPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isDirtyRef.current) {
+        return;
+      }
+      event.preventDefault();
+      // Chrome requires returnValue to be set to show its confirmation.
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (!isDirtyRef.current || event.defaultPrevented || event.button !== 0) {
+        return;
+      }
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest?.('a[href]');
+      if (!anchor || anchor.hasAttribute('target') || anchor.hasAttribute('download')) {
+        return;
+      }
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('#')) {
+        return;
+      }
+      let url: URL;
+      try {
+        url = new URL(href, window.location.origin);
+      } catch {
+        return;
+      }
+      if (url.origin !== window.location.origin || url.pathname === window.location.pathname) {
+        return;
+      }
+      event.preventDefault();
+      setPendingPath(`${url.pathname}${url.search}${url.hash}`);
+    };
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, []);
+
+  const requestNavigate = useCallback(
+    (path: string) => {
+      if (isDirtyRef.current) {
+        setPendingPath(path);
+      } else {
+        navigate(path);
+      }
+    },
+    [navigate],
+  );
+
+  const confirmNavigate = useCallback(() => {
+    if (pendingPath) {
+      const target = pendingPath;
+      setPendingPath(null);
+      navigate(target);
+    }
+  }, [pendingPath, navigate]);
+
+  const cancelNavigate = useCallback(() => setPendingPath(null), []);
+
+  return { pendingPath, requestNavigate, confirmNavigate, cancelNavigate };
+};

--- a/ui/src/pages/DeviceEditorPage.test.tsx
+++ b/ui/src/pages/DeviceEditorPage.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * DeviceEditorPage.test.tsx
+ *
+ * Data-safety regression test: the device editor previously had no
+ * unsaved-changes guard — clicking "Back" while the form was dirty
+ * navigated away immediately and silently discarded the in-progress
+ * edit. This pins the integration: a dirty new-device form shows a
+ * confirmation on Back, "Stay" keeps the user on the page, and "Leave"
+ * proceeds with the navigation.
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../i18n';
+import { DeviceEditorPage } from './DeviceEditorPage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ hostname: 'new' }),
+    useLocation: () => ({ pathname: '/device-config/new' }),
+  };
+});
+
+vi.mock('../api/client', () => ({
+  createDevice: vi.fn(),
+  updateDevice: vi.fn(),
+  deleteDevice: vi.fn(),
+  fetchConfigDevice: () => Promise.resolve({ device: null }),
+  fetchLibraryWalks: () => Promise.resolve([]),
+  fetchDeviceEditorSchema: () => Promise.resolve({ visibleSections: [] }),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderPage() {
+  return render(createElement(MemoryRouter, null, createElement(DeviceEditorPage)));
+}
+
+/**
+ * The new-device form loads through a chain of resolved promises
+ * (fetchConfigDevice, fetchDeviceEditorSchema) that each trigger a
+ * `reset()` of the underlying react-hook-form state. Waiting only for
+ * the hostname field to appear can race a change fired immediately
+ * after — the pending `reset()` clobbers it. A macrotask tick drains
+ * every already-queued microtask (including the reset chain) before the
+ * test interacts with the form.
+ */
+const flushPendingEffects = () => act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+
+describe('DeviceEditorPage — unsaved-changes navigation guard', () => {
+  it('shows a confirmation on Back when the form is dirty, and Stay keeps the user on the page', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/hostname/i)).toBeInTheDocument());
+    await flushPendingEffects();
+
+    fireEvent.change(screen.getByLabelText(/hostname/i), {
+      target: { value: 'edge-01' },
+    });
+
+    fireEvent.click(screen.getByTitle('Back to device list'));
+
+    expect(screen.getByText(/leave without saving/i)).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /^stay$/i }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.queryByText(/leave without saving/i)).not.toBeInTheDocument();
+  });
+
+  it('navigates away after the user confirms Leave', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/hostname/i)).toBeInTheDocument());
+    await flushPendingEffects();
+
+    fireEvent.change(screen.getByLabelText(/hostname/i), {
+      target: { value: 'edge-01' },
+    });
+
+    fireEvent.click(screen.getByTitle('Back to device list'));
+    fireEvent.click(screen.getByRole('button', { name: /^leave$/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/device-config');
+  });
+
+  it('navigates immediately on Back when the form has no unsaved changes', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/hostname/i)).toBeInTheDocument());
+    await flushPendingEffects();
+
+    fireEvent.click(screen.getByTitle('Back to device list'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/device-config');
+    expect(screen.queryByText(/leave without saving/i)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/DeviceEditorPage.tsx
+++ b/ui/src/pages/DeviceEditorPage.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   AdditionalIPsSection,
   BasicSettingsSection,
@@ -21,6 +22,7 @@ import {
   useDeviceEditor,
   YamlPreviewSection,
 } from '../components/device-editor';
+import { ConfirmModal } from '../ui/ConfirmModal';
 
 export const DeviceEditorPage: FC = () => {
   const {
@@ -47,7 +49,12 @@ export const DeviceEditorPage: FC = () => {
     handleSave,
     handleDelete,
     handleDiscard,
+    requestNavigateBack,
+    pendingLeavePath,
+    confirmLeave,
+    cancelLeave,
   } = useDeviceEditor();
+  const { t } = useTranslation('devices');
 
   // Generate YAML preview
   const yamlPreview = useMemo(() => buildYamlPreview(device), [device]);
@@ -82,7 +89,7 @@ export const DeviceEditorPage: FC = () => {
         onDelete={() => setShowDeleteConfirm(true)}
         onDiscard={handleDiscard}
         onSave={handleSave}
-        onNavigateBack={() => navigate('/device-config')}
+        onNavigateBack={requestNavigateBack}
       />
 
       {/* YAML Preview */}
@@ -217,6 +224,18 @@ export const DeviceEditorPage: FC = () => {
           onCancel={() => setShowDeleteConfirm(false)}
         />
       )}
+
+      {/* Unsaved-changes navigation guard — covers the Back button and
+          any in-app link clicked while the form is dirty. */}
+      <ConfirmModal
+        isOpen={pendingLeavePath !== null}
+        onConfirm={confirmLeave}
+        onCancel={cancelLeave}
+        title={t('editor.unsavedNavigation.title')}
+        message={t('editor.unsavedNavigation.message')}
+        confirmLabel={t('editor.unsavedNavigation.confirmLabel')}
+        cancelLabel={t('editor.unsavedNavigation.cancelLabel')}
+      />
     </div>
   );
 };

--- a/ui/src/pages/WalkValidatorPage.test.tsx
+++ b/ui/src/pages/WalkValidatorPage.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * WalkValidatorPage.test.tsx
+ *
+ * Data-safety regression test: "Auto-fix" rewrites the walk file in place
+ * (the .bak safety net was previously mentioned only in a hover tooltip).
+ * Clicking it must open a confirmation naming the target file and the
+ * .bak behavior, and the file must only be rewritten after the user
+ * confirms — never on the click itself.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../i18n';
+import { WalkValidatorPage } from './WalkValidatorPage';
+
+const fetchLibraryWalks = vi.fn();
+const fixWalk = vi.fn();
+const validateWalk = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchLibraryWalks: () => fetchLibraryWalks(),
+  fixWalk: (filename: string) => fixWalk(filename),
+  validateWalk: (filename: string) => validateWalk(filename),
+}));
+
+const files = [
+  { name: 'cisco/c3900.walk', sizeBytes: 2048, modifiedAt: '', source: 'user', edited: false },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('WalkValidatorPage — Auto-fix confirmation', () => {
+  it('does not rewrite the file on the Auto-fix click alone', async () => {
+    fetchLibraryWalks.mockResolvedValue(files);
+    render(<WalkValidatorPage />);
+
+    await waitFor(() => expect(screen.getByText(/cisco\/c3900\.walk/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /auto-fix/i }));
+
+    expect(fixWalk).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: /auto-fix walk file/i })).toBeInTheDocument();
+    expect(screen.getByText(/backup of the original is created/i)).toBeInTheDocument();
+  });
+
+  it('calls fixWalk only after the user confirms', async () => {
+    fetchLibraryWalks.mockResolvedValue(files);
+    fixWalk.mockResolvedValueOnce({
+      message: 'Fixed',
+      result: { totalLines: 1, validLines: 1, valid: true, issues: [], fixedCount: 1 },
+    });
+    render(<WalkValidatorPage />);
+
+    await waitFor(() => expect(screen.getByText(/cisco\/c3900\.walk/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /auto-fix/i }));
+    const confirmButtons = screen.getAllByRole('button', { name: /auto-fix/i });
+    // The dialog's confirm button is the last "Auto-fix"-labeled control.
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    await waitFor(() => expect(fixWalk).toHaveBeenCalledWith('cisco/c3900.walk'));
+  });
+
+  it('cancels without calling fixWalk', async () => {
+    fetchLibraryWalks.mockResolvedValue(files);
+    render(<WalkValidatorPage />);
+
+    await waitFor(() => expect(screen.getByText(/cisco\/c3900\.walk/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /auto-fix/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(fixWalk).not.toHaveBeenCalled();
+    expect(screen.queryByRole('heading', { name: /auto-fix walk file/i })).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { fetchLibraryWalks, fixWalk, type LibraryFileEntry, validateWalk } from '../api/client';
 import type { WalkValidationIssue, WalkValidationResponse } from '../api/types';
 import { Card, CardContent } from '../ui/Card';
+import { ConfirmModal } from '../ui/ConfirmModal';
 
 type Severity = 'error' | 'warning' | 'info';
 
@@ -26,6 +27,7 @@ const severityCounts = (issues: WalkValidationIssue[]): Record<Severity, number>
 
 export const WalkValidatorPage: FC = () => {
   const { t } = useTranslation('pages');
+  const { t: tCommon } = useTranslation('common');
   const [files, setFiles] = useState<LibraryFileEntry[]>([]);
   const [filesError, setFilesError] = useState<string | null>(null);
   const [filesLoading, setFilesLoading] = useState(true);
@@ -36,6 +38,7 @@ export const WalkValidatorPage: FC = () => {
   const [response, setResponse] = useState<WalkValidationResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<'idle' | 'validating' | 'fixing'>('idle');
+  const [showAutoFixConfirm, setShowAutoFixConfirm] = useState(false);
 
   // Hydrate the file dropdown from /api/v1/library/walks. The daemon's
   // walk validator (validateWalkFilePath) falls back to the library
@@ -156,7 +159,7 @@ export const WalkValidatorPage: FC = () => {
             </button>
             <button
               type="button"
-              onClick={() => void run('fixing')}
+              onClick={() => setShowAutoFixConfirm(true)}
               disabled={busy !== 'idle' || !targetPath}
               className="rounded bg-status-warning/20 px-3 py-compact-md text-sm font-medium text-status-warning ring-1 ring-status-warning/40 hover:bg-status-warning/30 disabled:opacity-50"
               title="Validate and rewrite the file in place. A .bak is created next to the original."
@@ -249,6 +252,20 @@ export const WalkValidatorPage: FC = () => {
           </CardContent>
         </Card>
       )}
+
+      <ConfirmModal
+        isOpen={showAutoFixConfirm}
+        onConfirm={() => {
+          setShowAutoFixConfirm(false);
+          void run('fixing');
+        }}
+        onCancel={() => setShowAutoFixConfirm(false)}
+        title={t('walkValidator.autoFixConfirmTitle')}
+        message={t('walkValidator.autoFixConfirmMessage', { file: targetPath })}
+        confirmLabel={tCommon('buttons.autoFix')}
+        cancelLabel={tCommon('buttons.cancel')}
+        confirmTone="blue"
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Four data-safety guards from the 2026-07-05 UX eval:

1. FTP password field (`device-editor/FTPSection.tsx`) — was `type="text"` (plaintext-visible credential); now `type="password"` with `autocomplete="new-password"`.
2. Walk Validator Auto-fix (`WalkValidatorPage.tsx`) — the file-mutating Auto-fix now opens the shared `ConfirmModal` (naming the file + `.bak` behavior) before calling `fixWalk`; was previously ungated.
3. Config-diff undecided blocks (`config/MergeControls.tsx`) — added a visible warning banner for undecided blocks and disabled "Preview Merged" until every block has a Left/Both/Right decision (Export was already gated). `merge-utils.ts` left as-is; the fix prevents reachable unsafe UI states.
4. Device-editor unsaved-changes guard (new `device-editor/useUnsavedChangesGuard.ts`) — guards in-app link clicks + Back (via `ConfirmModal`) and tab-close/refresh (via `beforeunload`). App uses plain `BrowserRouter` (not a data router), so `useBlocker` wasn't available; implemented via click interception rather than a router migration (out of scope for a bug-fix PR).

## Linked Issue

Related to #897

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

17 new tests across 5 new/updated test files (password type, Auto-fix confirm flow, undecided-block gating, unsaved-guard). en+es i18n parity added for every new string.

```text
npm run lint       # 0 issues
npm run typecheck  # tsgo, clean
npm run test       # 177/177 passed
npm run build      # pass
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (UI-only guards; no routes touched. FTP password field no longer renders plaintext.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (New confirm/warn copy localized en/es.)
