### PR TITLE
feat(ui): clarify template preview CTAs (Use as-is / Customize first)

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -690,8 +690,9 @@
       "closeButton": "Close",
       "editCopyTitle": "Clone this template to your saved configs and open the device editor",
       "cloning": "Cloning…",
-      "editCopy": "Edit a copy",
-      "pickTemplate": "Pick this template"
+      "editCopy": "Customize first",
+      "pickTemplate": "Use as-is",
+      "pickTemplateTitle": "Select this template as the active configuration to run unchanged"
     }
   },
   "license": {

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -690,8 +690,9 @@
       "closeButton": "Cerrar",
       "editCopyTitle": "Clone esta plantilla en sus configuraciones guardadas y abra el editor de dispositivos",
       "cloning": "Clonando…",
-      "editCopy": "Editar una copia",
-      "pickTemplate": "Elegir esta plantilla"
+      "editCopy": "Personalizar primero",
+      "pickTemplate": "Usar tal cual",
+      "pickTemplateTitle": "Seleccione esta plantilla como la configuración activa para ejecutarla sin cambios"
     }
   },
   "license": {

--- a/ui/src/components/TemplatePreviewModal.tsx
+++ b/ui/src/components/TemplatePreviewModal.tsx
@@ -228,7 +228,11 @@ export const TemplatePreviewModal: FC<TemplatePreviewModalProps> = ({
                   ? t('templates.previewModal.cloning')
                   : t('templates.previewModal.editCopy')}
               </Button>
-              <Button tone="violet" onClick={() => onUse(template)}>
+              <Button
+                tone="violet"
+                onClick={() => onUse(template)}
+                title={t('templates.previewModal.pickTemplateTitle')}
+              >
                 {t('templates.previewModal.pickTemplate')}
               </Button>
             </div>


### PR DESCRIPTION
## Summary

Phase 4d of the UX remediation — template preview CTA clarity. The three preview actions (Copy YAML / Edit a copy / Pick this template) read ambiguously; the 2026-07-05 eval flagged the CTA set as confusing. This relabels the two *action* buttons to say what they actually do:

- **"Pick this template" → "Use as-is"** — `onUse` selects the template as the active configuration to run unchanged.
- **"Edit a copy" → "Customize first"** — clones the template into saved configs and opens the device editor.

Also adds a tooltip to the "Use as-is" button, resolving the asymmetry the eval noted (only "Edit a copy" carried an explanatory `title`). en + es, both.

Note: the plan paired 4d with deleting a dead `analyzePcap` client wrapper — that wrapper no longer exists (removed in an earlier phase; only `analyzeWalk` remains in `client.ts`), so there is nothing to delete. The PCAP Analyzer tab already covers that CLI use case.

## Linked Issue

Related to #935

## Type of Change

- [x] Feature (UX copy clarity)

## Risk

- [x] Low

## Testing Evidence

```text
$ npm run typecheck        # tsgo --build --noEmit
(clean, no errors)

$ npm run test
 Test Files  47 passed (47)
      Tests  246 passed (246)          # incl. i18n.parity.test.ts (key parity + DNT) with new pickTemplateTitle key

$ npx @biomejs/biome check src/components/TemplatePreviewModal.tsx
Checked 1 file. No fixes applied.

$ npm run build
BUILD OK
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — copy-only UI change, no routes touched.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Label-only; behavior unchanged.)
