### PR TITLE
ci(release): use msn-ci-bot App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,24 +39,25 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          # niac uses the built-in GITHUB_TOKEN, not a fine-grained PAT. The
-          # MustardSeedNetworks org forbids fine-grained PATs whose lifetime is
-          # > 366 days, and rejects them at API-call time. That hard-fails
-          # release-please when RELEASE_PLEASE_TOKEN holds such a token: the
-          # `|| GITHUB_TOKEN` fallback never fires because the secret IS set
-          # (just rejected), so `||` keeps the rejected token.
-          #
-          # Trade-off: a GITHUB_TOKEN-authored tag does not fire release.yml's
-          # `push: tags: v*` trigger (GitHub's anti-recursion policy), so the
-          # release build is kicked manually / via workflow_dispatch for now.
-          # The longer-term fleet token strategy (a GitHub App token, which
-          # stem uses) is tracked separately — niac deliberately diverges here
-          # to keep release-please green without an org-forbidden PAT.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Short-lived GitHub App installation token (msn-ci-bot), minted
+          # per-run. Unlike GITHUB_TOKEN, an App-authored tag/PR DOES trigger
+          # downstream workflows — so release-please's release PR gets CI and
+          # its v* tag fires release.yml's `push: tags` build. App tokens are
+          # not subject to the org's fine-grained-PAT >366-day lifetime rule
+          # that rejected the old RELEASE_PLEASE_TOKEN. Standardized across the
+          # MSN fleet (seed/stem/niac/niac-java).
+          token: ${{ steps.app-token.outputs.token }}
           # NOTE: do NOT pass release-type here. It is declared per-package in
           # release-please-config.json (release-type: go). Passing it as a
           # direct action input forces a mode that ignores the config-file's


### PR DESCRIPTION
## Summary
Standardize niac-go release-please on the msn-ci-bot GitHub App token (App 4248428, org-wide, contents:write + pull_requests:write). Replaces the #949 GITHUB_TOKEN stopgap. App-authored tags/PRs trigger downstream workflows, so release PRs get CI and v* tags fire release.yml automatically. Part of the fleet App migration (seed/stem/niac/niac-java).

## Linked Issue
Related to #897. Supersedes #920 (App-token approach, now with the App live).

## Testing Evidence
```
$ python3 -c \"import yaml; yaml.safe_load(open(...)); print(1)\"
YAML OK
```
App verified live: `msn-ci-bot`, perms contents:write/pull_requests:write, installed on all MSN repos. Full validation is the next release-please run authoring a release PR that receives CI.

## Security and Release Checklist
- [x] Per-run short-lived App token (not a long-lived PAT)
- [x] Least-privilege App permissions
- [x] No untrusted input in run steps
- [x] Retires the rejected RELEASE_PLEASE_TOKEN dependency