### PR TITLE
refactor: use slices.ContainsFunc for membership checks (D1)

### DIFF
--- a/cmd/niac/root.go
+++ b/cmd/niac/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -168,13 +169,9 @@ func shouldUseLegacyCommand(args []string, root *cobra.Command) bool {
 		return false
 	}
 
-	for _, cmd := range root.Commands() {
-		if cmd.Name() == firstArg || cmd.HasAlias(firstArg) {
-			return false
-		}
-	}
-
-	return true
+	return !slices.ContainsFunc(root.Commands(), func(cmd *cobra.Command) bool {
+		return cmd.Name() == firstArg || cmd.HasAlias(firstArg)
+	})
 }
 
 func firstCommandArg(args []string, root *cobra.Command) string {

--- a/internal/api/devices_helpers.go
+++ b/internal/api/devices_helpers.go
@@ -52,12 +52,9 @@ func (s *Server) validateDeviceCreatePreconditions(
 
 // deviceExists checks if a device with the given hostname exists.
 func deviceExists(devices []config.Device, hostname string) bool {
-	for _, dev := range devices {
-		if dev.Name == hostname {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(devices, func(dev config.Device) bool {
+		return dev.Name == hostname
+	})
 }
 
 func deepCopyConfig(cfg *config.Config) *config.Config {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -28,6 +28,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -791,12 +792,9 @@ func addrIsNonLoopback(addr string) (bool, error) {
 	if lookupErr != nil {
 		return false, fmt.Errorf("lookup %q: %w", host, lookupErr)
 	}
-	for _, ipAddr := range ips {
-		if !ipAddr.IP.IsLoopback() {
-			return true, nil
-		}
-	}
-	return false, nil
+	return slices.ContainsFunc(ips, func(ipAddr net.IPAddr) bool {
+		return !ipAddr.IP.IsLoopback()
+	}), nil
 }
 
 // addrLookupTimeout bounds the DNS lookup inside addrIsNonLoopback so

--- a/internal/capture/interfaces.go
+++ b/internal/capture/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 
 	"github.com/gopacket/gopacket/pcap"
 )
@@ -25,13 +26,9 @@ func InterfaceExists(name string) bool {
 		return false
 	}
 
-	for _, device := range devices {
-		if device.Name == name {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(devices, func(device pcap.Interface) bool {
+		return device.Name == name
+	})
 }
 
 // ListInterfaces prints all available network interfaces.
@@ -111,13 +108,9 @@ func getUsableInterfacePrefixes() []string {
 
 // IsUsableInterface checks if an interface name matches usable prefixes.
 func IsUsableInterface(name string) bool {
-	for _, prefix := range getUsableInterfacePrefixes() {
-		if len(name) >= len(prefix) && name[:len(prefix)] == prefix {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(getUsableInterfacePrefixes(), func(prefix string) bool {
+		return len(name) >= len(prefix) && name[:len(prefix)] == prefix
+	})
 }
 
 // GetUsableInterfaces returns only usable network interfaces (ethernet, WiFi, loopback).

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -147,13 +148,9 @@ func inferYAMLDeviceType(yamlDevice converter.Device) string {
 }
 
 func containsAny(value string, needles ...string) bool {
-	for _, needle := range needles {
-		if strings.Contains(value, needle) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(needles, func(needle string) bool {
+		return strings.Contains(value, needle)
+	})
 }
 
 // parseDeviceMACAddress parses the MAC address for a device.

--- a/internal/config/yaml_load.go
+++ b/internal/config/yaml_load.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -186,13 +187,9 @@ func parseSegmentTag(tag string) (int, error) {
 }
 
 func configHasDevices(segments []Segment) bool {
-	for _, seg := range segments {
-		if len(seg.Devices) > 0 || seg.ConfigPath != "" {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(segments, func(seg Segment) bool {
+		return len(seg.Devices) > 0 || seg.ConfigPath != ""
+	})
 }
 
 func resolveIncludePath(configDir, includePath string) string {

--- a/internal/protocols/dhcp.go
+++ b/internal/protocols/dhcp.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
@@ -362,13 +363,9 @@ func macMatchesMask(mac, match, mask net.HardwareAddr) bool {
 
 // isIPInPool checks if IP is in the pool.
 func (h *DHCPHandler) isIPInPool(ip net.IP) bool {
-	for _, poolIP := range h.ipPool {
-		if poolIP.Equal(ip) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(h.ipPool, func(poolIP net.IP) bool {
+		return poolIP.Equal(ip)
+	})
 }
 
 // isIPLeased checks if IP is currently leased.

--- a/internal/protocols/dhcpv6.go
+++ b/internal/protocols/dhcpv6.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"slices"
 	"sync"
 	"time"
 
@@ -314,13 +315,9 @@ func findIPv6ServerDevice(devices []*config.Device) *config.Device {
 
 // hasIPv6Address checks if the IP list contains any IPv6 address.
 func hasIPv6Address(ips []net.IP) bool {
-	for _, ip := range ips {
-		if ip.To4() == nil && ip.To16() != nil {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(ips, func(ip net.IP) bool {
+		return ip.To4() == nil && ip.To16() != nil
+	})
 }
 
 // getFirstIPv6Address returns the first IPv6 address from the list.

--- a/internal/protocols/icmpv6.go
+++ b/internal/protocols/icmpv6.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"sync/atomic"
 
 	"github.com/gopacket/gopacket"
@@ -250,13 +251,9 @@ func (h *ICMPv6Handler) sendEchoReply(
 
 // deviceHasIP checks if a device has a specific IP address.
 func (h *ICMPv6Handler) deviceHasIP(device *config.Device, ip net.IP) bool {
-	for _, deviceIP := range device.IPAddresses {
-		if deviceIP.Equal(ip) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(device.IPAddresses, func(deviceIP net.IP) bool {
+		return deviceIP.Equal(ip)
+	})
 }
 
 // logEchoReplySent logs when an echo reply is sent.

--- a/internal/protocols/ip.go
+++ b/internal/protocols/ip.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
@@ -116,13 +117,9 @@ func (h *IPHandler) shouldProcessTTL(ip *layers.IPv4, devices []*config.Device) 
 		return true
 	}
 
-	for _, device := range devices {
-		if device.MapToIP != nil {
-			return false
-		}
-	}
-
-	return true
+	return !slices.ContainsFunc(devices, func(device *config.Device) bool {
+		return device.MapToIP != nil
+	})
 }
 
 // routeToProtocolHandler dispatches the packet to the appropriate L4 handler.

--- a/internal/protocols/snmp.go
+++ b/internal/protocols/snmp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 
 	"github.com/gopacket/gopacket/layers"
 	"github.com/gosnmp/gosnmp"
@@ -186,13 +187,9 @@ func snmpAccessAllowed(device *config.Device, srcIP net.IP) bool {
 		return true
 	}
 
-	for _, ip := range device.SNMPConfig.AccessList {
-		if ip != nil && ip.Equal(srcIP) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(device.SNMPConfig.AccessList, func(ip net.IP) bool {
+		return ip != nil && ip.Equal(srcIP)
+	})
 }
 
 func (h *SNMPHandler) decodeRequest(payload []byte) (*gosnmp.SnmpPacket, error) {

--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -255,13 +256,10 @@ func isSynthesizedTopologyOID(oid string) bool {
 	}
 
 	trimmed := strings.TrimPrefix(oid, ".")
-	for _, prefix := range prefixes {
-		if trimmed == prefix || strings.HasPrefix(trimmed, prefix+".") {
-			return true
-		}
-	}
 
-	return false
+	return slices.ContainsFunc(prefixes, func(prefix string) bool {
+		return trimmed == prefix || strings.HasPrefix(trimmed, prefix+".")
+	})
 }
 
 // HandleGet processes an SNMP GET request.

--- a/internal/protocols/snmp/walk_validator.go
+++ b/internal/protocols/snmp/walk_validator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -141,12 +142,9 @@ func isSkippableLine(trimmedLine string) bool {
 
 // containsError checks if any issue in the slice has error severity.
 func containsError(issues []ValidationIssue) bool {
-	for _, issue := range issues {
-		if issue.Severity == "error" {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(issues, func(issue ValidationIssue) bool {
+		return issue.Severity == "error"
+	})
 }
 
 // validateWalkLine validates a single line and returns any issues found, each

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -156,13 +157,10 @@ func configUsesVLANs(cfg *config.Config) bool {
 	if cfg == nil {
 		return false
 	}
-	for i := range cfg.Devices {
-		if cfg.Devices[i].VLAN > 0 {
-			return true
-		}
-	}
 
-	return false
+	return slices.ContainsFunc(cfg.Devices, func(d config.Device) bool {
+		return d.VLAN > 0
+	})
 }
 
 func NewStack(

--- a/internal/protocols/tcp.go
+++ b/internal/protocols/tcp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
@@ -280,13 +281,9 @@ func (h *TCPHandler) deviceHasIP(device *config.Device, targetIP any) bool {
 		return false
 	}
 
-	for _, deviceIP := range device.IPAddresses {
-		if deviceIP.Equal(ip) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(device.IPAddresses, func(deviceIP net.IP) bool {
+		return deviceIP.Equal(ip)
+	})
 }
 
 // lookupDestinationMAC looks up the MAC address for a destination IP, scoped

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/gopacket/gopacket"
@@ -411,14 +412,10 @@ func reflectorForIP(devices []*config.Device, ip net.IP) *config.Device {
 // reflectorSignatureMatch reports whether payload carries a reflector signature
 // at reflectorSigOffset.
 func reflectorSignatureMatch(payload []byte) bool {
-	for _, sig := range []string{reflectorSigData, reflectorSigProbe} {
-		if len(payload) >= reflectorSigOffset+len(sig) &&
-			string(payload[reflectorSigOffset:reflectorSigOffset+len(sig)]) == sig {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc([]string{reflectorSigData, reflectorSigProbe}, func(sig string) bool {
+		return len(payload) >= reflectorSigOffset+len(sig) &&
+			string(payload[reflectorSigOffset:reflectorSigOffset+len(sig)]) == sig
+	})
 }
 
 // wiggleTOS toggles the IP-precedence bit (or the bottom two DSCP bits when

--- a/internal/sanitize/ip.go
+++ b/internal/sanitize/ip.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -104,12 +105,10 @@ func isSpecialIP(ip string) bool {
 		"127.0.0.1", "127.0.0.0",
 		"224.0.0.", "239.255.255.250", // Multicast
 	}
-	for _, special := range specials {
-		if strings.HasPrefix(ip, special) || ip == special {
-			return true
-		}
-	}
-	return false
+
+	return slices.ContainsFunc(specials, func(special string) bool {
+		return strings.HasPrefix(ip, special) || ip == special
+	})
 }
 
 // looksLikeIPOctet reports whether s is a valid single IPv4 octet (0-255,

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -214,12 +215,10 @@ func Get(name string) (*Template, error) {
 func Exists(name string) bool {
 	name = strings.TrimSuffix(name, ".yaml")
 	reg, _ := loadRegistry()
-	for _, t := range reg {
-		if t.Name == name {
-			return true
-		}
-	}
-	return false
+
+	return slices.ContainsFunc(reg, func(t TemplateMetadata) bool {
+		return t.Name == name
+	})
 }
 
 // loadTemplate loads template content from embedded filesystem.


### PR DESCRIPTION
## Summary
Workstream D1 — replace hand-rolled "contains" loops with `slices.ContainsFunc` (Go 1.21). 19 sites converted across protocols/config/api/cmd; behavior-preserving. One site (`isIPLeased`) correctly skipped — `h.leases` is a map, not a slice.

## Linked Issue
Related to #981

## Type of Change
- [x] Chore / refactor / dependency update

## Risk
- [x] Low

## Testing Evidence
Verified on the branch (macOS, Go 1.26.4):
```text
go build ./...        → rc=0 (only benign pre-existing '-lpcap duplicate libraries' macOS linker warning)
go vet ./internal/... ./cmd/...  → clean
go test ./internal/... ./cmd/... → ok (agent run)
gofmt -l internal cmd → clean (no output)
golangci-lint run     → 0 issues (v2.12.2)
```
Tricky sites spot-checked: negated forms (`ip.go` shouldParseTTL, `root.go` shouldUseLegacyCommand) use `!slices.ContainsFunc(...)`; `server.go` addrIsNonLoopback preserves `(bool, error)` via `}), nil`.

## Security and Release Checklist
- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (None touched — pure membership-check refactor.)
- [x] Dependencies are pinned and justified if changed. (No dependency change — stdlib only.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (No behavior change.)