### PR TITLE
fix(release): install Syft under /tmp to keep the tree clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,11 +173,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -sSfL -o syft.tar.gz \
+          # Download + extract under /tmp, never in the repo tree — goreleaser
+          # aborts on a dirty git state, and a stray ./syft or ./syft.tar.gz
+          # left in the checkout would trip it.
+          curl -sSfL -o /tmp/syft.tar.gz \
             "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz"
-          echo "${SYFT_SHA256}  syft.tar.gz" | sha256sum -c -
-          tar -xzf syft.tar.gz syft
-          install -m 0755 syft /usr/local/bin/syft
+          echo "${SYFT_SHA256}  /tmp/syft.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/syft.tar.gz -C /tmp syft
+          install -m 0755 /tmp/syft /usr/local/bin/syft
+          rm -f /tmp/syft.tar.gz /tmp/syft
 
       - name: Install Cosign inside container
         run: |


### PR DESCRIPTION
## Summary
goreleaser aborts on a dirty git state. The "Install Syft" step extracted the bare `syft` binary into the repo root — the `.tar.gz` is gitignored via `*.tar.gz`, but the extracted binary is not — so `goreleaser release` failed the v0.94.2 build with `git is in a dirty state: ?? syft`. This downloads + extracts Syft under `/tmp` and cleans up, keeping the tree clean. (`niac-content-bundle.tar.gz` is already gitignored.)

Third latent bug in the goreleaser-cross release path, surfaced now that the earlier shell/pipefail fix lets these steps actually run.

## Linked Issue
Related to #897 (unblocks the v0.94.2 release build).

## Testing Evidence
```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML OK')"
YAML OK
```
Root cause from the failed run: `goreleaser (publish)` → `git is in a dirty state` → `?? syft`. Full validation is the re-fired v0.94.2 build after merge.

## Security and Release Checklist
- [x] Workflow-only change; no untrusted input in any run step
- [x] Keeps the release tree clean for goreleaser
- [x] Syft version pin + checksum unchanged
