### PR TITLE
chore(ui): drop unused @tanstack/react-query dep

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "niac-ui",
-  "version": "0.94.4",
+  "version": "0.94.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "niac-ui",
-      "version": "0.94.4",
+      "version": "0.94.5",
       "dependencies": {
         "@codemirror/commands": "6.10.4",
         "@codemirror/lang-yaml": "6.1.3",
@@ -47,7 +47,6 @@
         "@storybook/addon-onboarding": "10.4.6",
         "@storybook/addon-vitest": "10.4.6",
         "@storybook/react-vite": "10.4.6",
-        "@tanstack/react-query": "5.101.2",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
@@ -3751,34 +3750,6 @@
         "@tailwindcss/oxide": "4.3.2",
         "postcss": "^8.5.15",
         "tailwindcss": "4.3.2"
-      }
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
-      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.101.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -66,7 +66,6 @@
     "@storybook/addon-onboarding": "10.4.6",
     "@storybook/addon-vitest": "10.4.6",
     "@storybook/react-vite": "10.4.6",
-    "@tanstack/react-query": "5.101.2",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -69,7 +69,6 @@ export default defineConfig(({ mode }) => {
               id.includes('/node_modules/scheduler/')
             )
               return 'vendor-react';
-            if (id.includes('/node_modules/@tanstack/react-query/')) return 'vendor-query';
             if (
               id.includes('/node_modules/i18next/') ||
               id.includes('/node_modules/react-i18next/') ||


### PR DESCRIPTION
## Summary
`@tanstack/react-query@5.101.2` was installed but never imported. A signature-preserving `useApiResource` rewrite can't deliver the dedup it was wanted for (each call stays independent via `useId` keys); real dedup needs a 34-site meaningful-key migration whose benefit is modest here — the hot pollers are already fetched once and shared via `AppContext`. Decision (#991): don't adopt; remove the dead dep + its orphaned `vendor-query` manualChunk. Mirrors the React Compiler call (#988).

## Linked Issue
Related to #991

## Type of Change
- [x] Chore / refactor / dependency update

## Risk
- [x] Low

## Testing Evidence
```text
grep -rn @tanstack/react-query ui/src      → zero (confirmed unused)
grep -c @tanstack/react-query package.json package-lock.json → 0, 0
npx tsgo --build --noEmit                  → rc=0
npx biome check src/ vite.config.ts        → clean (320 files)
npm run build                              → built ok (manualChunks change safe)
```

## Security and Release Checklist
- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (n/a — devDep removal.)
- [x] Dependencies are pinned and justified if changed. (Removes an unused dep; no additions.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (No behavior change.)