### PR TITLE
fix(replay): anchor pcap os.Root at the validated allowed dir (#986)

### DIFF
--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -208,7 +208,7 @@ func TestValidatePcapFilePathFallsBackToLibrary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := server.validatePcapFilePath("lib-only.pcap")
+	got, _, err := server.validatePcapFilePath("lib-only.pcap")
 	if err != nil {
 		t.Fatalf("validatePcapFilePath: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestValidatePcapFilePathPreservesConfigDirPriority(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := server.validatePcapFilePath(filename)
+	got, _, err := server.validatePcapFilePath(filename)
 	if err != nil {
 		t.Fatalf("validatePcapFilePath: %v", err)
 	}

--- a/internal/api/pcap_validation.go
+++ b/internal/api/pcap_validation.go
@@ -47,12 +47,15 @@ func (s *Server) prepareReplayRequest(req ReplayRequest) (ReplayRequest, error) 
 
 	if req.InlineData == "" {
 		// SECURITY FIX #162: Validate PCAP file path to prevent arbitrary file access
-		validatedPath, err := s.validatePcapFilePath(req.File)
+		validatedPath, allowedDir, err := s.validatePcapFilePath(req.File)
 		if err != nil {
 			return req, err
 		}
 
 		req.File = validatedPath
+		// Anchor playback's os.Root at the allow-listed dir the file resolved
+		// under, so every path component is contained at open time (#986).
+		req.RootDir = allowedDir
 
 		return req, nil
 	}
@@ -80,38 +83,40 @@ func (s *Server) prepareReplayRequest(req ReplayRequest) (ReplayRequest, error) 
 // denied / not found) propagate via lastErr and fall through to the
 // next allowed dir; hard failures (extension, null byte, dir-not-file)
 // short-circuit out.
-func (s *Server) validatePcapFilePath(filename string) (string, error) {
+// Returns the validated absolute path and the allow-listed directory it
+// resolved under (so playback can anchor an os.Root there, #986).
+func (s *Server) validatePcapFilePath(filename string) (string, string, error) {
 	if filename == "" {
-		return "", errors.New("filename cannot be empty")
+		return "", "", errors.New("filename cannot be empty")
 	}
 
 	cleanPath := filepath.Clean(filename)
 	if strings.ContainsRune(cleanPath, 0) {
-		return "", errors.New("filename contains invalid characters")
+		return "", "", errors.New("filename contains invalid characters")
 	}
 
 	allowedDirs, err := s.resolvePcapAllowedDirs()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	var lastErr error
 	for _, allowedDir := range allowedDirs {
 		absPath, hardFail, attemptErr := tryPcapInDir(cleanPath, filename, allowedDir)
 		if hardFail {
-			return "", attemptErr
+			return "", "", attemptErr
 		}
 		if attemptErr != nil {
 			lastErr = attemptErr
 			continue
 		}
-		return absPath, nil
+		return absPath, allowedDir, nil
 	}
 
 	if lastErr != nil {
-		return "", lastErr
+		return "", "", lastErr
 	}
-	return "", fmt.Errorf("pcap file not found: %s", filename)
+	return "", "", fmt.Errorf("pcap file not found: %s", filename)
 }
 
 // tryPcapInDir resolves cleanPath against allowedDir and returns the

--- a/internal/api/pcap_validation_test.go
+++ b/internal/api/pcap_validation_test.go
@@ -62,7 +62,7 @@ func TestPrepareReplayRequestWhitespaceFile(t *testing.T) {
 func TestValidatePcapFilePathEmpty(t *testing.T) {
 	server, _ := newTestServer(t)
 
-	_, err := server.validatePcapFilePath("")
+	_, _, err := server.validatePcapFilePath("")
 	if err == nil {
 		t.Error("validatePcapFilePath('') should fail")
 	}
@@ -71,7 +71,7 @@ func TestValidatePcapFilePathEmpty(t *testing.T) {
 func TestValidatePcapFilePathNonExistent(t *testing.T) {
 	server, _ := newTestServer(t)
 
-	_, err := server.validatePcapFilePath("nonexistent.pcap")
+	_, _, err := server.validatePcapFilePath("nonexistent.pcap")
 	if err == nil {
 		t.Error("validatePcapFilePath(nonexistent) should fail")
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -197,6 +197,10 @@ type ReplayRequest struct {
 	Scale      float64 `json:"scale"`
 	InlineData string  `json:"data,omitempty"`
 	Uploaded   bool    `json:"-"`
+	// RootDir is the validated allow-listed directory File was resolved
+	// under; playback opens File through an os.Root anchored here so no path
+	// component can escape it. Server-set, never client-supplied.
+	RootDir string `json:"-"`
 }
 
 // ReplayState reports the current replay status.

--- a/internal/capture/playback.go
+++ b/internal/capture/playback.go
@@ -302,25 +302,38 @@ func (p *PlaybackEngine) logBasic(msg string, args ...any) {
 }
 
 // loadPCAP loads packets from a PCAP file.
-// openPCAPFile opens the configured playback file through an os.Root
-// rooted at its parent directory, so the kernel rejects the open when the
-// base name is a symlink escaping that directory. The file is reopened on
-// every loop iteration, so this containment runs on each open — it closes
-// the validate→open TOCTOU window that a plain pcap.OpenOffline (which
-// re-resolves the path inside libpcap) would leave. The caller owns the
-// returned file and must Close it.
+// openPCAPFile opens the configured playback file through an os.Root so the
+// kernel rejects the open if any path component escapes the root — including
+// via a symlink already on disk. The file is reopened on every loop
+// iteration, so this containment runs on each open, closing the validate→open
+// TOCTOU window that a plain pcap.OpenOffline (which re-resolves the path
+// inside libpcap) would leave. The root is anchored at the API-validated
+// allow-listed directory (config.RootDir) when set — covering intermediate
+// path components — else at the file's own parent directory (operator-
+// authored config / CLI paths). The caller owns the returned file.
 func (p *PlaybackEngine) openPCAPFile() (*os.File, error) {
 	cleanedName := filepath.Clean(p.config.FileName)
 	if strings.Contains(cleanedName, "..") {
 		return nil, fmt.Errorf("playback file path must not contain path traversal: %s", p.config.FileName)
 	}
-	root, err := os.OpenRoot(filepath.Dir(cleanedName))
+
+	rootDir := filepath.Clean(p.config.RootDir)
+	if p.config.RootDir == "" {
+		rootDir = filepath.Dir(cleanedName)
+	}
+
+	rel, err := filepath.Rel(rootDir, cleanedName)
+	if err != nil {
+		return nil, fmt.Errorf("resolve playback path under %s: %w", rootDir, err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
 	if err != nil {
 		return nil, fmt.Errorf("open playback directory: %w", err)
 	}
 	defer func() { _ = root.Close() }()
 
-	f, err := root.Open(filepath.Base(cleanedName))
+	f, err := root.Open(rel)
 	if err != nil {
 		return nil, fmt.Errorf("open PCAP file %s: %w", p.config.FileName, err)
 	}

--- a/internal/capture/playback_osroot_test.go
+++ b/internal/capture/playback_osroot_test.go
@@ -62,3 +62,59 @@ func TestPlaybackEngine_LoadPCAP_RejectsSymlinkEscape(t *testing.T) {
 		t.Fatal("expected loadPCAP to reject a symlink escaping its directory, got nil")
 	}
 }
+
+// TestPlaybackEngine_LoadPCAP_RejectsIntermediateSymlinkEscape proves #986:
+// with RootDir set to the validated allow-listed directory, a symlink at an
+// INTERMEDIATE path component (not just the base name) that escapes the root
+// is rejected. Anchoring only at filepath.Dir(FileName) (C1) would resolve
+// the intermediate symlink and open outside the allowed tree — RootDir
+// anchors at the allow-listed dir so os.Root checks every component.
+func TestPlaybackEngine_LoadPCAP_RejectsIntermediateSymlinkEscape(t *testing.T) {
+	// A real, loadable pcap outside the allow-listed dir.
+	realPcap := createTestPCAPFile(t, 1)
+	outsideDir := filepath.Dir(realPcap)
+
+	allowed := t.TempDir() // the validated RootDir
+	if err := os.Symlink(outsideDir, filepath.Join(allowed, "sub")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	// FileName resolves under RootDir textually (allowed/sub/test.pcap) but
+	// "sub" is a symlink escaping `allowed`; os.Root rooted at `allowed`
+	// rejects it. (The target IS loadable, so a pass proves the containment
+	// stops it, not a missing file.)
+	pb := &PlaybackEngine{
+		config: &config.CapturePlayback{
+			FileName: filepath.Join(allowed, "sub", filepath.Base(realPcap)),
+			RootDir:  allowed,
+		},
+		stopChan: make(chan struct{}),
+	}
+
+	if _, err := pb.loadPCAP(); err == nil {
+		t.Fatal("expected loadPCAP to reject an intermediate-directory symlink escaping the allowed root, got nil")
+	}
+}
+
+// TestPlaybackEngine_LoadPCAP_RootDirLoadsNestedFile confirms the RootDir
+// path still loads a legitimate file resolved relative to the allow-listed
+// directory (the happy path of the #986 anchoring).
+func TestPlaybackEngine_LoadPCAP_RootDirLoadsNestedFile(t *testing.T) {
+	path := createTestPCAPFile(t, 3)
+
+	pb := &PlaybackEngine{
+		config: &config.CapturePlayback{
+			FileName: path,
+			RootDir:  filepath.Dir(path),
+		},
+		stopChan: make(chan struct{}),
+	}
+
+	packets, err := pb.loadPCAP()
+	if err != nil {
+		t.Fatalf("loadPCAP with RootDir set: %v", err)
+	}
+	if len(packets) != 3 {
+		t.Fatalf("got %d packets, want 3", len(packets))
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -168,7 +168,15 @@ func (c *Config) NormalizedSegments() []Segment {
 
 // CapturePlayback represents PCAP file playback configuration.
 type CapturePlayback struct {
-	FileName  string
+	FileName string
+	// RootDir, when set, is the validated directory the file must resolve
+	// under. Playback opens the file through an os.Root anchored here, so
+	// the kernel rejects any component (including an intermediate-directory
+	// symlink) that escapes it — closing the validate→open TOCTOU across the
+	// whole path. The API replay handler sets this to the allow-listed pcap
+	// directory. When empty (operator-authored config / CLI paths), playback
+	// falls back to rooting at the file's own parent directory.
+	RootDir   string
 	LoopTime  int     // milliseconds
 	ScaleTime float64 // time scaling factor
 }

--- a/internal/replay/controller.go
+++ b/internal/replay/controller.go
@@ -111,6 +111,7 @@ func (c *Controller) Start(req api.ReplayRequest) (api.ReplayState, error) {
 
 	cfg := &config.CapturePlayback{
 		FileName:  req.File,
+		RootDir:   req.RootDir,
 		LoopTime:  req.LoopMs,
 		ScaleTime: req.Scale,
 	}


### PR DESCRIPTION
## Summary
C1 (#987) opened the replay pcap via `os.Root` rooted at `filepath.Dir(FileName)`, closing the base-name symlink TOCTOU but leaving a parent-directory race (Codex Medium on #987). This threads the API-validated allow-listed directory (`validatePcapFilePath` → `ReplayRequest.RootDir` → `config.CapturePlayback.RootDir`) into `playback.openPCAPFile`, which now anchors `os.Root` there and opens the path relative to it — so `os.Root` checks **every** path component, not just the base. When `RootDir` is unset (operator-authored config / CLI paths — no API-validated dir) it falls back to the file's own parent directory.

## Linked Issue
Closes #986

## Type of Change
- [x] Security hardening

## Risk
- [x] Low

## Testing Evidence
```text
go build ./...                          → rc=0
go test ./internal/api/... ./internal/capture/... ./internal/replay/... ./internal/config/... → all ok
  new: TestPlaybackEngine_LoadPCAP_RejectsIntermediateSymlinkEscape — PASS (proves the parent-dir race is closed)
  new: TestPlaybackEngine_LoadPCAP_RootDirLoadsNestedFile          — PASS (RootDir happy path)
golangci-lint run (cache-cleaned)       → 0 issues
gofmt -l / go vet                       → clean
```
Cross-model review (Codex): confirmed the fix contains intermediate-dir symlink escapes below RootDir, no `filepath.Rel` `..` bypass, and no new escape.

## Accepted residual (inherent trust-anchor boundary — not tracked)
Codex noted `os.OpenRoot(RootDir)` follows symlinks in the RootDir path *itself*, so swapping the allow-listed directory *itself* between validation and open would escape. This is the root-of-trust boundary — any anchoring has a top, and exploiting it requires write access to the niac config/library root (game-over regardless). Not fixable without moving the anchor one level up (which just relocates the same boundary). Accepted, not a follow-up.

## Security and Release Checklist
- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (Replay-path hardening; `validatePcapFilePath` now returns the matched dir, callers updated; `RootDir` is server-set, `json:"-"`, never client-supplied.)
- [x] Dependencies are pinned and justified if changed. (No dependency change.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (No behavior change for valid pcaps.)