### PR TITLE
ci(release): use GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,16 +43,20 @@ jobs:
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          # PAT (not GITHUB_TOKEN) so the release PR's CI runs and the
-          # tag-push event triggers release.yml. With GITHUB_TOKEN those
-          # downstream workflows are silently skipped per GitHub's
-          # anti-recursion policy — this bit niac in Phase 2 goreleaser-cross
-          # migration testing (a GITHUB_TOKEN-authored tag never fired
-          # release.yml's `push: tags: v*` trigger). Falls back to
-          # GITHUB_TOKEN if the secret isn't set, so the workflow doesn't
-          # break if the PAT expires before being renewed (cascade is lost
-          # until renewed). Matches seed/stem.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # niac uses the built-in GITHUB_TOKEN, not a fine-grained PAT. The
+          # MustardSeedNetworks org forbids fine-grained PATs whose lifetime is
+          # > 366 days, and rejects them at API-call time. That hard-fails
+          # release-please when RELEASE_PLEASE_TOKEN holds such a token: the
+          # `|| GITHUB_TOKEN` fallback never fires because the secret IS set
+          # (just rejected), so `||` keeps the rejected token.
+          #
+          # Trade-off: a GITHUB_TOKEN-authored tag does not fire release.yml's
+          # `push: tags: v*` trigger (GitHub's anti-recursion policy), so the
+          # release build is kicked manually / via workflow_dispatch for now.
+          # The longer-term fleet token strategy (a GitHub App token, which
+          # stem uses) is tracked separately — niac deliberately diverges here
+          # to keep release-please green without an org-forbidden PAT.
+          token: ${{ secrets.GITHUB_TOKEN }}
           # NOTE: do NOT pass release-type here. It is declared per-package in
           # release-please-config.json (release-type: go). Passing it as a
           # direct action input forces a mode that ignores the config-file's


### PR DESCRIPTION
## Summary

release-please has been failing red on every push to `main`:

```
release-please failed: The 'MustardSeedNetworks' organization forbids access via a
fine-grained personal access token if the token's lifetime is greater than 366 days.
```

The `RELEASE_PLEASE_TOKEN` secret holds a fine-grained PAT whose lifetime exceeds the
org's 366-day cap, so the org rejects it at API-call time. The workflow's
`secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN` fallback never engages, because
the secret **is** set (non-empty) — `||` only falls through on an empty value, not a
rejected one. Result: hard failure on every run.

This switches niac to the built-in `GITHUB_TOKEN`.

**Trade-off (deliberate):** a `GITHUB_TOKEN`-authored tag does not fire `release.yml`'s
`push: tags: v*` trigger (GitHub anti-recursion), so the release build is kicked via
`workflow_dispatch` until the fleet token strategy is settled. niac deliberately diverges
from stem here — stem keeps the GitHub App token approach. The longer-term fleet decision
is tracked in #920 and to be discussed separately.

## Linked Issue

Related to #897 (unblocks release-please so remediation work can ship releases).

## Testing Evidence

```
$ gh run view 28913971697 --log-failed | grep -i forbids
release-please failed: The 'MustardSeedNetworks' organization forbids access via a
fine-grained personal access token if the token's lifetime is greater than 366 days.
```

The failure is authentication-only; the fix removes the rejected credential. release-please
runs on `workflow_run` after CI, so the green run will be observable on merge to `main`.

## Security and Release Checklist

- [x] No untrusted input interpolated into `run:` steps (change is a `token:` input + comments)
- [x] Drops a long-lived PAT in favor of the ephemeral, auto-scoped `GITHUB_TOKEN`
- [x] `permissions:` block unchanged (contents: write, pull-requests: write)
- [x] No new secrets required
