### PR TITLE
refactor: use min/max builtins and range-over-int (D2)

### DIFF
--- a/internal/api/capture/analyze.go
+++ b/internal/api/capture/analyze.go
@@ -521,7 +521,7 @@ func topNFromMap(m map[string]int, n int) []IPCount {
 	})
 
 	result := make([]IPCount, 0, n)
-	for i := 0; i < len(sorted) && i < n; i++ {
+	for i := range min(len(sorted), n) {
 		result = append(result, IPCount{
 			IP:    sorted[i].key,
 			Count: sorted[i].value,

--- a/internal/interactive/display_utils.go
+++ b/internal/interactive/display_utils.go
@@ -122,9 +122,7 @@ func handleScrollInput(
 	case "up":
 		if selectedIdx > 0 {
 			selectedIdx--
-			if selectedIdx < scrollY {
-				scrollY = selectedIdx
-			}
+			scrollY = min(scrollY, selectedIdx)
 		}
 
 		return selectedIdx, scrollY, true
@@ -139,9 +137,7 @@ func handleScrollInput(
 		return selectedIdx, scrollY, true
 	case "pgup":
 		scrollY -= visibleRows
-		if scrollY < 0 {
-			scrollY = 0
-		}
+		scrollY = max(scrollY, 0)
 
 		return selectedIdx, scrollY, true
 	case "pgdown":

--- a/internal/mibdb/mibdb.go
+++ b/internal/mibdb/mibdb.go
@@ -449,9 +449,7 @@ func (h *VariMibIntegralHandler) Value() int64 {
 	}
 
 	// Ensure non-negative for counters
-	if value < 0 {
-		value = 0
-	}
+	value = max(value, 0)
 
 	return value
 }

--- a/internal/protocols/iperf3.go
+++ b/internal/protocols/iperf3.go
@@ -462,9 +462,7 @@ func (h *IPerf3Handler) sendResults(
 
 	// Calculate simulated results based on device config
 	duration := time.Since(session.StartTime).Seconds()
-	if duration < 1 {
-		duration = 1
-	}
+	duration = max(duration, 1)
 
 	// Use configured bandwidth or calculate from bytes received
 	downloadBps := cfg.DownloadMbps * iperf3BitsPerMbps

--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -466,9 +466,7 @@ func (a *Agent) ProcessPDU(
 			reps = SNMPRetryCount
 		}
 
-		if reps > MaxOIDResultSize {
-			reps = MaxOIDResultSize
-		}
+		reps = min(reps, MaxOIDResultSize)
 
 		return a.processGetBulk(vars, nonRepeaters, reps)
 	case gosnmp.Sequence,

--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -63,9 +63,7 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 
 		a.addLearnedFDBEntry(mac, bridgePort)
 
-		if bridgePort > maxPort {
-			maxPort = bridgePort
-		}
+		maxPort = max(maxPort, bridgePort)
 
 		changed = true
 	}

--- a/internal/protocols/snmp/synth/build.go
+++ b/internal/protocols/snmp/synth/build.go
@@ -123,12 +123,8 @@ func emitInterfaces(buf *bytes.Buffer, p Profile, dev DeviceInput, opts BuildOpt
 	if count <= 0 {
 		count = p.DefaultIfCount
 	}
-	if count > MaxInterfaces {
-		count = MaxInterfaces
-	}
-	if count < 1 {
-		count = 1
-	}
+	count = min(count, MaxInterfaces)
+	count = max(count, 1)
 
 	// 1.3.6.1.2.1.2.* — IF-MIB.
 	emitInteger(buf, "1.3.6.1.2.1.2.1.0", count) // ifNumber

--- a/internal/protocols/snmp/varimib.go
+++ b/internal/protocols/snmp/varimib.go
@@ -326,9 +326,7 @@ func (h *VariMibIntegralHandler) GetValue() any {
 	}
 
 	// Ensure non-negative for counter types
-	if value < 0 {
-		value = 0
-	}
+	value = max(value, 0)
 
 	// Return appropriate type based on ASN type
 	switch h.asnType {

--- a/internal/protocols/stp.go
+++ b/internal/protocols/stp.go
@@ -397,7 +397,7 @@ func (h *STPHandler) SendConfigBPDU(device *config.Device) error {
 // makeBridgeID creates a bridge ID from priority and MAC address.
 func (h *STPHandler) makeBridgeID(priority uint16, mac net.HardwareAddr) uint64 {
 	bridgeID := uint64(priority) << stpBridgeIDShift48
-	for i := 0; i < SizeOfMac && i < len(mac); i++ {
+	for i := range min(SizeOfMac, len(mac)) {
 		shift := stpBridgeIDShift40 - i*stpMACBytesShift
 		if shift >= 0 {
 			bridgeID |= uint64(mac[i]) << uint(shift)

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -441,9 +441,7 @@ func reflectorDelay(cfg *config.ReflectorConfig) time.Duration {
 		ms += getSimRand().IntN(2*cfg.JitterMs+1) - cfg.JitterMs
 	}
 
-	if ms < 0 {
-		ms = 0
-	}
+	ms = max(ms, 0)
 
 	return time.Duration(ms) * time.Millisecond
 }


### PR DESCRIPTION
## Summary

- Mechanical, behavior-preserving refactor (Workstream D2): replace manual clamp/max/min patterns with the Go 1.21 `min`/`max` builtins, and bounded index loops with Go 1.22 range-over-int, across 10 call sites in 9 files.
- No logic changes — each site was read in full before converting; two candidate sites (`internal/protocols/snmp/mib.go`, `internal/protocols/device_table.go`) were deliberately skipped because they assign a *second* variable alongside the bound, which `min`/`max` cannot express.

## Linked Issue

Related to #981

## Type of Change

- [x] Chore / refactor / dependency update

## Risk

- [x] Low

## Testing Evidence

```text
$ gofmt -l internal/api/capture/analyze.go internal/protocols/stp.go internal/protocols/snmp/peer_topology.go internal/mibdb/mibdb.go internal/protocols/snmp/varimib.go internal/protocols/iperf3.go internal/protocols/udp.go internal/protocols/snmp/agent.go internal/protocols/snmp/synth/build.go internal/interactive/display_utils.go
(no output — clean)

$ go build ./...
# github.com/MustardSeedNetworks/niac-go/cmd/niac
ld: warning: ignoring duplicate libraries: '-lpcap'   # benign macOS linker warning
(exit 0)

$ go test ./internal/... ./cmd/...
ok  	github.com/MustardSeedNetworks/niac-go/internal/api	12.067s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/auth	0.022s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/capture	0.026s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/csrf	0.025s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit	0.143s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/sse	0.341s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/templates	0.039s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore	0.033s
ok  	github.com/MustardSeedNetworks/niac-go/internal/apperr	0.017s
ok  	github.com/MustardSeedNetworks/niac-go/internal/capture	2.250s
ok  	github.com/MustardSeedNetworks/niac-go/internal/config	0.114s
ok  	github.com/MustardSeedNetworks/niac-go/internal/content	0.230s
ok  	github.com/MustardSeedNetworks/niac-go/internal/converter	0.030s
ok  	github.com/MustardSeedNetworks/niac-go/internal/daemon	13.222s
ok  	github.com/MustardSeedNetworks/niac-go/internal/device	0.390s
ok  	github.com/MustardSeedNetworks/niac-go/internal/interactive	1.050s
ok  	github.com/MustardSeedNetworks/niac-go/internal/ipc	0.102s
ok  	github.com/MustardSeedNetworks/niac-go/internal/library	0.689s
ok  	github.com/MustardSeedNetworks/niac-go/internal/license	2.091s
ok  	github.com/MustardSeedNetworks/niac-go/internal/logging	0.022s
ok  	github.com/MustardSeedNetworks/niac-go/internal/mibdb	0.177s
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols	0.766s
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp	6.519s
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp/synth	0.037s
ok  	github.com/MustardSeedNetworks/niac-go/internal/replay	0.068s
ok  	github.com/MustardSeedNetworks/niac-go/internal/safeconv	0.026s
ok  	github.com/MustardSeedNetworks/niac-go/internal/sanitize	0.020s
ok  	github.com/MustardSeedNetworks/niac-go/internal/stats	0.198s
ok  	github.com/MustardSeedNetworks/niac-go/internal/storage	0.083s
ok  	github.com/MustardSeedNetworks/niac-go/internal/templates	0.106s
ok  	github.com/MustardSeedNetworks/niac-go/internal/topology	0.032s
ok  	github.com/MustardSeedNetworks/niac-go/internal/truststore	0.031s
ok  	github.com/MustardSeedNetworks/niac-go/internal/version	0.016s
ok  	github.com/MustardSeedNetworks/niac-go/internal/walkanalysis	0.028s
ok  	github.com/MustardSeedNetworks/niac-go/cmd/niac	0.278s
?   	github.com/MustardSeedNetworks/niac-go/cmd/niac-convert	[no test files]
ok  	github.com/MustardSeedNetworks/niac-go/cmd/niac-schema	0.022s

$ golangci-lint run
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (N/A — no mutating routes, auth surfaces, or output encoding touched; this is a pure builtin-syntax substitution in existing arithmetic/loop bodies.)
- [x] Dependencies are pinned and justified if changed. (N/A — no dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (N/A — no behavior change.)
