### PR TITLE
refactor: use sync.OnceValues and maps.Keys/slices.Sorted (D3+D4)

### DIFF
--- a/cmd/niac/inject.go
+++ b/cmd/niac/inject.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strconv"
@@ -160,10 +161,7 @@ func runInject(args []string, options *injectOptions) error {
 	if !isValidErrorType(errorType) {
 		// Show both snake_case and canonical formats in error message
 		aliases := errorTypeAliases()
-		aliasKeys := make([]string, 0, len(aliases))
-		for k := range aliases {
-			aliasKeys = append(aliasKeys, k)
-		}
+		aliasKeys := slices.Collect(maps.Keys(aliases))
 		return fmt.Errorf("invalid error type: %s\n\nValid error types are:\n  %s\n\nOr use snake_case aliases:\n  %s",
 			errorType, strings.Join(validErrorTypes(), "\n  "), strings.Join(aliasKeys, "\n  "))
 	}

--- a/internal/api/sse/log_handler.go
+++ b/internal/api/sse/log_handler.go
@@ -31,18 +31,21 @@ type logHandler struct {
 	hub atomic.Pointer[Hub]
 }
 
-// sseLogTee and sseLogTeeOnce are package-globals because slog.SetDefault
-// is itself a process-global. The install-once + atomic hub rotation
-// pattern is what prevents the test-suite deadlock described on
-// InstallLogTee; any alternative that stuffs state somewhere else
-// would either duplicate the chain (the original bug) or hide globals
-// inside an unexported singleton with no practical difference.
+// getLogTee is a package-global because slog.SetDefault is itself a
+// process-global. The install-once + atomic hub rotation pattern is
+// what prevents the test-suite deadlock described on InstallLogTee; any
+// alternative that stuffs state somewhere else would either duplicate
+// the chain (the original bug) or hide globals inside an unexported
+// singleton with no practical difference.
 //
 //nolint:gochecknoglobals // process-global tee paired with slog.SetDefault.
-var (
-	sseLogTee     *logHandler
-	sseLogTeeOnce sync.Once
-)
+var getLogTee = sync.OnceValue(func() *logHandler {
+	h := &logHandler{
+		next: slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}),
+	}
+	slog.SetDefault(slog.New(h))
+	return h
+})
 
 // InstallLogTee makes sure a single logHandler is wrapped around
 // the slog default and points its broadcast target at hub. Safe to call
@@ -68,13 +71,7 @@ var (
 // which in the test suite produced a chain that grew one layer per
 // test and eventually hung shutdown.
 func InstallLogTee(hub *Hub) {
-	sseLogTeeOnce.Do(func() {
-		sseLogTee = &logHandler{
-			next: slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}),
-		}
-		slog.SetDefault(slog.New(sseLogTee))
-	})
-	sseLogTee.hub.Store(hub)
+	getLogTee().hub.Store(hub)
 }
 
 // NewLogHandler is retained for callers / tests that want a fresh

--- a/internal/protocols/snmp/mibzip.go
+++ b/internal/protocols/snmp/mibzip.go
@@ -6,9 +6,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -125,12 +127,7 @@ func (w *MibZipWriter) serializeNode(node *mibNode) {
 	}
 
 	// Get sorted child keys for deterministic output
-	keys := make([]int, 0, len(node.children))
-	for k := range node.children {
-		keys = append(keys, k)
-	}
-
-	sort.Ints(keys)
+	keys := slices.Sorted(maps.Keys(node.children))
 
 	// Process children
 	for _, k := range keys {

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -56,49 +56,38 @@ const (
 	metadataReadBytes = 4096
 )
 
-var (
-	registryOnce    sync.Once
-	registry        []TemplateMetadata
-	errLoadRegistry error
-)
-
 // loadRegistry reads every file in builtin/, parses its header comment
 // for description + use case, and returns the sorted metadata slice.
 // Cached after the first call.
-func loadRegistry() ([]TemplateMetadata, error) {
-	registryOnce.Do(func() {
-		entries, err := builtinFS.ReadDir("builtin")
-		if err != nil {
-			errLoadRegistry = fmt.Errorf("read builtin/: %w", err)
-			return
+var loadRegistry = sync.OnceValues(func() ([]TemplateMetadata, error) {
+	entries, err := builtinFS.ReadDir("builtin")
+	if err != nil {
+		return nil, fmt.Errorf("read builtin/: %w", err)
+	}
+
+	out := make([]TemplateMetadata, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".yaml")
+
+		content, readErr := loadTemplate(name)
+		if readErr != nil {
+			return nil, readErr
 		}
 
-		out := make([]TemplateMetadata, 0, len(entries))
-		for _, entry := range entries {
-			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
-				continue
-			}
-			name := strings.TrimSuffix(entry.Name(), ".yaml")
+		desc, useCase := parseHeaderMetadata(content)
+		out = append(out, TemplateMetadata{
+			Name:        name,
+			Description: desc,
+			UseCase:     useCase,
+		})
+	}
 
-			content, readErr := loadTemplate(name)
-			if readErr != nil {
-				errLoadRegistry = readErr
-				return
-			}
-
-			desc, useCase := parseHeaderMetadata(content)
-			out = append(out, TemplateMetadata{
-				Name:        name,
-				Description: desc,
-				UseCase:     useCase,
-			})
-		}
-
-		sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-		registry = out
-	})
-	return registry, errLoadRegistry
-}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+})
 
 // parseHeaderMetadata reads the leading comment block of a template
 // YAML file and pulls out a description and use-case string. Recognised

--- a/internal/walkanalysis/analyze.go
+++ b/internal/walkanalysis/analyze.go
@@ -10,7 +10,9 @@
 package walkanalysis
 
 import (
+	"maps"
 	"math"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -234,11 +236,7 @@ func extractInterfaces(entries []snmp.WalkEntry) ([]Interface, map[int]string, i
 		}
 	}
 
-	indices := make([]int, 0, len(accum))
-	for idx := range accum {
-		indices = append(indices, idx)
-	}
-	sort.Ints(indices)
+	indices := slices.Sorted(maps.Keys(accum))
 
 	nameByIndex := make(map[int]string, len(accum))
 	list := make([]Interface, 0, len(accum))


### PR DESCRIPTION
## Summary

Behavior-preserving Go modernization (D3+D4 batch, 5 sites):

- **D3 — `sync.OnceValues`/`OnceValue` (Go 1.21):**
  - `internal/templates/template.go`: `loadRegistry` — replaced the manual `sync.Once` + 3 package vars (`registryOnce`, `registry`, `errLoadRegistry`) with `var loadRegistry = sync.OnceValues(func() ([]TemplateMetadata, error) { ... })`.
  - `internal/api/sse/log_handler.go`: `InstallLogTee` — replaced `sseLogTee`/`sseLogTeeOnce` with `var getLogTee = sync.OnceValue(func() *logHandler { ... })`; `InstallLogTee` now just calls `getLogTee().hub.Store(hub)`.
- **D4 — `maps.Keys` + `slices.Sorted`/`slices.Collect` (Go 1.23):**
  - `internal/protocols/snmp/mibzip.go`: `serializeNode` — `keys := slices.Sorted(maps.Keys(node.children))` replaces the manual slice-build + `sort.Ints`.
  - `internal/walkanalysis/analyze.go`: same pattern for `indices` in the interface-accumulation path.
  - `cmd/niac/inject.go`: `runInject` — `aliasKeys := slices.Collect(maps.Keys(aliases))` (no sort needed; order was already unspecified).

No behavior change: caching semantics, error semantics, and sort order are all preserved. `sort` import was retained in `mibzip.go` and `analyze.go` (still used by other `sort.Slice`/`sort.Ints` calls in each file); goimports added the `maps`/`slices` imports automatically.

## Linked Issue

Related to #981

## Type of Change

- [x] Chore / refactor / dependency update

## Risk

- [x] Low

## Testing Evidence

```text
$ gofmt -l .
(clean, no output)

$ go build ./...
# github.com/MustardSeedNetworks/niac-go/cmd/niac
ld: warning: ignoring duplicate libraries: '-lpcap'
(build succeeds; warning is the known benign linker note)

$ go test ./internal/... ./cmd/...
ok  	github.com/MustardSeedNetworks/niac-go/internal/api	7.647s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/auth	0.027s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/capture	0.021s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/csrf	0.021s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit	0.130s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/sse	0.310s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/templates	0.033s
ok  	github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore	0.032s
ok  	github.com/MustardSeedNetworks/niac-go/internal/apperr	0.017s
ok  	github.com/MustardSeedNetworks/niac-go/internal/capture	2.451s
ok  	github.com/MustardSeedNetworks/niac-go/internal/config	0.077s
ok  	github.com/MustardSeedNetworks/niac-go/internal/content	0.241s
ok  	github.com/MustardSeedNetworks/niac-go/internal/converter	0.046s
ok  	github.com/MustardSeedNetworks/niac-go/internal/daemon	8.237s
ok  	github.com/MustardSeedNetworks/niac-go/internal/device	0.255s
ok  	github.com/MustardSeedNetworks/niac-go/internal/interactive	1.043s
ok  	github.com/MustardSeedNetworks/niac-go/internal/ipc	0.044s
ok  	github.com/MustardSeedNetworks/niac-go/internal/library	0.441s
ok  	github.com/MustardSeedNetworks/niac-go/internal/license	1.713s
ok  	github.com/MustardSeedNetworks/niac-go/internal/logging	0.019s
ok  	github.com/MustardSeedNetworks/niac-go/internal/mibdb	0.162s
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols	0.715s
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp	6.456s
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp/synth	0.021s
ok  	github.com/MustardSeedNetworks/niac-go/internal/replay	0.048s
ok  	github.com/MustardSeedNetworks/niac-go/internal/safeconv	0.014s
ok  	github.com/MustardSeedNetworks/niac-go/internal/sanitize	0.015s
ok  	github.com/MustardSeedNetworks/niac-go/internal/stats	0.150s
ok  	github.com/MustardSeedNetworks/niac-go/internal/storage	0.057s
ok  	github.com/MustardSeedNetworks/niac-go/internal/templates	0.052s
ok  	github.com/MustardSeedNetworks/niac-go/internal/topology	0.018s
ok  	github.com/MustardSeedNetworks/niac-go/internal/truststore	0.052s
ok  	github.com/MustardSeedNetworks/niac-go/internal/version	0.020s
ok  	github.com/MustardSeedNetworks/niac-go/internal/walkanalysis	0.028s
ok  	github.com/MustardSeedNetworks/niac-go/cmd/niac	0.136s
?   	github.com/MustardSeedNetworks/niac-go/cmd/niac-convert	[no test files]
ok  	github.com/MustardSeedNetworks/niac-go/cmd/niac-schema	0.019s

$ golangci-lint cache clean && golangci-lint run ./...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. — N/A, no routes or auth surfaces touched; this is an internal caching/sorting refactor only.
- [x] Dependencies are pinned and justified if changed. — No dependency changes; stdlib-only refactor.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. — N/A, no observable behavior change.
