### PR TITLE
ci: gate frontend on vitest + retry flaky libpcap-dev apt install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,20 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+        # Retry with backoff: packages.microsoft.com intermittently serves an
+        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
+        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
+        # into a self-healing step instead of a red run.
+        run: |
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
 
       - name: Verify dependencies
         # ./.github/actions/setup-go already runs `go mod download`; this
@@ -191,6 +204,12 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Run unit tests
+        # vitest gates the frontend job so a red or missing-provider test can
+        # never reach main invisibly (regression: #930 landed a red test while
+        # this job only ran lint/typecheck/build).
+        run: npm run test
+
       - name: Build
         run: npm run build
 
@@ -243,7 +262,20 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+        # Retry with backoff: packages.microsoft.com intermittently serves an
+        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
+        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
+        # into a self-healing step instead of a red run.
+        run: |
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
 
       - name: Run govulncheck
         # make security-backend installs govulncheck if missing and runs the
@@ -627,7 +659,20 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+        # Retry with backoff: packages.microsoft.com intermittently serves an
+        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
+        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
+        # into a self-healing step instead of a red run.
+        run: |
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
 
       - name: Download frontend build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -693,7 +738,20 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+        # Retry with backoff: packages.microsoft.com intermittently serves an
+        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
+        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
+        # into a self-healing step instead of a red run.
+        run: |
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
 
       - name: Download frontend build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -803,7 +861,20 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+        # Retry with backoff: packages.microsoft.com intermittently serves an
+        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
+        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
+        # into a self-healing step instead of a red run.
+        run: |
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
 
       - name: Download frontend build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,14 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
-        # Retry with backoff: packages.microsoft.com intermittently serves an
-        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
-        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
-        # into a self-healing step instead of a red run.
+        # packages.microsoft.com intermittently serves an unsigned/invalid
+        # InRelease that aborts `apt-get update` for the whole runner, even
+        # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
+        # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
+        # so a broken third-party mirror can't red the job, then retry the
+        # install with backoff for genuinely transient hiccups.
         run: |
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
           for i in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
               exit 0
@@ -262,11 +265,14 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
-        # Retry with backoff: packages.microsoft.com intermittently serves an
-        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
-        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
-        # into a self-healing step instead of a red run.
+        # packages.microsoft.com intermittently serves an unsigned/invalid
+        # InRelease that aborts `apt-get update` for the whole runner, even
+        # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
+        # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
+        # so a broken third-party mirror can't red the job, then retry the
+        # install with backoff for genuinely transient hiccups.
         run: |
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
           for i in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
               exit 0
@@ -659,11 +665,14 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
-        # Retry with backoff: packages.microsoft.com intermittently serves an
-        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
-        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
-        # into a self-healing step instead of a red run.
+        # packages.microsoft.com intermittently serves an unsigned/invalid
+        # InRelease that aborts `apt-get update` for the whole runner, even
+        # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
+        # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
+        # so a broken third-party mirror can't red the job, then retry the
+        # install with backoff for genuinely transient hiccups.
         run: |
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
           for i in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
               exit 0
@@ -738,11 +747,14 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
-        # Retry with backoff: packages.microsoft.com intermittently serves an
-        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
-        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
-        # into a self-healing step instead of a red run.
+        # packages.microsoft.com intermittently serves an unsigned/invalid
+        # InRelease that aborts `apt-get update` for the whole runner, even
+        # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
+        # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
+        # so a broken third-party mirror can't red the job, then retry the
+        # install with backoff for genuinely transient hiccups.
         run: |
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
           for i in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
               exit 0
@@ -861,11 +873,14 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
-        # Retry with backoff: packages.microsoft.com intermittently serves an
-        # invalid InRelease, flaking the whole job (killed Lighthouse/#928 +
-        # Security Scanning/#932). Three attempts turn a transient mirror hiccup
-        # into a self-healing step instead of a red run.
+        # packages.microsoft.com intermittently serves an unsigned/invalid
+        # InRelease that aborts `apt-get update` for the whole runner, even
+        # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
+        # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
+        # so a broken third-party mirror can't red the job, then retry the
+        # install with backoff for genuinely transient hiccups.
         run: |
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
           for i in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
               exit 0


### PR DESCRIPTION
## Summary

Two CI reliability fixes:

1. **Gate the Frontend job on vitest.** It ran Biome lint, token-discipline, typecheck, and build — but never `vitest`, so a red or missing-provider unit test could reach `main` invisibly (exactly the #930 regression: a filtered-export test rendered `PacketInspectorPage` without `AppProvider` after #927 and threw, undetected). Adds an `npm run test` step after typecheck; it gates merge via `CI Complete`.
2. **Retry the flaky `Install libpcap-dev` apt step.** `packages.microsoft.com` intermittently serves an invalid `InRelease`, failing `apt-get update` and killing whole jobs (Lighthouse in #928, Security Scanning in #932). All 5 instances (backend, security, build, e2e, lighthouse) now retry 3× with backoff and fail loudly only after exhaustion.

## Linked Issue

Related to #933

## Type of Change

- [x] CI / release / packaging

## Risk

- [x] Low

## Testing Evidence

```text
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"
YAML OK

$ cd ui && npm run test
 Test Files  47 passed (47)
      Tests  246 passed (246)
```

The vitest suite is green on this branch (no test code touched), so the new gate passes. The retry logic exits 0 on first success, sleeps with backoff between attempts, and `exit 1`s with a `::error::` after 3 failures.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — CI workflow only; no untrusted-input interpolation added.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (CI-internal only.)
