### PR TITLE
feat(ui): group TrafficSection into three collapsible subsections

### DIFF
--- a/ui/src/components/device-editor/TrafficSection.test.tsx
+++ b/ui/src/components/device-editor/TrafficSection.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * TrafficSection.test.tsx
+ *
+ * The traffic mechanisms (ARP announcements, periodic pings, random
+ * traffic) each collapse independently so a user can focus on one
+ * mechanism's fields without the others' state changing.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import '../../i18n';
+import type { Device } from '../../api/types';
+import { TrafficSection } from './TrafficSection';
+
+const baseDevice: Device = {
+  hostname: 'edge-01',
+  mac: '00:1A:2B:3C:4D:5E',
+  type: 'server',
+  traffic: {
+    enabled: true,
+    arpAnnouncements: { enabled: true, interval: 60 },
+    periodicPings: { enabled: true, interval: 30, payloadSize: 56 },
+    randomTraffic: { enabled: false, interval: 60, packetCount: 5, patterns: [] },
+  },
+};
+
+describe('TrafficSection', () => {
+  it('expands the ARP subsection by default and keeps the others collapsed', () => {
+    render(
+      <TrafficSection
+        device={baseDevice}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('traffic-subsection-arp-header')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByTestId('traffic-subsection-pings-header')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.getByTestId('traffic-subsection-random-header')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('toggles each subsection independently', async () => {
+    const user = userEvent.setup();
+    render(
+      <TrafficSection
+        device={baseDevice}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    const arpHeader = screen.getByTestId('traffic-subsection-arp-header');
+    const pingsHeader = screen.getByTestId('traffic-subsection-pings-header');
+
+    // Expand pings — ARP's own state must not change.
+    await user.click(pingsHeader);
+    expect(pingsHeader).toHaveAttribute('aria-expanded', 'true');
+    expect(arpHeader).toHaveAttribute('aria-expanded', 'true');
+
+    // Collapse ARP — pings must stay expanded.
+    await user.click(arpHeader);
+    expect(arpHeader).toHaveAttribute('aria-expanded', 'false');
+    expect(pingsHeader).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('hides subsection fields while collapsed but keeps the enable switch visible', async () => {
+    const user = userEvent.setup();
+    render(
+      <TrafficSection
+        device={baseDevice}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    // Pings subsection starts collapsed — its interval field is not rendered.
+    expect(screen.queryByText('Payload Size (bytes)')).toBeNull();
+
+    await user.click(screen.getByTestId('traffic-subsection-pings-header'));
+    expect(screen.getByText('Payload Size (bytes)')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/device-editor/TrafficSection.tsx
+++ b/ui/src/components/device-editor/TrafficSection.tsx
@@ -1,10 +1,60 @@
-import { Radio } from 'lucide-react';
-import type { FC } from 'react';
+import { ChevronDown, ChevronRight, Radio } from 'lucide-react';
+import { type FC, type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TrafficConfig } from '../../api/types';
 import { iconSizes } from '../../constants/sizes';
 import { CollapsibleSection, FormField } from '../form';
 import type { ProtocolSectionProps } from './types';
+
+interface TrafficSubsectionProps {
+  title: string;
+  testId: string;
+  defaultExpanded?: boolean;
+  headerExtra: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Independently-collapsible group within TrafficSection. Distinct from the
+ * top-level CollapsibleSection: the enable/disable switch (headerExtra)
+ * always stays visible so the traffic mechanism's on/off state is never
+ * hidden by collapsing — only its detail fields collapse.
+ */
+const TrafficSubsection: FC<TrafficSubsectionProps> = ({
+  title,
+  testId,
+  defaultExpanded = false,
+  headerExtra,
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState(defaultExpanded);
+
+  return (
+    <div className="rounded-lg border border-surface-border bg-bg-base/40 pad stack">
+      <div className="flex-between">
+        <button
+          type="button"
+          onClick={() => setIsOpen((open) => !open)}
+          aria-expanded={isOpen}
+          data-testid={testId}
+          className="flex items-center gap-compact text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-primary rounded-lg"
+        >
+          {isOpen ? (
+            <ChevronDown className={`${iconSizes.sm} text-text-muted`} />
+          ) : (
+            <ChevronRight className={`${iconSizes.sm} text-text-muted`} />
+          )}
+          <h4 className="label flex items-center gap-compact">
+            <Radio className={`${iconSizes.md} text-brand-accent`} />
+            {title}
+          </h4>
+        </button>
+        {headerExtra}
+      </div>
+      {isOpen && children}
+    </div>
+  );
+};
 
 export const TrafficSection: FC<ProtocolSectionProps> = ({
   device,
@@ -37,6 +87,22 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
     onUpdate('traffic', config);
   };
 
+  const enableSwitch = (checked: boolean, onChange: (checked: boolean) => void) => (
+    <label className="relative inline-flex items-center cursor-pointer">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="sr-only peer"
+      />
+      <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
+        <div
+          className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${checked ? 'translate-x-4' : ''}`}
+        />
+      </div>
+    </label>
+  );
+
   return (
     <CollapsibleSection
       title={t('editor.sections.traffic.title')}
@@ -49,36 +115,24 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
     >
       {device.traffic?.enabled && (
         <div className="stack-xl">
-          {/* ARP Announcements */}
-          <div className="rounded-lg border border-surface-border bg-bg-base/40 pad stack">
-            <div className="flex-between">
-              <h4 className="label flex items-center gap-compact">
-                <Radio className={`${iconSizes.md} text-brand-accent`} />
-                {t('editor.sections.traffic.arpAnnouncementsTitle')}
-              </h4>
-              <label className="relative inline-flex items-center cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={device.traffic.arpAnnouncements?.enabled ?? false}
-                  onChange={(e) => {
-                    const baseConfig = getTrafficConfig();
-                    updateTraffic({
-                      ...baseConfig,
-                      arpAnnouncements: {
-                        ...baseConfig.arpAnnouncements,
-                        enabled: e.target.checked,
-                      },
-                    });
-                  }}
-                  className="sr-only peer"
-                />
-                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
-                  <div
-                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${device.traffic.arpAnnouncements?.enabled ? 'translate-x-4' : ''}`}
-                  />
-                </div>
-              </label>
-            </div>
+          <TrafficSubsection
+            title={t('editor.sections.traffic.arpAnnouncementsTitle')}
+            testId="traffic-subsection-arp-header"
+            defaultExpanded
+            headerExtra={enableSwitch(
+              device.traffic.arpAnnouncements?.enabled ?? false,
+              (checked) => {
+                const baseConfig = getTrafficConfig();
+                updateTraffic({
+                  ...baseConfig,
+                  arpAnnouncements: {
+                    ...baseConfig.arpAnnouncements,
+                    enabled: checked,
+                  },
+                });
+              },
+            )}
+          >
             {device.traffic.arpAnnouncements?.enabled && (
               <FormField
                 label={t('editor.sections.traffic.intervalLabel')}
@@ -102,38 +156,22 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                 />
               </FormField>
             )}
-          </div>
+          </TrafficSubsection>
 
-          {/* Periodic Pings */}
-          <div className="rounded-lg border border-surface-border bg-bg-base/40 pad stack">
-            <div className="flex-between">
-              <h4 className="label flex items-center gap-compact">
-                <Radio className={`${iconSizes.md} text-brand-accent`} />
-                {t('editor.sections.traffic.periodicPingsTitle')}
-              </h4>
-              <label className="relative inline-flex items-center cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={device.traffic.periodicPings?.enabled ?? false}
-                  onChange={(e) => {
-                    const baseConfig = getTrafficConfig();
-                    updateTraffic({
-                      ...baseConfig,
-                      periodicPings: {
-                        ...baseConfig.periodicPings,
-                        enabled: e.target.checked,
-                      },
-                    });
-                  }}
-                  className="sr-only peer"
-                />
-                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
-                  <div
-                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${device.traffic.periodicPings?.enabled ? 'translate-x-4' : ''}`}
-                  />
-                </div>
-              </label>
-            </div>
+          <TrafficSubsection
+            title={t('editor.sections.traffic.periodicPingsTitle')}
+            testId="traffic-subsection-pings-header"
+            headerExtra={enableSwitch(device.traffic.periodicPings?.enabled ?? false, (checked) => {
+              const baseConfig = getTrafficConfig();
+              updateTraffic({
+                ...baseConfig,
+                periodicPings: {
+                  ...baseConfig.periodicPings,
+                  enabled: checked,
+                },
+              });
+            })}
+          >
             {device.traffic.periodicPings?.enabled && (
               <div className="grid gap-comfortable md:grid-cols-2">
                 <FormField
@@ -183,38 +221,22 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                 </FormField>
               </div>
             )}
-          </div>
+          </TrafficSubsection>
 
-          {/* Random Traffic */}
-          <div className="rounded-lg border border-surface-border bg-bg-base/40 pad stack">
-            <div className="flex-between">
-              <h4 className="label flex items-center gap-compact">
-                <Radio className={`${iconSizes.md} text-brand-accent`} />
-                {t('editor.sections.traffic.randomTrafficTitle')}
-              </h4>
-              <label className="relative inline-flex items-center cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={device.traffic.randomTraffic?.enabled ?? false}
-                  onChange={(e) => {
-                    const baseConfig = getTrafficConfig();
-                    updateTraffic({
-                      ...baseConfig,
-                      randomTraffic: {
-                        ...baseConfig.randomTraffic,
-                        enabled: e.target.checked,
-                      },
-                    });
-                  }}
-                  className="sr-only peer"
-                />
-                <div className="w-9 h-5 bg-bg-elevated rounded-full peer peer-checked:bg-brand-primary peer-focus:ring-2 peer-focus:ring-brand-primary transition-colors">
-                  <div
-                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-knob rounded-full transition-transform ${device.traffic.randomTraffic?.enabled ? 'translate-x-4' : ''}`}
-                  />
-                </div>
-              </label>
-            </div>
+          <TrafficSubsection
+            title={t('editor.sections.traffic.randomTrafficTitle')}
+            testId="traffic-subsection-random-header"
+            headerExtra={enableSwitch(device.traffic.randomTraffic?.enabled ?? false, (checked) => {
+              const baseConfig = getTrafficConfig();
+              updateTraffic({
+                ...baseConfig,
+                randomTraffic: {
+                  ...baseConfig.randomTraffic,
+                  enabled: checked,
+                },
+              });
+            })}
+          >
             {device.traffic.randomTraffic?.enabled && (
               <div className="stack-lg">
                 <div className="grid gap-comfortable md:grid-cols-2">
@@ -318,7 +340,7 @@ export const TrafficSection: FC<ProtocolSectionProps> = ({
                 </div>
               </div>
             )}
-          </div>
+          </TrafficSubsection>
         </div>
       )}
     </CollapsibleSection>


### PR DESCRIPTION
## Summary

- `TrafficSection.tsx` was a single flat list of three unrelated blocks (ARP announcements, periodic pings, random traffic) under one enable toggle, all rendering at once — high visual load once more than one mechanism is enabled.
- Grouped the fields into three independently-collapsible subsections, one per traffic-generation mechanism: **ARP Announcements**, **Periodic Pings**, **Random Traffic**. This is the natural grouping already implied by the data model (`TrafficConfig.arpAnnouncements` / `.periodicPings` / `.randomTraffic`) and by the existing per-mechanism enable switches and headings — each subsection's fields (interval, payload size, packet count, patterns) only ever pertain to that one mechanism, so grouping by mechanism keeps every field next to its sibling controls with no cross-cutting concerns to untangle.
- Added a small local `TrafficSubsection` wrapper (no existing lightweight collapsible primitive fit — `CollapsibleSection` is a full `Card` with its own enable-toggle chrome, too heavy to nest three times). It keeps the enable switch always visible in the header (so on/off state is never hidden) and collapses only the detail fields below it. Collapse state is local `useState`, ephemeral, not persisted. ARP is expanded by default; the other two start collapsed.
- Each subsection header carries `data-testid` (`traffic-subsection-{arp,pings,random}-header`) and reuses the existing i18n'd titles (`arpAnnouncementsTitle`, `periodicPingsTitle`, `randomTrafficTitle`) — no new translation keys were needed.

## Linked Issue

Related to #897

## Testing Evidence

```
$ npx tsgo --build
(no output, zero errors)

$ npx vitest run src/components/device-editor/TrafficSection.test.tsx
 RUN  v4.1.10 /Users/krisarmstrong/Developer/MustardSeedNetworks/niac-p7-traffic/ui
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ npx vitest run src/i18n src/components/device-editor
 RUN  v4.1.10 /Users/krisarmstrong/Developer/MustardSeedNetworks/niac-p7-traffic/ui
 Test Files  7 passed (7)
      Tests  47 passed (47)

$ npx vitest run src/i18n/i18n.parity.test.ts
 RUN  v4.1.10 /Users/krisarmstrong/Developer/MustardSeedNetworks/niac-p7-traffic/ui
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ npx biome check src/components/device-editor/TrafficSection.tsx src/components/device-editor/TrafficSection.test.tsx
Checked 2 files in 646ms. No fixes applied.
```

## Security and Release Checklist

- [x] No new user input surfaces or endpoints — this is a pure UI reorganization of existing form fields.
- [x] No new persistence — collapse state is local `useState`, not written to backend or `localStorage`.
- [x] No new i18n keys — reused existing `en`/`es` `devices.json` titles; `i18n.parity.test.ts` passes unchanged.
- [x] No new dependencies added.
- [x] `TrafficSection.tsx` stays under the 400-line cap (348 lines after `biome check --write`).
- [x] `npx tsgo --build`, `npx vitest run`, `npx biome check` all clean; no `biome-ignore`, no `any`.
