### PR TITLE
fix(release): build complete release + writable daemon cert dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,7 @@ _project_specs
 # Go workspace
 go.work.sum
 ui/storybook-static/
+
+# CI: sibling niac-demo-catalog corpus checkout for the niac-content bundle
+# (release.yml). Kept out of the tree so goreleaser does not see a dirty state.
+.content-corpus/

--- a/deploy/systemd/niac.service
+++ b/deploy/systemd/niac.service
@@ -8,6 +8,11 @@ Wants=network-online.target
 Type=simple
 User=niac
 Group=niac
+# ProtectSystem=strict makes / read-only; without a writable CWD the daemon
+# fails at first start creating its self-signed TLS cert dir ("mkdir certs:
+# read-only file system"). Root the working dir + cert dir under the
+# ReadWritePath /var/lib/niac so a fresh install starts cleanly.
+WorkingDirectory=/var/lib/niac
 ExecStart=/usr/bin/niac daemon
 Restart=on-failure
 RestartSec=5
@@ -38,6 +43,7 @@ LimitNPROC=4096
 
 # Environment
 Environment=HOME=/var/lib/niac
+Environment=NIAC_CERT_DIR=/var/lib/niac/certs
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Two fixes so a **GitHub CI release builds complete and installs cleanly** — both surfaced validating v0.94.2 on the CT304 lab container.

**1. niac-content (walks) deb never built.** The deploy-key corpus checkout lands in `.content-corpus/` inside the repo tree (untracked), so `goreleaser` aborted the niac-content job with `git is in a dirty state: ?? .content-corpus/`. Gitignore it.

**2. Daemon failed first-start on a fresh install.** `deploy/systemd/niac.service` has `ProtectSystem=strict` (/ read-only) and no `WorkingDirectory`, so the daemon died creating its self-signed TLS cert dir: `mkdir certs: read-only file system`. Set `WorkingDirectory=/var/lib/niac` + `NIAC_CERT_DIR=/var/lib/niac/certs` (both under the existing `ReadWritePaths`).

## Linked Issue
Related to #897.

## Testing Evidence
```
# Both root causes captured live:
#  niac-content job:  goreleaser -> git is in a dirty state -> ?? .content-corpus/
#  daemon on CT304:   failed to start daemon: ... mkdir certs: read-only file system
# Fix 2 verified on CT304: with NIAC_CERT_DIR set, niac.service -> active, /__version 200.
```
Full validation is the next CI release building the niac-content deb + a clean daemon start.

## Security and Release Checklist
- [x] gitignore only scopes the CI corpus checkout dir
- [x] cert dir stays within the existing ReadWritePaths (no hardening relaxed)
- [x] No untrusted input; workflow/packaging only
