### PR TITLE
feat(ui): non-color direction glyphs in StreamView

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -464,7 +464,9 @@
       "clientBytesLabel": "{{count}} B client",
       "serverBytesLabel": "{{count}} B server",
       "asciiToggle": "ASCII",
-      "hexToggle": "Hex"
+      "hexToggle": "Hex",
+      "clientToServerAriaLabel": "Client to server",
+      "serverToClientAriaLabel": "Server to client"
     },
     "conversations": {
       "emptyTitle": "No TCP/UDP conversations found",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -464,7 +464,9 @@
       "clientBytesLabel": "{{count}} B cliente",
       "serverBytesLabel": "{{count}} B servidor",
       "asciiToggle": "ASCII",
-      "hexToggle": "Hex"
+      "hexToggle": "Hex",
+      "clientToServerAriaLabel": "Cliente a servidor",
+      "serverToClientAriaLabel": "Servidor a cliente"
     },
     "conversations": {
       "emptyTitle": "No se encontraron conversaciones TCP/UDP",

--- a/ui/src/components/StreamView.test.tsx
+++ b/ui/src/components/StreamView.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * StreamView.test.tsx — direction glyphs.
+ *
+ * Regression coverage for direction being conveyed by color alone, which
+ * fails for colorblind users. Each stream segment must render a text glyph
+ * (independent of color) indicating client-to-server vs server-to-client.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '../i18n';
+import type { PcapPacket } from '../api/types';
+import { StreamView } from './StreamView';
+
+function makePacket(overrides: Partial<PcapPacket>): PcapPacket {
+  return {
+    id: '1',
+    number: 1,
+    timestamp: new Date().toISOString(),
+    protocol: 'TCP',
+    sourceIp: '10.0.0.1',
+    destIp: '10.0.0.2',
+    sourcePort: 1234,
+    destPort: 80,
+    length: 64,
+    info: 'packet',
+    rawData: '68656c6c6f',
+    ...overrides,
+  };
+}
+
+describe('StreamView — direction glyphs', () => {
+  it('renders a client-to-server glyph for segments from the client endpoint', () => {
+    render(
+      <StreamView
+        packets={[makePacket({ sourceIp: '10.0.0.1', sourcePort: 1234 })]}
+        clientEndpoint="10.0.0.1:1234"
+        onClose={() => undefined}
+      />,
+    );
+
+    const glyphs = screen.getAllByTestId('stream-direction-glyph');
+    expect(glyphs).toHaveLength(1);
+    expect(glyphs[0]).toHaveTextContent('→');
+    expect(glyphs[0]).toHaveAttribute('aria-label', 'Client to server');
+  });
+
+  it('renders a server-to-client glyph for segments from a different endpoint', () => {
+    render(
+      <StreamView
+        packets={[makePacket({ sourceIp: '10.0.0.2', sourcePort: 80 })]}
+        clientEndpoint="10.0.0.1:1234"
+        onClose={() => undefined}
+      />,
+    );
+
+    const glyphs = screen.getAllByTestId('stream-direction-glyph');
+    expect(glyphs).toHaveLength(1);
+    expect(glyphs[0]).toHaveTextContent('←');
+    expect(glyphs[0]).toHaveAttribute('aria-label', 'Server to client');
+  });
+});

--- a/ui/src/components/StreamView.tsx
+++ b/ui/src/components/StreamView.tsx
@@ -160,13 +160,29 @@ export const StreamView: FC<StreamViewProps> = memo(({ packets, clientEndpoint, 
               {segments.map((segment, idx) => (
                 <div
                   key={`${segment.timestamp}-${idx}`}
-                  className={`px-3 py-compact-md rounded whitespace-pre-wrap break-all ${
+                  className={`flex items-start gap-tight px-3 py-compact-md rounded whitespace-pre-wrap break-all ${
                     segment.isClient
                       ? 'bg-status-info/30 text-status-info border-l-2 border-status-info'
                       : 'bg-status-error/30 text-status-error border-l-2 border-status-error'
                   }`}
                 >
-                  {displayMode === 'ascii' ? hexToAscii(segment.data) : formatHex(segment.data)}
+                  {/* Non-color direction cue: color alone doesn't work for colorblind
+                      users, so a text glyph carries direction independently. */}
+                  <span
+                    role="img"
+                    aria-label={
+                      segment.isClient
+                        ? t('packets.streamView.clientToServerAriaLabel')
+                        : t('packets.streamView.serverToClientAriaLabel')
+                    }
+                    data-testid="stream-direction-glyph"
+                    className="shrink-0 font-bold"
+                  >
+                    {segment.isClient ? '→' : '←'}
+                  </span>
+                  <span>
+                    {displayMode === 'ascii' ? hexToAscii(segment.data) : formatHex(segment.data)}
+                  </span>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- StreamView's client/server segment direction was conveyed by color alone (blue/red backgrounds), which is inaccessible to colorblind users and in non-color contexts.
- Add a `→` / `←` text glyph next to each stream segment, in addition to the existing color, with an i18n'd `aria-label` (`role="img"`) describing the direction and a `data-testid="stream-direction-glyph"` for test targeting.
- Added English and Spanish locale keys (`packets.streamView.clientToServerAriaLabel` / `serverToClientAriaLabel`) and a vitest covering both directions.

## Linked Issue
Related to #897

## Testing Evidence
```
$ npx tsgo --build
(no output — clean)

$ npx vitest run
 Test Files  53 passed (53)
      Tests  270 passed (270)
   Duration  20.34s

$ npx biome check .
Checked 335 files in 1111ms. No fixes applied.
```

## Security and Release Checklist
- [x] No new state-changing routes; frontend-only, presentational change.
- [x] No new dependencies added.
- [x] `npx tsgo --build`, `npx vitest run`, `npx biome check .` all clean (see evidence above).
- [x] i18n parity maintained — `en`/`es` `pages.json` both updated with the same key set; `i18n.parity.test.ts` passes.
- [x] No customer-facing AI/banned vocabulary introduced.
