### PR TITLE
feat(replay): apply a BPF filter on replay (selective subset)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.etcd.io/bbolt v1.5.0
+	golang.org/x/net v0.56.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.53.0
@@ -60,7 +61,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -137,6 +137,7 @@ const (
 	maxReplayPPS        = 10_000_000  // max replay rate (packets/sec)
 	maxReplayMbps       = 1_000_000.0 // max replay throughput cap (Mbps)
 	maxReplayLoopCount  = 1_000_000   // max bounded replay passes
+	maxBPFFilterLen     = 1024        // max replay BPF filter expression length
 	truncateErrorValue  = 50          // truncate value for error messages
 	protocolCapacity    = 8           // initial protocol slice capacity
 	historyListLimit    = 20          // limit for history listing
@@ -211,6 +212,9 @@ type ReplayRequest struct {
 	// unbounded when loopMs>0, single-shot otherwise; N>0 stops after N passes,
 	// back-to-back when loopMs==0).
 	LoopCount int `json:"loopCount,omitempty"`
+	// BPFFilter replays only packets matching this tcpdump-style filter
+	// (e.g. "udp port 53"); empty replays every packet.
+	BPFFilter string `json:"bpfFilter,omitempty"`
 	// RootDir is the validated allow-listed directory File was resolved
 	// under; playback opens File through an os.Root anchored here so no path
 	// component can escape it. Server-set, never client-supplied.
@@ -227,6 +231,7 @@ type ReplayState struct {
 	Pps       float64   `json:"pps,omitempty"`
 	MbpsCap   float64   `json:"mbpsCap,omitempty"`
 	LoopCount int       `json:"loopCount,omitempty"`
+	BPFFilter string    `json:"bpfFilter,omitempty"`
 	StartedAt time.Time `json:"startedAt,omitzero"`
 
 	// Progress counters for the current (or most recent) replay iteration.
@@ -239,6 +244,8 @@ type ReplayState struct {
 	PercentComplete float64 `json:"percentComplete,omitempty"`
 	// Passes counts completed replay iterations across the run ("iteration N").
 	Passes uint64 `json:"passes"`
+	// PacketsFiltered counts packets skipped by bpfFilter in the current pass.
+	PacketsFiltered uint64 `json:"packetsFiltered"`
 }
 
 // ReplayManager controls PCAP playback from the API server.

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/capture"
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
 )
@@ -408,8 +409,36 @@ func validateReplayRequest(req ReplayRequest) []ErrorDetail {
 	}
 
 	errs = append(errs, validateReplayRate(req)...)
+	errs = append(errs, validateReplayFilter(req)...)
 
 	return errs
+}
+
+// validateReplayFilter checks the replay BPF filter length and that it
+// compiles, so the API rejects a malformed expression with a clean 400 before
+// playback starts.
+func validateReplayFilter(req ReplayRequest) []ErrorDetail {
+	if req.BPFFilter == "" {
+		return nil
+	}
+
+	if len(req.BPFFilter) > maxBPFFilterLen {
+		return []ErrorDetail{{
+			Field: "bpfFilter",
+			Issue: "bpfFilter exceeds maximum length of 1024 characters",
+			Value: "[too long]",
+		}}
+	}
+
+	if err := capture.ValidateBPFExpr(req.BPFFilter); err != nil {
+		return []ErrorDetail{{
+			Field: "bpfFilter",
+			Issue: err.Error(),
+			Value: req.BPFFilter,
+		}}
+	}
+
+	return nil
 }
 
 // validateReplayRate validates the rate mode and its mode-specific parameter.

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -372,6 +373,31 @@ func TestValidateReplayRequest_LoopCount(t *testing.T) {
 		{name: "positive count", req: ReplayRequest{LoopCount: 5}, wantErrs: 0},
 		{name: "negative count", req: ReplayRequest{LoopCount: -1}, wantErrs: 1},
 		{name: "over max", req: ReplayRequest{LoopCount: maxReplayLoopCount + 1}, wantErrs: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateReplayRequest(tt.req)
+			if len(errs) != tt.wantErrs {
+				t.Errorf("validateReplayRequest() returned %d errors, want %d", len(errs), tt.wantErrs)
+				for _, e := range errs {
+					t.Logf("  error: field=%s issue=%s", e.Field, e.Issue)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateReplayRequest_BPFFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      ReplayRequest
+		wantErrs int
+	}{
+		{name: "empty filter", req: ReplayRequest{}, wantErrs: 0},
+		{name: "valid filter", req: ReplayRequest{BPFFilter: "udp port 53"}, wantErrs: 0},
+		{name: "malformed filter", req: ReplayRequest{BPFFilter: "not a bpf !!!"}, wantErrs: 1},
+		{name: "over length", req: ReplayRequest{BPFFilter: strings.Repeat("a", maxBPFFilterLen+1)}, wantErrs: 1},
 	}
 
 	for _, tt := range tests {

--- a/internal/capture/playback.go
+++ b/internal/capture/playback.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
 	"github.com/gopacket/gopacket/pcapgo"
+	"golang.org/x/net/bpf"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
@@ -61,6 +63,14 @@ type PlaybackEngine struct {
 	// packetsSent it is not reset per pass), so a looping replay can report
 	// "iteration N".
 	passes atomic.Uint64
+	// packetsFiltered counts packets skipped by BPFFilter this pass (reset
+	// alongside packetsSent).
+	packetsFiltered atomic.Uint64
+
+	// bpfVM is the compiled replay filter, or nil when no BPFFilter is set. Set
+	// under mu in Start before the playback goroutine spawns; read only by that
+	// single goroutine, so its serial Run calls need no further locking.
+	bpfVM *bpf.VM
 }
 
 // PlaybackPacket represents a packet with timestamp for playback.
@@ -72,11 +82,12 @@ type PlaybackPacket struct {
 // PlaybackProgress reports live counters for an in-progress (or just
 // finished) replay iteration.
 type PlaybackProgress struct {
-	PacketsSent  uint64
-	BytesSent    uint64
-	TotalPackets uint64
-	TotalBytes   uint64
-	Passes       uint64
+	PacketsSent     uint64
+	BytesSent       uint64
+	TotalPackets    uint64
+	TotalBytes      uint64
+	Passes          uint64
+	PacketsFiltered uint64
 }
 
 // NewPlaybackEngine creates a new PCAP playback engine.
@@ -93,11 +104,12 @@ func NewPlaybackEngine(engine *Engine, playbackConfig *config.CapturePlayback, d
 // concurrently with playbackLoop.
 func (p *PlaybackEngine) Progress() PlaybackProgress {
 	return PlaybackProgress{
-		PacketsSent:  p.packetsSent.Load(),
-		BytesSent:    p.bytesSent.Load(),
-		TotalPackets: p.totalPackets.Load(),
-		TotalBytes:   p.totalBytes.Load(),
-		Passes:       p.passes.Load(),
+		PacketsSent:     p.packetsSent.Load(),
+		BytesSent:       p.bytesSent.Load(),
+		TotalPackets:    p.totalPackets.Load(),
+		TotalBytes:      p.totalBytes.Load(),
+		Passes:          p.passes.Load(),
+		PacketsFiltered: p.packetsFiltered.Load(),
 	}
 }
 
@@ -108,16 +120,20 @@ func (p *PlaybackEngine) Start() error {
 		return ErrNoPlaybackConfiguration
 	}
 
-	// Verify the PCAP file opens safely before spawning the playback
-	// goroutine. openPCAPFile enforces containment via os.Root, so a file
-	// that is a symlink escaping its directory is rejected at the syscall
-	// rather than merely string-checked. The file is reopened per loop in
-	// forEachPacket; this is the early pre-flight so Start reports the error.
-	preflight, err := p.openPCAPFile()
-	if err != nil {
+	// Pre-flight the file (and compile any BPF filter) before spawning the
+	// playback goroutine, so a bad path or filter is reported synchronously.
+	if err := p.verifyPCAPOpens(); err != nil {
 		return err
 	}
-	_ = preflight.Close()
+
+	var filterVM *bpf.VM
+	if p.config.BPFFilter != "" {
+		compiled, err := p.compileFilter()
+		if err != nil {
+			return err
+		}
+		filterVM = compiled
+	}
 
 	p.mu.Lock()
 
@@ -131,6 +147,7 @@ func (p *PlaybackEngine) Start() error {
 	// Recreate stopChan so Start→Stop→Start is safe.
 	p.stopChan = make(chan struct{})
 	p.passes.Store(0)
+	p.bpfVM = filterVM
 	p.mu.Unlock()
 
 	if p.debugLevel >= 1 {
@@ -247,6 +264,7 @@ func (p *PlaybackEngine) playOnce() {
 	// (0 on the first pass → Progress omits percentComplete).
 	p.packetsSent.Store(0)
 	p.bytesSent.Store(0)
+	p.packetsFiltered.Store(0)
 	p.totalPackets.Store(p.cachedTotalPackets.Load())
 	p.totalBytes.Store(p.cachedTotalBytes.Load())
 
@@ -261,6 +279,13 @@ func (p *PlaybackEngine) playOnce() {
 	err := p.forEachPacket(func(pkt PlaybackPacket) bool {
 		if p.isStopped() {
 			return true
+		}
+		// Drop packets the BPF filter rejects before they affect timing or
+		// counters — timing is relative to the first *sent* packet.
+		if !p.matchesFilter(pkt.Data) {
+			p.packetsFiltered.Add(1)
+
+			return false
 		}
 		if read == 0 {
 			firstPacketTime = pkt.Timestamp
@@ -403,6 +428,36 @@ func (p *PlaybackEngine) logBasic(msg string, args ...any) {
 	}
 }
 
+// verifyPCAPOpens confirms the PCAP opens under os.Root containment (a symlink
+// escaping its directory is rejected at the syscall), so Start reports a bad
+// path synchronously rather than in the playback goroutine.
+func (p *PlaybackEngine) verifyPCAPOpens() error {
+	f, err := p.openPCAPFile()
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
+}
+
+// compileFilter opens the capture to read its link type and compiles BPFFilter
+// into a match VM. Called only when BPFFilter is set, so it never returns a nil
+// VM with a nil error.
+func (p *PlaybackEngine) compileFilter() (*bpf.VM, error) {
+	f, err := p.openPCAPFile()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	reader, err := newPacketReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("open PCAP for filter: %w", err)
+	}
+
+	return compileBPFVM(reader.LinkType(), p.config.BPFFilter)
+}
+
 // openPCAPFile opens the configured playback file through an os.Root so the
 // kernel rejects the open if any path component escapes the root — including
 // via a symlink already on disk. The file is reopened on every loop
@@ -445,6 +500,7 @@ func (p *PlaybackEngine) openPCAPFile() (*os.File, error) {
 // readers used for playback.
 type packetReader interface {
 	ReadPacketData() ([]byte, gopacket.CaptureInfo, error)
+	LinkType() layers.LinkType
 }
 
 // newPacketReader selects the classic-pcap or pcapng reader by sniffing

--- a/internal/capture/playback_filter.go
+++ b/internal/capture/playback_filter.go
@@ -1,0 +1,67 @@
+package capture
+
+import (
+	"fmt"
+
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcap"
+	"golang.org/x/net/bpf"
+)
+
+// bpfSnaplen is the capture length used when compiling a replay BPF filter; it
+// bounds how far into each packet the program may read. Full frames (including
+// jumbo) fit within it.
+const bpfSnaplen = 262144
+
+// ValidateBPFExpr reports whether expr is a compilable BPF filter. It compiles
+// against Ethernet — the common replay link type — purely as a syntax gate so
+// the API can reject a bad expression up front; playback recompiles against the
+// capture's actual link type at Start.
+func ValidateBPFExpr(expr string) error {
+	if _, err := pcap.CompileBPFFilter(layers.LinkTypeEthernet, bpfSnaplen, expr); err != nil {
+		return fmt.Errorf("invalid BPF filter: %w", err)
+	}
+
+	return nil
+}
+
+// compileBPFVM compiles expr for linkType into a pure-Go VM that matches packet
+// bytes. Compilation uses libpcap (already linked for live capture) but no live
+// handle — so the replay read path stays CGO-free and the VM runs in Go.
+func compileBPFVM(linkType layers.LinkType, expr string) (*bpf.VM, error) {
+	insns, err := pcap.CompileBPFFilter(linkType, bpfSnaplen, expr)
+	if err != nil {
+		return nil, fmt.Errorf("compile BPF filter: %w", err)
+	}
+
+	program := make([]bpf.Instruction, len(insns))
+	for i, in := range insns {
+		program[i] = bpf.RawInstruction{Op: in.Code, Jt: in.Jt, Jf: in.Jf, K: in.K}.Disassemble()
+	}
+
+	vm, err := bpf.NewVM(program)
+	if err != nil {
+		return nil, fmt.Errorf("build BPF program: %w", err)
+	}
+
+	return vm, nil
+}
+
+// matchesFilter reports whether data passes the compiled filter. A nil VM (no
+// filter configured) passes every packet.
+func (p *PlaybackEngine) matchesFilter(data []byte) bool {
+	if p.bpfVM == nil {
+		return true
+	}
+
+	n, err := p.bpfVM.Run(data)
+	if err != nil {
+		// A compiled program shouldn't fail on well-formed input; drop the
+		// packet rather than send something the filter couldn't vet.
+		p.logError("BPF filter evaluation failed", "error", err)
+
+		return false
+	}
+
+	return n > 0
+}

--- a/internal/capture/playback_filter_test.go
+++ b/internal/capture/playback_filter_test.go
@@ -1,0 +1,160 @@
+package capture
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcapgo"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// udpPacketBytes serializes an Ethernet/IPv4/UDP frame to dstPort.
+func udpPacketBytes(t *testing.T, dstPort layers.UDPPort) []byte {
+	t.Helper()
+
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+		DstMAC:       net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    net.IP{10, 0, 0, 1},
+		DstIP:    net.IP{10, 0, 0, 2},
+	}
+	udp := &layers.UDP{SrcPort: 40000, DstPort: dstPort}
+	if err := udp.SetNetworkLayerForChecksum(ip); err != nil {
+		t.Fatalf("checksum layer: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	if err := gopacket.SerializeLayers(buf, opts, eth, ip, udp, gopacket.Payload([]byte("x"))); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+// createMixedUDPPCAP writes dns packets to UDP/53 followed by other packets to
+// UDP/80 and returns the file path.
+func createMixedUDPPCAP(t *testing.T, dns, other int) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "mixed.pcap")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	w := pcapgo.NewWriter(f)
+	if err = w.WriteFileHeader(1600, layers.LinkTypeEthernet); err != nil {
+		t.Fatalf("header: %v", err)
+	}
+
+	write := func(port layers.UDPPort, n int) {
+		data := udpPacketBytes(t, port)
+		for range n {
+			ci := gopacket.CaptureInfo{Timestamp: time.Now(), CaptureLength: len(data), Length: len(data)}
+			if err = w.WritePacket(ci, data); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}
+	}
+	write(53, dns)
+	write(80, other)
+
+	return path
+}
+
+// TestMatchesFilter checks the compiled filter accepts matching packets and
+// drops the rest, and that a nil VM (no filter) passes everything.
+func TestMatchesFilter(t *testing.T) {
+	vm, err := compileBPFVM(layers.LinkTypeEthernet, "udp port 53")
+	if err != nil {
+		t.Fatalf("compileBPFVM: %v", err)
+	}
+	filtered := &PlaybackEngine{bpfVM: vm}
+
+	if !filtered.matchesFilter(udpPacketBytes(t, 53)) {
+		t.Error("udp/53 should match \"udp port 53\"")
+	}
+	if filtered.matchesFilter(udpPacketBytes(t, 80)) {
+		t.Error("udp/80 should not match \"udp port 53\"")
+	}
+
+	open := &PlaybackEngine{}
+	if !open.matchesFilter(udpPacketBytes(t, 80)) {
+		t.Error("nil filter should pass every packet")
+	}
+}
+
+// TestValidateBPFExpr accepts a well-formed filter and rejects garbage.
+func TestValidateBPFExpr(t *testing.T) {
+	if err := ValidateBPFExpr("udp port 53"); err != nil {
+		t.Errorf("valid filter rejected: %v", err)
+	}
+	if err := ValidateBPFExpr("this is not a bpf filter !!!"); err == nil {
+		t.Error("malformed filter accepted")
+	}
+}
+
+// TestReplay_BPFFilter_MalformedFailsStart proves a bad filter is reported
+// synchronously by Start rather than swallowed in the playback goroutine.
+func TestReplay_BPFFilter_MalformedFailsStart(t *testing.T) {
+	pb := newLoopbackPlayback(t, &config.CapturePlayback{
+		FileName:  createTestPCAPFile(t, 1),
+		BPFFilter: "not a valid filter !!!",
+	})
+
+	if err := pb.Start(); err == nil {
+		pb.Stop()
+		t.Fatal("Start should fail on a malformed BPF filter")
+	}
+}
+
+// TestReplay_BPFFilter_SelectsSubset replays a mixed capture with a filter and
+// confirms only matching packets are sent, the rest counted as filtered.
+func TestReplay_BPFFilter_SelectsSubset(t *testing.T) {
+	const (
+		dns   = 3
+		other = 2
+	)
+	pb := newLoopbackPlayback(t, &config.CapturePlayback{
+		FileName:  createMixedUDPPCAP(t, dns, other),
+		BPFFilter: "udp port 53",
+		RateMode:  config.RateTopspeed,
+	})
+
+	if err := pb.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pb.Stop()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		p := pb.Progress()
+		if p.PacketsSent+p.PacketsFiltered == dns+other {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	got := pb.Progress()
+	if got.PacketsSent != dns {
+		t.Errorf("PacketsSent = %d, want %d (udp/53 only)", got.PacketsSent, dns)
+	}
+	if got.PacketsFiltered != other {
+		t.Errorf("PacketsFiltered = %d, want %d (udp/80 dropped)", got.PacketsFiltered, other)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -210,6 +210,9 @@ type CapturePlayback struct {
 	PacketsPerSec float64
 	// MbpsCap is the throughput cap for RateMbps (megabits/second).
 	MbpsCap float64
+	// BPFFilter, when set, replays only packets matching this tcpdump-style
+	// filter (e.g. "udp port 53"). Empty replays every packet.
+	BPFFilter string
 }
 
 // DiscoveryProtocols configures discovery protocol behavior.

--- a/internal/replay/controller.go
+++ b/internal/replay/controller.go
@@ -64,6 +64,7 @@ func (c *Controller) Status() api.ReplayState {
 		state.BytesTotal = progress.TotalBytes
 		state.PercentComplete = percentComplete(progress.PacketsSent, progress.TotalPackets)
 		state.Passes = progress.Passes
+		state.PacketsFiltered = progress.PacketsFiltered
 	}
 	return state
 }
@@ -119,6 +120,7 @@ func (c *Controller) Start(req api.ReplayRequest) (api.ReplayState, error) {
 		PacketsPerSec: req.Pps,
 		MbpsCap:       req.MbpsCap,
 		LoopCount:     req.LoopCount,
+		BPFFilter:     req.BPFFilter,
 	}
 	player := capture.NewPlaybackEngine(c.engine, cfg, c.debugLevel)
 	if err := player.Start(); err != nil {
@@ -144,6 +146,7 @@ func (c *Controller) Start(req api.ReplayRequest) (api.ReplayState, error) {
 		Pps:       req.Pps,
 		MbpsCap:   req.MbpsCap,
 		LoopCount: req.LoopCount,
+		BPFFilter: req.BPFFilter,
 		StartedAt: time.Now().UTC(),
 	}
 	if req.Uploaded {


### PR DESCRIPTION
## Summary

`config.CapturePlayback` gains `BPFFilter`: replay only the packets matching a
tcpdump-style expression (e.g. `udp port 53`) — selective replay of a subset.

**Mechanism note (differs from the original doc).** The doc suggested wiring
`Engine.SetBPFFilter` into the read path. Post-C1 that path is pure-Go `pcapgo`
with no libpcap handle, and `SetBPFFilter` sets a filter on the live-capture
handle — during replay that's the *output* NIC, so it would filter what you
*read from the NIC*, not what you *replay from the file*. Instead the filter is:
- compiled **offline** via `pcap.CompileBPFFilter` (libpcap is already linked for
  live capture; no live handle needed), then
- matched per packet in a pure-Go `golang.org/x/net/bpf` VM in the streaming send
  loop — so the replay read path stays CGO-free.

The filter compiles in `Start`'s preflight against the capture's link type, so a
bad expression fails `Start` synchronously; `validateReplayRequest` also
length-caps (1024) and compile-checks it for a clean 400. Non-matching packets
are skipped and counted (`PlaybackProgress.PacketsFiltered` → `ReplayState`).

Fifth and final Workstream-R replay must-have — with R1–R5 shipped, the
"≥ tcpreplay" positioning claim is now supportable.

## Linked Issue

Related to #897

## Testing Evidence

```text
$ go build ./... && go vet ./... && go mod tidy   # ok; x/net promoted to direct
$ golangci-lint run ./internal/capture/... ./internal/replay/... ./internal/api/... ./internal/config/...
0 issues.
$ go test ./internal/capture/... ./internal/replay/... ./internal/config/... -race
ok  internal/capture   ok  internal/replay   ok  internal/config
$ go test ./internal/api/... -race
ok  internal/api
```
New tests: `TestMatchesFilter` (compiled VM accepts/rejects), `TestValidateBPFExpr`,
`TestReplay_BPFFilter_MalformedFailsStart` (synchronous Start error),
`TestReplay_BPFFilter_SelectsSubset` (mixed capture → only matching packets sent,
rest counted filtered), `TestValidateReplayRequest_BPFFilter`.

## Security and Release Checklist

- [x] Untrusted BPF expression is compiled by hardened libpcap `pcap_compile`
      (a bounded DSL parser — no filesystem/network/shell side effects),
      length-capped, validated up front. The program runs in the memory-safe
      pure-Go `x/net/bpf` VM against packet bytes, never in C.
- [x] `bpfVM` set under `mu` before the playback goroutine spawns; read only by
      that single goroutine (serial `Run`) — `-race` clean. os.Root file
      containment on the open path unchanged.
- [x] No new mutating/state-changing HTTP routes; reuses the existing replay
      start handler + CSRF/auth wrappers. New field additive/optional.
- [x] Promotes `golang.org/x/net` to a direct dep (was indirect; libpcap already
      linked — no new module). `govulncheck` gate runs in CI.
- [x] `golangci-lint` clean (0 issues), `gosec` clean, `go test -race` clean.

> Reviewed in-house (not via Codex) given the security-adjacent surface.
