### PR TITLE
feat(walk): add OID to validation issues + OID column/filter

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -592,7 +592,18 @@
       "issues": "Issues"
     },
     "batchStatusValid": "Valid",
-    "batchStatusInvalid": "Invalid"
+    "batchStatusInvalid": "Invalid",
+    "issuesTable": {
+      "line": "Line",
+      "severity": "Severity",
+      "message": "Message",
+      "original": "Original",
+      "oid": "OID"
+    },
+    "oidFilterLabel": "Filter by OID",
+    "oidFilterPlaceholder": "e.g. .1.3.6.1.2.1.1",
+    "noMatchingIssues": "No issues match that OID filter.",
+    "showingFiltered": "Showing first {{shown}} of {{filtered}} matching issues ({{total}} total) — auto-fix to clear them all."
   },
   "walkAnalyzer": {
     "label": "Walk Analyzer",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -592,7 +592,18 @@
       "issues": "Problemas"
     },
     "batchStatusValid": "Válido",
-    "batchStatusInvalid": "No válido"
+    "batchStatusInvalid": "No válido",
+    "issuesTable": {
+      "line": "Línea",
+      "severity": "Gravedad",
+      "message": "Mensaje",
+      "original": "Original",
+      "oid": "OID"
+    },
+    "oidFilterLabel": "Filtrar por OID",
+    "oidFilterPlaceholder": "p. ej. .1.3.6.1.2.1.1",
+    "noMatchingIssues": "Ningún problema coincide con ese filtro de OID.",
+    "showingFiltered": "Mostrando los primeros {{shown}} de {{filtered}} problemas coincidentes ({{total}} en total) — corrija automáticamente para eliminarlos todos."
   },
   "walkAnalyzer": {
     "label": "Analizador de Walk",

--- a/internal/protocols/snmp/walk.go
+++ b/internal/protocols/snmp/walk.go
@@ -196,6 +196,19 @@ func ParseWalkFile(filename string) ([]WalkEntry, error) {
 	return entries, nil
 }
 
+// extractLineOID extracts the OID portion of a raw walk-file line (everything
+// before the first "="), trimmed of whitespace. Returns "" if the line has no
+// "=" separator. Shared between ParseWalkFile's line parser and the walk
+// validator so both agree on what counts as "the OID for this line".
+func extractLineOID(line string) string {
+	parts := strings.SplitN(strings.TrimSpace(line), "=", OIDPartsMinPDU)
+	if len(parts) != OIDPartsMinPDU {
+		return ""
+	}
+
+	return strings.TrimSpace(parts[0])
+}
+
 // parseWalkLine parses a single line from a walk file.
 func parseWalkLine(line string) (*WalkEntry, error) {
 	// Match pattern: OID = TYPE: VALUE
@@ -205,7 +218,7 @@ func parseWalkLine(line string) (*WalkEntry, error) {
 		return nil, ErrInvalidWalkFormat
 	}
 
-	oid := strings.TrimSpace(parts[0])
+	oid := extractLineOID(line)
 	rest := strings.TrimSpace(parts[1])
 
 	// net-snmp emits zero-length octet strings with no type prefix, as

--- a/internal/protocols/snmp/walk_validator.go
+++ b/internal/protocols/snmp/walk_validator.go
@@ -18,6 +18,7 @@ type ValidationIssue struct {
 	Original   string `json:"original"`
 	Suggestion string `json:"suggestion,omitempty"`
 	AutoFix    bool   `json:"auto_fix"` // Whether this can be auto-fixed
+	OID        string `json:"oid,omitempty"`
 }
 
 // ValidationResult contains the results of validating a walk file.
@@ -148,8 +149,23 @@ func containsError(issues []ValidationIssue) bool {
 	return false
 }
 
-// validateWalkLine validates a single line and returns any issues found.
+// validateWalkLine validates a single line and returns any issues found, each
+// stamped with the OID parsed from the line (via the shared extractLineOID
+// parser used by ParseWalkFile). Structural issues where no OID could be
+// parsed (e.g. a missing "=" separator) are left with an empty OID.
 func validateWalkLine(lineNum int, line string) []ValidationIssue {
+	issues := collectWalkLineIssues(lineNum, line)
+
+	lineOID := extractLineOID(line)
+	for i := range issues {
+		issues[i].OID = lineOID
+	}
+
+	return issues
+}
+
+// collectWalkLineIssues performs the actual per-line validation checks.
+func collectWalkLineIssues(lineNum int, line string) []ValidationIssue {
 	var issues []ValidationIssue
 
 	trimmedLine := strings.TrimSpace(line)

--- a/internal/protocols/snmp/walk_validator_test.go
+++ b/internal/protocols/snmp/walk_validator_test.go
@@ -1,0 +1,91 @@
+package snmp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestValidateWalkFile_IssueOID verifies that ValidationIssue.OID is populated
+// with the OID parsed from the offending line, using the same line parser
+// ParseWalkFile relies on (extractLineOID), for issues tied to a specific line.
+func TestValidateWalkFile_IssueOID(t *testing.T) {
+	tmpDir := t.TempDir()
+	walkPath := filepath.Join(tmpDir, "test.walk")
+
+	// Line 1 is valid. Line 2 has a misspelled type ("STRNG") on a known OID,
+	// which should surface a warning issue carrying that OID. Line 3 has no
+	// "=" separator at all, so no OID can be parsed for its issue.
+	content := ".1.3.6.1.2.1.1.1.0 = STRING: \"Cisco IOS Software\"\n" +
+		".1.3.6.1.2.1.1.5.0 = STRNG: \"router1\"\n" +
+		"not-a-valid-line-at-all\n"
+
+	if err := os.WriteFile(walkPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write test walk file: %v", err)
+	}
+
+	result, err := ValidateWalkFile(walkPath)
+	if err != nil {
+		t.Fatalf("ValidateWalkFile returned error: %v", err)
+	}
+
+	var misspellingIssue, missingEqualsIssue *ValidationIssue
+	for i := range result.Issues {
+		issue := &result.Issues[i]
+		switch issue.Line {
+		case 2:
+			misspellingIssue = issue
+		case 3:
+			missingEqualsIssue = issue
+		}
+	}
+
+	if misspellingIssue == nil {
+		t.Fatalf("expected an issue on line 2, got issues: %+v", result.Issues)
+	}
+
+	wantOID := ".1.3.6.1.2.1.1.5.0"
+	if misspellingIssue.OID != wantOID {
+		t.Errorf("line 2 issue OID = %q, want %q", misspellingIssue.OID, wantOID)
+	}
+
+	if missingEqualsIssue == nil {
+		t.Fatalf("expected an issue on line 3, got issues: %+v", result.Issues)
+	}
+
+	if missingEqualsIssue.OID != "" {
+		t.Errorf("line 3 (no '=' separator) issue OID = %q, want empty", missingEqualsIssue.OID)
+	}
+}
+
+// TestValidateWalkLine_OIDMatchesExtractLineOID verifies every issue returned
+// for a line carries the same OID extractLineOID would parse from that line,
+// confirming the validator reuses the shared walk-line OID parser rather than
+// a bespoke extraction.
+func TestValidateWalkLine_OIDMatchesExtractLineOID(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{name: "double dot OID", line: ".1.3.6.1..2.1.1.1.0 = STRING: \"x\""},
+		{name: "trailing dot OID", line: ".1.3.6.1.2.1.1.1.0. = STRING: \"x\""},
+		{name: "unquoted string value", line: ".1.3.6.1.2.1.1.5.0 = STRING: router1"},
+		{name: "misspelled type", line: ".1.3.6.1.2.1.1.5.0 = STRNG: \"router1\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := validateWalkLine(1, tt.line)
+			if len(issues) == 0 {
+				t.Fatalf("expected at least one issue for line %q", tt.line)
+			}
+
+			want := extractLineOID(tt.line)
+			for _, issue := range issues {
+				if issue.OID != want {
+					t.Errorf("issue OID = %q, want %q (line=%q)", issue.OID, want, tt.line)
+				}
+			}
+		})
+	}
+}

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -90,6 +90,7 @@ export interface WalkValidationIssue {
   original: string;
   suggestion?: string;
   autoFix: boolean;
+  oid?: string;
 }
 
 /**

--- a/ui/src/pages/WalkValidatorPage.test.tsx
+++ b/ui/src/pages/WalkValidatorPage.test.tsx
@@ -148,3 +148,63 @@ describe('WalkValidatorPage — Validate all', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('daemon unavailable');
   });
 });
+
+describe('WalkValidatorPage — OID column and filter', () => {
+  const validateResult = {
+    message: 'Walk file has 2 issues',
+    result: {
+      totalLines: 2,
+      validLines: 0,
+      valid: false,
+      issues: [
+        {
+          line: 1,
+          severity: 'warning',
+          message: "Type 'strng' appears to be misspelled",
+          original: '.1.3.6.1.2.1.1.5.0 = strng: "router1"',
+          autoFix: true,
+          oid: '.1.3.6.1.2.1.1.5.0',
+        },
+        {
+          line: 2,
+          severity: 'error',
+          message: "Missing ':' separator between type and value",
+          original: '.1.3.6.1.4.1.9.1.1 = STRINGnope',
+          autoFix: false,
+          oid: '.1.3.6.1.4.1.9.1.1',
+        },
+      ],
+    },
+  };
+
+  it('renders the OID for each issue in the results table', async () => {
+    fetchLibraryWalks.mockResolvedValue(files);
+    validateWalk.mockResolvedValueOnce(validateResult);
+    render(<WalkValidatorPage />);
+
+    await waitFor(() => expect(screen.getByText(/cisco\/c3900\.walk/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /^validate$/i }));
+
+    expect(await screen.findByText('.1.3.6.1.2.1.1.5.0')).toBeInTheDocument();
+    expect(screen.getByText('.1.3.6.1.4.1.9.1.1')).toBeInTheDocument();
+  });
+
+  it('narrows the displayed issues by OID substring', async () => {
+    fetchLibraryWalks.mockResolvedValue(files);
+    validateWalk.mockResolvedValueOnce(validateResult);
+    render(<WalkValidatorPage />);
+
+    await waitFor(() => expect(screen.getByText(/cisco\/c3900\.walk/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /^validate$/i }));
+
+    await waitFor(() => expect(screen.getByText('.1.3.6.1.2.1.1.5.0')).toBeInTheDocument());
+    expect(screen.getByText('.1.3.6.1.4.1.9.1.1')).toBeInTheDocument();
+
+    const filterInput = screen.getByPlaceholderText(/1\.3\.6\.1\.2\.1\.1/);
+    fireEvent.change(filterInput, { target: { value: '9.1.1' } });
+
+    await waitFor(() => expect(screen.queryByText('.1.3.6.1.2.1.1.5.0')).not.toBeInTheDocument());
+    expect(screen.getByText('.1.3.6.1.4.1.9.1.1')).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -47,6 +47,7 @@ export const WalkValidatorPage: FC = () => {
 
   const [selectedFile, setSelectedFile] = useState<string>('');
   const [customPath, setCustomPath] = useState<string>('');
+  const [oidFilter, setOidFilter] = useState<string>('');
 
   const [response, setResponse] = useState<WalkValidationResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -90,6 +91,17 @@ export const WalkValidatorPage: FC = () => {
   const issues = response?.result?.issues ?? [];
   const counts = useMemo(() => severityCounts(issues), [issues]);
 
+  // OID filter applies to the FULL issue list before the 200-row display
+  // cap below, so a match past the cap is still reachable by filtering.
+  const filteredIssues = useMemo(() => {
+    const needle = oidFilter.trim().toLowerCase();
+    if (!needle) return issues;
+    return issues.filter((issue) => (issue.oid ?? '').toLowerCase().includes(needle));
+  }, [issues, oidFilter]);
+
+  const ISSUES_DISPLAY_CAP = 200;
+  const visibleIssues = filteredIssues.slice(0, ISSUES_DISPLAY_CAP);
+
   const run = useCallback(
     async (action: 'validating' | 'fixing') => {
       if (!targetPath) {
@@ -102,6 +114,7 @@ export const WalkValidatorPage: FC = () => {
         const result =
           action === 'fixing' ? await fixWalk(targetPath) : await validateWalk(targetPath);
         setResponse(result);
+        setOidFilter('');
       } catch (err) {
         setError((err as Error).message);
       } finally {
@@ -261,20 +274,37 @@ export const WalkValidatorPage: FC = () => {
               )}
             </header>
 
+            {issues.length > 0 && (
+              <label className="block text-sm">
+                <span className="text-text-secondary">{t('walkValidator.oidFilterLabel')}</span>
+                <input
+                  type="text"
+                  value={oidFilter}
+                  onChange={(e) => setOidFilter(e.target.value)}
+                  placeholder={t('walkValidator.oidFilterPlaceholder')}
+                  title="Filters the full issue list by OID substring before applying the display cap below."
+                  className="mt-tight w-full max-w-sm rounded border border-surface-border bg-bg-base/60 px-3 py-row font-mono text-xs text-text-primary placeholder:text-text-muted focus:border-status-info focus:outline-none"
+                />
+              </label>
+            )}
+
             {issues.length === 0 ? (
               <p className="text-sm text-text-muted">No issues reported.</p>
+            ) : filteredIssues.length === 0 ? (
+              <p className="text-sm text-text-muted">{t('walkValidator.noMatchingIssues')}</p>
             ) : (
               <table className="w-full text-sm">
                 <thead className="bg-bg-base/40 text-left text-xs uppercase tracking-wider text-text-muted">
                   <tr>
-                    <th className="px-3 py-row w-16">Line</th>
-                    <th className="px-3 py-row w-24">Severity</th>
-                    <th className="px-3 py-row">Message</th>
-                    <th className="px-3 py-row">Original</th>
+                    <th className="px-3 py-row w-16">{t('walkValidator.issuesTable.line')}</th>
+                    <th className="px-3 py-row w-24">{t('walkValidator.issuesTable.severity')}</th>
+                    <th className="px-3 py-row">{t('walkValidator.issuesTable.message')}</th>
+                    <th className="px-3 py-row">{t('walkValidator.issuesTable.oid')}</th>
+                    <th className="px-3 py-row">{t('walkValidator.issuesTable.original')}</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-knob/5">
-                  {issues.slice(0, 200).map((issue, idx) => (
+                  {visibleIssues.map((issue, idx) => (
                     <tr
                       key={`${issue.line}-${idx}`}
                       className="text-text-primary hover:bg-bg-base/40"
@@ -290,6 +320,9 @@ export const WalkValidatorPage: FC = () => {
                         </span>
                       </td>
                       <td className="px-3 py-row">{issue.message}</td>
+                      <td className="px-3 py-row font-mono text-xs text-text-muted">
+                        {issue.oid ?? ''}
+                      </td>
                       <td className="px-3 py-row truncate font-mono text-xs text-text-muted">
                         {issue.original}
                       </td>
@@ -298,9 +331,13 @@ export const WalkValidatorPage: FC = () => {
                 </tbody>
               </table>
             )}
-            {issues.length > 200 && (
+            {filteredIssues.length > ISSUES_DISPLAY_CAP && (
               <p className="text-xs text-text-muted">
-                Showing first 200 of {issues.length} issues — auto-fix to clear them all.
+                {t('walkValidator.showingFiltered', {
+                  shown: ISSUES_DISPLAY_CAP,
+                  filtered: filteredIssues.length,
+                  total: issues.length,
+                })}
               </p>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary
- Add an `OID` field to `snmp.ValidationIssue`, populated from the shared `extractLineOID` walk-line parser (also used by `ParseWalkFile`) so validator issues and replay parsing agree on what "the OID for this line" means; structural issues with no parseable OID (e.g. missing `=` separator) leave it empty via `omitempty`.
- Surface the OID in the Walk Validator UI: a new OID column in the issues table plus a substring filter, applied to the full issue list before the existing 200-row display cap so filtering can reach issues past the cap.
- Add the new column header / filter label / placeholder / "no matches" / "showing filtered" strings to both `en` and `es` `pages.json` under `walkValidator`, keeping OID/SNMP/walk verbatim in the Spanish copy per the DNT convention.

## Linked Issue
Related to #897

## Testing Evidence
```text
$ go test ./internal/protocols/snmp/... -race
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp	7.764s
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp/synth	1.040s

$ go test ./internal/api/... -race
ok  	github.com/MustardSeedNetworks/niac-go/internal/api	87.962s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/auth	1.080s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/capture	1.083s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/csrf	1.060s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit	1.244s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/sse	1.404s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/templates	1.124s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore	1.109s

$ golangci-lint run ./internal/protocols/snmp/... ./internal/api/...
0 issues.

$ npm run typecheck
> niac-ui@0.0.0 typecheck
> tsgo --build --noEmit
(clean, no output)

$ npm run test
 Test Files  47 passed (47)
      Tests  250 passed (250)
   Duration  41.22s

$ npx @biomejs/biome check src/
Checked 290 files in 790ms. No fixes applied.

$ npm run build
../internal/api/ui/assets/WalkValidatorPage-DRj_CH9F.js  11.28 kB │ gzip: 3.13 kB
...
✓ built in 1.75s

$ ./scripts/check-token-discipline.sh
OK: blocking color-token discipline is clean (advisory warnings, if any, are non-blocking).
```

## Security and Release Checklist
- [x] No new secrets or credentials introduced
- [x] No auth/CSRF surface touched — this change adds a read-only field to an existing GET/POST validation response, no new mutating routes
- [x] No default credentials involved
- [x] `go test -race`, `golangci-lint`, `tsgo` typecheck, `vitest`, and Biome all clean with zero suppressions
- [x] i18n parity + DNT (do-not-translate) test passes for the new strings (OID/SNMP/walk kept verbatim in es)
