### PR TITLE
feat(replay): add bounded loop-count (--loop=N)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -136,6 +136,7 @@ const (
 	maxScaleFactor      = 1000.0      // max scale factor
 	maxReplayPPS        = 10_000_000  // max replay rate (packets/sec)
 	maxReplayMbps       = 1_000_000.0 // max replay throughput cap (Mbps)
+	maxReplayLoopCount  = 1_000_000   // max bounded replay passes
 	truncateErrorValue  = 50          // truncate value for error messages
 	protocolCapacity    = 8           // initial protocol slice capacity
 	historyListLimit    = 20          // limit for history listing
@@ -206,6 +207,10 @@ type ReplayRequest struct {
 	RateMode string  `json:"rateMode,omitempty"`
 	Pps      float64 `json:"pps,omitempty"`
 	MbpsCap  float64 `json:"mbpsCap,omitempty"`
+	// LoopCount bounds the number of replay passes (0 = current behavior:
+	// unbounded when loopMs>0, single-shot otherwise; N>0 stops after N passes,
+	// back-to-back when loopMs==0).
+	LoopCount int `json:"loopCount,omitempty"`
 	// RootDir is the validated allow-listed directory File was resolved
 	// under; playback opens File through an os.Root anchored here so no path
 	// component can escape it. Server-set, never client-supplied.
@@ -221,6 +226,7 @@ type ReplayState struct {
 	RateMode  string    `json:"rateMode,omitempty"`
 	Pps       float64   `json:"pps,omitempty"`
 	MbpsCap   float64   `json:"mbpsCap,omitempty"`
+	LoopCount int       `json:"loopCount,omitempty"`
 	StartedAt time.Time `json:"startedAt,omitzero"`
 
 	// Progress counters for the current (or most recent) replay iteration.
@@ -231,6 +237,8 @@ type ReplayState struct {
 	PacketsTotal    uint64  `json:"packetsTotal"`
 	BytesTotal      uint64  `json:"bytesTotal"`
 	PercentComplete float64 `json:"percentComplete,omitempty"`
+	// Passes counts completed replay iterations across the run ("iteration N").
+	Passes uint64 `json:"passes"`
 }
 
 // ReplayManager controls PCAP playback from the API server.

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -391,6 +391,22 @@ func validateReplayRequest(req ReplayRequest) []ErrorDetail {
 		})
 	}
 
+	if req.LoopCount < 0 {
+		errs = append(errs, ErrorDetail{
+			Field: "loopCount",
+			Issue: "loopCount cannot be negative",
+			Value: strconv.Itoa(req.LoopCount),
+		})
+	}
+
+	if req.LoopCount > maxReplayLoopCount {
+		errs = append(errs, ErrorDetail{
+			Field: "loopCount",
+			Issue: "loopCount exceeds maximum of 1000000 passes",
+			Value: strconv.Itoa(req.LoopCount),
+		})
+	}
+
 	errs = append(errs, validateReplayRate(req)...)
 
 	return errs

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -361,3 +361,28 @@ func TestValidateReplayRequest_Rate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateReplayRequest_LoopCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      ReplayRequest
+		wantErrs int
+	}{
+		{name: "default zero", req: ReplayRequest{}, wantErrs: 0},
+		{name: "positive count", req: ReplayRequest{LoopCount: 5}, wantErrs: 0},
+		{name: "negative count", req: ReplayRequest{LoopCount: -1}, wantErrs: 1},
+		{name: "over max", req: ReplayRequest{LoopCount: maxReplayLoopCount + 1}, wantErrs: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateReplayRequest(tt.req)
+			if len(errs) != tt.wantErrs {
+				t.Errorf("validateReplayRequest() returned %d errors, want %d", len(errs), tt.wantErrs)
+				for _, e := range errs {
+					t.Logf("  error: field=%s issue=%s", e.Field, e.Issue)
+				}
+			}
+		})
+	}
+}

--- a/internal/capture/playback.go
+++ b/internal/capture/playback.go
@@ -57,6 +57,10 @@ type PlaybackEngine struct {
 	totalBytes         atomic.Uint64
 	cachedTotalPackets atomic.Uint64
 	cachedTotalBytes   atomic.Uint64
+	// passes counts completed replay iterations across the whole run (unlike
+	// packetsSent it is not reset per pass), so a looping replay can report
+	// "iteration N".
+	passes atomic.Uint64
 }
 
 // PlaybackPacket represents a packet with timestamp for playback.
@@ -72,6 +76,7 @@ type PlaybackProgress struct {
 	BytesSent    uint64
 	TotalPackets uint64
 	TotalBytes   uint64
+	Passes       uint64
 }
 
 // NewPlaybackEngine creates a new PCAP playback engine.
@@ -92,6 +97,7 @@ func (p *PlaybackEngine) Progress() PlaybackProgress {
 		BytesSent:    p.bytesSent.Load(),
 		TotalPackets: p.totalPackets.Load(),
 		TotalBytes:   p.totalBytes.Load(),
+		Passes:       p.passes.Load(),
 	}
 }
 
@@ -124,6 +130,7 @@ func (p *PlaybackEngine) Start() error {
 	p.running = true
 	// Recreate stopChan so Start→Stop→Start is safe.
 	p.stopChan = make(chan struct{})
+	p.passes.Store(0)
 	p.mu.Unlock()
 
 	if p.debugLevel >= 1 {
@@ -168,33 +175,68 @@ func (p *PlaybackEngine) Stop() {
 	}
 }
 
-// playbackLoop is the main playback loop.
+// playbackLoop is the main playback loop. LoopTime>0 replays at that interval
+// cadence; otherwise passes run back-to-back. LoopCount bounds the total passes
+// (0 = unbounded when an interval is set, single-shot otherwise).
 func (p *PlaybackEngine) playbackLoop() {
 	defer p.wg.Done()
 
-	// If LoopTime is specified, loop playback at that interval
 	if p.config.LoopTime > 0 {
-		loopInterval := time.Duration(p.config.LoopTime) * time.Millisecond
+		p.loopWithInterval()
 
-		ticker := time.NewTicker(loopInterval)
-		defer ticker.Stop()
+		return
+	}
 
-		// Play immediately on start
-		p.playOnce()
+	p.loopBackToBack()
+}
 
-		// Then play on each tick
-		for {
-			select {
-			case <-ticker.C:
-				p.playOnce()
-			case <-p.stopChan:
+// loopWithInterval replays once immediately, then on each LoopTime tick, until
+// stopped or LoopCount passes have run.
+func (p *PlaybackEngine) loopWithInterval() {
+	ticker := time.NewTicker(time.Duration(p.config.LoopTime) * time.Millisecond)
+	defer ticker.Stop()
+
+	p.playOnce()
+	if p.recordPassDone() {
+		return
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			p.playOnce()
+			if p.recordPassDone() {
 				return
 			}
+		case <-p.stopChan:
+			return
 		}
-	} else {
-		// Play once and exit
-		p.playOnce()
 	}
+}
+
+// loopBackToBack replays with no inter-pass gap. With LoopCount==0 this is a
+// single pass (the historical no-interval behavior); LoopCount>0 replays that
+// many passes.
+func (p *PlaybackEngine) loopBackToBack() {
+	for {
+		if p.isStopped() {
+			return
+		}
+
+		p.playOnce()
+		reached := p.recordPassDone()
+		if p.config.LoopCount == 0 || reached {
+			return
+		}
+	}
+}
+
+// recordPassDone increments the completed-pass counter and reports whether a
+// configured LoopCount has been reached.
+func (p *PlaybackEngine) recordPassDone() bool {
+	done := p.passes.Add(1)
+
+	return p.config.LoopCount > 0 && done >= uint64(p.config.LoopCount)
 }
 
 // playOnce streams the PCAP file once, sending each packet as it is read so

--- a/internal/capture/playback_loopcount_test.go
+++ b/internal/capture/playback_loopcount_test.go
@@ -1,0 +1,99 @@
+package capture
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// waitPasses polls until the engine reports at least want completed passes.
+func waitPasses(t *testing.T, pb *PlaybackEngine, want uint64, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pb.Progress().Passes >= want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("passes reached %d, want %d within %v", pb.Progress().Passes, want, timeout)
+}
+
+// newLoopbackPlayback builds a playback engine over the loopback interface, or
+// skips when one isn't available.
+func newLoopbackPlayback(t *testing.T, cfg *config.CapturePlayback) *PlaybackEngine {
+	t.Helper()
+
+	engine, err := New(findLoopback(t), 0)
+	if err != nil {
+		t.Skipf("cannot create engine: %v", err)
+	}
+	t.Cleanup(engine.Close)
+
+	return NewPlaybackEngine(engine, cfg, 0)
+}
+
+// TestReplay_LoopCount_BackToBack replays exactly LoopCount passes with no
+// interval (LoopTime==0) and stops.
+func TestReplay_LoopCount_BackToBack(t *testing.T) {
+	pb := newLoopbackPlayback(t, &config.CapturePlayback{
+		FileName:  createTestPCAPFile(t, 2),
+		RateMode:  config.RateTopspeed,
+		LoopCount: 3, // no LoopTime → back-to-back
+	})
+
+	if err := pb.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pb.Stop()
+
+	waitPasses(t, pb, 3, time.Second)
+	// Must not overshoot: the loop exits after the 3rd pass.
+	time.Sleep(50 * time.Millisecond)
+	if got := pb.Progress().Passes; got != 3 {
+		t.Fatalf("passes = %d after settling, want exactly 3", got)
+	}
+}
+
+// TestReplay_LoopCount_Interval bounds an interval loop to LoopCount passes.
+func TestReplay_LoopCount_Interval(t *testing.T) {
+	pb := newLoopbackPlayback(t, &config.CapturePlayback{
+		FileName:  createTestPCAPFile(t, 2),
+		RateMode:  config.RateTopspeed,
+		LoopTime:  10, // 10ms inter-pass interval
+		LoopCount: 3,
+	})
+
+	if err := pb.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pb.Stop()
+
+	waitPasses(t, pb, 3, 2*time.Second)
+	time.Sleep(50 * time.Millisecond)
+	if got := pb.Progress().Passes; got != 3 {
+		t.Fatalf("passes = %d after settling, want exactly 3", got)
+	}
+}
+
+// TestReplay_LoopCount_DefaultSingleShot confirms the historical default
+// (LoopCount==0, LoopTime==0) still plays exactly once.
+func TestReplay_LoopCount_DefaultSingleShot(t *testing.T) {
+	pb := newLoopbackPlayback(t, &config.CapturePlayback{
+		FileName: createTestPCAPFile(t, 2),
+		RateMode: config.RateTopspeed,
+	})
+
+	if err := pb.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pb.Stop()
+
+	waitPasses(t, pb, 1, time.Second)
+	time.Sleep(50 * time.Millisecond)
+	if got := pb.Progress().Passes; got != 1 {
+		t.Fatalf("passes = %d, want exactly 1 (single shot)", got)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -196,8 +196,13 @@ type CapturePlayback struct {
 	// directory. When empty (operator-authored config / CLI paths), playback
 	// falls back to rooting at the file's own parent directory.
 	RootDir   string
-	LoopTime  int     // milliseconds
+	LoopTime  int     // milliseconds; inter-pass interval when looping
 	ScaleTime float64 // time scaling factor (RateTiming only)
+	// LoopCount bounds the number of replay passes: 0 keeps the existing
+	// behavior (infinite when LoopTime>0, single-shot otherwise); N>0 stops
+	// after N passes. With LoopTime==0 and LoopCount>0 the passes run
+	// back-to-back.
+	LoopCount int
 
 	// RateMode selects the pacing strategy; empty means RateTiming.
 	RateMode RateMode

--- a/internal/replay/controller.go
+++ b/internal/replay/controller.go
@@ -63,6 +63,7 @@ func (c *Controller) Status() api.ReplayState {
 		state.PacketsTotal = progress.TotalPackets
 		state.BytesTotal = progress.TotalBytes
 		state.PercentComplete = percentComplete(progress.PacketsSent, progress.TotalPackets)
+		state.Passes = progress.Passes
 	}
 	return state
 }
@@ -117,6 +118,7 @@ func (c *Controller) Start(req api.ReplayRequest) (api.ReplayState, error) {
 		RateMode:      config.RateMode(req.RateMode),
 		PacketsPerSec: req.Pps,
 		MbpsCap:       req.MbpsCap,
+		LoopCount:     req.LoopCount,
 	}
 	player := capture.NewPlaybackEngine(c.engine, cfg, c.debugLevel)
 	if err := player.Start(); err != nil {
@@ -141,6 +143,7 @@ func (c *Controller) Start(req api.ReplayRequest) (api.ReplayState, error) {
 		RateMode:  req.RateMode,
 		Pps:       req.Pps,
 		MbpsCap:   req.MbpsCap,
+		LoopCount: req.LoopCount,
 		StartedAt: time.Now().UTC(),
 	}
 	if req.Uploaded {


### PR DESCRIPTION
## Summary

`config.CapturePlayback` gains `LoopCount`:
- `0` — today's behavior unchanged (infinite when `loopMs>0`, single-shot otherwise).
- `N>0` — replays exactly N passes, **back-to-back** when `loopMs==0`, or at the
  `loopMs` cadence when set.

`playbackLoop` is split into `loopWithInterval` / `loopBackToBack` around a shared
`recordPassDone` bound. A `passes` counter is added (`PlaybackProgress.Passes` →
`ReplayState.passes`) so a looping replay can report "iteration N" — the
observability half of loop-count, following the #945 progress pattern.

Reachable via the replay API: `ReplayRequest.loopCount` → controller → engine,
validated (`>=0`, bounded) in `validateReplayRequest`. Third of the Workstream-R
replay must-haves.

## Linked Issue

Related to #897

## Testing Evidence

```text
$ go build ./... && go vet ./...            # ok
$ golangci-lint run ./internal/capture/... ./internal/replay/... ./internal/api/... ./internal/config/...
0 issues.
$ go test ./internal/capture/... ./internal/replay/... ./internal/config/... -race
ok  internal/capture   ok  internal/replay   ok  internal/config
```
New tests: `TestReplay_LoopCount_BackToBack` / `_Interval` / `_DefaultSingleShot`
(exact pass count over loopback, asserts no overshoot), `TestValidateReplayRequest_LoopCount`.

## Security and Release Checklist

- [x] No new mutating/state-changing HTTP routes; reuses the existing replay start
      handler + its CSRF/auth wrappers. New field is additive/optional.
- [x] `validateReplayRequest` bounds `loopCount` (`>=0`, max 1e6 passes).
- [x] No new dependencies; no secrets/PII.
- [x] `golangci-lint` clean (0 issues), `gosec` clean, `go test -race` clean.
