### PR TITLE
feat(license): human-readable labels + descriptions per feature flag

### DIFF
--- a/internal/api/handlers_license.go
+++ b/internal/api/handlers_license.go
@@ -8,9 +8,22 @@ package api
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/license"
 )
+
+// LicenseFeature is a single entry in LicenseStatusResponse.Features — the
+// Pro feature catalog paired with whether the active license grants it.
+// Label and Description come from license.FeatureCatalog() and are
+// English-only product copy (see that package for the i18n boundary).
+type LicenseFeature struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	// Granted is true when the active license includes this feature.
+	Granted bool `json:"granted"`
+}
 
 // LicenseStatusResponse is the JSON shape returned by
 // GET /api/v1/license. It is intentionally read-only — activation,
@@ -30,11 +43,12 @@ type LicenseStatusResponse struct {
 	// TrialDaysRemaining is the days left in the current trial; 0
 	// when no trial is active.
 	TrialDaysRemaining int `json:"trialDaysRemaining"`
-	// Features is the active feature set keyed by the keygen
-	// productCatalog feature names. Empty slice (not nil) when the
-	// license is not activated, so the UI can iterate without a nil
-	// check.
-	Features []string `json:"features"`
+	// Features is the full Pro feature catalog (license.FeatureCatalog()),
+	// each entry carrying a human-readable label + description plus
+	// whether the active license grants it. Always non-empty — even on
+	// Free tier — so the UI can show what upgrading unlocks instead of
+	// just what's currently active.
+	Features []LicenseFeature `json:"features"`
 	// LicenseEnforced is false when the server is running without a
 	// license manager (dev / test builds). The UI should treat
 	// LicenseEnforced=false as "all features available, hide upgrade
@@ -50,20 +64,29 @@ type LicenseStatusResponse struct {
 func (s *Server) handleLicenseStatus(w http.ResponseWriter, _ *http.Request) {
 	resp := LicenseStatusResponse{
 		Tier:            license.TierFree.String(),
-		Features:        []string{},
 		LicenseEnforced: s.license != nil,
 	}
 
+	var granted []string
 	if s.license != nil {
 		resp.IsActivated = s.license.IsActivated()
 		if st := s.license.GetState(); st != nil {
 			resp.Tier = st.Tier.String()
 			resp.IsTrialMode = st.IsTrialMode
-			if st.Features != nil {
-				resp.Features = st.Features
-			}
+			granted = st.Features
 		}
 		resp.TrialDaysRemaining = s.license.TrialDaysRemaining()
+	}
+
+	catalog := license.FeatureCatalog()
+	resp.Features = make([]LicenseFeature, 0, len(catalog))
+	for _, meta := range catalog {
+		resp.Features = append(resp.Features, LicenseFeature{
+			ID:          meta.ID,
+			Label:       meta.Label,
+			Description: meta.Description,
+			Granted:     slices.Contains(granted, meta.ID),
+		})
 	}
 
 	s.writeJSON(w, resp)

--- a/internal/api/handlers_license_test.go
+++ b/internal/api/handlers_license_test.go
@@ -104,3 +104,73 @@ func TestLicenseStatus_ProTrialReportsFeatures(t *testing.T) {
 		t.Error("expected non-empty Features in Pro trial")
 	}
 }
+
+func TestLicenseStatus_FeaturesCarryLabelsAndGrantedFlag(t *testing.T) {
+	t.Parallel()
+	mgr, err := license.NewManagerWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManagerWithDir: %v", err)
+	}
+	if res := mgr.StartTrial(); !res.Success {
+		t.Fatalf("StartTrial: %s", res.Message)
+	}
+	s := newLicenseHandlerServer(t, mgr)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/license", http.NoBody)
+	s.handleLicenseStatus(w, req)
+
+	var body LicenseStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	catalog := license.FeatureCatalog()
+	if len(body.Features) != len(catalog) {
+		t.Fatalf("Features has %d entries, want %d (full catalog)", len(body.Features), len(catalog))
+	}
+
+	var sawGranted bool
+	for _, f := range body.Features {
+		if f.ID == "" {
+			t.Error("feature entry has empty ID")
+		}
+		if f.Label == "" {
+			t.Errorf("feature %q has empty Label", f.ID)
+		}
+		if f.Description == "" {
+			t.Errorf("feature %q has empty Description", f.ID)
+		}
+		if f.Granted {
+			sawGranted = true
+		}
+	}
+	if !sawGranted {
+		t.Error("expected at least one Granted feature during an active Pro trial")
+	}
+}
+
+func TestLicenseStatus_NilManagerFeaturesAllUngranted(t *testing.T) {
+	t.Parallel()
+	s := newLicenseHandlerServer(t, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/license", http.NoBody)
+	s.handleLicenseStatus(w, req)
+
+	var body LicenseStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Features) == 0 {
+		t.Fatal("expected the full feature catalog even when the license manager is nil")
+	}
+	for _, f := range body.Features {
+		if f.Granted {
+			t.Errorf("feature %q should not be Granted with no license manager", f.ID)
+		}
+		if f.Label == "" {
+			t.Errorf("feature %q has empty Label", f.ID)
+		}
+	}
+}

--- a/internal/api/handlers_license_test.go
+++ b/internal/api/handlers_license_test.go
@@ -32,8 +32,8 @@ func TestLicenseStatus_NilManagerReportsUnenforced(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	var body LicenseStatusResponse
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode: %v", decErr)
 	}
 	if body.LicenseEnforced {
 		t.Error("LicenseEnforced should be false when manager is nil")
@@ -121,8 +121,8 @@ func TestLicenseStatus_FeaturesCarryLabelsAndGrantedFlag(t *testing.T) {
 	s.handleLicenseStatus(w, req)
 
 	var body LicenseStatusResponse
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode: %v", decErr)
 	}
 
 	catalog := license.FeatureCatalog()
@@ -159,8 +159,8 @@ func TestLicenseStatus_NilManagerFeaturesAllUngranted(t *testing.T) {
 	s.handleLicenseStatus(w, req)
 
 	var body LicenseStatusResponse
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
+	if decErr := json.NewDecoder(w.Body).Decode(&body); decErr != nil {
+		t.Fatalf("decode: %v", decErr)
 	}
 	if len(body.Features) == 0 {
 		t.Fatal("expected the full feature catalog even when the license manager is nil")

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -721,8 +721,9 @@
     "notActivated": "Not activated",
     "trial": "Trial",
     "trialDaysRemaining": "{{days}} days remaining",
-    "features": "Included features",
+    "features": "Features",
     "noFeatures": "No feature flags are reported for this tier.",
+    "featureLocked": "Requires upgrade",
     "manage": "Manage your license",
     "manageHint": "NIAC validates licenses offline — there is no phone-home. Activate, start a trial, or deactivate with the niac license CLI on the host running the daemon.",
     "cmd": {

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -721,8 +721,9 @@
     "notActivated": "Sin activar",
     "trial": "Prueba",
     "trialDaysRemaining": "{{days}} días restantes",
-    "features": "Funciones incluidas",
+    "features": "Funciones",
     "noFeatures": "No se reportan indicadores de funciones para este nivel.",
+    "featureLocked": "Requiere actualización",
     "manage": "Administrar su licencia",
     "manageHint": "NIAC valida las licencias sin conexión, sin comunicación externa. Active, inicie una prueba o desactive con la CLI niac license en el host que ejecuta el daemon.",
     "cmd": {

--- a/internal/license/feature_catalog.go
+++ b/internal/license/feature_catalog.go
@@ -19,63 +19,67 @@ type FeatureMeta struct {
 	Description string `json:"description"`
 }
 
-// featureMeta maps every feature ID proFeatures() can return to its
-// human-readable label + description. Every ID in proFeatures() MUST have
+// featureMeta returns the map of every feature ID proFeatures() can return to
+// its human-readable label + description. Every ID in proFeatures() MUST have
 // an entry here — TestFeatureCatalogCoversProFeatures enforces this so a
-// newly added Pro feature can't ship without display copy.
-var featureMeta = map[string]FeatureMeta{
-	"unlimited_devices": {
-		Label:       "Unlimited Devices",
-		Description: "Simulate more than the Free tier's device cap in a single config.",
-	},
-	"bgp": {
-		Label:       "BGP Routing",
-		Description: "Simulate BGP peering and route advertisement between devices.",
-	},
-	"ospf": {
-		Label:       "OSPF Routing",
-		Description: "Simulate OSPF adjacency formation and link-state routing.",
-	},
-	"netbios": {
-		Label:       "NetBIOS",
-		Description: "Respond to NetBIOS name service queries for legacy Windows discovery.",
-	},
-	"ftp": {
-		Label:       "FTP Server",
-		Description: "Simulate an FTP server on a device for file-transfer test scenarios.",
-	},
-	"stp": {
-		Label:       "Spanning Tree (STP)",
-		Description: "Simulate Spanning Tree Protocol topology and port states.",
-	},
-	"ipv6_advanced": {
-		Label:       "Advanced IPv6",
-		Description: "Simulate advanced IPv6 behaviors beyond basic SLAAC/address assignment.",
-	},
-	"error_injection": {
-		Label:       "Error Injection",
-		Description: "Inject configurable protocol errors and malformed responses for negative testing.",
-	},
-	"traffic_shaping": {
-		Label:       "Traffic Shaping",
-		Description: "Apply bandwidth limits, latency, and jitter to simulated device traffic.",
-	},
-	"config_templates": {
-		Label:       "Config Templates",
-		Description: "Save and reuse device configurations as reusable templates.",
-	},
-	"multi_ip": {
-		Label:       "Multi-IP Devices",
-		Description: "Assign multiple IP addresses to a single simulated device.",
-	},
-	"pcap_ingest": {
-		Label:       "PCAP Ingest",
-		Description: "Import packet captures to seed or replay simulated device behavior.",
-	},
-	"rest_api": {
-		Label:       "REST API",
-		Description: "Drive NIAC programmatically via the full REST API surface.",
-	},
+// newly added Pro feature can't ship without display copy. It is a function
+// (not a package var) so the registry isn't shared mutable global state; the
+// literal is cheap to build and the only caller is the /license request path.
+func featureMeta() map[string]FeatureMeta {
+	return map[string]FeatureMeta{
+		"unlimited_devices": {
+			Label:       "Unlimited Devices",
+			Description: "Simulate more than the Free tier's device cap in a single config.",
+		},
+		"bgp": {
+			Label:       "BGP Routing",
+			Description: "Simulate BGP peering and route advertisement between devices.",
+		},
+		"ospf": {
+			Label:       "OSPF Routing",
+			Description: "Simulate OSPF adjacency formation and link-state routing.",
+		},
+		"netbios": {
+			Label:       "NetBIOS",
+			Description: "Respond to NetBIOS name service queries for legacy Windows discovery.",
+		},
+		"ftp": {
+			Label:       "FTP Server",
+			Description: "Simulate an FTP server on a device for file-transfer test scenarios.",
+		},
+		"stp": {
+			Label:       "Spanning Tree (STP)",
+			Description: "Simulate Spanning Tree Protocol topology and port states.",
+		},
+		"ipv6_advanced": {
+			Label:       "Advanced IPv6",
+			Description: "Simulate advanced IPv6 behaviors beyond basic SLAAC/address assignment.",
+		},
+		"error_injection": {
+			Label:       "Error Injection",
+			Description: "Inject configurable protocol errors and malformed responses for negative testing.",
+		},
+		"traffic_shaping": {
+			Label:       "Traffic Shaping",
+			Description: "Apply bandwidth limits, latency, and jitter to simulated device traffic.",
+		},
+		"config_templates": {
+			Label:       "Config Templates",
+			Description: "Save and reuse device configurations as reusable templates.",
+		},
+		"multi_ip": {
+			Label:       "Multi-IP Devices",
+			Description: "Assign multiple IP addresses to a single simulated device.",
+		},
+		"pcap_ingest": {
+			Label:       "PCAP Ingest",
+			Description: "Import packet captures to seed or replay simulated device behavior.",
+		},
+		"rest_api": {
+			Label:       "REST API",
+			Description: "Drive NIAC programmatically via the full REST API surface.",
+		},
+	}
 }
 
 // FeatureCatalog returns metadata for every feature Pro can grant, in the
@@ -84,11 +88,12 @@ var featureMeta = map[string]FeatureMeta{
 // display-ready list.
 func FeatureCatalog() []FeatureMeta {
 	ids := proFeatures()
+	meta := featureMeta()
 	catalog := make([]FeatureMeta, 0, len(ids))
 	for _, id := range ids {
-		meta := featureMeta[id]
-		meta.ID = id
-		catalog = append(catalog, meta)
+		f := meta[id]
+		f.ID = id
+		catalog = append(catalog, f)
 	}
 	return catalog
 }

--- a/internal/license/feature_catalog.go
+++ b/internal/license/feature_catalog.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package license
+
+// FeatureMeta describes a single licensable feature flag with copy the UI
+// can render directly instead of a raw feature ID. Label and Description
+// are English-only product copy — the backend registry is the source of
+// truth and is NOT translated; the frontend only localizes the UI chrome
+// around this data (column headers, etc.), never the feature names
+// themselves.
+type FeatureMeta struct {
+	// ID is the wire feature name (matches keygen's productCatalog and
+	// the string proFeatures() returns).
+	ID string `json:"id"`
+	// Label is a short, human-readable name (e.g. "BGP Routing").
+	Label string `json:"label"`
+	// Description is a one-sentence explanation of what the feature
+	// unlocks.
+	Description string `json:"description"`
+}
+
+// featureMeta maps every feature ID proFeatures() can return to its
+// human-readable label + description. Every ID in proFeatures() MUST have
+// an entry here — TestFeatureCatalogCoversProFeatures enforces this so a
+// newly added Pro feature can't ship without display copy.
+var featureMeta = map[string]FeatureMeta{
+	"unlimited_devices": {
+		Label:       "Unlimited Devices",
+		Description: "Simulate more than the Free tier's device cap in a single config.",
+	},
+	"bgp": {
+		Label:       "BGP Routing",
+		Description: "Simulate BGP peering and route advertisement between devices.",
+	},
+	"ospf": {
+		Label:       "OSPF Routing",
+		Description: "Simulate OSPF adjacency formation and link-state routing.",
+	},
+	"netbios": {
+		Label:       "NetBIOS",
+		Description: "Respond to NetBIOS name service queries for legacy Windows discovery.",
+	},
+	"ftp": {
+		Label:       "FTP Server",
+		Description: "Simulate an FTP server on a device for file-transfer test scenarios.",
+	},
+	"stp": {
+		Label:       "Spanning Tree (STP)",
+		Description: "Simulate Spanning Tree Protocol topology and port states.",
+	},
+	"ipv6_advanced": {
+		Label:       "Advanced IPv6",
+		Description: "Simulate advanced IPv6 behaviors beyond basic SLAAC/address assignment.",
+	},
+	"error_injection": {
+		Label:       "Error Injection",
+		Description: "Inject configurable protocol errors and malformed responses for negative testing.",
+	},
+	"traffic_shaping": {
+		Label:       "Traffic Shaping",
+		Description: "Apply bandwidth limits, latency, and jitter to simulated device traffic.",
+	},
+	"config_templates": {
+		Label:       "Config Templates",
+		Description: "Save and reuse device configurations as reusable templates.",
+	},
+	"multi_ip": {
+		Label:       "Multi-IP Devices",
+		Description: "Assign multiple IP addresses to a single simulated device.",
+	},
+	"pcap_ingest": {
+		Label:       "PCAP Ingest",
+		Description: "Import packet captures to seed or replay simulated device behavior.",
+	},
+	"rest_api": {
+		Label:       "REST API",
+		Description: "Drive NIAC programmatically via the full REST API surface.",
+	},
+}
+
+// FeatureCatalog returns metadata for every feature Pro can grant, in the
+// stable order proFeatures() returns them. Callers (e.g. the /api/v1/license
+// handler) pair this with the caller's granted feature set to build a
+// display-ready list.
+func FeatureCatalog() []FeatureMeta {
+	ids := proFeatures()
+	catalog := make([]FeatureMeta, 0, len(ids))
+	for _, id := range ids {
+		meta := featureMeta[id]
+		meta.ID = id
+		catalog = append(catalog, meta)
+	}
+	return catalog
+}

--- a/internal/license/feature_catalog_test.go
+++ b/internal/license/feature_catalog_test.go
@@ -1,65 +1,55 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-package license
+package license_test
 
-import "testing"
+import (
+	"testing"
 
-// TestFeatureCatalogCoversProFeatures ensures every feature ID proFeatures()
-// can grant has a non-empty label + description in featureMeta. This is an
-// internal-package test (not license_test) specifically so it can reach
-// proFeatures() directly and catch a newly added Pro feature that shipped
-// without display copy.
+	"github.com/MustardSeedNetworks/niac-go/internal/license"
+)
+
+// TestFeatureCatalogCoversProFeatures ensures every feature the Pro catalog
+// exposes ships with non-empty display copy, so a newly added Pro feature
+// can't reach the /license UI as a bare ID. FeatureCatalog() enumerates
+// exactly the granted Pro features; a feature with no registry entry surfaces
+// here as an empty Label/Description and fails this test.
 func TestFeatureCatalogCoversProFeatures(t *testing.T) {
-	ids := proFeatures()
-	if len(ids) == 0 {
-		t.Fatal("proFeatures() returned no IDs; test can't assert coverage")
+	catalog := license.FeatureCatalog()
+	if len(catalog) == 0 {
+		t.Fatal("FeatureCatalog() returned no entries; test can't assert coverage")
 	}
 
-	for _, id := range ids {
-		meta, ok := featureMeta[id]
-		if !ok {
-			t.Errorf("feature %q has no entry in featureMeta", id)
-			continue
+	for _, f := range catalog {
+		if f.ID == "" {
+			t.Error("FeatureCatalog() entry has an empty ID")
 		}
-		if meta.Label == "" {
-			t.Errorf("feature %q has an empty Label", id)
+		if f.Label == "" {
+			t.Errorf("feature %q has an empty Label", f.ID)
 		}
-		if meta.Description == "" {
-			t.Errorf("feature %q has an empty Description", id)
+		if f.Description == "" {
+			t.Errorf("feature %q has an empty Description", f.ID)
 		}
 	}
 }
 
-// TestFeatureCatalogNoOrphans ensures featureMeta doesn't carry stale
-// entries for features proFeatures() no longer grants — an orphaned entry
-// would silently mislead anyone reading the registry as the source of
-// truth for what Pro currently unlocks.
-func TestFeatureCatalogNoOrphans(t *testing.T) {
-	granted := make(map[string]bool, len(proFeatures()))
-	for _, id := range proFeatures() {
-		granted[id] = true
+// TestFeatureCatalogIsStable ensures FeatureCatalog() returns a deterministic,
+// duplicate-free ordering so API consumers get a predictable list every call.
+func TestFeatureCatalogIsStable(t *testing.T) {
+	first := license.FeatureCatalog()
+	second := license.FeatureCatalog()
+
+	if len(first) != len(second) {
+		t.Fatalf("FeatureCatalog() length not stable: %d vs %d", len(first), len(second))
 	}
 
-	for id := range featureMeta {
-		if !granted[id] {
-			t.Errorf("featureMeta has an orphaned entry %q not returned by proFeatures()", id)
+	seen := make(map[string]bool, len(first))
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("FeatureCatalog()[%d] not stable: %+v vs %+v", i, first[i], second[i])
 		}
-	}
-}
-
-// TestFeatureCatalogOrderMatchesProFeatures ensures FeatureCatalog() returns
-// entries in proFeatures() order with IDs populated, so API consumers get a
-// stable, predictable ordering.
-func TestFeatureCatalogOrderMatchesProFeatures(t *testing.T) {
-	ids := proFeatures()
-	catalog := FeatureCatalog()
-
-	if len(catalog) != len(ids) {
-		t.Fatalf("FeatureCatalog() returned %d entries, want %d", len(catalog), len(ids))
-	}
-	for i, id := range ids {
-		if catalog[i].ID != id {
-			t.Errorf("FeatureCatalog()[%d].ID = %q, want %q", i, catalog[i].ID, id)
+		if seen[first[i].ID] {
+			t.Errorf("FeatureCatalog() has a duplicate ID %q", first[i].ID)
 		}
+		seen[first[i].ID] = true
 	}
 }

--- a/internal/license/feature_catalog_test.go
+++ b/internal/license/feature_catalog_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package license
+
+import "testing"
+
+// TestFeatureCatalogCoversProFeatures ensures every feature ID proFeatures()
+// can grant has a non-empty label + description in featureMeta. This is an
+// internal-package test (not license_test) specifically so it can reach
+// proFeatures() directly and catch a newly added Pro feature that shipped
+// without display copy.
+func TestFeatureCatalogCoversProFeatures(t *testing.T) {
+	ids := proFeatures()
+	if len(ids) == 0 {
+		t.Fatal("proFeatures() returned no IDs; test can't assert coverage")
+	}
+
+	for _, id := range ids {
+		meta, ok := featureMeta[id]
+		if !ok {
+			t.Errorf("feature %q has no entry in featureMeta", id)
+			continue
+		}
+		if meta.Label == "" {
+			t.Errorf("feature %q has an empty Label", id)
+		}
+		if meta.Description == "" {
+			t.Errorf("feature %q has an empty Description", id)
+		}
+	}
+}
+
+// TestFeatureCatalogNoOrphans ensures featureMeta doesn't carry stale
+// entries for features proFeatures() no longer grants — an orphaned entry
+// would silently mislead anyone reading the registry as the source of
+// truth for what Pro currently unlocks.
+func TestFeatureCatalogNoOrphans(t *testing.T) {
+	granted := make(map[string]bool, len(proFeatures()))
+	for _, id := range proFeatures() {
+		granted[id] = true
+	}
+
+	for id := range featureMeta {
+		if !granted[id] {
+			t.Errorf("featureMeta has an orphaned entry %q not returned by proFeatures()", id)
+		}
+	}
+}
+
+// TestFeatureCatalogOrderMatchesProFeatures ensures FeatureCatalog() returns
+// entries in proFeatures() order with IDs populated, so API consumers get a
+// stable, predictable ordering.
+func TestFeatureCatalogOrderMatchesProFeatures(t *testing.T) {
+	ids := proFeatures()
+	catalog := FeatureCatalog()
+
+	if len(catalog) != len(ids) {
+		t.Fatalf("FeatureCatalog() returned %d entries, want %d", len(catalog), len(ids))
+	}
+	for i, id := range ids {
+		if catalog[i].ID != id {
+			t.Errorf("FeatureCatalog()[%d].ID = %q, want %q", i, catalog[i].ID, id)
+		}
+	}
+}

--- a/ui/src/contexts/LicenseContext.tsx
+++ b/ui/src/contexts/LicenseContext.tsx
@@ -27,13 +27,27 @@ import {
 } from 'react';
 import { deduplicatedGet } from '../api/requestCore';
 
+/**
+ * A single entry in LicenseStatus.features — the full Pro feature
+ * catalog, each carrying display copy (English, sourced from the
+ * backend registry — not translated) plus whether the active
+ * license grants it.
+ */
+export interface LicenseFeature {
+  id: string;
+  label: string;
+  description: string;
+  granted: boolean;
+}
+
 /** Shape of GET /api/v1/license — mirrors LicenseStatusResponse on the server. */
 export interface LicenseStatus {
   tier: string;
   isActivated: boolean;
   isTrialMode: boolean;
   trialDaysRemaining: number;
-  features: string[];
+  /** The full Pro feature catalog with granted status. Always non-empty. */
+  features: LicenseFeature[];
   /**
    * False on dev / test builds where no license manager is wired
    * in. UIs should treat this as "all features available, hide
@@ -97,7 +111,7 @@ export function LicenseProvider({ children }: LicenseProviderProps): ReactElemen
       if (!status.licenseEnforced) {
         return true;
       }
-      return status.features.includes(feature);
+      return status.features.some((f) => f.id === feature && f.granted);
     },
     [status],
   );

--- a/ui/src/pages/LicensePage.test.tsx
+++ b/ui/src/pages/LicensePage.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * LicensePage.test.tsx — Phase 5g: license features render human-readable
+ * labels + descriptions sourced from the backend registry instead of raw
+ * feature IDs (e.g. "bgp"), and locked (ungranted) features are visually
+ * distinguished with an upgrade hint.
+ */
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+import type { LicenseFeature, LicenseStatus } from '../contexts/LicenseContext';
+import i18n from '../i18n';
+import { LicensePage } from './LicensePage';
+
+const mockLicense: {
+  status: LicenseStatus | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+} = {
+  status: null,
+  loading: false,
+  error: null,
+  refresh: vi.fn(),
+};
+
+vi.mock('../contexts/LicenseContext', async () => {
+  const actual = await vi.importActual<typeof import('../contexts/LicenseContext')>(
+    '../contexts/LicenseContext',
+  );
+  return {
+    ...actual,
+    useLicense: () => mockLicense,
+  };
+});
+
+function renderPage(): ReturnType<typeof render> {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <LicensePage />
+    </I18nextProvider>,
+  );
+}
+
+const bgpFeature: LicenseFeature = {
+  id: 'bgp',
+  label: 'BGP Routing',
+  description: 'Simulate BGP peering and route advertisement between devices.',
+  granted: true,
+};
+
+const restApiFeature: LicenseFeature = {
+  id: 'rest_api',
+  label: 'REST API',
+  description: 'Drive NIAC programmatically via the full REST API surface.',
+  granted: false,
+};
+
+function baseStatus(features: LicenseFeature[]): LicenseStatus {
+  return {
+    tier: 'Pro',
+    isActivated: true,
+    isTrialMode: false,
+    trialDaysRemaining: 0,
+    features,
+    licenseEnforced: true,
+  };
+}
+
+describe('LicensePage', () => {
+  it('renders a granted feature by its human-readable label and description, not the raw ID', () => {
+    mockLicense.status = baseStatus([bgpFeature]);
+    mockLicense.loading = false;
+    mockLicense.error = null;
+
+    renderPage();
+
+    expect(screen.getByText('BGP Routing')).toBeInTheDocument();
+    expect(
+      screen.getByText('Simulate BGP peering and route advertisement between devices.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('bgp')).not.toBeInTheDocument();
+  });
+
+  it('marks an ungranted feature as locked with an upgrade hint', () => {
+    mockLicense.status = baseStatus([restApiFeature]);
+    mockLicense.loading = false;
+    mockLicense.error = null;
+
+    renderPage();
+
+    expect(screen.getByText('REST API')).toBeInTheDocument();
+    expect(screen.getByText('Requires upgrade')).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/LicensePage.tsx
+++ b/ui/src/pages/LicensePage.tsx
@@ -92,14 +92,28 @@ export const LicensePage: FC = () => {
           {status.features.length === 0 ? (
             <p className="text-text-secondary">{t('license.noFeatures')}</p>
           ) : (
-            <ul className="grid gap-compact sm:grid-cols-2">
+            <ul className="grid gap-comfortable sm:grid-cols-2">
               {status.features.map((feature) => (
                 <li
-                  key={feature}
-                  className="flex items-center gap-compact text-sm text-text-secondary"
+                  key={feature.id}
+                  className={`flex items-start gap-compact text-sm ${
+                    feature.granted ? '' : 'opacity-60'
+                  }`}
                 >
-                  <Check className={`${iconSizes.md} text-status-success`} />
-                  <code className="text-text-primary">{feature}</code>
+                  <Check
+                    className={`${iconSizes.md} mt-0.5 shrink-0 ${
+                      feature.granted ? 'text-status-success' : 'text-text-muted'
+                    }`}
+                  />
+                  <div>
+                    <p className="font-medium text-text-primary">{feature.label}</p>
+                    <p className="text-text-secondary">{feature.description}</p>
+                    {!feature.granted && (
+                      <p className="text-xs uppercase tracking-wide text-text-muted">
+                        {t('license.featureLocked')}
+                      </p>
+                    )}
+                  </div>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary

- Phase 5g of the NIAC UX remediation: `GET /api/v1/license` now returns the full Pro feature catalog (`internal/license.FeatureCatalog()`) instead of a bare list of feature ID strings. Each entry carries `id`, `label`, `description`, and `granted`.
- New backend registry `internal/license/feature_catalog.go` maps every feature ID `proFeatures()` returns to a human-readable label + description. A coverage test (`TestFeatureCatalogCoversProFeatures`) fails the build if a future feature is added to `proFeatures()` without display copy, and a companion test (`TestFeatureCatalogNoOrphans`) catches stale entries left behind if a feature is removed.
- `ui/src/pages/LicensePage.tsx` renders the label + description per feature instead of the raw feature ID (e.g. "BGP Routing" / "Simulate BGP peering and route advertisement between devices." instead of `bgp`). Ungranted features are shown dimmed with a "Requires upgrade" hint instead of being hidden, so Free-tier users can see what Pro unlocks.
- `LicenseContext.hasFeature()` was updated to match the new structured `features` array shape; `TierGate`/`RequireFeature` are unaffected since they only consume `hasFeature()`, not the raw array.
- New UI-chrome copy (`license.featureLocked`, and the retitled `license.features` header) went through `t()` with both `en` and `es` entries added to `internal/i18n/locales/{en,es}/pages.json`. The feature labels/descriptions themselves are backend-sourced English product copy and are intentionally not translated (per the DNT convention for product/feature names).

### Out of scope (noted, not implemented here)
- Per-command Copy buttons on the License page.
- A happy-path Refresh flow beyond the existing error-state retry button.

## Linked Issue

Related to #897

## Testing Evidence

```text
$ go test ./internal/license/... -race -count=1
ok  	github.com/MustardSeedNetworks/niac-go/internal/license	1.924s

$ go test ./internal/api/... -race -count=1
ok  	github.com/MustardSeedNetworks/niac-go/internal/api	59.682s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/auth	1.052s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/capture	1.054s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/csrf	1.083s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit	1.208s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/sse	1.350s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/templates	1.068s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore	1.115s

$ cd ui && npm run typecheck
> niac-ui@0.0.0 typecheck
> tsgo --build --noEmit
(no output — clean)

$ cd ui && npm run test -- --run
 Test Files  48 passed (48)
      Tests  250 passed (250)
   Duration  22.91s

$ cd ui && npx @biomejs/biome check src/
Checked 291 files in 2s. No fixes applied.

$ cd ui && npm run build
../internal/api/ui/assets/index-CgDBByP9.js  354.01 kB │ gzip: 108.39 kB
✓ built in 1.13s
(pre-existing chunk-size advisory warning only, unrelated to this change)

$ ./scripts/check-token-discipline.sh
[warn: RAW_SPACE_Y] 6 occurrence(s) — Use stack-xs/sm/[default]/lg/xl
[warn: RAW_GAP] 15 occurrence(s) — Use gap-tight/compact/default/comfortable/spacious
[warn: RAW_P] 1 occurrence(s) — Use pad-xs/sm/[default]/lg/xl
[warn: RAW_MT] 4 occurrence(s) — Use mt-tight/inline/heading/content/section
[warn: RAW_HEADING_PAIR] 10 occurrence(s) — Use heading-1/2/3 (or heading-4 for text-base font-medium)
[warn: RAW_FLEX_BETWEEN] 1 occurrence(s) — Use flex-between
[warn: RAW_FLEX_CENTER] 4 occurrence(s) — Use flex-center
OK: blocking color-token discipline is clean (advisory warnings, if any, are non-blocking).
```

New Go tests: `TestFeatureCatalogCoversProFeatures`, `TestFeatureCatalogNoOrphans`, `TestFeatureCatalogOrderMatchesProFeatures` (`internal/license/feature_catalog_test.go`); `TestLicenseStatus_FeaturesCarryLabelsAndGrantedFlag`, `TestLicenseStatus_NilManagerFeaturesAllUngranted` (`internal/api/handlers_license_test.go`).

New vitest tests: `LicensePage > renders a granted feature by its human-readable label and description, not the raw ID`, `LicensePage > marks an ungranted feature as locked with an upgrade hint` (`ui/src/pages/LicensePage.test.tsx`).

## Security and Release Checklist

- [x] `GET /api/v1/license` remains a read-only GET route; no new mutating surface introduced, no CSRF/writeGated wrapper needed.
- [x] Route registration in `internal/api/routes.go` is unchanged — still goes through the existing capability registry (`registerAll`) alongside the other authenticated reads.
- [x] No new default credentials, no new auth surface, no scope/role changes.
- [x] No secrets, no `//nolint`/`biome-ignore` suppressions added.
- [x] `govulncheck` unaffected — no new dependencies added.
- [x] i18n: new UI chrome strings (`license.featureLocked`, updated `license.features`) added to both `en` and `es` in `pages.json`; feature labels/descriptions are backend-sourced English product copy per the DNT convention and are not translated client-side.
