### PR TITLE
ci(lint): exclude SA5011 in tests under Go 1.26.5 tooling lag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -527,6 +527,18 @@ linters:
       - common-false-positives
     # Excluding configuration per-path, per-linter, per-text and per-source.
     rules:
+      # TEMPORARY (tooling lag): golangci-lint 2.12.2 (latest, built with
+      # go1.26.2) bundles a staticcheck that does not recognize
+      # testing.T.Fatal as terminating under Go 1.26.5, producing SA5011
+      # false-positives on the idiomatic `if x == nil { t.Fatal(...) }; x.field`
+      # pattern (49 sites, all in _test.go). The code is correct — t.Fatal
+      # calls runtime.Goexit. Introduced with the Go 1.26.5 bump for
+      # GO-2026-4970. REMOVE this rule when golangci-lint ships a Go
+      # 1.26.5-compatible release (warn-unused: true above will flag it as
+      # unused once that lands, as a reminder).
+      - text: 'SA5011'
+        path: '_test\.go'
+        linters: [ staticcheck ]
       - source: 'TODO'
         linters: [ godot ]
       - text: 'should have a package comment'


### PR DESCRIPTION
## Summary
golangci-lint 2.12.2 (latest, go1.26.2 build) throws 49 SA5011 false-positives across 9 _test.go files under Go 1.26.5 — its staticcheck no longer treats t.Fatal as terminating on the `if x == nil { t.Fatal }; x.field` pattern. Code is correct (t.Fatal calls runtime.Goexit). Adds a scoped, TEMPORARY SA5011 exclusion for _test.go with removal condition (warn-unused flags it when golangci-lint ships a 1.26.5 build). Owner-approved workaround.

## Linked Issue
Related to #897; unblocks the Go 1.26.5 bump (#970) fleet-wide.

## Testing Evidence
```
SA5011 reproduces only in CI (golangci-lint runs under 1.26.5); local binary is go1.26.2 so cannot reproduce. This PRs own Backend job validates the exclusion works.
```

## Security and Release Checklist
- [x] Scoped to _test.go + SA5011 only (not a blanket disable)
- [x] Documented as temporary with an automatic removal reminder
- [x] Owner-approved (no silent suppression)