### PR TITLE
chore: onboard Renovate via shared org preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>MustardSeedNetworks/.github"]
+}


### PR DESCRIPTION
## Summary

Adds a 3-line `renovate.json` extending the fleet-wide preset at `MustardSeedNetworks/.github`. All dependency/lockstep policy (Go toolchain, Node, tsgo, golangci-lint, Actions SHAs, Go + npm deps) now lives in ONE file — this repo just inherits it. Ends the manual, per-repo dependency bumping.

## Linked Issue

Related to #1004

## Testing Evidence

Config-only change. The shared preset was validated as JSON on creation:

```
$ python3 -c "import json; json.load(open('default.json')); print('valid')"
valid
```

Renovate performs its own config validation during onboarding once the App is installed. This PR is inert until then, so there is no runtime behavior to exercise.

## Security and Release Checklist

- No product code changed — pure CI/automation config.
- No secrets, no new runtime dependencies.
- Inert until the Renovate GitHub App is installed on the org; cannot affect builds or releases before that.