### PR TITLE
docs: define pre-1.0 stabilization contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ the lab.
 - **Per-protocol debug levels** — turn verbose logging on/off at the protocol layer without restarting
 - **PCAP analysis** — `niac analyze-pcap` summarises captures by protocol; `niac analyze-walk` extracts topology from SNMP walks
 - **Error injection** — inject latency, loss, jitter, or protocol-specific faults on a running simulation
-- **Web UI** — daemon mode exposes a React/TypeScript control plane on port 8080
+- **Web UI** — daemon mode exposes a React/TypeScript control plane over HTTPS
+  on port 8445
 - **Interactive TUI** — single-screen control for ad-hoc lab use
 - **Templates** — ship YAML scenarios (`niac template`) and run them anywhere
 
@@ -48,14 +49,14 @@ sudo ./niac run eth0 my-lab.yaml
 
 # Or start the daemon + web UI
 sudo ./niac daemon
-# → open http://localhost:8080
+# → open https://localhost:8445
 ```
 
 ## Commands
 
 | Command | Purpose |
 |---------|---------|
-| `niac daemon` | Run with web UI control plane (port 8080) |
+| `niac daemon` | Run with HTTPS web UI control plane (port 8445) |
 | `niac run <iface> <config>` | Run a simulation on a real interface |
 | `niac interactive <iface> <config>` | Run with a TUI dashboard |
 | `niac init [out]` | Interactive template wizard |
@@ -153,10 +154,11 @@ See [`docs/SHARED_DEMO_CATALOG.md`](docs/SHARED_DEMO_CATALOG.md).
 | `make fmt-all` | Auto-format everything |
 | `make schema` | Regenerate JSON schema from `Config` struct |
 
-Verified versions: **Go 1.26.4**, Node.js 26.4.0+, golangci-lint v2.12.2.
-Cross-platform releases (Linux/macOS/Windows × amd64/arm64) are built by
-the `release.yml` workflow on native GitHub runners after release-please
-creates a `v*` tag.
+Verified versions: **Go 1.26.5**, Node.js 26.4.0, golangci-lint v2.12.2.
+All release artifacts are built in GitHub Actions by the pinned `release.yml`
+pipeline after release-please creates a `v*` tag. Linux and Apple Silicon macOS
+use GoReleaser Cross; Windows uses native GitHub runners with CGO and the Npcap
+SDK. Intel macOS is not a supported release target.
 
 ## Versioning & Releases
 

--- a/docs/BREAKING_CHANGES.md
+++ b/docs/BREAKING_CHANGES.md
@@ -1,73 +1,20 @@
-# Breaking Change Policy
+# Compatibility Policy
 
-## Semantic Versioning
+NIAC is pre-1.0. Until the `v1.0.0` tag, releases may replace configuration,
+API, CLI, storage, and protocol behavior without a compatibility shim or
+deprecation period. Active callers and documentation are migrated in the same
+change.
 
-NIAC-Go follows [Semantic Versioning 2.0.0](https://semver.org/):
+Every breaking change must still be explicit in the changelog and release
+notes. Silent behavior changes are not acceptable.
 
-- **MAJOR** (X.0.0): Breaking changes
-- **MINOR** (x.X.0): New features, backward compatible
-- **PATCH** (x.x.X): Bug fixes, backward compatible
+## Starting with v1.0.0
 
-## Breaking Changes
+NIAC will follow Semantic Versioning 2.0.0:
 
-### What Constitutes a Breaking Change?
+- Major releases may contain breaking changes.
+- Minor releases add backward-compatible capability.
+- Patch releases contain backward-compatible fixes.
 
-- Removing API endpoints or changing their behavior
-- Changing configuration file format incomp atibly
-- Removing CLI flags or commands
-- Changing default behavior that affects existing workflows
-- Modifying packet formats or protocol behavior
-
-### Deprecation Process
-
-1. **Announce**: Document in CHANGELOG with **[DEPRECATED]** tag
-2. **Grace Period**: Minimum 2 minor versions (e.g., deprecated in 2.5, removed in 2.7)
-3. **Warnings**: Log warnings when deprecated features are used
-4. **Remove**: Only in MAJOR version bump
-
-### API Versioning
-
-API versions are embedded in URLs (`/api/v1/`). When breaking changes are needed:
-
-1. Create new version (`/api/v2/`)
-2. Support old version for 6+ months
-3. Document migration path
-4. Announce end-of-life date
-
-## Backward Compatibility Guarantees
-
-### Configuration Files
-
-YAML configuration format is stable within MAJOR versions. Minor versions may add new fields but won't remove or change existing ones.
-
-### API Stability
-
-Within a MAJOR version:
-- Endpoint URLs won't change
-- Response formats remain compatible
-- New optional fields may be added
-- Required fields won't be added to requests
-
-### CLI Stability
-
-Command-line interface is stable within MAJOR versions:
-- Flags won't be removed
-- Flag behavior won't change
-- New flags may be added
-- Deprecated flags will warn before removal
-
-## Migration Guides
-
-Breaking changes will always include detailed migration guides in:
-- CHANGELOG.md
-- GitHub release notes
-- Migration guide documents (docs/MIGRATION-vX.md)
-
-## Exception: Security Fixes
-
-Security vulnerabilities may require breaking changes in PATCH versions if:
-- Critical security impact (CVSS >= 9.0)
-- No backward-compatible fix possible
-- Affects default secure operation
-
-These will be clearly documented and announced.
+Any post-1.0 exception required to correct a security vulnerability will be
+documented with its impact and migration steps.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -532,9 +532,10 @@ Generated pages:
 - `niac-init.1` - Init wizard
 - `niac-completion.1` - Shell completion
 
-## Legacy Mode
+## Direct Invocation Mode
 
-NIAC maintains backward compatibility with the original command-line interface.
+The original positional command form remains available in the current pre-1.0
+binary. It is not a compatibility guarantee for future pre-1.0 releases.
 
 ```bash
 niac <interface> <config-file> [flags]
@@ -748,7 +749,6 @@ niac my-config.yaml  # Uses environment defaults
 
 ## See Also
 
-- [Configuration Reference](CONFIG_REFERENCE.md)
-- [Template Guide](TEMPLATES.md)
+- [Configuration schema](schemas/niac.schema.json)
 - [Examples](../examples/)
 - [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,44 +1,50 @@
 # Distribution
 
-NIAC distribution is handled by GitHub Releases.
+GitHub Actions is the only release build environment, and GitHub Releases is
+the canonical distribution channel. Release Please owns version selection,
+changelog PRs, tags, and release creation. A `v*` tag starts
+`.github/workflows/release.yml`.
 
-Release Please owns version selection, changelog PRs, release tags, and GitHub
-release creation. When a `v*` tag is created, `.github/workflows/release.yml`
-builds native artifacts on GitHub-hosted runners:
+## Release Artifacts
 
-| Platform | Runner | Artifact |
-| --- | --- | --- |
-| Linux amd64 | `ubuntu-latest` | `.tar.gz` |
-| Linux arm64 | `ubuntu-24.04-arm` | `.tar.gz` |
-| macOS amd64 | `macos-13` | `.tar.gz` |
-| macOS arm64 | `macos-14` | `.tar.gz` |
-| Windows amd64 | `windows-latest` | `.zip` |
-| Windows arm64 | `windows-11-arm` | `.zip` |
+GoReleaser Cross builds the Linux and macOS archives from one pinned container.
+Windows binaries are built on native GitHub Windows runners with CGO and the
+Npcap SDK, then added to the same release. The workflow publishes:
 
-Each release also publishes `checksums.txt` and a GitHub build-provenance
-attestation.
+- Linux amd64 and arm64 archives and packages
+- macOS arm64 archive (Apple Silicon only)
+- Windows amd64 and arm64 archives
+- checksums, SBOMs, signatures, and build provenance
 
-## Local Development
-
-Local builds are for development and validation:
-
-```bash
-make build
-make test
-make verify
-```
-
-Local commands do not build release artifacts for other operating systems. The
-full release matrix belongs in GitHub Actions so Linux, macOS, and Windows
-artifacts are built on their native operating systems.
+The workflow does not produce an Intel macOS build or a macOS installer
+package. `deploy/macos/build-pkg.sh` is a development-validation helper only;
+its output is never a release artifact.
 
 ## Release Flow
 
-1. Merge normal feature/fix commits into `main`.
-2. Release Please opens or updates the release PR.
-3. Review and merge the release PR.
-4. Release Please creates the GitHub release and `v*` tag.
-5. The release workflow attaches native artifacts to that release.
+1. Merge reviewed fixes into `main` through required CI.
+2. Review and merge the Release Please PR.
+3. Release Please creates the GitHub release and `v*` tag.
+4. The release workflow builds and attaches all artifacts.
+5. Install the published Linux packages on the Ubuntu and Fedora targets.
+6. Query each installed service over its default loopback listener with
+   `ssh <server> 'curl -sk https://localhost:8445/__version' | jq` and verify
+   the response reports the tag, commit, build time, and a non-empty UI build
+   hash.
 
-Do not create local release tags or local GitHub releases by hand except for an
-explicit emergency recovery.
+Do not create release tags or GitHub releases by hand except for an explicitly
+approved release-recovery operation.
+
+## Local Validation
+
+Local builds prove source quality. They never produce or replace release
+artifacts; all release builds run in GitHub Actions.
+
+```bash
+make lint
+make fmt-check
+make test
+make test-e2e
+make security
+make build
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,210 +1,42 @@
-# NIAC-Go Documentation
+# NIAC Documentation
 
-Comprehensive documentation for Network In A Can - Go Edition.
+NIAC is a source-available network device simulator distributed under the
+[Business Source License 1.1](../LICENSE).
 
-## Quick Start
+## Start Here
 
-- [Installation & Setup](../README.md#installation)
-- [First Simulation](../README.md#quick-start)
-- [Configuration Guide](../ARCHITECTURE.md#configuration)
+- [Project overview and quick start](../README.md)
+- [Deployment](DEPLOYMENT.md)
+- [Distribution and release validation](DISTRIBUTION.md)
+- [CLI reference](CLI_REFERENCE.md)
+- [REST API](REST_API.md)
+- [Web UI](WEBUI.md)
+- [Monitoring](MONITORING.md)
+- [Configuration schema](schemas/niac.schema.json)
+- [Pre-1.0 roadmap](ROADMAP.md)
+- [Compatibility policy](BREAKING_CHANGES.md)
 
-## Core Documentation
+## API Modes
 
-### User Guides
+The installed daemon is HTTPS-only and listens on `127.0.0.1:8445` by default.
+Its API base URL is `https://localhost:8445/api/v1/`; use `-k` only when testing
+with the generated self-signed development certificate.
 
-- **[FAQ](FAQ.md)** - Frequently asked questions and troubleshooting
-- **[API Examples](API_EXAMPLES.md)** - curl, Python, JavaScript, Go, PowerShell examples
-- **[Performance Tuning](PERFORMANCE.md)** - Optimization guide for different workloads
-- **[Deployment Guide](DEPLOYMENT.md)** - Native Linux, macOS, and Windows deployment
-- **[CI/CD Integration](CI_CD.md)** - GitHub Actions, GitLab CI, Jenkins examples
+The ad-hoc `niac run <interface> <config> --web` mode is an explicit plaintext
+mode and defaults to port 8080. Because it binds all interfaces, set
+`NIAC_API_TOKEN` before enabling it. Examples that use
+`http://localhost:8080` apply only to that mode.
 
-### Protocol Guides
+Authenticated requests use a bearer token. Mutating requests also require the
+CSRF token returned by `/api/v1/csrf-token`.
 
-- **[SNMP Walk Files](SNMP_WALKS.md)** - Creating, optimizing, and contributing walk files
-- **DNS Configuration** - See [examples/dns-server.yaml](../examples/)
-- **DHCP Configuration** - See [examples/dhcp-server.yaml](../examples/)
-- **HTTP/FTP Configuration** - See [examples/](../examples/)
+## Development
 
-### Development
+- [Architecture](ARCHITECTURE.md)
+- [Architecture decisions](adr/)
+- [Contributing](../CONTRIBUTING.md)
+- [Performance](PERFORMANCE.md)
+- [SNMP walk files](SNMP_WALKS.md)
 
-- **[Architecture](../ARCHITECTURE.md)** - System design and internals
-- **[Contributing](../CONTRIBUTING.md)** - How to contribute
-- **[Breaking Changes Policy](BREAKING_CHANGES.md)** - Versioning and compatibility
-
-## API Reference
-
-### REST API
-
-- **Base URL**: `http://localhost:8080/api/v1/`
-- **Authentication**: Bearer token in `Authorization` header
-- **CSRF Protection**: Required for POST/PUT/PATCH/DELETE
-- **OpenAPI Specification**: [openapi.yaml](openapi.yaml) - Complete OpenAPI 3.0 spec
-
-**Endpoints:**
-
-| Method | Endpoint | Description | Auth | CSRF |
-|--------|----------|-------------|------|------|
-| GET | `/stats` | System statistics | Yes | No |
-| GET | `/devices` | List devices | Yes | No |
-| GET | `/config` | Get configuration | Yes | No |
-| PUT | `/config` | Update configuration | Yes | Yes |
-| GET | `/replay` | Replay status | Yes | No |
-| POST | `/replay` | Start PCAP replay | Yes | Yes |
-| DELETE | `/replay` | Stop PCAP replay | Yes | Yes |
-| GET | `/csrf-token` | Get CSRF token | Yes | No |
-| GET | `/version` | API version | Yes | No |
-
-See [API_EXAMPLES.md](API_EXAMPLES.md) for detailed usage or [openapi.yaml](openapi.yaml) for the complete OpenAPI specification.
-
-### Prometheus Metrics
-
-- **Endpoint**: `http://localhost:9090/metrics`
-- **Authentication**: None
-- **Format**: Prometheus text format
-
-**Available Metrics:**
-
-- `niac_packets_sent_total` - Total packets sent
-- `niac_packets_received_total` - Total packets received
-- `niac_arp_requests_total` - ARP requests processed
-- `niac_icmp_requests_total` - ICMP (ping) requests processed
-- `niac_dns_queries_total` - DNS queries processed
-- `niac_dhcp_requests_total` - DHCP requests processed
-- `niac_errors_total` - Total errors encountered
-
-## Configuration Reference
-
-### Device Types
-
-- `router` - Layer 3 routing device
-- `switch` - Layer 2 switching device
-- `server` - End host / server
-- `firewall` - Security appliance
-- `loadbalancer` - Load balancing device
-
-### Protocol Configuration
-
-Each device supports:
-- **ARP**: Automatic (responds to ARP requests)
-- **ICMP**: Automatic (responds to ping)
-- **DNS**: Configure via `dns_config`
-- **DHCP**: Configure via `dhcp_config`
-- **HTTP**: Configure via `http_config`
-- **FTP**: Configure via `ftp_config`
-- **SNMP**: Configure via `snmp_config`
-- **LLDP**: Configure via `lldp_config`
-- **CDP**: Configure via `cdp_config`
-
-See [examples/](../examples/) for complete configuration examples.
-
-## Command-Line Reference
-
-```bash
-# Run simulation
-niac run config.yaml [--api ADDR] [--debug LEVEL]
-
-# Validate configuration
-niac config validate config.yaml
-
-# Configuration tools
-niac config export config.yaml
-niac config diff config1.yaml config2.yaml
-niac config merge base.yaml overlay.yaml
-
-# Version info
-niac version
-
-# Generate man pages
-niac man
-```
-
-## Troubleshooting
-
-### Common Issues
-
-**Permission Denied**
-```bash
-# Solution: Run with sudo or grant capabilities
-sudo niac run config.yaml
-# OR
-sudo setcap cap_net_raw,cap_net_admin=eip /usr/local/bin/niac
-```
-
-**Port Already in Use**
-```bash
-# Find process using port
-sudo lsof -i :8080
-# Kill or use different port
-niac run config.yaml --api :8081
-```
-
-**High Memory Usage**
-- Check goroutine count: `GET /api/v1/stats`
-- Reduce device count or debug level
-- See [PERFORMANCE.md](PERFORMANCE.md)
-
-**Devices Not Responding**
-- Verify interface is up: `ip link show`
-- Check firewall rules: `sudo iptables -L`
-- Enable debug: `--debug 2`
-
-## Performance Benchmarks
-
-| Metric | Value |
-|--------|-------|
-| Startup Time | ~5ms |
-| Memory (idle) | ~15MB |
-| Memory (100 devices) | ~50MB |
-| Error Injection Rate | 7.7M/sec |
-| Packet Processing | ~100K pps/core |
-| ARP/ICMP Response | ~50K req/sec |
-
-See [PERFORMANCE.md](PERFORMANCE.md) for tuning guide.
-
-## Security
-
-### Authentication
-
-API requires Bearer token authentication:
-```bash
-export NIAC_API_TOKEN=$(openssl rand -base64 32)
-niac run config.yaml --api :8080
-```
-
-### CSRF Protection
-
-State-changing operations require CSRF token:
-1. GET `/api/v1/csrf-token` to retrieve token
-2. Include `X-CSRF-Token` header in POST/PUT/PATCH/DELETE requests
-
-### Rate Limiting
-
-- **Default**: 100 requests/second per IP
-- **Burst**: 200 requests
-- **Response**: HTTP 429 when exceeded
-
-### Security Headers
-
-All API responses include:
-- `X-Content-Type-Options: nosniff`
-- `X-Frame-Options: DENY`
-- `Strict-Transport-Security` (with HTTPS)
-- `Content-Security-Policy`
-
-## Support & Community
-
-- **Issues**: [GitHub Issues](https://github.com/MustardSeedNetworks/niac-go/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/MustardSeedNetworks/niac-go/discussions)
-- **Changelog**: [CHANGELOG.md](../CHANGELOG.md)
-- **License**: MIT License
-
-## Version History
-
-- **v2.6.0** - Quality improvements, documentation, monitoring enhancements
-- **v2.5.0** - Defensive security improvements
-- **v2.4.1** - Rate limiter security fixes
-- **v2.4.0** - API rate limiting, error standardization
-- **v2.3.2** - HIGH security fixes
-- **v2.3.1** - CRITICAL security fixes
-
-See [CHANGELOG.md](../CHANGELOG.md) for complete history.
+Run `niac <command> --help` for the command surface shipped by the current
+binary. Generated help is authoritative when an older example disagrees.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,292 +1,41 @@
-# NIAC-Go Roadmap
+# NIAC Roadmap
 
-## Completed Releases ✅
+NIAC is in pre-1.0 stabilization. Product features are frozen until every exit
+criterion below is complete and verified from a release-built artifact.
 
-### v1.12.0 - Interactive TUI ✅
-**Released**: January 7, 2025
-- ✅ `niac interactive` command for Terminal UI mode
-- ✅ Real-time device monitoring
-- ✅ Interactive error injection
-- ✅ Bubble Tea-based interface
+## Pre-1.0 Exit Criteria
 
-### v1.11.0 - Templates & Quick Start ✅
-**Released**: January 7, 2025
-- ✅ 7 pre-built configuration templates
-- ✅ Template commands (list, show, use)
-- ✅ Embedded templates in binary
+- [ ] Validate the routed CyberScope scenario end to end, including DHCP,
+  routed discovery, SNMP walks, and Link-Live observation.
+- [ ] Make injected interface faults observable through IF-MIB and EtherLike-MIB
+  counters while preserving monotonic counter behavior.
+- [ ] Verify the Free-tier ten-device runtime limit and keep product, API, UI,
+  and operator documentation aligned with that contract.
+- [ ] Remove stale roadmap, compatibility, licensing, and deployment claims from
+  active documentation and close superseded tracking issues.
+- [ ] Pass lint, formatting, unit, integration, browser, security, package,
+  install, and deployment validation for the release candidate.
 
-### v1.10.0 - Foundation & Validation ✅
-**Released**: January 7, 2025
-- ✅ Modern CLI framework (Cobra)
-- ✅ `niac validate` command
-- ✅ Comprehensive configuration validator
-- ✅ Structured error reporting
-- ✅ JSON output for CI/CD
+No new product capability enters the pre-1.0 line until these criteria pass.
 
-### v1.9.0 - Code Quality ✅
-**Released**: January 6, 2025
-- ✅ Complexity reduction
-- ✅ Integer overflow fixes
-- ✅ 30+ new constants
+## v1 Product Boundary
 
-### v1.7.0 - Testing & Quality ✅
-**Released**: January 5, 2025
-- ✅ 87 new tests
-- ✅ 50%+ test coverage
-- ✅ Configuration validator
+NIAC simulates configurable network devices and protocol behavior for lab,
+monitoring, discovery, and troubleshooting workflows. The supported surface
+includes the CLI, embedded web UI, API, topology and scenario configuration,
+packet capture analysis and replay, and the protocol implementations shipped in
+the current binary.
 
-### v1.6.0 - Traffic & SNMP Traps ✅
-**Released**: January 4, 2025
-- ✅ Configurable traffic patterns
-- ✅ SNMP trap generation
-- ✅ Complete YAML configuration
+The v1 contract will limit NIAC Free to ten simulated devices across every
+configuration and startup path. NIAC Pro will remove that soft limit and unlock
+the Pro capability set. License validation remains local-only.
 
-### v1.5.0 - Enhanced Configuration ✅
-**Released**: January 3, 2025
-- ✅ Color-coded debug output
-- ✅ Per-protocol debug control
-- ✅ Multiple IPs per device
+## Release Process
 
-### v1.0.0 - Initial Release ✅
-**Released**: December 20, 2024
-- ✅ Complete protocol stack (19 protocols)
-- ✅ Interactive error injection
-- ✅ Device simulation
+Release Please owns version selection and creates the release PR. Merging that
+PR creates the tag; the release workflow then builds, signs, attests, and
+publishes the platform artifacts. See [Distribution](DISTRIBUTION.md) for the
+artifact matrix and validation contract.
 
----
-
-## Completed: v1.13.0 - Enhanced CLI & Configuration Tools ✅
-
-**Released**: January 7, 2025
-
-### Features
-- ✅ **Enhanced Help & Completion**
-  - Command completion (bash, zsh, fish, powershell)
-  - Rich help examples for all commands
-  - Man pages generation
-- ✅ **Configuration Export Tools**
-  - `niac config export` - Export and normalize configs
-  - `niac config diff` - Compare configurations
-  - `niac config merge` - Merge base and overlay
-- ✅ **Documentation**
-  - CLI reference guide (docs/CLI_REFERENCE.md)
-  - CHANGELOG.md with full release history
-  - Complete man pages (12 pages)
-
----
-
-## Future Releases
-
-### v2.0.0 - REST API & Basic Web
-**Target**: 2-3 months
-
-**Philosophy**: Start simple with Go templates and progressive enhancement, not a complex SPA.
-
-#### REST API
-- [ ] HTTP server with standard library (net/http or Chi/Echo)
-- [ ] REST endpoints for device status, stats, config
-- [ ] JSON responses for all data
-- [ ] Basic authentication (optional)
-- [ ] API versioning (/api/v1/)
-
-#### Simple Web UI (Go Templates + HTMX)
-- [ ] **Server-rendered HTML** with Go templates
-- [ ] **HTMX** for dynamic updates (no build step!)
-- [ ] Status dashboard (device list, stats)
-- [ ] Real-time updates via SSE (Server-Sent Events) or HTMX polling
-- [ ] Simple device controls (start/stop, error injection)
-- [ ] Embedded in single binary (no separate frontend)
-
-**Why HTMX over React?**
-- No build step, no node_modules, no complexity
-- Server-driven, fits Go's strengths
-- Progressive enhancement from HTML
-- Tiny (~14KB), works without JavaScript
-- Perfect for admin/monitoring tools
-
-### v2.1.0 - Enhanced Web Features
-**Target**: 3-4 months
-
-- [x] SSE for true real-time updates (implemented)
-- [ ] Device topology visualization (simple SVG/Canvas, no heavy library)
-- [ ] Configuration editor (YAML textarea with validation)
-- [ ] Log viewer with filtering
-- [ ] Packet statistics graphs (simple charts, maybe Chart.js or pure SVG)
-- [ ] Export stats as CSV/JSON
-
-### v2.2.0 - Native Distribution
-**Target**: 4-6 months
-
-- [ ] Native GitHub release artifacts for Linux, macOS, and Windows
-- [ ] Checksums and SLSA provenance on every release
-- [ ] Clear install docs for libpcap/Npcap prerequisites
-- [ ] Optional service helpers for systemd, launchd, and Windows service use
-- [ ] FreeBSD experimental build validation when a FreeBSD runner strategy is selected
-
----
-
-## Architecture Philosophy
-
-**Embedded Everything**: Keep NIAC as a single binary with optional features.
-
-```bash
-# CLI mode (current)
-niac interactive en0 config.yaml
-
-# Web mode (v2.0.0+)
-niac web en0 config.yaml
-  └── Serves web UI on http://localhost:8080
-  └── REST API on http://localhost:8080/api/v1/
-  └── SSE updates on http://localhost:8080/events
-
-# Release mode
-# GitHub release artifacts are built natively for Linux, macOS, and Windows.
-```
-
-**Technology Stack (v2.0.0)**:
-- **Backend**: Go net/http or Chi router
-- **Templates**: Go html/template
-- **Interactivity**: HTMX (~14KB) for AJAX-style updates
-- **Styling**: Simple CSS (or Pico.css/Water.css for classless styling)
-- **Real-time**: SSE (Server-Sent Events) - simpler than WebSocket
-- **No build step**: Everything embedded in Go binary
-
----
-
-## Version Breakdown Summary
-
-| Version | Focus | Key Features | ETA |
-|---------|-------|--------------|-----|
-| **v1.0.0** | Core | Protocols, SNMP, Interactive, Simulation | ✅ DONE |
-| **v1.5-v1.9** | Quality | Testing, Config, Code Quality | ✅ DONE |
-| **v1.10.0** | Foundation | Cobra CLI, Validation, Error Reporting | ✅ DONE |
-| **v1.11.0** | Templates | Pre-built configs, Quick start | ✅ DONE |
-| **v1.12.0** | TUI | Interactive terminal UI, Monitoring | ✅ DONE |
-| **v1.13.0** | CLI/Tools | Shell completion, Man pages, Config tools | ✅ DONE |
-| **v2.0.0** | Web API | REST API, HTMX UI, Simple Dashboard | 2-3 months |
-| **v2.1.0** | Web Enhanced | Charts, Topology, Editor | 3-4 months |
-| **v2.2.0** | Native Distribution | GitHub release artifacts, checksums, provenance | 4-6 months |
-
----
-
-## Future Ideas (v2.x+)
-
-### Advanced Features
-- [ ] Performance profiling and optimization
-- [ ] Packet capture to PCAP file
-- [ ] PCAP file replay
-- [ ] Custom protocol definitions (plugin system)
-- [ ] Network topology import (from real networks)
-- [ ] Integration with network tools (Wireshark, tcpdump)
-- [ ] Statistical analysis for traffic patterns
-- [ ] Cloud deployment (AWS, GCP, Azure)
-- [ ] SaaS offering (hosted NIAC)
-
-### Protocol Enhancements
-- [ ] BGP routing simulation
-- [ ] OSPF routing simulation
-- [ ] EIGRP routing simulation
-- [ ] MPLS label switching
-- [ ] VPN/IPSec simulation
-- [ ] WiFi 802.11 simulation
-- [ ] Bluetooth simulation
-- [ ] LoRaWAN simulation
-- [ ] 5G/LTE simulation
-
-### Enterprise Features
-- [ ] Multi-user support
-- [ ] Role-based access control (RBAC)
-- [ ] Audit logging
-- [ ] SSO/LDAP integration
-- [ ] High availability (HA) mode
-- [ ] Distributed simulation (multiple hosts)
-- [ ] Central management server
-- [ ] Scenario library and sharing
-- [ ] Compliance reporting
-
----
-
-## Technology Stack (Future)
-
-### Current (v1.0-1.2)
-- **Language**: Go 1.21+
-- **UI**: Terminal (Bubbletea)
-- **Config**: Custom .cfg format
-- **Deployment**: Native binary
-
-### v1.3
-- **Config**: JSON (primary), YAML (optional), .cfg (legacy)
-- **Validation**: JSON Schema
-
-### v2.0
-- **Backend**: Go with Gin/Echo web framework
-- **Frontend**: React/Vue/Svelte (TBD)
-- **API**: REST + SSE (Server-Sent Events)
-- **Distribution**: Native GitHub release artifacts
-- **Database**: SQLite (embedded) or PostgreSQL (optional)
-- **Auth**: JWT tokens
-- **Monitoring**: Prometheus metrics, Grafana dashboards
-
----
-
-## Decision Points
-
-### Config Format (v1.3)
-**Status**: JSON recommended, YAML optional
-- Primary: JSON for tooling, validation, web integration
-- Secondary: YAML for human readability
-- Legacy: CFG for backward compatibility
-
-### Web UI Framework (v2.0)
-**Status**: To be decided
-**Options**:
-1. **React** - Most popular, huge ecosystem
-2. **Vue** - Easier learning curve, great docs
-3. **Svelte** - Fastest, smallest bundles
-4. **HTMX** - Minimal JS, server-driven (interesting for Go devs)
-
-**Recommendation**: Start with HTMX for simplicity, migrate to React if needed
-
-### Web UI Architecture (v2.0)
-**Status**: Hybrid approach recommended
-- Embed UI in binary for ease of use
-- Support API-only mode for custom integrations
-- Allow external UI connections
-
----
-
-## Open Questions
-
-1. **Config v1.3**: Should we support config encryption for sensitive data (SNMP communities, passwords)?
-2. **Web UI v2.0**: Real-time vs polling for updates? → RESOLVED: SSE (Server-Sent Events) implemented
-3. **Containers v2.0**: Support rootless containers or require privileged mode?
-4. **Cloud v2.x**: Should we build a hosted SaaS version?
-5. **Licensing**: Keep open source or dual-license (open + commercial)?
-
----
-
-## Community & Contribution
-
-### v1.3 Goals
-- [ ] Public GitHub repository
-- [ ] CONTRIBUTING.md guide
-- [ ] Issue templates
-- [ ] Pull request templates
-- [ ] Code of conduct
-- [ ] Security policy
-- [ ] Community Discord/Slack
-- [ ] Documentation site
-
-### v2.0 Goals
-- [ ] Plugin system for custom protocols
-- [ ] Marketplace for scenarios/configs
-- [ ] Video tutorials
-- [ ] Blog posts and articles
-- [ ] Conference talks
-- [ ] Academic partnerships (universities, research)
-
----
-
-**Last Updated**: January 5, 2025
-**Maintained By**: Kris Armstrong
-**Status**: Living document, updated as project evolves
+After v1.0.0, roadmap work will be selected through the project feature-scope
+and marketability gates. It is intentionally not precommitted here.

--- a/docs/WEBUI.md
+++ b/docs/WEBUI.md
@@ -6,24 +6,17 @@ The NIAC-Go WebUI provides a web-based interface for monitoring and controlling 
 
 ## Accessing the WebUI
 
-### Starting the API Server
+### Starting the Daemon
 
 ```bash
-# Generate API token
-export NIAC_API_TOKEN=$(openssl rand -base64 32)
-
-# Start with API server
-sudo niac run config.yaml --api :8080
-
-# Open browser to http://localhost:8080
+niac daemon
+# Open https://localhost:8445
 ```
 
 ### Authentication
 
-1. On first visit, you'll be prompted for the API token
-2. Enter the `NIAC_API_TOKEN` value
-3. Token is stored in browser localStorage
-4. Click "Connect" to authenticate
+The default loopback daemon does not require a token. A non-loopback listener
+requires `NIAC_API_TOKEN`; enter that token when the Web UI prompts for it.
 
 ## Main Dashboard
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,10 +8,11 @@ info:
     device monitoring, configuration updates, and PCAP replay functionality.
 
     ## Authentication
-    This specification models authenticated listeners. Non-loopback listeners
-    require Bearer authentication; set `NIAC_API_TOKEN` before starting the
+    This specification models authenticated listeners. Configure bearer
+    authentication with `NIAC_API_TOKEN` or a token file before starting the
     server. The installed loopback-only daemon also permits tokenless local
-    access.
+    access, which is documented separately because OpenAPI 3.0 cannot apply
+    security requirements per server.
 
     ## CSRF Protection
     State-changing operations (POST, PUT, PATCH, DELETE) require a CSRF token.
@@ -32,7 +33,7 @@ info:
 
 servers:
   - url: https://localhost:8445/api/v1
-    description: Installed loopback daemon; bearer token optional on loopback
+    description: Installed loopback daemon with bearer authentication configured
   - url: https://niac.example.com/api/v1
     description: Production server (example)
   - url: http://localhost:8080/api/v1

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,8 +8,10 @@ info:
     device monitoring, configuration updates, and PCAP replay functionality.
 
     ## Authentication
-    All endpoints require Bearer token authentication. Set the token via
-    the `NIAC_API_TOKEN` environment variable when starting the server.
+    This specification models authenticated listeners. Non-loopback listeners
+    require Bearer authentication; set `NIAC_API_TOKEN` before starting the
+    server. The installed loopback-only daemon also permits tokenless local
+    access.
 
     ## CSRF Protection
     State-changing operations (POST, PUT, PATCH, DELETE) require a CSRF token.
@@ -20,19 +22,21 @@ info:
     - Default: 100 requests/second per IP
     - Burst: 200 requests
     - Response: HTTP 429 when exceeded
-  version: 2.8.1
+  version: "v1"
   contact:
     name: Kris Armstrong
     url: https://github.com/MustardSeedNetworks/niac-go
   license:
-    name: MIT
+    name: Business Source License 1.1
     url: https://github.com/MustardSeedNetworks/niac-go/blob/main/LICENSE
 
 servers:
-  - url: http://localhost:8080/api/v1
-    description: Local development server
+  - url: https://localhost:8445/api/v1
+    description: Installed loopback daemon; bearer token optional on loopback
   - url: https://niac.example.com/api/v1
     description: Production server (example)
+  - url: http://localhost:8080/api/v1
+    description: Explicit `niac run --web` mode; NIAC_API_TOKEN required
 
 security:
   - BearerAuth: []


### PR DESCRIPTION
## Summary

- replace the obsolete post-1.0 roadmap with the five stabilization exit criteria
- align active docs with HTTPS daemon behavior, BSL 1.1 licensing, and the pre-1.0 compatibility policy
- document Apple Silicon-only macOS support and GitHub Actions as the sole release build environment
- correct the Web UI startup path, OpenAPI server/auth guidance, and active documentation links

## Linked Issue

Related to #882

## Testing Evidence

```text
make fmt-check
All formatting checks passed

npx markdownlint-cli2 --no-globs docs/README.md docs/ROADMAP.md docs/BREAKING_CHANGES.md docs/DISTRIBUTION.md
Summary: 0 error(s)

git diff --check
(no output)
```

Independent review completed; all findings were addressed.

## Security and Release Checklist

- [x] No product behavior or security boundary changed
- [x] No secrets or customer data added
- [x] Release artifacts documented as GitHub Actions-only
- [x] macOS release target documented as Apple Silicon only
- [x] Installed-daemon validation uses the loopback HTTPS listener

Repository-wide markdown lint still reports pre-existing legacy-document violations outside this PR's replacement documents.
