### PR TITLE
feat: expose SNMP parity overlays in device editor

### DIFF
--- a/internal/api/devices_handlers_test.go
+++ b/internal/api/devices_handlers_test.go
@@ -741,6 +741,27 @@ func TestCreateDeviceFromRequest(t *testing.T) {
 	})
 }
 
+func TestCreateDeviceFromRequestPersistsSNMPOverlay(t *testing.T) {
+	dev, err := createDeviceFromRequest(DeviceCreateRequest{
+		Hostname: "edge-1",
+		Type:     "switch",
+		SNMPAgent: &SNMPAgentRequest{
+			Community: "NetAllyDemo",
+			WalkFiles: []string{"cisco/base.walk", "cisco/vendor.walk"},
+			AddMibs:   []AddMibRequest{{OID: "1.3.6.1.4.1.9.1.1.0", Type: "STRING", Value: "9300"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createDeviceFromRequest: %v", err)
+	}
+	if dev.SNMPConfig.Community != "NetAllyDemo" || len(dev.SNMPConfig.WalkFiles) != 2 {
+		t.Fatalf("SNMP config not persisted: %+v", dev.SNMPConfig)
+	}
+	if got := dev.SNMPConfig.AddMibs[0]; got.OID != "1.3.6.1.4.1.9.1.1.0" || got.Value != "9300" {
+		t.Fatalf("AddMib not persisted: %+v", got)
+	}
+}
+
 func TestCollectDeviceProtocols(t *testing.T) {
 	t.Run("no protocols", func(t *testing.T) {
 		dev := &config.Device{Name: "test"}

--- a/internal/api/devices_helpers.go
+++ b/internal/api/devices_helpers.go
@@ -202,8 +202,25 @@ func applyPartialDeviceUpdate(dev *config.Device, req DeviceUpdateRequest) error
 		}
 		dev.Interfaces = interfaces
 	}
+	if req.SNMPAgent != nil {
+		applySNMPAgentRequest(&dev.SNMPConfig, req.SNMPAgent)
+	}
 
 	return nil
+}
+
+func applySNMPAgentRequest(dst *config.SNMPConfig, src *SNMPAgentRequest) {
+	dst.Community = strings.TrimSpace(src.Community)
+	dst.SysName = strings.TrimSpace(src.SysName)
+	dst.SysDescr = strings.TrimSpace(src.SysDescr)
+	dst.SysContact = strings.TrimSpace(src.SysContact)
+	dst.SysLocation = strings.TrimSpace(src.SysLocation)
+	dst.WalkFile = strings.TrimSpace(src.WalkFile)
+	dst.WalkFiles = append([]string(nil), src.WalkFiles...)
+	dst.AddMibs = make([]config.AddMib, 0, len(src.AddMibs))
+	for _, mib := range src.AddMibs {
+		dst.AddMibs = append(dst.AddMibs, config.AddMib{OID: mib.OID, Type: mib.Type, Value: mib.Value})
+	}
 }
 
 func interfaceUpdatesToConfig(updates []DeviceInterfaceUpdate) ([]config.Interface, error) {
@@ -323,6 +340,9 @@ func createDeviceFromRequest(req DeviceCreateRequest) (*config.Device, error) {
 			return nil, err
 		}
 		dev.Interfaces = interfaces
+	}
+	if req.SNMPAgent != nil {
+		applySNMPAgentRequest(&dev.SNMPConfig, req.SNMPAgent)
 	}
 
 	if req.RawYAML != "" {

--- a/internal/api/devices_responses.go
+++ b/internal/api/devices_responses.go
@@ -62,6 +62,7 @@ func buildSNMPAgentResponse(dev *config.Device) *SNMPAgentResponse {
 		SysDescr:    dev.SNMPConfig.SysDescr,
 		SysContact:  dev.SNMPConfig.SysContact,
 		WalkFile:    dev.SNMPConfig.WalkFile,
+		WalkFiles:   append([]string(nil), dev.SNMPConfig.WalkFiles...),
 	}
 
 	if len(dev.SNMPConfig.AddMibs) > 0 {

--- a/internal/api/devices_types.go
+++ b/internal/api/devices_types.go
@@ -36,11 +36,30 @@ type SNMPAgentResponse struct {
 	SysDescr    string           `json:"sysdescr,omitempty"`
 	SysContact  string           `json:"syscontact,omitempty"`
 	WalkFile    string           `json:"walkFile,omitempty"`
+	WalkFiles   []string         `json:"walkFiles,omitempty"`
 	AddMibs     []AddMibResponse `json:"addMibs,omitempty"`
 }
 
 // AddMibResponse represents an additional MIB entry.
 type AddMibResponse struct {
+	OID   string `json:"oid"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// SNMPAgentRequest is the editable SNMP subset accepted by device CRUD.
+type SNMPAgentRequest struct {
+	Community   string          `json:"community,omitempty"`
+	SysName     string          `json:"sysName,omitempty"`
+	SysDescr    string          `json:"sysDescr,omitempty"`
+	SysContact  string          `json:"sysContact,omitempty"`
+	SysLocation string          `json:"sysLocation,omitempty"`
+	WalkFile    string          `json:"walkFile,omitempty"`
+	WalkFiles   []string        `json:"walkFiles,omitempty"`
+	AddMibs     []AddMibRequest `json:"addMibs,omitempty"`
+}
+
+type AddMibRequest struct {
 	OID   string `json:"oid"`
 	Type  string `json:"type"`
 	Value string `json:"value"`
@@ -140,6 +159,7 @@ type DeviceCreateRequest struct {
 	InterfaceDetails []DeviceInterfaceUpdate `json:"interfaceDetails,omitempty"`
 	Template         string                  `json:"template,omitempty"` // Use template as base
 	RawYAML          string                  `json:"rawYaml,omitempty"`  // Advanced: full YAML
+	SNMPAgent        *SNMPAgentRequest       `json:"snmpAgent,omitempty"`
 }
 
 // DeviceUpdateRequest represents a request to update a device.
@@ -150,6 +170,7 @@ type DeviceUpdateRequest struct {
 	Interfaces       []DeviceInterfaceUpdate `json:"interfaces,omitempty"`
 	InterfaceDetails []DeviceInterfaceUpdate `json:"interfaceDetails,omitempty"`
 	RawYAML          string                  `json:"rawYaml,omitempty"` // Full YAML for the device
+	SNMPAgent        *SNMPAgentRequest       `json:"snmpAgent,omitempty"`
 }
 
 // DeviceCloneRequest represents a request to clone a device.

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -135,8 +135,12 @@ func (v *Validator) validateSNMPCommunity(device *Device, prefix string) {
 	if configured && strings.TrimSpace(cfg.Community) == "" {
 		v.addError(prefix+".snmp_agent.community", "SNMPv1/v2c requires an explicit community")
 	}
-	seen := make(map[string]struct{}, len(cfg.AddMibs))
-	for i, mib := range cfg.AddMibs {
+	v.validateSNMPAddMibs(cfg.AddMibs, prefix)
+}
+
+func (v *Validator) validateSNMPAddMibs(mibs []AddMib, prefix string) {
+	seen := make(map[string]struct{}, len(mibs))
+	for i, mib := range mibs {
 		oid := strings.TrimPrefix(strings.TrimSpace(mib.OID), ".")
 		if !isValidOIDText(oid) {
 			v.addError(

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -135,6 +135,40 @@ func (v *Validator) validateSNMPCommunity(device *Device, prefix string) {
 	if configured && strings.TrimSpace(cfg.Community) == "" {
 		v.addError(prefix+".snmp_agent.community", "SNMPv1/v2c requires an explicit community")
 	}
+	seen := make(map[string]struct{}, len(cfg.AddMibs))
+	for i, mib := range cfg.AddMibs {
+		oid := strings.TrimPrefix(strings.TrimSpace(mib.OID), ".")
+		if !isValidOIDText(oid) {
+			v.addError(
+				fmt.Sprintf("%s.snmp_agent.add_mibs[%d].oid", prefix, i),
+				"MIB OID must contain numeric dotted components",
+			)
+		}
+		if _, duplicate := seen[oid]; duplicate {
+			v.addError(fmt.Sprintf("%s.snmp_agent.add_mibs[%d].oid", prefix, i), "duplicate MIB OID")
+		}
+		seen[oid] = struct{}{}
+		if strings.TrimSpace(mib.Type) == "" {
+			v.addError(fmt.Sprintf("%s.snmp_agent.add_mibs[%d].type", prefix, i), "MIB type is required")
+		}
+	}
+}
+
+func isValidOIDText(oid string) bool {
+	if oid == "" {
+		return false
+	}
+	for part := range strings.SplitSeq(oid, ".") {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // validateDeviceIdentity validates device name and type fields.

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -353,3 +353,20 @@ func TestValidate_InvalidDNSRecord(t *testing.T) {
 		t.Error("Expected invalid for empty DNS record name")
 	}
 }
+
+func TestValidate_AddMibOID(t *testing.T) {
+	cfg := &Config{Devices: []Device{{
+		Name: "switch-1", Type: "switch",
+		MACAddress:  net.HardwareAddr{0x02, 0, 0, 0, 0, 1},
+		IPAddresses: []net.IP{net.ParseIP("192.0.2.1")},
+		SNMPConfig: SNMPConfig{Community: "public", AddMibs: []AddMib{
+			{OID: "1.3.6.1.4.1.9.1", Type: "STRING", Value: "9300"},
+			{OID: "bad.oid", Type: "STRING", Value: "bad"},
+			{OID: "1.3.6.1.4.1.9.1", Type: "STRING", Value: "duplicate"},
+		}},
+	}}}
+	result := NewValidator("test.yaml").Validate(cfg)
+	if result.Valid {
+		t.Fatal("expected invalid AddMib OID configuration")
+	}
+}

--- a/internal/protocols/snmp/walk.go
+++ b/internal/protocols/snmp/walk.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"bufio"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -86,19 +87,25 @@ func isHexByte(s string) bool {
 }
 
 // appendHexContinuation folds a Hex-STRING continuation line's octets into the
-// preceding entry. Hex values are stored as a space-free upper-of-lower hex
-// string (see parseHexStringValue), so append the same normalized form.
+// preceding entry. Values are kept as binary octets so SNMP marshaling emits
+// the captured bytes rather than their hexadecimal text representation.
 func appendHexContinuation(entry *WalkEntry, line string) {
 	if entry.Type != gosnmp.OctetString {
 		return
 	}
 
-	prev, ok := entry.Value.(string)
+	prev, ok := entry.Value.([]byte)
 	if !ok {
 		return
 	}
 
-	entry.Value = prev + strings.ReplaceAll(line, " ", "")
+	continuation, err := decodeHexOctets(line)
+	if err != nil {
+		return
+	}
+	combined := append([]byte(nil), prev...)
+	combined = append(combined, continuation...)
+	entry.Value = combined
 }
 
 // WalkEntry represents a single entry from an SNMP walk file.
@@ -283,7 +290,7 @@ func parseTypeAndValue(typeStr, valueStr string) (gosnmp.Asn1BER, any, error) {
 	case "IPADDRESS", "IP ADDRESS", "IPADDR":
 		return gosnmp.IPAddress, valueStr, nil
 	case "BITS":
-		return gosnmp.OctetString, strings.TrimPrefix(valueStr, "0x"), nil
+		return parseHexStringValue(valueStr)
 	case "HEX-STRING", "HEX":
 		return parseHexStringValue(valueStr)
 	case "OPAQUE":
@@ -359,10 +366,26 @@ func parseTimeticksValue(valueStr string) (gosnmp.Asn1BER, any, error) {
 }
 
 func parseHexStringValue(valueStr string) (gosnmp.Asn1BER, any, error) {
-	value := strings.ReplaceAll(valueStr, " ", "")
-	value = strings.TrimPrefix(value, "0x")
+	value, err := decodeHexOctets(valueStr)
+	if err != nil {
+		return 0, nil, err
+	}
 
 	return gosnmp.OctetString, value, nil
+}
+
+func decodeHexOctets(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(strings.TrimPrefix(value, "0x"), "0X")
+	value = strings.ReplaceAll(value, " ", "")
+	value = strings.ReplaceAll(value, "\t", "")
+
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode hexadecimal octets: %w", err)
+	}
+
+	return decoded, nil
 }
 
 // ExportToWalkFile exports MIB entries to a walk file format.

--- a/internal/protocols/snmp/walk_test.go
+++ b/internal/protocols/snmp/walk_test.go
@@ -62,6 +62,47 @@ func TestParseWalkLineBoundsOutOfRange32BitValues(t *testing.T) {
 	}
 }
 
+func TestParseWalkLineHexValuesAreBinaryOctets(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{name: "hex string", line: ".1 = Hex-STRING: 00 11 aa ff"},
+		{name: "bits", line: ".1 = BITS: 0x00 11 aa ff"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, err := parseWalkLine(tt.line)
+			if err != nil {
+				t.Fatalf("parseWalkLine() error = %v", err)
+			}
+			got, ok := entry.Value.([]byte)
+			if !ok {
+				t.Fatalf("parseWalkLine() value type = %T, want []byte", entry.Value)
+			}
+			want := []byte{0x00, 0x11, 0xaa, 0xff}
+			if string(got) != string(want) {
+				t.Fatalf("parseWalkLine() value = %x, want %x", got, want)
+			}
+		})
+	}
+}
+
+func TestParseWalkLineHexContinuationAppendsBinaryOctets(t *testing.T) {
+	entry, err := parseWalkLine(".1 = Hex-STRING: 00 11")
+	if err != nil {
+		t.Fatalf("parseWalkLine() error = %v", err)
+	}
+	appendHexContinuation(entry, "aa ff")
+	got, ok := entry.Value.([]byte)
+	if !ok {
+		t.Fatalf("entry value type = %T, want []byte", entry.Value)
+	}
+	if want := []byte{0x00, 0x11, 0xaa, 0xff}; string(got) != string(want) {
+		t.Fatalf("entry value = %x, want %x", got, want)
+	}
+}
+
 // TestParseWalkFile_SymlinkRejection verifies symlink attacks are rejected.
 func TestParseWalkFile_SymlinkRejection(t *testing.T) {
 	// Create temporary directory and files
@@ -407,9 +448,9 @@ func TestParseWalkFile_HexContinuation(t *testing.T) {
 		t.Fatalf("expected 2 entries (continuation folded, not a new OID), got %d", len(entries))
 	}
 
-	const wantHex = "00112233445566778899AABB" // 12 octets: line 1 + folded line 2
-	if hex, _ := entries[0].Value.(string); hex != wantHex {
-		t.Errorf("hex value = %q, want %q (continuation not folded)", hex, wantHex)
+	wantHex := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb}
+	if hex, _ := entries[0].Value.([]byte); string(hex) != string(wantHex) {
+		t.Errorf("hex value = %x, want %x (continuation not folded)", hex, wantHex)
 	}
 }
 

--- a/internal/walkanalysis/analyze.go
+++ b/internal/walkanalysis/analyze.go
@@ -10,6 +10,7 @@
 package walkanalysis
 
 import (
+	"encoding/hex"
 	"maps"
 	"math"
 	"slices"
@@ -553,10 +554,14 @@ func lookupString(byOID map[string]snmp.WalkEntry, oid string) string {
 }
 
 func entryString(e snmp.WalkEntry) string {
-	if s, ok := e.Value.(string); ok {
-		return strings.TrimSpace(s)
+	switch value := e.Value.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []byte:
+		return hex.EncodeToString(value)
+	default:
+		return ""
 	}
-	return ""
 }
 
 // entryInt returns an SNMP Integer value (ifType, admin/oper status).

--- a/ui/src/components/device-editor/SnmpSection.tsx
+++ b/ui/src/components/device-editor/SnmpSection.tsx
@@ -129,7 +129,7 @@ export const SnmpSection: FC<SNMPSectionProps> = ({
               <span className="text-sm font-medium text-text-primary">MIB overrides</span>
               <button
                 type="button"
-                className="rounded bg-brand-primary px-2 py-1 text-xs text-white"
+                className="rounded bg-brand-primary px-2 py-1 text-xs text-knob"
                 onClick={() => updateAddMibs([...addMibs, { oid: '', type: 'STRING', value: '' }])}
               >
                 Add OID

--- a/ui/src/components/device-editor/SnmpSection.tsx
+++ b/ui/src/components/device-editor/SnmpSection.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { AddMib, MibType } from '../../api/service-protocol-types';
 import type { SNMPAgent } from '../../api/types';
 import { CollapsibleSection, FormField } from '../form';
 import { SynthesizeWalkControl } from './SynthesizeWalkControl';
@@ -33,6 +34,20 @@ export const SnmpSection: FC<SNMPSectionProps> = ({
   const currentWalk = device.snmpAgent?.walkFile ?? '';
   const currentWalkMissing =
     currentWalk !== '' && !(walkFiles ?? []).some((file) => file.name === currentWalk);
+
+  const addMibs = device.snmpAgent?.addMibs ?? [];
+  const updateAddMibs = (next: AddMib[]) => updateSnmp({ ...getSnmpConfig(), addMibs: next });
+  const mibTypes: MibType[] = [
+    'STRING',
+    'INTEGER',
+    'Counter32',
+    'Counter64',
+    'Gauge32',
+    'TimeTicks',
+    'OID',
+    'IpAddress',
+    'Hex-STRING',
+  ];
 
   return (
     <CollapsibleSection
@@ -107,6 +122,77 @@ export const SnmpSection: FC<SNMPSectionProps> = ({
               disabled={isNewDevice}
               onSynthesized={(walkPath) => updateSnmp({ ...getSnmpConfig(), walkFile: walkPath })}
             />
+          </div>
+
+          <div className="md:col-span-2 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-text-primary">MIB overrides</span>
+              <button
+                type="button"
+                className="rounded bg-brand-primary px-2 py-1 text-xs text-white"
+                onClick={() => updateAddMibs([...addMibs, { oid: '', type: 'STRING', value: '' }])}
+              >
+                Add OID
+              </button>
+            </div>
+            {addMibs.map((mib, index) => (
+              <div
+                className="grid gap-2 md:grid-cols-[2fr_1fr_2fr_auto]"
+                key={`${index}-${mib.oid}`}
+              >
+                <input
+                  aria-label="MIB OID"
+                  className={inputClassName}
+                  placeholder="1.3.6.1.4.1..."
+                  value={mib.oid}
+                  onChange={(e) =>
+                    updateAddMibs(
+                      addMibs.map((item, i) =>
+                        i === index ? { ...item, oid: e.target.value } : item,
+                      ),
+                    )
+                  }
+                />
+                <select
+                  aria-label="MIB type"
+                  className={selectClassName}
+                  value={mib.type}
+                  onChange={(e) =>
+                    updateAddMibs(
+                      addMibs.map((item, i) =>
+                        i === index ? { ...item, type: e.target.value as MibType } : item,
+                      ),
+                    )
+                  }
+                >
+                  {mibTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  aria-label="MIB value"
+                  className={inputClassName}
+                  value={mib.value}
+                  onChange={(e) =>
+                    updateAddMibs(
+                      addMibs.map((item, i) =>
+                        i === index ? { ...item, value: e.target.value } : item,
+                      ),
+                    )
+                  }
+                />
+                <button
+                  type="button"
+                  aria-label="Remove MIB override"
+                  className="rounded border border-status-error px-2 text-status-error"
+                  onClick={() => updateAddMibs(addMibs.filter((_, i) => i !== index))}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/ui/src/components/device-editor/yamlBuilder.ts
+++ b/ui/src/components/device-editor/yamlBuilder.ts
@@ -31,6 +31,20 @@ const appendSnmpLines = (lines: string[], device: Device) => {
   if (device.snmpAgent.walkFile) {
     lines.push(`      walkFile: "${device.snmpAgent.walkFile}"`);
   }
+  if (device.snmpAgent.walkFiles && device.snmpAgent.walkFiles.length > 0) {
+    lines.push('      walkFiles:');
+    for (const walkFile of device.snmpAgent.walkFiles) {
+      lines.push(`        - "${walkFile}"`);
+    }
+  }
+  if (device.snmpAgent.addMibs && device.snmpAgent.addMibs.length > 0) {
+    lines.push('      addMibs:');
+    for (const mib of device.snmpAgent.addMibs) {
+      lines.push(`        - oid: "${mib.oid}"`);
+      lines.push(`          type: "${mib.type}"`);
+      lines.push(`          value: "${mib.value}"`);
+    }
+  }
 };
 
 const appendInterfaceLines = (lines: string[], device: Device) => {


### PR DESCRIPTION
## Summary
- decode Hex-STRING and BITS walk values into binary octets
- preserve wrapped hexadecimal continuations as binary data
- expose ordered walks and typed AddMib overlays in the modern device editor
- persist SNMP overlay fields through device CRUD and YAML preview

## Linked Issue
Related to #1017

## Testing Evidence
```text
go test ./internal/api
go test ./internal/protocols/snmp
go test ./internal/walkanalysis
Biome check and tsgo typecheck passed
Pre-commit gitleaks, golangci-lint, gosec, full Go tests, and frontend checks passed
```

## Security and Release Checklist
- no new dependencies
- no secrets or network ingestion
- GitHub CI remains the release gate