### PR TITLE
ci: pin fleet-shared reusable workflows to a tagged SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
   # Defined once in MustardSeedNetworks/.github (fleet-shared); ci-complete
   # still needs: [semgrep]. Edit the pinned version / config policy there.
   semgrep:
-    uses: MustardSeedNetworks/.github/.github/workflows/semgrep.yml@main
+    uses: MustardSeedNetworks/.github/.github/workflows/semgrep.yml@762b756e6fb5803443b9bcfdba03b88596c18e04 # v1.0.0
     permissions:
       contents: read
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -21,4 +21,4 @@ jobs:
   # The gate is defined once in the fleet-shared repo; this repo only wires it.
   # To change license policy for the fleet, edit that workflow, not this file.
   license-check:
-    uses: MustardSeedNetworks/.github/.github/workflows/license-check.yml@main
+    uses: MustardSeedNetworks/.github/.github/workflows/license-check.yml@762b756e6fb5803443b9bcfdba03b88596c18e04 # v1.0.0


### PR DESCRIPTION
## Summary

Pin the `license-check` + `semgrep` reusable-workflow refs to `MustardSeedNetworks/.github@v1.0.0` (`762b756`) instead of `@main`. Matches the fleet's action-pinning discipline and the `.github` README pattern; the earlier `@main` was an inconsistency. Renovate bumps these `github-actions` refs like any other pinned action (same model as the `foundation` Go module), so the one-edit-point holds while a bad shared-workflow push is gated by each repo's CI rather than landing instantly fleet-wide.

## Linked Issue

Related to #1004

## Testing Evidence

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('.github/workflows/license-check.yml'))"   # valid
```
Pins to the exact SHA the reusable workflows were already running at (v1.0.0); behavior unchanged.

## Security and Release Checklist

- [x] Resolves the supply-chain mutable-ref finding on the reusable-workflow refs.
- [x] Immutable SHA pin + version comment; Renovate-tracked.
- [x] No behavior change.