### PR TITLE
ci(license-check): ignore first-party foundation module

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -54,6 +54,7 @@ jobs:
 
           go-licenses check ./... \
             --ignore=github.com/MustardSeedNetworks/niac-go \
+            --ignore=github.com/MustardSeedNetworks/foundation \
             --disallowed_types=forbidden,restricted || {
             echo "❌ FAILED: Incompatible licenses found in Go dependencies"
             echo ""


### PR DESCRIPTION
## Summary

`go-licenses` flags `github.com/MustardSeedNetworks/foundation` as a disallowed license because foundation is BUSL-1.1 (source-available, not in the OSI allow-list). It is our own first-party module — not a third-party copyleft risk — so ignore it exactly as the workflow already ignores the `niac-go` module itself. The gate still catches GPL/AGPL/SSPL contamination in real third-party dependencies.

Keeps the License Compliance Check green now that niac consumes foundation (merged in #1005).

## Linked Issue

Related to #1004

## Testing Evidence

```
Config-only change to .github/workflows/license-check.yml (one --ignore flag).
Same fix verified green on stem's equivalent workflow (License Compliance Check: SUCCESS).
```

## Security and Release Checklist

- [x] Only our own first-party BUSL module is ignored; third-party GPL/AGPL/SSPL detection unchanged.
- [x] No untrusted input in the workflow change (static flag).