### PR TITLE
feat(replay): add topspeed / pps / Mbps-cap rate modes

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -127,17 +127,19 @@ const (
 	ErrMsgRequestBodyTooLarge = "http: request body too large"
 
 	// Validation and limit constants.
-	requestIDBytes      = 16       // bytes for unique request ID
-	maxURLLength        = 2048     // max webhook URL length
-	maxInterfaceNameLen = 15       // Linux IFNAMSIZ limit
-	maxPathLength       = 4096     // max file path length
-	maxQueryParamLen    = 1024     // max query parameter length
-	maxLoopMs           = 86400000 // max loop ms (24 hours)
-	maxScaleFactor      = 1000.0   // max scale factor
-	truncateErrorValue  = 50       // truncate value for error messages
-	protocolCapacity    = 8        // initial protocol slice capacity
-	historyListLimit    = 20       // limit for history listing
-	maxFileEntries      = 200      // max file entries to return
+	requestIDBytes      = 16          // bytes for unique request ID
+	maxURLLength        = 2048        // max webhook URL length
+	maxInterfaceNameLen = 15          // Linux IFNAMSIZ limit
+	maxPathLength       = 4096        // max file path length
+	maxQueryParamLen    = 1024        // max query parameter length
+	maxLoopMs           = 86400000    // max loop ms (24 hours)
+	maxScaleFactor      = 1000.0      // max scale factor
+	maxReplayPPS        = 10_000_000  // max replay rate (packets/sec)
+	maxReplayMbps       = 1_000_000.0 // max replay throughput cap (Mbps)
+	truncateErrorValue  = 50          // truncate value for error messages
+	protocolCapacity    = 8           // initial protocol slice capacity
+	historyListLimit    = 20          // limit for history listing
+	maxFileEntries      = 200         // max file entries to return
 
 	// HTTP server timeout constants.
 	httpReadTimeout       = 10 // seconds
@@ -197,6 +199,13 @@ type ReplayRequest struct {
 	Scale      float64 `json:"scale"`
 	InlineData string  `json:"data,omitempty"`
 	Uploaded   bool    `json:"-"`
+	// RateMode paces the replay: "" / "timing" honors original inter-packet
+	// timing (× Scale); "topspeed" sends back-to-back; "pps" holds Pps
+	// packets/sec; "mbps" caps average throughput at MbpsCap. Pps/MbpsCap are
+	// only read in their matching mode.
+	RateMode string  `json:"rateMode,omitempty"`
+	Pps      float64 `json:"pps,omitempty"`
+	MbpsCap  float64 `json:"mbpsCap,omitempty"`
 	// RootDir is the validated allow-listed directory File was resolved
 	// under; playback opens File through an os.Root anchored here so no path
 	// component can escape it. Server-set, never client-supplied.
@@ -209,6 +218,9 @@ type ReplayState struct {
 	File      string    `json:"file"`
 	LoopMs    int       `json:"loopMs"`
 	Scale     float64   `json:"scale"`
+	RateMode  string    `json:"rateMode,omitempty"`
+	Pps       float64   `json:"pps,omitempty"`
+	MbpsCap   float64   `json:"mbpsCap,omitempty"`
 	StartedAt time.Time `json:"startedAt,omitzero"`
 
 	// Progress counters for the current (or most recent) replay iteration.

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
 )
 
@@ -387,6 +388,58 @@ func validateReplayRequest(req ReplayRequest) []ErrorDetail {
 			Field: "scale",
 			Issue: "scale exceeds maximum of 1000x",
 			Value: fmt.Sprintf("%f", req.Scale),
+		})
+	}
+
+	errs = append(errs, validateReplayRate(req)...)
+
+	return errs
+}
+
+// validateReplayRate validates the rate mode and its mode-specific parameter.
+// A pacing mode overrides the captured timing, so only the parameter that the
+// selected mode consumes is checked.
+func validateReplayRate(req ReplayRequest) []ErrorDetail {
+	var errs []ErrorDetail
+
+	switch config.RateMode(req.RateMode) {
+	case "", config.RateTiming, config.RateTopspeed:
+		// No rate parameter to validate.
+	case config.RatePPS:
+		if req.Pps <= 0 {
+			errs = append(errs, ErrorDetail{
+				Field: "pps",
+				Issue: `pps must be greater than 0 when rateMode is "pps"`,
+				Value: fmt.Sprintf("%f", req.Pps),
+			})
+		}
+		if req.Pps > maxReplayPPS {
+			errs = append(errs, ErrorDetail{
+				Field: "pps",
+				Issue: "pps exceeds maximum of 10000000 packets/sec",
+				Value: fmt.Sprintf("%f", req.Pps),
+			})
+		}
+	case config.RateMbps:
+		if req.MbpsCap <= 0 {
+			errs = append(errs, ErrorDetail{
+				Field: "mbpsCap",
+				Issue: `mbpsCap must be greater than 0 when rateMode is "mbps"`,
+				Value: fmt.Sprintf("%f", req.MbpsCap),
+			})
+		}
+		if req.MbpsCap > maxReplayMbps {
+			errs = append(errs, ErrorDetail{
+				Field: "mbpsCap",
+				Issue: "mbpsCap exceeds maximum of 1000000 Mbps",
+				Value: fmt.Sprintf("%f", req.MbpsCap),
+			})
+		}
+	default:
+		errs = append(errs, ErrorDetail{
+			Field: "rateMode",
+			Issue: "rateMode must be one of: timing, topspeed, pps, mbps",
+			Value: req.RateMode,
 		})
 	}
 

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -330,3 +330,34 @@ func TestValidateAlertConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateReplayRequest_Rate(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      ReplayRequest
+		wantErrs int
+	}{
+		{name: "timing default", req: ReplayRequest{}, wantErrs: 0},
+		{name: "topspeed", req: ReplayRequest{RateMode: "topspeed"}, wantErrs: 0},
+		{name: "pps valid", req: ReplayRequest{RateMode: "pps", Pps: 1000}, wantErrs: 0},
+		{name: "pps missing rate", req: ReplayRequest{RateMode: "pps"}, wantErrs: 1},
+		{name: "pps negative", req: ReplayRequest{RateMode: "pps", Pps: -5}, wantErrs: 1},
+		{name: "pps too high", req: ReplayRequest{RateMode: "pps", Pps: maxReplayPPS + 1}, wantErrs: 1},
+		{name: "mbps valid", req: ReplayRequest{RateMode: "mbps", MbpsCap: 100}, wantErrs: 0},
+		{name: "mbps missing cap", req: ReplayRequest{RateMode: "mbps"}, wantErrs: 1},
+		{name: "mbps too high", req: ReplayRequest{RateMode: "mbps", MbpsCap: maxReplayMbps + 1}, wantErrs: 1},
+		{name: "unknown mode", req: ReplayRequest{RateMode: "warpspeed"}, wantErrs: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateReplayRequest(tt.req)
+			if len(errs) != tt.wantErrs {
+				t.Errorf("validateReplayRequest() returned %d errors, want %d", len(errs), tt.wantErrs)
+				for _, e := range errs {
+					t.Logf("  error: field=%s issue=%s", e.Field, e.Issue)
+				}
+			}
+		})
+	}
+}

--- a/internal/capture/playback.go
+++ b/internal/capture/playback.go
@@ -21,6 +21,9 @@ import (
 // Playback constants.
 const (
 	debugLevelBasic = 2 // debug level for basic playback logging
+
+	bitsPerByte = 8 // bits in a byte, for Mbps pacing
+	bitsPerMbit = 1_000_000
 )
 
 // Sentinel errors for playback.
@@ -220,7 +223,9 @@ func (p *PlaybackEngine) playOnce() {
 		if read == 0 {
 			firstPacketTime = pkt.Timestamp
 		}
-		if !p.waitForPacketTiming(pkt, startTime, firstPacketTime) {
+		// read/readBytes are the counts already sent, which the pps/mbps
+		// governors pace against.
+		if !p.sleepOrStop(p.pacingDelay(pkt, read, readBytes, startTime, firstPacketTime)) {
 			return true
 		}
 
@@ -260,20 +265,63 @@ func (p *PlaybackEngine) isStopped() bool {
 	}
 }
 
-// waitForPacketTiming waits until it's time to send the packet.
-// Returns false if playback was stopped during the wait.
+// waitForPacketTiming waits until it's time to send the packet under the
+// original-timing rate mode. Returns false if playback was stopped during the
+// wait.
 func (p *PlaybackEngine) waitForPacketTiming(pkt PlaybackPacket, startTime, firstPacketTime time.Time) bool {
-	sleepDuration := p.calculatePacketDelay(pkt, startTime, firstPacketTime)
-	if sleepDuration <= 0 {
+	return p.sleepOrStop(p.calculatePacketDelay(pkt, startTime, firstPacketTime))
+}
+
+// sleepOrStop waits for delay, returning true when it elapses or immediately if
+// delay <= 0, and false if playback is stopped first.
+func (p *PlaybackEngine) sleepOrStop(delay time.Duration) bool {
+	if delay <= 0 {
 		return true
 	}
 
 	select {
-	case <-time.After(sleepDuration):
+	case <-time.After(delay):
 		return true
 	case <-p.stopChan:
 		return false
 	}
+}
+
+// pacingDelay returns how long to wait before sending the current packet under
+// the configured rate mode. sentPackets/sentBytes are the counts already sent
+// this pass (the pps/mbps governors pace the average rate against them).
+func (p *PlaybackEngine) pacingDelay(
+	pkt PlaybackPacket,
+	sentPackets, sentBytes uint64,
+	startTime, firstPacketTime time.Time,
+) time.Duration {
+	switch p.config.RateMode {
+	case config.RateTopspeed:
+		return 0
+	case config.RatePPS:
+		// Send packet index N (0-based) at startTime + N/pps seconds.
+		targetElapsed := float64(sentPackets) / p.config.PacketsPerSec * float64(time.Second)
+		return rateDelay(startTime, time.Duration(targetElapsed))
+	case config.RateMbps:
+		// Hold average throughput at the cap: having already sent sentBytes,
+		// the next send is due at startTime + sentBytes*8 / (mbps*1e6) seconds.
+		targetElapsed := float64(sentBytes*bitsPerByte) / (p.config.MbpsCap * bitsPerMbit) * float64(time.Second)
+		return rateDelay(startTime, time.Duration(targetElapsed))
+	case config.RateTiming:
+		return p.calculatePacketDelay(pkt, startTime, firstPacketTime)
+	default: // empty / unknown → original timing
+		return p.calculatePacketDelay(pkt, startTime, firstPacketTime)
+	}
+}
+
+// rateDelay returns the wait needed for targetElapsed to have passed since
+// startTime, or 0 if that moment is already past.
+func rateDelay(startTime time.Time, targetElapsed time.Duration) time.Duration {
+	if d := time.Until(startTime.Add(targetElapsed)); d > 0 {
+		return d
+	}
+
+	return 0
 }
 
 // sendPacketWithLogging sends a packet and logs the result.

--- a/internal/capture/playback_rate_test.go
+++ b/internal/capture/playback_rate_test.go
@@ -1,0 +1,136 @@
+package capture
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// TestPacingDelay_ModeMath checks the per-mode pacing math. rateDelay only
+// computes a duration (it never sleeps), so large target elapsed values are
+// cheap and keep the assertions off the wall clock: with startTime == now the
+// returned delay is essentially the whole target interval.
+func TestPacingDelay_ModeMath(t *testing.T) {
+	start := time.Now()
+	pkt := PlaybackPacket{Data: make([]byte, 1250), Timestamp: start} // 1250 B = 10000 bits
+
+	tests := []struct {
+		name        string
+		cfg         config.CapturePlayback
+		sentPackets uint64
+		sentBytes   uint64
+		wantZero    bool          // expect exactly 0
+		lo, hi      time.Duration // else expect (lo, hi]
+	}{
+		{
+			name:        "topspeed",
+			cfg:         config.CapturePlayback{RateMode: config.RateTopspeed},
+			sentPackets: 100,
+			sentBytes:   1 << 20,
+			wantZero:    true,
+		},
+		{
+			name:        "pps first packet is immediate",
+			cfg:         config.CapturePlayback{RateMode: config.RatePPS, PacketsPerSec: 10},
+			sentPackets: 0,
+			wantZero:    true,
+		},
+		{
+			name:        "pps paces to rate",
+			cfg:         config.CapturePlayback{RateMode: config.RatePPS, PacketsPerSec: 10},
+			sentPackets: 100,
+			lo:          9 * time.Second,
+			hi:          10 * time.Second,
+		},
+		{
+			name:      "mbps first byte is immediate",
+			cfg:       config.CapturePlayback{RateMode: config.RateMbps, MbpsCap: 1},
+			sentBytes: 0,
+			wantZero:  true,
+		},
+		// 1_250_000 B = 10_000_000 bits; at 1 Mbps that is 10s of target elapsed.
+		{
+			name:      "mbps caps throughput",
+			cfg:       config.CapturePlayback{RateMode: config.RateMbps, MbpsCap: 1},
+			sentBytes: 1_250_000,
+			lo:        9 * time.Second,
+			hi:        10 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			pb := &PlaybackEngine{config: &cfg, stopChan: make(chan struct{})}
+
+			got := pb.pacingDelay(pkt, tc.sentPackets, tc.sentBytes, start, start)
+			if tc.wantZero {
+				if got != 0 {
+					t.Fatalf("pacingDelay = %v, want 0", got)
+				}
+
+				return
+			}
+			if got <= tc.lo || got > tc.hi {
+				t.Fatalf("pacingDelay = %v, want in (%v, %v]", got, tc.lo, tc.hi)
+			}
+		})
+	}
+}
+
+// TestPacingDelay_TimingModeDelegates confirms the default and explicit timing
+// modes fall through to calculatePacketDelay (original inter-packet spacing).
+func TestPacingDelay_TimingModeDelegates(t *testing.T) {
+	start := time.Now()
+	first := PlaybackPacket{Timestamp: start}
+	later := PlaybackPacket{Timestamp: start.Add(500 * time.Millisecond)}
+
+	for _, mode := range []config.RateMode{"", config.RateTiming} {
+		cfg := config.CapturePlayback{RateMode: mode}
+		pb := &PlaybackEngine{config: &cfg, stopChan: make(chan struct{})}
+
+		// calculatePacketDelay reads time.Now() internally, so two calls differ
+		// by sub-microsecond wall-clock drift — compare within a small tolerance.
+		want := pb.calculatePacketDelay(later, start, first.Timestamp)
+		got := pb.pacingDelay(later, 1, 0, start, first.Timestamp)
+		if diff := got - want; diff < -time.Millisecond || diff > time.Millisecond {
+			t.Fatalf("mode %q: pacingDelay = %v, want ≈ calculatePacketDelay = %v", mode, got, want)
+		}
+	}
+}
+
+// TestReplay_Topspeed_IgnoresCapturedTiming proves the governor is wired into
+// the real send loop: a capture whose packets are 10ms apart (≈190ms in timing
+// mode) replays near-instantly under topspeed.
+func TestReplay_Topspeed_IgnoresCapturedTiming(t *testing.T) {
+	iface := findLoopback(t)
+
+	engine, err := New(iface, 0)
+	if err != nil {
+		t.Skipf("cannot create engine: %v", err)
+	}
+	defer engine.Close()
+
+	const count = 20
+	pb := NewPlaybackEngine(engine, &config.CapturePlayback{
+		FileName: createTestPCAPFile(t, count),
+		RateMode: config.RateTopspeed,
+	}, 0)
+
+	if err = pb.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pb.Stop()
+
+	// Topspeed should send all 20 well under the ~190ms the captured timing
+	// would impose. Poll briefly so the test isn't tied to a fixed sleep.
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if pb.Progress().PacketsSent == count {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("topspeed sent %d/%d packets within 100ms", pb.Progress().PacketsSent, count)
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -166,6 +166,25 @@ func (c *Config) NormalizedSegments() []Segment {
 	return []Segment{{Tag: UntaggedTag, Devices: c.Devices}}
 }
 
+// RateMode selects how replay paces its packet sends. ScaleTime applies only
+// in RateTiming.
+type RateMode string
+
+const (
+	// RateTiming (the default, also the zero value "") replays packets at their
+	// original inter-packet spacing, optionally sped up/slowed by ScaleTime.
+	RateTiming RateMode = "timing"
+	// RateTopspeed sends packets back-to-back with no inter-packet delay,
+	// ignoring the captured timestamps.
+	RateTopspeed RateMode = "topspeed"
+	// RatePPS paces sends to a fixed packets-per-second (PacketsPerSec),
+	// ignoring the captured timestamps.
+	RatePPS RateMode = "pps"
+	// RateMbps paces sends to cap average throughput at MbpsCap megabits/sec,
+	// ignoring the captured timestamps.
+	RateMbps RateMode = "mbps"
+)
+
 // CapturePlayback represents PCAP file playback configuration.
 type CapturePlayback struct {
 	FileName string
@@ -178,7 +197,14 @@ type CapturePlayback struct {
 	// falls back to rooting at the file's own parent directory.
 	RootDir   string
 	LoopTime  int     // milliseconds
-	ScaleTime float64 // time scaling factor
+	ScaleTime float64 // time scaling factor (RateTiming only)
+
+	// RateMode selects the pacing strategy; empty means RateTiming.
+	RateMode RateMode
+	// PacketsPerSec is the target rate for RatePPS (packets/second).
+	PacketsPerSec float64
+	// MbpsCap is the throughput cap for RateMbps (megabits/second).
+	MbpsCap float64
 }
 
 // DiscoveryProtocols configures discovery protocol behavior.

--- a/internal/replay/controller.go
+++ b/internal/replay/controller.go
@@ -110,10 +110,13 @@ func (c *Controller) Start(req api.ReplayRequest) (api.ReplayState, error) {
 	c.cleanupTempFile()
 
 	cfg := &config.CapturePlayback{
-		FileName:  req.File,
-		RootDir:   req.RootDir,
-		LoopTime:  req.LoopMs,
-		ScaleTime: req.Scale,
+		FileName:      req.File,
+		RootDir:       req.RootDir,
+		LoopTime:      req.LoopMs,
+		ScaleTime:     req.Scale,
+		RateMode:      config.RateMode(req.RateMode),
+		PacketsPerSec: req.Pps,
+		MbpsCap:       req.MbpsCap,
 	}
 	player := capture.NewPlaybackEngine(c.engine, cfg, c.debugLevel)
 	if err := player.Start(); err != nil {
@@ -135,6 +138,9 @@ func (c *Controller) Start(req api.ReplayRequest) (api.ReplayState, error) {
 		File:      req.File,
 		LoopMs:    req.LoopMs,
 		Scale:     req.Scale,
+		RateMode:  req.RateMode,
+		Pps:       req.Pps,
+		MbpsCap:   req.MbpsCap,
 		StartedAt: time.Now().UTC(),
 	}
 	if req.Uploaded {


### PR DESCRIPTION
## Summary

`ScaleTime` can only speed up / slow down the captured inter-packet timing — it
cannot express a fixed packet rate, a throughput cap, or send-as-fast-as-possible
(the most-requested tcpreplay rate features). This adds a rate governor:

- `config.CapturePlayback` gains `RateMode` (`timing` (default) / `topspeed` /
  `pps` / `mbps`), `PacketsPerSec`, `MbpsCap`.
- `pacingDelay` + `sleepOrStop` in the streaming send loop: `timing` keeps the
  existing `calculatePacketDelay`; `topspeed` sends back-to-back; `pps` holds a
  fixed packets/sec; `mbps` caps average throughput. The pps/mbps governors pace
  against the packets/bytes already sent this pass, and honor the stop signal.
- Reachable via the replay API: `ReplayRequest` gains `rateMode`/`pps`/`mbpsCap`,
  echoed in `ReplayState`; `validateReplayRequest` rejects an unknown mode and a
  missing / negative / oversized rate for the selected mode.

Second of the Workstream-R replay must-haves. UI exposure is a separate
follow-up; the `.niac` converter text format is unchanged (its use case is
`LoopTime`/`ScaleTime`).

## Linked Issue

Related to #897

## Testing Evidence

```text
$ go build ./... && go vet ./...            # ok
$ golangci-lint run ./internal/capture/... ./internal/replay/... ./internal/api/... ./internal/config/...
0 issues.
$ go test ./internal/capture/... ./internal/replay/... ./internal/config/... -race
ok  internal/capture   ok  internal/replay   ok  internal/config
$ go test ./internal/api/... -race           # ok (validateReplayRequest rate cases)
```
New tests: `TestPacingDelay_ModeMath` (topspeed/pps/mbps math), `_TimingModeDelegates`,
`TestReplay_Topspeed_IgnoresCapturedTiming` (governor wired into the real loop over
loopback), `TestValidateReplayRequest_Rate` (10 accept/reject cases).

## Security and Release Checklist

- [x] No new mutating/state-changing HTTP routes; reuses the existing replay
      start handler + its CSRF/auth wrappers. New fields are additive/optional.
- [x] `validateReplayRequest` bounds the new numeric inputs (max pps / max Mbps)
      to prevent resource-exhaustion via absurd rates.
- [x] No new dependencies; no secrets/PII.
- [x] `golangci-lint` clean (0 issues), `gosec` clean, `go test -race` clean.
