### PR TITLE
fix(i18n): keep 'walk'/'Walks' verbatim in es + gate it in CI

### DIFF
--- a/internal/i18n/locales/es/errors.json
+++ b/internal/i18n/locales/es/errors.json
@@ -45,7 +45,7 @@
   },
   "walk": {
     "validationFailed": "La validación falló",
-    "parseError": "No se pudo analizar el archivo de recorrido"
+    "parseError": "No se pudo analizar el archivo walk"
   },
   "injection": {
     "deviceLabel": "Dispositivo",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -121,7 +121,7 @@
     "title": "Dispositivos en ejecución",
     "description": "Vista de solo lectura de los dispositivos que el daemon está simulando actualmente, junto con el YAML en ejecución.",
     "ipAddressesHeader": "Direcciones IP",
-    "availableSnmpWalks": "Recorridos SNMP disponibles",
+    "availableSnmpWalks": "Walks SNMP disponibles",
     "editInLibrary": "Editar en la biblioteca de dispositivos",
     "useInEditor": "Usar en el editor de dispositivos",
     "subtitle": "Dispositivos generados a partir del YAML de configuración activo",
@@ -595,19 +595,19 @@
     "batchStatusInvalid": "No válido"
   },
   "walkAnalyzer": {
-    "label": "Analizador de recorridos",
-    "title": "Analizador de recorridos",
-    "description": "Analice un archivo de recorrido SNMP para extraer la identidad del dispositivo, el inventario de interfaces y las adyacencias de vecinos LLDP/CDP.",
-    "pageTitle": "Analizador de recorridos",
-    "noWalksFound": "No se encontraron recorridos",
+    "label": "Analizador de Walk",
+    "title": "Analizador de Walk",
+    "description": "Analice un archivo walk de SNMP para extraer la identidad del dispositivo, el inventario de interfaces y las adyacencias de vecinos LLDP/CDP.",
+    "pageTitle": "Analizador de Walk",
+    "noWalksFound": "No se encontraron walks",
     "pastePathLabel": "O pegue una ruta absoluta",
     "noNeighborsFound": "No se encontraron vecinos LLDP/CDP.",
     "noInterfacesFound": "No se encontraron interfaces."
   },
   "libraryWalks": {
-    "label": "Recorridos",
-    "title": "Biblioteca de recorridos",
-    "description": "Navegador de solo lectura para los archivos de recorrido {{protocol}} en disco que el daemon sirve desde la biblioteca unificada."
+    "label": "Walks",
+    "title": "Biblioteca de Walk",
+    "description": "Navegador de solo lectura para los archivos walk de {{protocol}} en disco que el daemon sirve desde la biblioteca unificada."
   },
   "libraryPcaps": {
     "label": "{{format}}",

--- a/ui/src/i18n/i18n.parity.test.ts
+++ b/ui/src/i18n/i18n.parity.test.ts
@@ -77,6 +77,11 @@ const DNT_TERMS = [
   'jitter',
   'throughput',
   'latency',
+  // Domain nouns kept verbatim app-wide (the Library "Walks" section, the
+  // "Walk Analyzer", device-editor "walk file"). es must not render these as
+  // "recorrido". Both forms: singular "walk"/"Walk" and plural "walks"/"Walks".
+  'walk',
+  'Walks',
 ];
 
 function flatKeyPaths(node: Json, prefix = ''): string[] {


### PR DESCRIPTION
## Summary

Follow-up to the Phase 3/4 i18n work. Several es locale strings translated the domain noun **walk → "recorrido"**, which drifts from the app-wide convention: the device editor keeps "Archivo walk", the Library section is "Walks" / "Walks SNMP", and en uses "Walks"/"walk" as the labeled feature noun throughout. This normalizes every remaining occurrence and adds a CI gate so it can't regress.

**es strings fixed (walk/Walks kept verbatim):**
- `pages.json` → `walkAnalyzer.*` ("Analizador de recorridos" → "Analizador de Walk"; description "archivo de recorrido SNMP" → "archivo walk de SNMP"; "No se encontraron recorridos" → "No se encontraron walks")
- `pages.json` → `libraryWalks.*` ("Recorridos" → "Walks"; "Biblioteca de recorridos" → "Biblioteca de Walk"; "archivos de recorrido" → "archivos walk")
- `pages.json` → `devices.availableSnmpWalks` ("Recorridos SNMP disponibles" → "Walks SNMP disponibles")
- `errors.json` → `walk.parseError` ("archivo de recorrido" → "archivo walk")

**CI gate:** added `walk` and `Walks` to the `DNT_TERMS` list in `i18n.parity.test.ts`. The parity test already fails when a DNT term in an en value is missing from the matching es value — this extends that protection to the walk noun (singular + plural). The term list previously didn't cover it, which is exactly how the drift slipped in past the gate.

## Linked Issue

Related to #897

## Type of Change

- [x] Defect fix (localization consistency) + test hardening

## Risk

- [x] Low

## Testing Evidence

```text
$ npx vitest run src/i18n/i18n.parity.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)      # DNT + key-parity, now including walk/Walks

$ npm run typecheck   # tsgo --build --noEmit
(clean)

$ npm run test
 Test Files  47 passed (47)
      Tests  248 passed (248)

$ npx @biomejs/biome check src/i18n/i18n.parity.test.ts
Checked 1 file. No fixes applied.

$ npm run build
BUILD_OK
```

A pre-add scan confirmed every en value containing walk/Walks now has the term in its es counterpart (0 violations), so the new gate is satisfied repo-wide.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — locale strings + test only.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Localized copy only.)
