### PR TITLE
fix(ui): restore green PacketInspectorPage filtered-export test (AppProvider dep)

### DIFF
--- a/ui/src/pages/PacketInspectorPage.test.tsx
+++ b/ui/src/pages/PacketInspectorPage.test.tsx
@@ -34,6 +34,18 @@ vi.mock('../hooks/useEventSource', () => ({
   },
 }));
 
+// The page consumes the shared sim-status poll via useSimulationStatus
+// (useAppState('simStatus') under an AppProvider). Mock the hook so this
+// unit test doesn't need the whole AppProvider + its fan of client polls.
+vi.mock('../hooks/useSimulationStatus', () => ({
+  useSimulationStatus: () => ({
+    data: { running: false },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
 async function readBlobAsJson(blob: Blob): Promise<unknown> {
   const text = await blob.text();
   return JSON.parse(text);


### PR DESCRIPTION
## Summary

Fixes a red test on `main`: `PacketInspectorPage.test.tsx > filtered export`. #927 wired `PacketInspectorPage` onto the shared `useSimulationStatus` hook (`useAppState('simStatus')`), which requires an `AppProvider`. #923's pre-existing filtered-export test renders the page bare, so it started throwing `useAppContext must be used within AppProvider`. This mocks the `useSimulationStatus` hook so the unit test stays isolated from the whole `AppProvider` + its fan of client polls (the cleaner fix vs. standing up the full provider).

**Why it slipped through:** CI does not run vitest — the frontend job only runs lint/typecheck/build — so a failing unit test reached main invisibly. Filing a follow-up to add vitest to CI (standards-hardening).

## Linked Issue

Related to #897

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

Test-only change. Full ui suite green after the fix:

```text
npx vitest run src/pages/PacketInspectorPage.test.tsx   # 1 file, 1 test passed
npx vitest run                                           # 42 files, 223 tests passed
npm run typecheck                                        # tsgo, clean
npm run build                                            # succeeds
```

(Local `npm run lint` is blocked by unrelated nested-worktree biome.json collisions in this dev checkout; CI runs biome in a clean checkout.)

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (Test-only; no routes touched.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (No behavior change.)
