### PR TITLE
feat(replay): stream pcap replay instead of materializing the whole file

### DIFF
--- a/internal/capture/capture_coverage_test.go
+++ b/internal/capture/capture_coverage_test.go
@@ -389,9 +389,9 @@ func TestPlaybackEngine_LoadPCAP_EmptyFile(t *testing.T) {
 		stopChan: make(chan struct{}),
 	}
 
-	packets, err := pb.loadPCAP()
+	packets, err := collectPlayback(pb)
 	if err != nil {
-		t.Fatalf("loadPCAP on empty file failed: %v", err)
+		t.Fatalf("collectPlayback on empty file failed: %v", err)
 	}
 
 	if len(packets) != 0 {
@@ -416,7 +416,7 @@ func TestPlaybackEngine_LoadPCAP_InvalidFile(t *testing.T) {
 		stopChan: make(chan struct{}),
 	}
 
-	_, err = pb.loadPCAP()
+	_, err = collectPlayback(pb)
 	if err == nil {
 		t.Error("Expected error loading invalid PCAP file")
 	}

--- a/internal/capture/playback.go
+++ b/internal/capture/playback.go
@@ -20,8 +20,7 @@ import (
 
 // Playback constants.
 const (
-	debugLevelBasic  = 2    // debug level for basic playback logging
-	initialPacketCap = 1000 // initial packet slice capacity
+	debugLevelBasic = 2 // debug level for basic playback logging
 )
 
 // Sentinel errors for playback.
@@ -42,12 +41,19 @@ type PlaybackEngine struct {
 
 	// Progress counters, read via Progress(). packetsSent/bytesSent reset at
 	// the start of each playOnce (so a looped replay reports per-iteration
-	// progress rather than an ever-growing total); totalPackets/totalBytes
-	// are set once loadPCAP finishes reading the file.
-	packetsSent  atomic.Uint64
-	bytesSent    atomic.Uint64
-	totalPackets atomic.Uint64
-	totalBytes   atomic.Uint64
+	// progress rather than an ever-growing total). Because playback now streams
+	// the file rather than materializing it, the total isn't known until a pass
+	// finishes: totalPackets/totalBytes stay 0 during the first pass (Progress
+	// then omits percentComplete rather than faking it) and are populated from
+	// cachedTotal* — the counts observed on the previous completed pass — at the
+	// start of every subsequent looped pass, so a loop shows a real bar from
+	// pass two on.
+	packetsSent        atomic.Uint64
+	bytesSent          atomic.Uint64
+	totalPackets       atomic.Uint64
+	totalBytes         atomic.Uint64
+	cachedTotalPackets atomic.Uint64
+	cachedTotalBytes   atomic.Uint64
 }
 
 // PlaybackPacket represents a packet with timestamp for playback.
@@ -97,7 +103,7 @@ func (p *PlaybackEngine) Start() error {
 	// goroutine. openPCAPFile enforces containment via os.Root, so a file
 	// that is a symlink escaping its directory is rejected at the syscall
 	// rather than merely string-checked. The file is reopened per loop in
-	// loadPCAP; this is the early pre-flight so Start reports the error.
+	// forEachPacket; this is the early pre-flight so Start reports the error.
 	preflight, err := p.openPCAPFile()
 	if err != nil {
 		return err
@@ -188,54 +194,60 @@ func (p *PlaybackEngine) playbackLoop() {
 	}
 }
 
-// playOnce plays the PCAP file once.
+// playOnce streams the PCAP file once, sending each packet as it is read so
+// the whole capture is never held in memory (multi-hundred-MB demo corpus).
 func (p *PlaybackEngine) playOnce() {
-	packets, err := p.loadPCAP()
+	// Reset per-iteration progress. The total isn't known until this pass
+	// finishes reading, so seed it from the previous pass's observed counts
+	// (0 on the first pass → Progress omits percentComplete).
+	p.packetsSent.Store(0)
+	p.bytesSent.Store(0)
+	p.totalPackets.Store(p.cachedTotalPackets.Load())
+	p.totalBytes.Store(p.cachedTotalBytes.Load())
+
+	startTime := time.Now()
+
+	var (
+		read            uint64
+		readBytes       uint64
+		firstPacketTime time.Time
+	)
+
+	err := p.forEachPacket(func(pkt PlaybackPacket) bool {
+		if p.isStopped() {
+			return true
+		}
+		if read == 0 {
+			firstPacketTime = pkt.Timestamp
+		}
+		if !p.waitForPacketTiming(pkt, startTime, firstPacketTime) {
+			return true
+		}
+
+		read++
+		readBytes += uint64(len(pkt.Data))
+		p.sendPacketWithLogging(pkt, read, p.totalPackets.Load())
+
+		return false
+	})
 	if err != nil {
 		p.logError("Error loading PCAP", "error", err)
 		return
 	}
 
-	// Reset per-iteration progress counters so a looped replay reports
-	// progress against the current pass, not a running lifetime total.
-	var totalBytes uint64
-	for _, pkt := range packets {
-		totalBytes += uint64(len(pkt.Data))
-	}
-	p.packetsSent.Store(0)
-	p.bytesSent.Store(0)
-	p.totalPackets.Store(uint64(len(packets)))
-	p.totalBytes.Store(totalBytes)
-
-	if len(packets) == 0 {
+	if read == 0 {
 		p.logBasic("No packets found in PCAP file")
 		return
 	}
 
-	p.logBasic("Replaying packets from PCAP", "count", len(packets), "filename", p.config.FileName)
+	// Publish the observed totals so this (and any subsequent looped) pass can
+	// report a real percentComplete.
+	p.cachedTotalPackets.Store(read)
+	p.cachedTotalBytes.Store(readBytes)
+	p.totalPackets.Store(read)
+	p.totalBytes.Store(readBytes)
 
-	p.replayPackets(packets)
-}
-
-// replayPackets replays all packets with proper timing.
-func (p *PlaybackEngine) replayPackets(packets []PlaybackPacket) {
-	startTime := time.Now()
-	firstPacketTime := packets[0].Timestamp
-	totalPackets := len(packets)
-
-	for i, pkt := range packets {
-		if p.isStopped() {
-			return
-		}
-
-		if !p.waitForPacketTiming(pkt, startTime, firstPacketTime) {
-			return
-		}
-
-		p.sendPacketWithLogging(pkt, i+1, totalPackets)
-	}
-
-	p.logPlaybackComplete(startTime, totalPackets)
+	p.logPlaybackComplete(startTime, read)
 }
 
 // isStopped checks if the playback should stop.
@@ -265,7 +277,7 @@ func (p *PlaybackEngine) waitForPacketTiming(pkt PlaybackPacket, startTime, firs
 }
 
 // sendPacketWithLogging sends a packet and logs the result.
-func (p *PlaybackEngine) sendPacketWithLogging(pkt PlaybackPacket, packetNum, totalPackets int) {
+func (p *PlaybackEngine) sendPacketWithLogging(pkt PlaybackPacket, packetNum, totalPackets uint64) {
 	err := p.engine.SendPacket(pkt.Data)
 	if err != nil {
 		p.logBasic("Error sending packet", "packetNum", packetNum, "error", err)
@@ -279,7 +291,7 @@ func (p *PlaybackEngine) sendPacketWithLogging(pkt PlaybackPacket, packetNum, to
 }
 
 // logPlaybackComplete logs the playback completion message.
-func (p *PlaybackEngine) logPlaybackComplete(startTime time.Time, packetCount int) {
+func (p *PlaybackEngine) logPlaybackComplete(startTime time.Time, packetCount uint64) {
 	if p.debugLevel < debugLevelBasic {
 		return
 	}
@@ -301,7 +313,6 @@ func (p *PlaybackEngine) logBasic(msg string, args ...any) {
 	}
 }
 
-// loadPCAP loads packets from a PCAP file.
 // openPCAPFile opens the configured playback file through an os.Root so the
 // kernel rejects the open if any path component escapes the root — including
 // via a symlink already on disk. The file is reopened on every loop
@@ -369,29 +380,32 @@ func newPacketReader(f *os.File) (packetReader, error) {
 	return pcapgo.NewReader(f)
 }
 
-func (p *PlaybackEngine) loadPCAP() ([]PlaybackPacket, error) {
+// forEachPacket streams the configured PCAP file, invoking fn for each packet
+// as it is read — never holding more than one packet, so replay memory is
+// independent of file size. fn returns true to stop early (e.g. on the stop
+// signal). It returns an error only when the file cannot be opened or its
+// header cannot be read; a malformed/truncated trailing packet stops the read
+// and replays the valid prefix (logged), matching the previous behaviour.
+func (p *PlaybackEngine) forEachPacket(fn func(PlaybackPacket) bool) error {
 	f, err := p.openPCAPFile()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer func() { _ = f.Close() }()
 
 	reader, err := newPacketReader(f)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open PCAP file: %w", err)
+		return fmt.Errorf("failed to open PCAP file: %w", err)
 	}
 
-	// Pre-allocate slice with reasonable initial capacity to reduce reallocations.
-	packets := make([]PlaybackPacket, 0, initialPacketCap)
-
+	var read int
 	for {
 		data, ci, readErr := reader.ReadPacketData()
 		if readErr != nil {
 			// EOF is the normal terminator. A malformed/truncated trailing
-			// packet stops the read and replays what was read so far —
-			// matching the old break-on-nil-packet behaviour, but logged.
+			// packet stops the read and replays what was read so far — logged.
 			if !errors.Is(readErr, io.EOF) {
-				p.logError("stopped PCAP read at unreadable packet", "error", readErr, "read", len(packets))
+				p.logError("stopped PCAP read at unreadable packet", "error", readErr, "read", read)
 			}
 			break
 		}
@@ -399,13 +413,13 @@ func (p *PlaybackEngine) loadPCAP() ([]PlaybackPacket, error) {
 		// Copy: pcapgo may reuse the backing array on the next read.
 		buf := make([]byte, len(data))
 		copy(buf, data)
-		packets = append(packets, PlaybackPacket{
-			Data:      buf,
-			Timestamp: ci.Timestamp,
-		})
+		read++
+		if fn(PlaybackPacket{Data: buf, Timestamp: ci.Timestamp}) {
+			break
+		}
 	}
 
-	return packets, nil
+	return nil
 }
 
 // calculatePacketDelay calculates how long to wait before sending a packet

--- a/internal/capture/playback_osroot_test.go
+++ b/internal/capture/playback_osroot_test.go
@@ -19,9 +19,9 @@ func TestPlaybackEngine_LoadPCAP_RoundTrip(t *testing.T) {
 		stopChan: make(chan struct{}),
 	}
 
-	packets, err := pb.loadPCAP()
+	packets, err := collectPlayback(pb)
 	if err != nil {
-		t.Fatalf("loadPCAP: %v", err)
+		t.Fatalf("collectPlayback: %v", err)
 	}
 	if len(packets) != 3 {
 		t.Fatalf("got %d packets, want 3", len(packets))
@@ -58,8 +58,8 @@ func TestPlaybackEngine_LoadPCAP_RejectsSymlinkEscape(t *testing.T) {
 		stopChan: make(chan struct{}),
 	}
 
-	if _, err := pb.loadPCAP(); err == nil {
-		t.Fatal("expected loadPCAP to reject a symlink escaping its directory, got nil")
+	if _, err := collectPlayback(pb); err == nil {
+		t.Fatal("expected playback to reject a symlink escaping its directory, got nil")
 	}
 }
 
@@ -91,8 +91,8 @@ func TestPlaybackEngine_LoadPCAP_RejectsIntermediateSymlinkEscape(t *testing.T) 
 		stopChan: make(chan struct{}),
 	}
 
-	if _, err := pb.loadPCAP(); err == nil {
-		t.Fatal("expected loadPCAP to reject an intermediate-directory symlink escaping the allowed root, got nil")
+	if _, err := collectPlayback(pb); err == nil {
+		t.Fatal("expected playback to reject an intermediate-directory symlink escaping the allowed root, got nil")
 	}
 }
 
@@ -110,9 +110,9 @@ func TestPlaybackEngine_LoadPCAP_RootDirLoadsNestedFile(t *testing.T) {
 		stopChan: make(chan struct{}),
 	}
 
-	packets, err := pb.loadPCAP()
+	packets, err := collectPlayback(pb)
 	if err != nil {
-		t.Fatalf("loadPCAP with RootDir set: %v", err)
+		t.Fatalf("collectPlayback with RootDir set: %v", err)
 	}
 	if len(packets) != 3 {
 		t.Fatalf("got %d packets, want 3", len(packets))

--- a/internal/capture/playback_streaming_test.go
+++ b/internal/capture/playback_streaming_test.go
@@ -1,0 +1,111 @@
+package capture
+
+import (
+	"os"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// collectPlayback drains the streaming reader into a slice for assertions that
+// predate streaming (they asserted against the old loadPCAP slice). Production
+// replay never materializes the file; this is a test-only convenience over
+// forEachPacket.
+func collectPlayback(pb *PlaybackEngine) ([]PlaybackPacket, error) {
+	var pkts []PlaybackPacket
+	err := pb.forEachPacket(func(p PlaybackPacket) bool {
+		pkts = append(pkts, p)
+		return false
+	})
+
+	return pkts, err
+}
+
+// TestPlaybackEngine_ForEachPacket_StreamsLargeFile drives a 50k-packet capture
+// through the streaming reader and asserts every packet is delivered one at a
+// time — the memory-bound win over the old whole-file slice load.
+func TestPlaybackEngine_ForEachPacket_StreamsLargeFile(t *testing.T) {
+	const want = 50000
+	path := createTestPCAPFile(t, want)
+
+	pb := &PlaybackEngine{
+		config:   &config.CapturePlayback{FileName: path},
+		stopChan: make(chan struct{}),
+	}
+
+	var (
+		read  int
+		bytes uint64
+	)
+	err := pb.forEachPacket(func(p PlaybackPacket) bool {
+		read++
+		bytes += uint64(len(p.Data))
+
+		return false
+	})
+	if err != nil {
+		t.Fatalf("forEachPacket: %v", err)
+	}
+	if read != want {
+		t.Fatalf("streamed %d packets, want %d", read, want)
+	}
+	if bytes == 0 {
+		t.Fatal("streamed zero bytes")
+	}
+}
+
+// TestPlaybackEngine_ForEachPacket_EarlyStop verifies the callback can halt the
+// stream before EOF — the path the stop signal takes mid-replay.
+func TestPlaybackEngine_ForEachPacket_EarlyStop(t *testing.T) {
+	path := createTestPCAPFile(t, 10)
+
+	pb := &PlaybackEngine{
+		config:   &config.CapturePlayback{FileName: path},
+		stopChan: make(chan struct{}),
+	}
+
+	var read int
+	err := pb.forEachPacket(func(PlaybackPacket) bool {
+		read++
+
+		return read == 3 // stop after the third packet
+	})
+	if err != nil {
+		t.Fatalf("forEachPacket: %v", err)
+	}
+	if read != 3 {
+		t.Fatalf("stopped after %d packets, want 3", read)
+	}
+}
+
+// TestPlaybackEngine_ForEachPacket_TruncatedTrailer confirms R4: a capture whose
+// final packet record is truncated replays the valid prefix and stops cleanly
+// (log-and-break) rather than erroring or panicking.
+func TestPlaybackEngine_ForEachPacket_TruncatedTrailer(t *testing.T) {
+	const valid = 5
+	path := createTestPCAPFile(t, valid)
+
+	// Append a partial per-packet record header so the reader hits an
+	// unexpected EOF after the valid packets.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = f.Write([]byte{0x01, 0x02, 0x03, 0x04, 0x05}); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	pb := &PlaybackEngine{
+		config:   &config.CapturePlayback{FileName: path},
+		stopChan: make(chan struct{}),
+	}
+
+	packets, err := collectPlayback(pb)
+	if err != nil {
+		t.Fatalf("collectPlayback on truncated file: %v", err)
+	}
+	if len(packets) != valid {
+		t.Fatalf("replayed %d packets from truncated capture, want %d (valid prefix)", len(packets), valid)
+	}
+}

--- a/internal/capture/playback_test.go
+++ b/internal/capture/playback_test.go
@@ -361,7 +361,7 @@ func TestPlaybackEngine_LoadPCAP(t *testing.T) {
 	pb := NewPlaybackEngine(engine, playbackConfig, 0)
 
 	// Test loading PCAP
-	packets, err := pb.loadPCAP()
+	packets, err := collectPlayback(pb)
 	if err != nil {
 		t.Fatalf("Failed to load PCAP: %v", err)
 	}


### PR DESCRIPTION
## Summary

Replace `loadPCAP`'s whole-file `[]PlaybackPacket` materialization with a
`forEachPacket` streaming seam so replay memory is independent of capture size
(the demo corpus has multi-hundred-MB files). `playOnce` now reads and sends
each packet as it is read; `replayPackets` and `loadPCAP` are gone.

**Progress under streaming.** The packet total isn't known until a pass finishes
reading, so `totalPackets`/`totalBytes` stay `0` during the first pass — `Progress()`
already omits `percentComplete` rather than faking `0` (#945) — and are seeded from
the previous pass's observed counts at the start of every subsequent looped pass, so
a looped replay shows a real progress bar from pass two on. Single non-looped replay
reports a live count with total-unknown until completion, which the #945 UI already
handles.

**Malformed/truncated handling (R4).** The C1 log-and-break on an unreadable trailing
packet is preserved and now locked in by a truncated-trailer test.

First of the Workstream-R replay must-haves (`NIAC_REPLAY_POSITIONING_2026-07-07.md §2`).

## Linked Issue

Related to #897

## Testing Evidence

```text
$ go build ./...            # ok
$ go vet ./internal/capture/...   # ok
$ golangci-lint run ./internal/capture/... ./internal/replay/...
0 issues.
$ go test ./internal/capture/... ./internal/replay/... -race
ok  github.com/MustardSeedNetworks/niac-go/internal/capture  3.3s
ok  github.com/MustardSeedNetworks/niac-go/internal/replay    1.0s
$ go test ./internal/api/... -race
ok  github.com/MustardSeedNetworks/niac-go/internal/api  50.6s   (+ subpackages ok)
```
New tests: `TestPlaybackEngine_ForEachPacket_StreamsLargeFile` (50k packets),
`_EarlyStop`, `_TruncatedTrailer`. Existing `loadPCAP` tests migrated to a
`collectPlayback` helper over `forEachPacket`; the os.Root containment tests
(symlink / intermediate-symlink escape rejection) are preserved unchanged in intent.

## Security and Release Checklist

- [x] No new mutating/state-changing HTTP routes; no auth/CSRF surface change.
- [x] os.Root containment (#986/#993) on the open path is unchanged — the streaming
      rewrite touches only the read loop, not `openPCAPFile`.
- [x] No new dependencies; no secrets/PII.
- [x] `golangci-lint` clean (0 issues), `gosec` clean, `go test -race` clean.
