### PR TITLE
fix(security): bump Go 1.26.4 -> 1.26.5 for GO-2026-4970

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MustardSeedNetworks/niac-go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
## Summary
Bumps go.mod to Go 1.26.5 to clear the newly-published **GO-2026-4970** stdlib CVE (Root escape via symlink + trailing slash in `os`), which govulncheck (hard gate) flags as reachable through our `os.Root` containment in `internal/library`. This currently blocks every open PR fleet-wide.

## Linked Issue
Related to #897.

## Testing Evidence
```
$ go version   # after bump
go version go1.26.5 darwin/arm64
$ govulncheck ./internal/library/
No vulnerabilities found.
$ go build ./...  # exit 0
```

## Security and Release Checklist
- [x] Clears a reachable stdlib CVE (govulncheck hard gate)
- [x] setup-go reads go.mod, so CI toolchain follows automatically
- [x] Release build resolves 1.26.5 via GOTOOLCHAIN (goreleaser-cross:v1.26.5 image pending upstream)