### PR TITLE
feat(api): surface real libpcap BPF compile error to the UI

### DIFF
--- a/internal/api/capture_filter.go
+++ b/internal/api/capture_filter.go
@@ -62,8 +62,12 @@ func (s *Server) handleCaptureFilterSet(w http.ResponseWriter, r *http.Request) 
 
 	if err := stack.SetCaptureFilter(req.Filter); err != nil {
 		s.logger.ErrorContext(r.Context(), "[API] Failed to set capture filter", "filter", req.Filter, "error", err)
+		// The libpcap compile error describes the caller's own filter
+		// expression, so it is safe to echo back verbatim.
 		writeError(w, r, http.StatusBadRequest, "invalid_filter",
-			"Invalid BPF filter expression", nil)
+			"Invalid BPF filter expression", []ErrorDetail{
+				{Field: "filter", Issue: err.Error(), Value: req.Filter},
+			})
 
 		return
 	}

--- a/internal/api/capture_filter_test.go
+++ b/internal/api/capture_filter_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/capture"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+
+	captureengine "github.com/MustardSeedNetworks/niac-go/internal/capture"
+)
+
+// newLoopbackCaptureServer builds a test server whose stack has a real
+// capture engine attached to the loopback interface, so BPF filter
+// validation exercises the actual libpcap compiler. Skips when no
+// loopback interface is available or when running under CI (same
+// convention as internal/capture's engine tests).
+func newLoopbackCaptureServer(t *testing.T) *Server {
+	t.Helper()
+
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping test in CI environment (requires packet capture privileges)")
+	}
+
+	var iface string
+
+	for _, name := range []string{"lo", "lo0", "Loopback"} {
+		if captureengine.InterfaceExists(name) {
+			iface = name
+
+			break
+		}
+	}
+
+	if iface == "" {
+		t.Skip("No loopback interface found")
+	}
+
+	engine, err := captureengine.New(iface, 0)
+	if err != nil {
+		t.Skipf("Cannot create capture engine: %v", err)
+	}
+
+	t.Cleanup(engine.Close)
+
+	cfg := mustLoadConfig(t, baseConfigYAML)
+	stack := protocols.NewStack(engine, cfg, logging.NewDebugConfig(0))
+
+	return &Server{
+		cfg: ServerConfig{
+			Stack:     stack,
+			Config:    cfg,
+			Interface: iface,
+			Version:   "test",
+		},
+		logger:    slog.Default(),
+		pcapCache: capture.NewCache(),
+	}
+}
+
+// TestHandleCaptureFilterSetInvalidReturnsLibpcapReason verifies that a
+// malformed BPF filter surfaces the real libpcap compile error in the
+// response body, not just the generic "invalid" message.
+func TestHandleCaptureFilterSetInvalidReturnsLibpcapReason(t *testing.T) {
+	server := newLoopbackCaptureServer(t)
+
+	for _, filter := range []string{"tcp port", "nonsense &&"} {
+		t.Run(filter, func(t *testing.T) {
+			assertRejectedFilterHasLibpcapReason(t, server, filter)
+		})
+	}
+}
+
+// assertRejectedFilterHasLibpcapReason submits filter and checks that the
+// 400 response carries the real libpcap compile error as an ErrorDetail,
+// not just the generic top-level message.
+func assertRejectedFilterHasLibpcapReason(t *testing.T, server *Server, filter string) {
+	t.Helper()
+
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/v1/capture/filter",
+		strings.NewReader(`{"filter":"`+filter+`"}`),
+	)
+	rec := httptest.NewRecorder()
+
+	server.handleCaptureFilter(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+
+	if resp.Message != "Invalid BPF filter expression" {
+		t.Fatalf("expected generic message preserved, got %q", resp.Message)
+	}
+
+	if len(resp.Details) != 1 {
+		t.Fatalf("expected 1 error detail, got %d: %+v", len(resp.Details), resp.Details)
+	}
+
+	detail := resp.Details[0]
+	if detail.Field != "filter" {
+		t.Fatalf("expected detail field %q, got %q", "filter", detail.Field)
+	}
+
+	if detail.Value != filter {
+		t.Fatalf("expected detail value %q, got %q", filter, detail.Value)
+	}
+
+	if detail.Issue == "" || detail.Issue == "Invalid BPF filter expression" {
+		t.Fatalf("expected real libpcap compile error, got %q", detail.Issue)
+	}
+}
+
+// TestHandleCaptureFilterSetValidClearsError confirms a valid filter still
+// succeeds and returns no error details.
+func TestHandleCaptureFilterSetValidClearsError(t *testing.T) {
+	server := newLoopbackCaptureServer(t)
+
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/v1/capture/filter",
+		strings.NewReader(`{"filter":"ip"}`),
+	)
+	rec := httptest.NewRecorder()
+
+	server.handleCaptureFilter(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Skipf("valid filter rejected on this platform/interface: %s", rec.Body.String())
+	}
+}

--- a/ui/src/api/errors.ts
+++ b/ui/src/api/errors.ts
@@ -7,15 +7,26 @@
  * FIX #177: Inconsistent error handling
  */
 
+/** Field-level detail attached to an API error response (see internal/api ErrorDetail). */
+export interface ApiErrorDetail {
+  readonly field?: string;
+  readonly issue: string;
+  readonly value?: string;
+}
+
 export class ApiError extends Error {
   readonly status: number;
   readonly code: string;
+  /** Structured per-field detail, when the server included one (e.g. an
+   * invalid BPF filter's libpcap compile error). */
+  readonly details: readonly ApiErrorDetail[];
 
-  constructor(message: string, status: number, code = 'API_ERROR') {
+  constructor(message: string, status: number, code = 'API_ERROR', details: ApiErrorDetail[] = []) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
     this.code = code;
+    this.details = details;
   }
 }
 

--- a/ui/src/api/requestCore.ts
+++ b/ui/src/api/requestCore.ts
@@ -1,4 +1,4 @@
-import { ApiError, NetworkError, TimeoutError } from './errors';
+import { ApiError, type ApiErrorDetail, NetworkError, TimeoutError } from './errors';
 
 /**
  * Core HTTP request infrastructure for the API client. Everything that
@@ -167,10 +167,14 @@ async function buildRequestHeaders(path: string, init: RequestInit) {
 function parseApiError(text: string, status: number, fallback = ''): ApiError {
   if (text) {
     try {
-      const parsed = JSON.parse(text) as { error?: string; message?: string };
+      const parsed = JSON.parse(text) as {
+        error?: string;
+        message?: string;
+        details?: ApiErrorDetail[];
+      };
       const message = parsed.message || fallback || text;
       const code = parsed.error || 'API_ERROR';
-      return new ApiError(message, status, code);
+      return new ApiError(message, status, code, parsed.details ?? []);
     } catch {
       // Body wasn't JSON — fall through to raw text.
     }

--- a/ui/src/components/BpfFilterBar.test.tsx
+++ b/ui/src/components/BpfFilterBar.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * BpfFilterBar.test.tsx — Phase 5b: the "Invalid BPF filter expression"
+ * alert must show the real libpcap compile error the API attaches as a
+ * structured detail, not just the generic top-level message.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '../i18n';
+import { ApiError } from '../api/errors';
+import { BpfFilterBar } from './BpfFilterBar';
+
+const getCaptureFilter = vi.fn();
+const setCaptureFilter = vi.fn();
+const clearCaptureFilter = vi.fn();
+
+vi.mock('../api/capture', () => ({
+  getCaptureFilter: () => getCaptureFilter(),
+  setCaptureFilter: (filter: string) => setCaptureFilter(filter),
+  clearCaptureFilter: () => clearCaptureFilter(),
+}));
+
+describe('BpfFilterBar', () => {
+  beforeEach(() => {
+    getCaptureFilter.mockReset().mockResolvedValue({ active: false, filter: '' });
+    setCaptureFilter.mockReset();
+    clearCaptureFilter.mockReset();
+  });
+
+  it('shows the real libpcap compile error from the structured detail', async () => {
+    setCaptureFilter.mockRejectedValue(
+      new ApiError('Invalid BPF filter expression', 400, 'invalid_filter', [
+        {
+          field: 'filter',
+          issue: "failed to set BPF filter: can't parse filter expression: syntax error",
+          value: 'tcp port',
+        },
+      ]),
+    );
+
+    render(<BpfFilterBar />);
+
+    const input = await screen.findByPlaceholderText(/./);
+    fireEvent.change(input, { target: { value: 'tcp port' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/can't parse filter expression: syntax error/)).toBeInTheDocument(),
+    );
+  });
+
+  it('falls back to the generic message when the server sends no detail', async () => {
+    setCaptureFilter.mockRejectedValue(new ApiError('Invalid BPF filter expression', 400));
+
+    render(<BpfFilterBar />);
+
+    const input = await screen.findByPlaceholderText(/./);
+    fireEvent.change(input, { target: { value: 'garbage' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() =>
+      expect(screen.getByText('Invalid BPF filter expression')).toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/src/components/BpfFilterBar.tsx
+++ b/ui/src/components/BpfFilterBar.tsx
@@ -2,11 +2,29 @@ import { AlertCircle, CheckCircle2, Filter, X } from 'lucide-react';
 import { type FC, memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { clearCaptureFilter, getCaptureFilter, setCaptureFilter } from '../api/capture';
+import { isApiError } from '../api/errors';
 import { iconSizes } from '../constants/sizes';
 import { Button } from '../ui/Button';
 import { InfoPopover } from '../ui/InfoPopover';
 import { SmallText } from '../ui/Typography';
 import { getErrorMessage } from '../utils/format';
+
+/**
+ * Extract the server-reported reason a BPF filter was rejected. When the
+ * API attaches a structured detail (the real libpcap compile error), use
+ * it instead of the generic top-level message so the operator sees why
+ * their expression failed, not just that it did.
+ */
+function getFilterRejectionReason(err: unknown, fallback: string): string {
+  if (isApiError(err)) {
+    const filterDetail = err.details.find((detail) => detail.field === 'filter');
+    if (filterDetail?.issue) {
+      return filterDetail.issue;
+    }
+  }
+
+  return getErrorMessage(err) || fallback;
+}
 
 /** Common BPF filter presets. */
 const BPF_PRESETS = [
@@ -73,7 +91,7 @@ export const BpfFilterBar: FC = memo(() => {
       setActiveFilter(result.filter);
       setIsActive(result.active);
     } catch (err) {
-      setError(getErrorMessage(err) || tPages('packets.bpfFilter.invalidFilterError'));
+      setError(getFilterRejectionReason(err, tPages('packets.bpfFilter.invalidFilterError')));
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- The `/api/v1/capture/filter` PUT handler discarded the real libpcap compile error from `SetCaptureFilter` and always returned a generic `"Invalid BPF filter expression"` message, so operators had no way to know *why* their filter was rejected.
- `handleCaptureFilterSet` now attaches the real libpcap error as a structured `ErrorDetail{Field: "filter", Issue: <libpcap message>, Value: <submitted filter>}` alongside the unchanged generic top-level message. A libpcap *compile* error only describes the caller's own submitted filter, so it is safe to echo back.
- `ApiError` on the UI side gained an optional `details: ApiErrorDetail[]` field, populated by `parseApiError` from the response body's `details` array.
- `BpfFilterBar` now prefers the `filter`-field detail's `issue` text over the generic fallback message when rendering the inline error, so the actual libpcap reason (e.g. `can't parse filter expression: syntax error`) is shown next to the input. The existing BPF jargon popover is untouched.
- No new user-visible static strings were added (the error text itself is a dynamic libpcap message), so no i18n key changes were needed.

## Linked Issue
Related to #897

## Testing Evidence
```text
$ go test ./internal/api/... -race -run 'CaptureFilter' -v
=== RUN   TestHandleCaptureFilterSetInvalidReturnsLibpcapReason
=== RUN   TestHandleCaptureFilterSetInvalidReturnsLibpcapReason/tcp_port
2026/07/07 19:13:54 ERROR [API] Failed to set capture filter filter="tcp port" error="failed to set BPF filter: can't parse filter expression: syntax error"
=== RUN   TestHandleCaptureFilterSetInvalidReturnsLibpcapReason/nonsense_&&
2026/07/07 19:13:54 ERROR [API] Failed to set capture filter filter="nonsense &&" error="failed to set BPF filter: can't parse filter expression: syntax error"
--- PASS: TestHandleCaptureFilterSetInvalidReturnsLibpcapReason (0.01s)
    --- PASS: TestHandleCaptureFilterSetInvalidReturnsLibpcapReason/tcp_port (0.00s)
    --- PASS: TestHandleCaptureFilterSetInvalidReturnsLibpcapReason/nonsense_&& (0.00s)
=== RUN   TestHandleCaptureFilterSetValidClearsError
2026/07/07 19:13:54 INFO [API] Capture filter set filter=ip
--- PASS: TestHandleCaptureFilterSetValidClearsError (0.01s)
PASS
ok  	github.com/MustardSeedNetworks/niac-go/internal/api	1.054s

$ go test ./internal/api/... -race
ok  	github.com/MustardSeedNetworks/niac-go/internal/api	50.454s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/auth	1.032s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/capture	1.031s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/csrf	1.028s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit	1.153s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/sse	1.326s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/templates	1.046s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore	1.064s

$ golangci-lint run ./internal/api/...
# no issues in capture_filter.go / capture_filter_test.go
# (3 unrelated pre-existing findings from other packages resolved against a
#  stale sibling worktree path, not this change)

$ cd ui && npm run typecheck
> niac-ui@0.0.0 typecheck
> tsgo --build --noEmit
(no output — clean)

$ npm run test
 Test Files  48 passed (48)
      Tests  250 passed (250)

$ npx @biomejs/biome check src/
Checked 291 files in 2s. No fixes applied.

$ npm run build
✓ built in 1.35s

$ ../scripts/check-token-discipline.sh
OK: blocking color-token discipline is clean (advisory warnings, if any, are non-blocking).
```

Note: `scripts/i18n/validate.sh` reports 2 pre-existing failures (an unused-key list and an `i18next` version pin drift) that are present identically on `origin/main` before this change (verified via `git stash` + re-run) — unrelated to this PR.

## Security and Release Checklist
- [x] No new AI-customer-facing surface; no banned vocabulary introduced.
- [x] The echoed libpcap message describes only the caller's own submitted BPF filter (their own input round-tripped back to them) — not an internal error, stack trace, or unrelated system detail. No new information disclosure.
- [x] CSRF/auth/rate-limit posture unchanged — this only enriches an existing 400 error response body on an existing mutating route (`PUT /api/v1/capture/filter`), the wrapper stack is untouched.
- [x] No `//nolint`, `biome-ignore`, or `#nosec` suppressions added.
- [x] `go test ./internal/api/... -race` green; UI `typecheck`, `test`, `biome check`, and `build` all green.
- [x] No new user-visible static strings requiring i18n keys (the surfaced text is a dynamic libpcap error message, not a translatable UI label).
