### PR TITLE
fix(release): make manual dispatch snapshot-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@
 # Triggers:
 #   - push to a v* tag: real release — builds, signs, publishes, generates
 #     SLSA L3 provenance
-#   - workflow_dispatch with dry_run=true: snapshot only — no publish, no
-#     signing, no provenance; artifacts uploaded for inspection
+#   - workflow_dispatch: snapshot only — no publish, signing, or provenance;
+#     artifacts are uploaded for inspection
 #   - workflow_dispatch with provenance_only=true (ref=<existing tag>):
 #     skips goreleaser entirely, recomputes artifact subjects from the
 #     already-published checksums.txt on that tag's GitHub release, then
 #     runs attest-build-provenance + uploads the .intoto.jsonl. Used to
 #     retroactively attest tags that shipped before the provenance job
-#     existed. provenance_only takes precedence over dry_run.
+#     existed. provenance_only skips the snapshot jobs.
 #
 # Toolchain notes:
 #   The goreleaser-cross Docker image ships:
@@ -45,10 +45,6 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: "Snapshot build only — do not publish or sign"
-        type: boolean
-        default: true
       provenance_only:
         description: "Backfill: skip build, recompute subjects from the existing release's checksums.txt, attest + upload bundle"
         type: boolean
@@ -236,7 +232,7 @@ jobs:
   # so all cross-compile toolchains are present.
   # =========================================================================
   goreleaser:
-    name: goreleaser ${{ inputs.dry_run && '(snapshot)' || '(release)' }}
+    name: goreleaser ${{ github.event_name == 'workflow_dispatch' && '(snapshot)' || '(release)' }}
     if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
     needs: [build-ui, build-windows]
@@ -327,7 +323,7 @@ jobs:
           chmod +x /usr/local/bin/cosign
 
       - name: Install GitHub CLI inside container
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'push' }}
         # goreleaser-cross has no gh CLI; needed below to upload the
         # hand-packaged Windows archives to the release goreleaser just
         # published. Pinned + checksummed tarball, same pattern as Syft.
@@ -345,14 +341,14 @@ jobs:
           rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_CLI_VERSION}_linux_amd64"
 
       - name: Run goreleaser (snapshot/dry-run)
-        if: inputs.dry_run
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           UI_BUILD_HASH: ${{ needs.build-ui.outputs.ui_hash }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goreleaser release --snapshot --clean --skip=publish,sign,announce
 
       - name: Run goreleaser (publish)
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'push' }}
         env:
           UI_BUILD_HASH: ${{ needs.build-ui.outputs.ui_hash }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -370,7 +366,7 @@ jobs:
         shell: bash
         env:
           REF_NAME: ${{ github.ref_name }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           set -euo pipefail
           if [ "${DRY_RUN}" = "true" ]; then
@@ -396,7 +392,7 @@ jobs:
         # then appends to the checksums.txt the goreleaser step above
         # already uploaded to the release and re-signs + re-uploads it so
         # it stays the single authoritative manifest for every platform.
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -422,7 +418,7 @@ jobs:
             checksums.txt checksums.txt.cosign.bundle
 
       - name: Capture artifact hashes for SLSA provenance
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'push' }}
         id: hashes
         shell: bash
         run: |
@@ -436,7 +432,7 @@ jobs:
           echo "hashes=$(base64 -w0 dist/checksums.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Upload dry-run artifact bundle for inspection
-        if: inputs.dry_run
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: goreleaser-dryrun-${{ github.run_id }}
@@ -527,17 +523,17 @@ jobs:
           cp dist/niac-content-*.tar.gz niac-content-bundle.tar.gz
 
       - name: Build niac-content packages (snapshot/dry-run)
-        if: ${{ env.HAS_CONTENT_KEY == 'true' && inputs.dry_run }}
+        if: ${{ env.HAS_CONTENT_KEY == 'true' && github.event_name == 'workflow_dispatch' }}
         run: goreleaser release --config .goreleaser.content.yml --snapshot --clean --skip=publish,sign,announce
 
       - name: Build + append niac-content packages (release)
-        if: ${{ env.HAS_CONTENT_KEY == 'true' && !inputs.dry_run }}
+        if: ${{ env.HAS_CONTENT_KEY == 'true' && github.event_name == 'push' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goreleaser release --config .goreleaser.content.yml --clean
 
       - name: Upload dry-run niac-content packages for inspection
-        if: ${{ env.HAS_CONTENT_KEY == 'true' && inputs.dry_run }}
+        if: ${{ env.HAS_CONTENT_KEY == 'true' && github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: niac-content-dryrun-${{ github.run_id }}
@@ -613,7 +609,7 @@ jobs:
     # Skip on dry-run snapshots; require one of the two upstreams to have
     # succeeded. `!cancelled()` lets this job run even though one of the
     # two `needs` is intentionally skipped per dispatch path.
-    if: ${{ !inputs.dry_run && !cancelled() && (needs.goreleaser.result == 'success' || needs.goreleaser-backfill-hashes.result == 'success') }}
+    if: ${{ !cancelled() && (github.event_name == 'push' || inputs.provenance_only) && (needs.goreleaser.result == 'success' || needs.goreleaser-backfill-hashes.result == 'success') }}
     needs: [goreleaser, goreleaser-backfill-hashes]
     runs-on: ubuntu-latest
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,12 +86,14 @@ local scripts to create release tags, GitHub releases, or server deployments.
 
 ## Releasing
 
-Release Please tags releases from `main`. The release pipeline supports a
-dry-run mode so you can validate end-to-end without publishing assets:
+Release Please tags releases from `main`. By default, a manual release-workflow
+dispatch builds a snapshot so you can validate end-to-end without publishing or
+signing assets. The `provenance_only` input is reserved for backfilling signed
+provenance on an existing release.
 
 ```sh
-# Dry-run on the current branch (default dry_run=true).
-gh workflow run release.yml --ref my-branch -f dry_run=true
+# Snapshot the current branch.
+gh workflow run release.yml --ref my-branch
 
 # Watch progress
 gh run watch

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -182,8 +182,8 @@ re-investigate.
 - ✅ **All workflows have concurrency groups** (PR #486).
 - ✅ **All `@actions/*` and third-party action versions standardised**
   to current latest majors (PR #486).
-- ✅ **Release pipeline supports `dry_run`** and produced 6-platform
-  artifacts on v0.66.36 with no broken-tag chain (PR #485 + #486).
+- ✅ **Manual release dispatch produces snapshot artifacts only**; publishing
+  is reserved for CI runs triggered by version tags.
 - ✅ **JSON Schema published + CI-guarded** (this PR).
 - ✅ **Per-page help on all 15 pages** (this PR).
 - ✅ **Tooltips on every interactive control on touched pages** (this


### PR DESCRIPTION
## Summary

- reserve publishing, signing, and provenance generation for version-tag pushes
- make every normal manual dispatch a snapshot-only CI build
- preserve the explicit provenance-only backfill path for existing releases
- update the audit documentation to match the enforced workflow

## Linked Issue

Closes #902

## Testing Evidence

```text
workflow safety assertions  PASS
workflow YAML parse         PASS
actionlint                  PASS (known custom windows-11-arm runner configured)
make fmt-check              PASS
make lint                   PASS (81 linters, 0 issues; Biome clean)
make security               PASS (govulncheck 0, npm audit 0, gitleaks 0)
isolated timing test        PASS (0.46s, threshold 5s)
isolated license lifecycle  PASS (0.70s)
Codex review                PASS (no regressions found)
```

Two local full-suite runs were invalidated by concurrent repository work: the
timing assertion exceeded its wall-clock threshold under load and the license
lifecycle test transiently failed. Both passed immediately in isolation. This
PR must not merge unless the required GitHub CI full suite is green.

## Security and Release Checklist

- [x] Manual dispatch cannot publish a release
- [x] Version-tag pushes remain the only normal publish path
- [x] Provenance backfill remains explicit and target-tagged
- [x] No secrets or vulnerabilities introduced
- [x] Independent review completed before commit
