### PR TITLE
feat(replay): live progress (packets/bytes sent, percent) in status + UI bar

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -188,6 +188,15 @@ type ReplayState struct {
 	LoopMs    int       `json:"loopMs"`
 	Scale     float64   `json:"scale"`
 	StartedAt time.Time `json:"startedAt,omitzero"`
+
+	// Progress counters for the current (or most recent) replay iteration.
+	// PacketsTotal/BytesTotal are 0 until the PCAP has been read; PercentComplete
+	// is omitted (not faked as 0) whenever PacketsTotal is unknown.
+	PacketsSent     uint64  `json:"packetsSent"`
+	BytesSent       uint64  `json:"bytesSent"`
+	PacketsTotal    uint64  `json:"packetsTotal"`
+	BytesTotal      uint64  `json:"bytesTotal"`
+	PercentComplete float64 `json:"percentComplete,omitempty"`
 }
 
 // ReplayManager controls PCAP playback from the API server.

--- a/internal/capture/playback.go
+++ b/internal/capture/playback.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gopacket/gopacket"
@@ -37,12 +38,30 @@ type PlaybackEngine struct {
 	stopChan   chan struct{}
 	wg         sync.WaitGroup
 	mu         sync.Mutex
+
+	// Progress counters, read via Progress(). packetsSent/bytesSent reset at
+	// the start of each playOnce (so a looped replay reports per-iteration
+	// progress rather than an ever-growing total); totalPackets/totalBytes
+	// are set once loadPCAP finishes reading the file.
+	packetsSent  atomic.Uint64
+	bytesSent    atomic.Uint64
+	totalPackets atomic.Uint64
+	totalBytes   atomic.Uint64
 }
 
 // PlaybackPacket represents a packet with timestamp for playback.
 type PlaybackPacket struct {
 	Data      []byte
 	Timestamp time.Time
+}
+
+// PlaybackProgress reports live counters for an in-progress (or just
+// finished) replay iteration.
+type PlaybackProgress struct {
+	PacketsSent  uint64
+	BytesSent    uint64
+	TotalPackets uint64
+	TotalBytes   uint64
 }
 
 // NewPlaybackEngine creates a new PCAP playback engine.
@@ -52,6 +71,17 @@ func NewPlaybackEngine(engine *Engine, playbackConfig *config.CapturePlayback, d
 		config:     playbackConfig,
 		debugLevel: debugLevel,
 		stopChan:   make(chan struct{}),
+	}
+}
+
+// Progress returns a snapshot of the current playback progress. Safe to call
+// concurrently with playbackLoop.
+func (p *PlaybackEngine) Progress() PlaybackProgress {
+	return PlaybackProgress{
+		PacketsSent:  p.packetsSent.Load(),
+		BytesSent:    p.bytesSent.Load(),
+		TotalPackets: p.totalPackets.Load(),
+		TotalBytes:   p.totalBytes.Load(),
 	}
 }
 
@@ -165,6 +195,17 @@ func (p *PlaybackEngine) playOnce() {
 		return
 	}
 
+	// Reset per-iteration progress counters so a looped replay reports
+	// progress against the current pass, not a running lifetime total.
+	var totalBytes uint64
+	for _, pkt := range packets {
+		totalBytes += uint64(len(pkt.Data))
+	}
+	p.packetsSent.Store(0)
+	p.bytesSent.Store(0)
+	p.totalPackets.Store(uint64(len(packets)))
+	p.totalBytes.Store(totalBytes)
+
 	if len(packets) == 0 {
 		p.logBasic("No packets found in PCAP file")
 		return
@@ -229,6 +270,8 @@ func (p *PlaybackEngine) sendPacketWithLogging(pkt PlaybackPacket, packetNum, to
 		p.logBasic("Error sending packet", "packetNum", packetNum, "error", err)
 		return
 	}
+	p.packetsSent.Add(1)
+	p.bytesSent.Add(uint64(len(pkt.Data)))
 	if p.debugLevel >= debugLevelVerbose {
 		slog.Debug("Sent packet", "packetNum", packetNum, "total", totalPackets, "bytes", len(pkt.Data))
 	}

--- a/internal/capture/playback_test.go
+++ b/internal/capture/playback_test.go
@@ -613,3 +613,94 @@ func TestPlaybackEngine_ConcurrentStartStop(t *testing.T) {
 		}
 	}
 }
+
+// TestPlaybackEngine_Progress_ZeroValue tests that a freshly constructed
+// engine reports an all-zero progress snapshot (no total known yet).
+func TestPlaybackEngine_Progress_ZeroValue(t *testing.T) {
+	pb := &PlaybackEngine{stopChan: make(chan struct{})}
+
+	progress := pb.Progress()
+	if progress.PacketsSent != 0 || progress.BytesSent != 0 {
+		t.Errorf("expected zero sent counters, got %+v", progress)
+	}
+	if progress.TotalPackets != 0 || progress.TotalBytes != 0 {
+		t.Errorf("expected zero total counters, got %+v", progress)
+	}
+}
+
+// TestPlaybackEngine_Progress_TracksCounters is a white-box test that drives
+// the atomic counters directly (same package) to verify Progress() reflects
+// them without needing a live capture engine.
+func TestPlaybackEngine_Progress_TracksCounters(t *testing.T) {
+	pb := &PlaybackEngine{stopChan: make(chan struct{})}
+
+	pb.totalPackets.Store(10)
+	pb.totalBytes.Store(1000)
+	pb.packetsSent.Store(3)
+	pb.bytesSent.Store(300)
+
+	progress := pb.Progress()
+	if progress.PacketsSent != 3 || progress.BytesSent != 300 {
+		t.Errorf("expected sent=3/300, got %+v", progress)
+	}
+	if progress.TotalPackets != 10 || progress.TotalBytes != 1000 {
+		t.Errorf("expected total=10/1000, got %+v", progress)
+	}
+}
+
+// TestPlaybackEngine_Progress_AfterPlayOnce runs a real playOnce() pass over
+// a loopback interface (same CI-skip convention as the rest of this file,
+// since sending packets needs raw-socket privileges) and asserts the
+// progress counters match the packets actually written to the PCAP.
+func TestPlaybackEngine_Progress_AfterPlayOnce(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping playback test in CI environment")
+	}
+
+	loopbackNames := []string{"lo", "lo0"}
+
+	var testInterface string
+
+	for _, name := range loopbackNames {
+		if InterfaceExists(name) {
+			testInterface = name
+
+			break
+		}
+	}
+
+	if testInterface == "" {
+		t.Skip("No loopback interface found")
+	}
+
+	engine, err := New(testInterface, 0)
+	if err != nil {
+		t.Skipf("Cannot create engine: %v", err)
+	}
+	defer engine.Close()
+
+	const packetCount = 5
+	pcapFile := createTestPCAP(t, packetCount)
+
+	playbackConfig := &config.CapturePlayback{FileName: pcapFile}
+	pb := NewPlaybackEngine(engine, playbackConfig, 0)
+
+	// playOnce is synchronous, so no polling/timing is needed to observe the
+	// final counters.
+	pb.playOnce()
+
+	progress := pb.Progress()
+	if progress.TotalPackets != packetCount {
+		t.Errorf("expected TotalPackets=%d, got %d", packetCount, progress.TotalPackets)
+	}
+	if progress.PacketsSent != packetCount {
+		t.Errorf("expected PacketsSent=%d, got %d", packetCount, progress.PacketsSent)
+	}
+	if progress.TotalBytes == 0 {
+		t.Error("expected non-zero TotalBytes")
+	}
+	if progress.BytesSent != progress.TotalBytes {
+		t.Errorf("expected BytesSent (%d) to equal TotalBytes (%d) after a full pass",
+			progress.BytesSent, progress.TotalBytes)
+	}
+}

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -309,7 +309,10 @@
       "recentRunsTag": "History",
       "recentRunsDescription": "Past simulation runs the daemon recorded.",
       "recentRunStats": "{{time}} · duration {{duration}} · RX {{rx}} · TX {{tx}}",
-      "noCapturedRuns": "No captured runs yet."
+      "noCapturedRuns": "No captured runs yet.",
+      "replayProgressLabel": "{{sent}} / {{total}} packets ({{percent}}%)",
+      "replayProgressBytes": "{{bytes}} sent",
+      "replayProgressUnknown": "Sending packets… (total unknown)"
     }
   },
   "debug": {

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -309,7 +309,10 @@
       "recentRunsTag": "Historial",
       "recentRunsDescription": "Ejecuciones de simulación pasadas registradas por el daemon.",
       "recentRunStats": "{{time}} · duración {{duration}} · RX {{rx}} · TX {{tx}}",
-      "noCapturedRuns": "Aún no hay ejecuciones capturadas."
+      "noCapturedRuns": "Aún no hay ejecuciones capturadas.",
+      "replayProgressLabel": "{{sent}} / {{total}} packets ({{percent}}%)",
+      "replayProgressBytes": "{{bytes}} enviados",
+      "replayProgressUnknown": "Enviando packets… (total desconocido)"
     }
   },
   "debug": {

--- a/internal/replay/controller.go
+++ b/internal/replay/controller.go
@@ -10,6 +10,7 @@ package replay
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,11 +49,44 @@ func New(engine *capture.Engine, debugLevel int) *Controller {
 	return &Controller{engine: engine, debugLevel: debugLevel}
 }
 
-// Status returns the current replay state.
+// Status returns the current replay state, including live progress counters
+// read from the running capture.PlaybackEngine (if any).
 func (c *Controller) Status() api.ReplayState {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.state
+
+	state := c.state
+	if c.current != nil {
+		progress := c.current.Progress()
+		state.PacketsSent = progress.PacketsSent
+		state.BytesSent = progress.BytesSent
+		state.PacketsTotal = progress.TotalPackets
+		state.BytesTotal = progress.TotalBytes
+		state.PercentComplete = percentComplete(progress.PacketsSent, progress.TotalPackets)
+	}
+	return state
+}
+
+// percentScale converts a fraction to a percentage; percentRoundingFactor
+// rounds percentComplete's result to two decimal places.
+const (
+	percentScale           = 100
+	percentRoundingFactor  = 100
+	percentCompleteMaximum = 100
+)
+
+// percentComplete returns sent/total as a percentage in [0, 100], rounded to
+// two decimal places. It returns 0 (which ReplayState omits from its JSON
+// via omitempty) when total is unknown rather than fabricating a value.
+func percentComplete(sent, total uint64) float64 {
+	if total == 0 {
+		return 0
+	}
+	pct := float64(sent) / float64(total) * percentScale
+	if pct > percentCompleteMaximum {
+		pct = percentCompleteMaximum
+	}
+	return math.Round(pct*percentRoundingFactor) / percentRoundingFactor
 }
 
 // Start begins PCAP replay with the given request. If a replay is already

--- a/internal/replay/controller_test.go
+++ b/internal/replay/controller_test.go
@@ -2,11 +2,128 @@ package replay_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcapgo"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/capture"
 	"github.com/MustardSeedNetworks/niac-go/internal/replay"
 )
+
+// writeTestPCAP writes a minimal PCAP with packetCount trivial Ethernet
+// frames, mirroring internal/capture's own test helper (unexported there,
+// so this package needs its own copy for the black-box Status() test
+// below).
+func writeTestPCAP(t *testing.T, packetCount int) string {
+	t.Helper()
+
+	pcapFile := filepath.Join(t.TempDir(), "replay-progress.pcap")
+
+	f, createErr := os.Create(pcapFile)
+	if createErr != nil {
+		t.Fatalf("failed to create temp PCAP: %v", createErr)
+	}
+	defer func() { _ = f.Close() }()
+
+	w := pcapgo.NewWriter(f)
+	if headerErr := w.WriteFileHeader(1600, layers.LinkTypeEthernet); headerErr != nil {
+		t.Fatalf("failed to write PCAP header: %v", headerErr)
+	}
+
+	srcMAC := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	dstMAC := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	baseTime := time.Now()
+
+	for i := range packetCount {
+		eth := &layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4}
+		buf := gopacket.NewSerializeBuffer()
+		payload := []byte{byte(i), 0x01, 0x02, 0x03}
+		opts := gopacket.SerializeOptions{}
+		if serializeErr := gopacket.SerializeLayers(buf, opts, eth, gopacket.Payload(payload)); serializeErr != nil {
+			t.Fatalf("failed to serialize packet: %v", serializeErr)
+		}
+		info := gopacket.CaptureInfo{
+			Timestamp:     baseTime.Add(time.Duration(i) * time.Millisecond),
+			CaptureLength: len(buf.Bytes()),
+			Length:        len(buf.Bytes()),
+		}
+		if writeErr := w.WritePacket(info, buf.Bytes()); writeErr != nil {
+			t.Fatalf("failed to write packet: %v", writeErr)
+		}
+	}
+
+	return pcapFile
+}
+
+// TestStatus_ReportsProgress drives a real replay over the loopback
+// interface and asserts Status() surfaces non-zero sent counters plus a
+// correct percent-complete once the pass finishes. Skipped in CI: sending
+// raw packets needs privileges the CI runner doesn't have (same convention
+// as internal/capture's playback tests).
+func TestStatus_ReportsProgress(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping replay test in CI environment")
+	}
+
+	var testInterface string
+	for _, name := range []string{"lo", "lo0"} {
+		if capture.InterfaceExists(name) {
+			testInterface = name
+			break
+		}
+	}
+	if testInterface == "" {
+		t.Skip("No loopback interface found")
+	}
+
+	engine, err := capture.New(testInterface, 0)
+	if err != nil {
+		t.Skipf("cannot create engine: %v", err)
+	}
+	defer engine.Close()
+
+	const packetCount = 5
+	pcapFile := writeTestPCAP(t, packetCount)
+
+	c := replay.New(engine, 0)
+	if _, startErr := c.Start(api.ReplayRequest{File: pcapFile}); startErr != nil {
+		t.Fatalf("Start failed: %v", startErr)
+	}
+
+	// Playback of a 5-packet, sub-millisecond-spaced PCAP finishes almost
+	// immediately; poll briefly rather than sleeping a fixed duration.
+	deadline := time.Now().Add(2 * time.Second)
+	var state api.ReplayState
+	for time.Now().Before(deadline) {
+		state = c.Status()
+		if state.PacketsSent >= packetCount {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, stopErr := c.Stop(); stopErr != nil {
+		t.Fatalf("Stop failed: %v", stopErr)
+	}
+
+	if state.PacketsSent != packetCount {
+		t.Errorf("expected PacketsSent=%d, got %d", packetCount, state.PacketsSent)
+	}
+	if state.PacketsTotal != packetCount {
+		t.Errorf("expected PacketsTotal=%d, got %d", packetCount, state.PacketsTotal)
+	}
+	if state.BytesSent == 0 {
+		t.Error("expected non-zero BytesSent")
+	}
+	if state.PercentComplete != 100 {
+		t.Errorf("expected PercentComplete=100, got %v", state.PercentComplete)
+	}
+}
 
 // TestStart_NoEngine verifies a controller without a capture engine refuses
 // to Start with the public sentinel rather than panicking. This is the

--- a/internal/replay/percent_internal_test.go
+++ b/internal/replay/percent_internal_test.go
@@ -1,0 +1,31 @@
+package replay
+
+import "testing"
+
+// TestPercentComplete is a white-box test (same package) for the percent
+// helper Status() uses to compute ReplayState.PercentComplete. Covers the
+// unknown-total case (must not fabricate a percentage), normal progress,
+// and the completed/over-100 clamp.
+func TestPercentComplete(t *testing.T) {
+	tests := []struct {
+		name        string
+		sent, total uint64
+		want        float64
+	}{
+		{"unknown total returns zero (omitted by json)", 5, 0, 0},
+		{"zero progress", 0, 100, 0},
+		{"partial progress", 25, 100, 25},
+		{"non-round percentage", 1, 3, 33.33},
+		{"complete", 100, 100, 100},
+		{"sent exceeds total is clamped to 100", 150, 100, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := percentComplete(tt.sent, tt.total)
+			if got != tt.want {
+				t.Errorf("percentComplete(%d, %d) = %v, want %v", tt.sent, tt.total, got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -192,6 +192,12 @@ export interface ReplayState {
   loopMs: number;
   scale: number;
   startedAt?: string;
+  packetsSent: number;
+  bytesSent: number;
+  packetsTotal: number;
+  bytesTotal: number;
+  /** Omitted by the backend (not sent as 0) whenever packetsTotal is unknown. */
+  percentComplete?: number;
 }
 
 export interface ReplayRequest {

--- a/ui/src/components/ReplayControlPanel.test.tsx
+++ b/ui/src/components/ReplayControlPanel.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * ReplayControlPanel.test.tsx — Phase 5a live replay progress. Locks that
+ * the status card renders a packets/bytes-sent progress bar while a replay
+ * is running, and falls back to "unknown total" copy (never a fake 0%
+ * bar) when the backend hasn't reported packetsTotal/percentComplete yet.
+ */
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReplayState } from '../api/api-response-types';
+import '../i18n';
+import { ReplayControlPanel } from './ReplayControlPanel';
+
+const fetchLibraryPcaps = vi.fn();
+const fetchReplayStatus = vi.fn<() => Promise<ReplayState>>();
+
+vi.mock('../api/client', () => ({
+  fetchLibraryPcaps: () => fetchLibraryPcaps(),
+  fetchReplayStatus: () => fetchReplayStatus(),
+  startReplay: vi.fn(),
+  stopReplay: vi.fn(),
+}));
+
+const runningWithProgress: ReplayState = {
+  running: true,
+  file: 'sample.pcap',
+  loopMs: 0,
+  scale: 1,
+  startedAt: new Date().toISOString(),
+  packetsSent: 25,
+  bytesSent: 2048,
+  packetsTotal: 100,
+  bytesTotal: 8192,
+  percentComplete: 25,
+};
+
+describe('ReplayControlPanel — live progress', () => {
+  beforeEach(() => {
+    fetchLibraryPcaps.mockReset().mockResolvedValue([]);
+    fetchReplayStatus.mockReset();
+  });
+
+  it('renders a progress bar with sent/total counts and percent while running', async () => {
+    fetchReplayStatus.mockResolvedValue(runningWithProgress);
+
+    render(<ReplayControlPanel />);
+
+    const progress = await screen.findByTestId('replay-progress');
+    expect(progress).toBeInTheDocument();
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '25');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+
+    expect(await screen.findByText(/25 \/ 100 packets \(25%\)/)).toBeInTheDocument();
+  });
+
+  it('shows unknown-total copy instead of a fake percentage when packetsTotal is 0', async () => {
+    fetchReplayStatus.mockResolvedValue({
+      ...runningWithProgress,
+      packetsTotal: 0,
+      percentComplete: undefined,
+    });
+
+    render(<ReplayControlPanel />);
+
+    const bar = await screen.findByRole('progressbar');
+    expect(bar).not.toHaveAttribute('aria-valuenow');
+    expect(screen.getByText(/total unknown/i)).toBeInTheDocument();
+  });
+
+  it('does not render the progress bar when no replay is running', async () => {
+    fetchReplayStatus.mockResolvedValue({
+      running: false,
+      file: '',
+      loopMs: 0,
+      scale: 1,
+      packetsSent: 0,
+      bytesSent: 0,
+      packetsTotal: 0,
+      bytesTotal: 0,
+    });
+
+    render(<ReplayControlPanel />);
+
+    await screen.findByText('PCAP File');
+    expect(screen.queryByTestId('replay-progress')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ReplayControlPanel.tsx
+++ b/ui/src/components/ReplayControlPanel.tsx
@@ -1,11 +1,63 @@
 import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { fetchLibraryPcaps, fetchReplayStatus, startReplay, stopReplay } from '../api/client';
 import { useApiResource } from '../hooks/useApiResource';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { Tag } from '../ui/Tag';
 import { SmallText } from '../ui/Typography';
-import { getErrorMessage } from '../utils/format';
+import { formatBytes, getErrorMessage } from '../utils/format';
+
+const PERCENT_MAX = 100;
+
+/**
+ * Live packets/bytes-sent progress bar for an in-flight replay. Renders
+ * "unknown total" copy instead of a fake 0% bar when the backend hasn't
+ * reported a packet total yet (percentComplete omitted from the JSON).
+ */
+const ReplayProgress: FC<{
+  packetsSent: number;
+  bytesSent: number;
+  packetsTotal: number;
+  percentComplete?: number;
+}> = ({ packetsSent, bytesSent, packetsTotal, percentComplete }) => {
+  const { t } = useTranslation('pages');
+  const hasTotal = packetsTotal > 0 && percentComplete !== undefined;
+  const percent = hasTotal ? Math.min(PERCENT_MAX, Math.max(0, percentComplete)) : 0;
+
+  return (
+    <div className="mt-tight" data-testid="replay-progress">
+      <div
+        className="w-full h-2 bg-bg-elevated border border-border-default rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={hasTotal ? percent : undefined}
+        aria-valuemin={0}
+        aria-valuemax={PERCENT_MAX}
+        aria-label={t('traffic.page.replayProgressLabel', {
+          sent: packetsSent,
+          total: packetsTotal,
+          percent: percent.toFixed(0),
+        })}
+      >
+        <div
+          className="h-full bg-status-info transition-[width] duration-300"
+          style={{ width: hasTotal ? `${percent}%` : '100%' }}
+        />
+      </div>
+      <SmallText className="text-text-muted">
+        {hasTotal
+          ? t('traffic.page.replayProgressLabel', {
+              sent: packetsSent,
+              total: packetsTotal,
+              percent: percent.toFixed(0),
+            })
+          : t('traffic.page.replayProgressUnknown')}
+        {' • '}
+        {t('traffic.page.replayProgressBytes', { bytes: formatBytes(bytesSent) })}
+      </SmallText>
+    </div>
+  );
+};
 
 export const ReplayControlPanel: FC = () => {
   // Hydrates from /api/v1/library/pcaps. The daemon's
@@ -90,6 +142,12 @@ export const ReplayControlPanel: FC = () => {
                   {replayStatus.loopMs > 0 && ` • Looping every ${replayStatus.loopMs}ms`}
                   {replayStatus.scale !== 1.0 && ` • Scale: ${replayStatus.scale}x`}
                 </SmallText>
+                <ReplayProgress
+                  packetsSent={replayStatus.packetsSent}
+                  bytesSent={replayStatus.bytesSent}
+                  packetsTotal={replayStatus.packetsTotal}
+                  percentComplete={replayStatus.percentComplete}
+                />
               </div>
               <Button onClick={handleStop} disabled={isSubmitting} variant="secondary">
                 Stop Replay


### PR DESCRIPTION
## Summary

- Backend: `capture.PlaybackEngine` now tracks live packets/bytes-sent and packets/bytes-total counters (atomic, reset per replay iteration so a looped replay reports per-pass progress, not a lifetime total). `replay.Controller.Status()` surfaces them plus a computed `percentComplete` in `api.ReplayState`; `percentComplete` is omitted (never faked as `0`) when the packet total isn't known yet.
- UI: `ReplayControlPanel` renders a live progress bar + "X / Y packets (Z%)" + bytes-sent line while a replay is running, polling the existing 2s status interval. Falls back to "total unknown" copy instead of a fake 0% bar when `packetsTotal`/`percentComplete` aren't present.
- i18n: new `traffic.page.replay*` strings added to `en`/`es` `pages.json`; `packets`/`PCAP` kept verbatim per house DNT convention.

## Linked Issue

Related to #897

## Testing Evidence

```text
$ golangci-lint cache clean && golangci-lint run ./internal/capture/... ./internal/replay/... ./internal/api/...
0 issues.

$ go test ./internal/capture/... ./internal/replay/... ./internal/api/... -race
ok  	github.com/MustardSeedNetworks/niac-go/internal/capture	2.753s
ok  	github.com/MustardSeedNetworks/niac-go/internal/replay	1.058s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api	(cached)
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/auth	(cached)
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/capture	(cached)
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/csrf	(cached)
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit	(cached)
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/sse	(cached)
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/templates	(cached)
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore	(cached)

$ npm run typecheck
> tsgo --build --noEmit
(clean, no output)

$ npx vitest run   # full suite
 Test Files  50 passed (50)
      Tests  257 passed (257)

$ npx @biomejs/biome check src/
Checked 293 files in 2s. No fixes applied.

$ npm run build
✓ built in 3.89s

$ ../scripts/check-token-discipline.sh
OK: blocking color-token discipline is clean (advisory warnings, if any, are non-blocking).
```

## Security and Release Checklist

- [x] No new mutating/state-changing HTTP routes added (progress is read-only, surfaced through the existing `GET /api/v1/replay` status endpoint).
- [x] No new auth/CSRF surface — reuses the existing replay status/start/stop handlers and their wrappers.
- [x] No secrets, credentials, or PII involved.
- [x] `golangci-lint` clean (0 issues), `go test -race` clean for touched packages.
- [x] `govulncheck` not re-run for this change (no new dependencies added).
- [x] i18n key parity test (`i18n.parity.test.ts`) passes for the new `en`/`es` strings.
