### PR TITLE
feat: add routed lab observability

### DIFF
--- a/docs/design/2026-07-routed-virtual-lab-plan.md
+++ b/docs/design/2026-07-routed-virtual-lab-plan.md
@@ -1,6 +1,6 @@
 # Plan: Routed virtual labs behind one isolated attachment
 
-**Status:** In implementation — core Phases 0-5 complete; Phase 6 next
+**Status:** In implementation — core Phases 0-6 complete; Phase 7 next
 
 **Date:** 2026-07-20
 
@@ -16,7 +16,7 @@
 | 1 — compiler | Complete | Immutable topology compiler and validation tests |
 | 2-4 — fabric and IPv4 | Complete | Attachment-aware egress, scoped services, forwarding, fragmentation, ICMP, and routed response tests |
 | 5 — management plane | Core complete | Shared device state, first IOS-like CLI profile, packet-backed SSH, SNMP projection, configuration lifecycle, SYSLOG/SNMP state notifications, and Pro gate |
-| 6 — observability | Next | API/UI forwarding counters and packet-inspector route decisions remain |
+| 6 — observability | Complete | API/UI fabric topology and counters, packet route decisions, physical/virtual VLAN labels, and unsafe-attachment errors |
 | 7 — hardware acceptance | Pending | Reference eight-subnet lab and 24-hour isolation run remain |
 
 ## Outcome

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -334,13 +334,23 @@ type SimulationRequest struct {
 
 // SimulationStatus represents the current simulation status.
 type SimulationStatus struct {
-	Running       bool      `json:"running"`
-	Interface     string    `json:"interface,omitempty"`
-	ConfigPath    string    `json:"configPath,omitempty"`
-	ConfigName    string    `json:"configName,omitempty"`
-	DeviceCount   int       `json:"deviceCount"`
-	StartedAt     time.Time `json:"startedAt,omitzero"`
-	UptimeSeconds float64   `json:"uptimeSeconds"`
+	Running       bool                    `json:"running"`
+	Interface     string                  `json:"interface,omitempty"`
+	ConfigPath    string                  `json:"configPath,omitempty"`
+	ConfigName    string                  `json:"configName,omitempty"`
+	DeviceCount   int                     `json:"deviceCount"`
+	StartedAt     time.Time               `json:"startedAt,omitzero"`
+	UptimeSeconds float64                 `json:"uptimeSeconds"`
+	Fabric        *SimulationFabricStatus `json:"fabric,omitempty"`
+}
+
+// SimulationFabricStatus exposes the active routed topology and its live counters.
+type SimulationFabricStatus struct {
+	Topology    fabric.Topology `json:"topology"`
+	Forwarded   uint64          `json:"forwarded"`
+	Drops       uint64          `json:"drops"`
+	Received    uint64          `json:"received"`
+	Transmitted uint64          `json:"transmitted"`
 }
 
 // DaemonController interface for daemon mode operations.

--- a/internal/api/sse/packet_observer.go
+++ b/internal/api/sse/packet_observer.go
@@ -112,6 +112,17 @@ func packetToWire(direction string, pkt *protocols.Packet) map[string]any {
 	if pkt.VLAN >= 0 {
 		out["vlan"] = pkt.VLAN
 	}
+	trace := pkt.FabricTrace()
+	if trace.IngressNetwork != "" {
+		out["ingress_network"] = trace.IngressNetwork
+		if trace.PhysicalVLAN > 0 {
+			out["physical_vlan"] = trace.PhysicalVLAN
+		}
+		out["route_decision"] = trace.RouteDecision
+		out["hop"] = trace.Hop
+		out["egress_network"] = trace.EgressNetwork
+		out["egress_rejection_reason"] = trace.RejectionReason
+	}
 	enrichWithLayers(out, pkt.Buffer)
 	return out
 }

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -379,7 +379,7 @@ func (v *Validator) validateSingleTrapReceiver(receiver, path string) {
 		return
 	}
 
-	host, _, err := net.SplitHostPort(receiver)
+	host, port, err := net.SplitHostPort(receiver)
 	if err != nil {
 		if ip := net.ParseIP(receiver); ip == nil {
 			v.addError(path, "invalid trap receiver format: "+receiver)
@@ -390,6 +390,11 @@ func (v *Validator) validateSingleTrapReceiver(receiver, path string) {
 
 	if ip := net.ParseIP(host); ip == nil {
 		v.addError(path, "invalid IP in trap receiver: "+host)
+		return
+	}
+	value, err := strconv.ParseUint(port, 10, 16)
+	if !validPortSyntax(port) || err != nil || value == 0 {
+		v.addError(path, "invalid trap receiver port: "+port)
 	}
 }
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -361,6 +361,39 @@ func TestValidate_InvalidTrapReceiver(t *testing.T) {
 	}
 }
 
+func TestValidate_TrapReceiverPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		receiver string
+		valid    bool
+	}{
+		{name: "valid", receiver: "192.0.2.10:162", valid: true},
+		{name: "nonnumeric", receiver: "192.0.2.10:abc"},
+		{name: "zero", receiver: "192.0.2.10:0"},
+		{name: "out of range", receiver: "192.0.2.10:65536"},
+		{name: "signed", receiver: "192.0.2.10:+162"},
+		{name: "zero padded", receiver: "192.0.2.10:0162"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Devices: []Device{{
+				Name: "trap-device", Type: "router",
+				MACAddress:  net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+				IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				SNMPConfig: SNMPConfig{
+					Community: "public",
+					Traps:     &TrapConfig{Enabled: true, Receivers: []string{tt.receiver}},
+				},
+			}}}
+
+			result := NewValidator("test.yaml").Validate(cfg)
+			if result.Valid != tt.valid {
+				t.Fatalf("Valid = %v, want %v; errors = %#v", result.Valid, tt.valid, result.Errors)
+			}
+		})
+	}
+}
+
 func TestValidate_InvalidDNSRecord(t *testing.T) {
 	cfg := &Config{
 		Devices: []Device{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -688,6 +688,16 @@ func (d *Daemon) GetStatus() api.SimulationStatus {
 		if d.simulation.cfg != nil {
 			status.DeviceCount = d.simulation.cfg.DeviceCount()
 		}
+		if d.simulation.fabric != nil {
+			stats := d.simulation.stack.GetStats()
+			status.Fabric = &api.SimulationFabricStatus{
+				Topology:    *d.simulation.fabric,
+				Forwarded:   stats.FabricForwarded,
+				Drops:       stats.FabricDrops,
+				Received:    stats.PacketsReceived,
+				Transmitted: stats.PacketsSent,
+			}
+		}
 	}
 
 	return status

--- a/internal/daemon/daemon_coverage_test.go
+++ b/internal/daemon/daemon_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,9 @@ import (
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api"
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
 )
 
 // createMinimalConfig creates a minimal config with one device for testing.
@@ -202,6 +206,33 @@ func TestGetStatus_WithSimulationAndConfig(t *testing.T) {
 
 	if status.DeviceCount != 1 {
 		t.Errorf("Expected DeviceCount=1, got %d", status.DeviceCount)
+	}
+}
+
+func TestGetStatusIncludesActiveFabric(t *testing.T) {
+	daemon, err := NewDaemon(Config{StoragePath: "disabled"})
+	if err != nil {
+		t.Fatalf("NewDaemon failed: %v", err)
+	}
+	cfg := createMinimalConfig(t)
+	topology := &fabric.Topology{
+		Binding: fabric.CompiledBinding{
+			Binding: fabric.Binding{Attachment: "tester", Interface: "eth0", Mode: fabric.ModeAccess, AccessVLAN: 200},
+			Network: "access",
+		},
+		Networks: []fabric.Network{{Name: "access", Prefix: netip.MustParsePrefix("10.0.0.0/24"), VirtualVLAN: 20}},
+	}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	stack.ConfigureFabric(topology)
+	daemon.simulation = &Simulation{
+		Interface: "eth0", StartedAt: time.Now(), cfg: cfg, stack: stack, fabric: topology,
+	}
+
+	status := daemon.GetStatus()
+
+	if status.Fabric == nil || status.Fabric.Topology.Binding.AccessVLAN != 200 ||
+		status.Fabric.Topology.Networks[0].VirtualVLAN != 20 {
+		t.Fatalf("Fabric status = %#v", status.Fabric)
 	}
 }
 

--- a/internal/fabric/types.go
+++ b/internal/fabric/types.go
@@ -50,7 +50,7 @@ type Binding struct {
 	Attachment     string         `json:"attachment"`
 	Interface      string         `json:"interface"`
 	Mode           AttachmentMode `json:"mode"`
-	AccessVLAN     uint16         `json:"accessVlan,omitempty"`
+	AccessVLAN     uint16         `json:"physicalVlan,omitempty"`
 	PolicyApproved bool           `json:"-"`
 }
 

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -105,6 +105,19 @@
       "downloadYamlTitle": "Download the running config as YAML (the equivalent of niac config dump).",
       "downloadYaml": "Download YAML"
     },
+    "fabric": {
+      "attachment": "Attachment",
+      "physicalVlan": "Physical VLAN",
+      "virtualVlan": "Virtual VLAN",
+      "virtualNetworks": "Virtual networks",
+      "routes": "Routes",
+      "forwarded": "Forwarded",
+      "drops": "Drops",
+      "received": "Received",
+      "transmitted": "Transmitted",
+      "untagged": "untagged",
+      "none": "none"
+    },
     "preview": {
       "selectedPrefix": "Selected:",
       "previewOnly": "Preview only — Start to launch",
@@ -148,6 +161,9 @@
       "vlanLabel": "Access VLAN (1–4094)",
       "requestError": "Preflight failed",
       "safe": "Topology and binding preflight passed for {{count}} virtual networks. Verify host-side isolation before connecting the tester.",
+      "physicalVlanSummary": "Physical VLAN: {{vlan}}. Virtual VLANs remain isolated inside NIAC.",
+      "untagged": "untagged",
+      "unsafeTitle": "Unsafe physical attachment — simulation start is blocked",
       "checkLabel": "Run preflight",
       "startLabel": "Start simulation"
     },
@@ -541,6 +557,12 @@
       "hexDumpLabel": "Hex Dump",
       "packetDetailsLabel": "Packet Details",
       "summaryLabel": "Summary",
+      "ingressNetwork": "Ingress network",
+      "routeDecision": "Route decision",
+      "hop": "Hop",
+      "egressNetwork": "Egress network",
+      "physicalVlan": "Physical VLAN",
+      "egressRejectionReason": "Egress rejection",
       "standaloneDescriptionPart1": "Sniff an interface without starting a simulation. Frames stream into the viewer below as soon as they hit the wire. Or",
       "standaloneStartSimLink": "start a simulation",
       "standaloneDescriptionPart2": "if you want NIAC to also respond on the wire.",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -105,6 +105,19 @@
       "downloadYamlTitle": "Descargue la configuración en ejecución como YAML (equivalente a niac config dump).",
       "downloadYaml": "Descargar YAML"
     },
+    "fabric": {
+      "attachment": "Conexión",
+      "physicalVlan": "VLAN física",
+      "virtualVlan": "VLAN virtual",
+      "virtualNetworks": "Redes virtuales",
+      "routes": "Rutas",
+      "forwarded": "Reenviados",
+      "drops": "Descartes",
+      "received": "Recibidos",
+      "transmitted": "Transmitidos",
+      "untagged": "sin etiqueta",
+      "none": "ninguna"
+    },
     "preview": {
       "selectedPrefix": "Seleccionado:",
       "previewOnly": "Solo vista previa — Inicie para lanzar",
@@ -148,6 +161,9 @@
       "vlanLabel": "VLAN de acceso (1–4094)",
       "requestError": "Falló la comprobación previa",
       "safe": "La topología y la conexión pasaron la comprobación para {{count}} redes virtuales. Verifica el aislamiento del host antes de conectar el probador.",
+      "physicalVlanSummary": "VLAN física: {{vlan}}. Las VLAN virtuales permanecen aisladas dentro de NIAC.",
+      "untagged": "sin etiqueta",
+      "unsafeTitle": "Conexión física insegura — el inicio de la simulación está bloqueado",
       "checkLabel": "Ejecutar comprobación",
       "startLabel": "Iniciar simulación"
     },
@@ -541,6 +557,12 @@
       "hexDumpLabel": "Volcado hexadecimal",
       "packetDetailsLabel": "Detalles del paquete",
       "summaryLabel": "Resumen",
+      "ingressNetwork": "Red de entrada",
+      "routeDecision": "Decisión de ruta",
+      "hop": "Salto",
+      "egressNetwork": "Red de salida",
+      "physicalVlan": "VLAN física",
+      "egressRejectionReason": "Rechazo de salida",
       "standaloneDescriptionPart1": "Capture una interfaz sin iniciar una simulación. Las tramas se transmiten al visor a continuación en cuanto llegan al cable. O",
       "standaloneStartSimLink": "inicie una simulación",
       "standaloneDescriptionPart2": "si quiere que NIAC también responda en el cable.",

--- a/internal/protocols/egress_policy_test.go
+++ b/internal/protocols/egress_policy_test.go
@@ -135,6 +135,30 @@ func TestRoutedEgressRejectionIsObservable(t *testing.T) {
 	}
 }
 
+func TestRoutedSendQueueOverflowIsObservable(t *testing.T) {
+	stack := newStack(&recordingCapture{}, &config.Config{}, logging.NewDebugConfig(0))
+	stack.ConfigureFabric(&fabric.Topology{Binding: fabric.CompiledBinding{
+		Binding: fabric.Binding{Mode: fabric.ModeAccess, AccessVLAN: 200, PolicyApproved: true},
+	}})
+	stack.sendQueue = make(chan *Packet, 1)
+	stack.Send(NewPacket(64))
+	observer := &recordingObserver{}
+	stack.AddPacketObserver(observer)
+
+	stack.Send(NewPacket(64))
+
+	if observer.pkt == nil {
+		t.Fatal("observer did not receive dropped packet")
+	}
+	trace := observer.pkt.FabricTrace()
+	if trace.RouteDecision != "dropped" || trace.RejectionReason != "send_queue_full" {
+		t.Fatalf("FabricTrace() = %#v", trace)
+	}
+	if got := stack.GetStats().FabricDrops; got != 1 {
+		t.Fatalf("FabricDrops = %d, want 1", got)
+	}
+}
+
 func assertUntaggedFrame(t *testing.T, frame []byte) {
 	t.Helper()
 	if len(frame) < ethHeaderLen {

--- a/internal/protocols/egress_policy_test.go
+++ b/internal/protocols/egress_policy_test.go
@@ -113,6 +113,28 @@ func TestRoutedEgressStripsStackedAndProviderTags(t *testing.T) {
 	}
 }
 
+func TestRoutedEgressRejectionIsObservable(t *testing.T) {
+	stack := newStack(&recordingCapture{}, &config.Config{}, logging.NewDebugConfig(0))
+	stack.ConfigureFabric(&fabric.Topology{Binding: fabric.CompiledBinding{
+		Binding: fabric.Binding{Mode: fabric.ModeAccess, AccessVLAN: 200, PolicyApproved: true},
+	}})
+	observer := &recordingObserver{}
+	stack.AddPacketObserver(observer)
+
+	stack.sendPacket(&Packet{Buffer: []byte{0x01}, Length: 1})
+
+	if observer.pkt == nil {
+		t.Fatal("observer did not receive rejected packet")
+	}
+	trace := observer.pkt.FabricTrace()
+	if trace.RouteDecision != "dropped" || trace.RejectionReason != "egress_rejected" {
+		t.Fatalf("FabricTrace() = %#v", trace)
+	}
+	if got := stack.GetStats().FabricDrops; got != 1 {
+		t.Fatalf("FabricDrops = %d, want 1", got)
+	}
+}
+
 func assertUntaggedFrame(t *testing.T, frame []byte) {
 	t.Helper()
 	if len(frame) < ethHeaderLen {

--- a/internal/protocols/fabric_forwarding_test.go
+++ b/internal/protocols/fabric_forwarding_test.go
@@ -39,6 +39,36 @@ func TestFabricRoutesInternalTargetThroughAttachmentRouter(t *testing.T) {
 	if !stack.deviceOwnsIPv4(targets[0], net.ParseIP("10.20.0.10")) {
 		t.Fatal("resolved fabric endpoint must own its interface address")
 	}
+	trace := pkt.FabricTrace()
+	if trace.RouteDecision != "forwarded" || trace.EgressNetwork != "internal" || trace.Hop != "edge:inside" {
+		t.Fatalf("FabricTrace() = %#v", trace)
+	}
+	if got := stack.GetStats().FabricForwarded; got != 1 {
+		t.Fatalf("FabricForwarded = %d, want 1", got)
+	}
+}
+
+func TestFabricRecordsMissingRouteDrop(t *testing.T) {
+	cfg, topology, routerMAC := forwardingFixture(t)
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	stack.ConfigureFabric(topology)
+	pkt := NewPacket(64)
+	pkt.PutDestMAC(routerMAC)
+
+	targets := stack.ipHandler.getTargetDevices(
+		&layers.IPv4{DstIP: net.ParseIP("10.99.0.10")}, pkt, 1, 0,
+	)
+
+	if targets != nil {
+		t.Fatalf("targets = %#v, want nil", targets)
+	}
+	trace := pkt.FabricTrace()
+	if trace.RouteDecision != "dropped" || trace.RejectionReason != "no_route" {
+		t.Fatalf("FabricTrace() = %#v", trace)
+	}
+	if got := stack.GetStats().FabricDrops; got != 1 {
+		t.Fatalf("FabricDrops = %d, want 1", got)
+	}
 }
 
 func TestCLIShutdownChangesFabricDelivery(t *testing.T) {

--- a/internal/protocols/fabric_runtime.go
+++ b/internal/protocols/fabric_runtime.go
@@ -47,6 +47,8 @@ type fabricResolution struct {
 	firstHopIP     netip.Addr
 	firstHopMAC    net.HardwareAddr
 	firstHopDevice *config.Device
+	egressNetwork  string
+	routeVia       string
 }
 
 func newFabricRuntime(topology *fabric.Topology, cfg *config.Config) *fabricRuntime {
@@ -146,11 +148,11 @@ func (r *fabricRuntime) resolveIPv4(dst netip.Addr, ingressMAC net.HardwareAddr)
 	}
 	if endpoint.network == r.attachmentNetwork {
 		return fabricResolution{
-			device: endpoint.device, replySourceMAC: cloneMAC(endpoint.mac),
+			device: endpoint.device, replySourceMAC: cloneMAC(endpoint.mac), egressNetwork: endpoint.network,
 		}, true
 	}
 
-	router := r.routeFor(dst, ingressMAC)
+	router, route := r.routeFor(dst, ingressMAC)
 	if router == nil {
 		return fabricResolution{}, false
 	}
@@ -162,6 +164,7 @@ func (r *fabricRuntime) resolveIPv4(dst netip.Addr, ingressMAC net.HardwareAddr)
 		device: endpoint.device, replySourceMAC: cloneMAC(router.mac), routed: true,
 		firstHopIP:  firstHopIP,
 		firstHopMAC: cloneMAC(router.mac), firstHopDevice: router.device,
+		egressNetwork: endpoint.network, routeVia: route.via,
 	}, true
 }
 
@@ -218,9 +221,10 @@ func (r *fabricRuntime) endpointForAddress(address netip.Addr) (fabricEndpoint, 
 	return fabricEndpoint{}, false
 }
 
-func (r *fabricRuntime) routeFor(dst netip.Addr, ingressMAC net.HardwareAddr) *fabricRouter {
+func (r *fabricRuntime) routeFor(dst netip.Addr, ingressMAC net.HardwareAddr) (*fabricRouter, fabricRoute) {
 	bestBits := -1
 	var best *fabricRouter
+	var bestRoute fabricRoute
 	for i := range r.attachmentRouters {
 		router := &r.attachmentRouters[i]
 		if !bytes.Equal(router.mac, ingressMAC) || !r.interfaceAvailable(router.device, router.attachmentInterface) {
@@ -233,10 +237,11 @@ func (r *fabricRuntime) routeFor(dst netip.Addr, ingressMAC net.HardwareAddr) *f
 			if route.destination.Contains(dst) && route.destination.Bits() > bestBits {
 				bestBits = route.destination.Bits()
 				best = router
+				bestRoute = route
 			}
 		}
 	}
-	return best
+	return best, bestRoute
 }
 
 func (r *fabricRuntime) routesFor(router *fabricRouter) []fabricRoute {

--- a/internal/protocols/ip.go
+++ b/internal/protocols/ip.go
@@ -112,24 +112,7 @@ func (h *IPHandler) getTargetDevices(
 	vlan int,
 ) []*config.Device {
 	if h.stack.fabric != nil {
-		if ip.DstIP.Equal(net.IPv4bcast) && h.stack.fabric.attachmentDHCP != nil {
-			return []*config.Device{h.stack.fabric.attachmentDHCP}
-		}
-		dst, ok := netip.AddrFromSlice(ip.DstIP)
-		if !ok {
-			return nil
-		}
-		resolution, resolved := h.stack.fabric.resolveIPv4(dst.Unmap(), pkt.GetDestMAC())
-		if !resolved {
-			return nil
-		}
-		pkt.fabricReplySourceMAC = cloneMAC(resolution.replySourceMAC)
-		if resolution.routed {
-			pkt.fabricFirstHopIP = net.IP(resolution.firstHopIP.AsSlice())
-			pkt.fabricFirstHopMAC = cloneMAC(resolution.firstHopMAC)
-			pkt.fabricFirstHopDevice = resolution.firstHopDevice
-		}
-		return []*config.Device{resolution.device}
+		return h.getFabricTarget(ip, pkt)
 	}
 	serialNum := pkt.SerialNumber
 	isBroadcast := ip.DstIP.Equal([]byte{255, 255, 255, 255})
@@ -148,6 +131,40 @@ func (h *IPHandler) getTargetDevices(
 	}
 
 	return devices
+}
+
+func (h *IPHandler) getFabricTarget(ip *layers.IPv4, pkt *Packet) []*config.Device {
+	if ip.DstIP.Equal(net.IPv4bcast) && h.stack.fabric.attachmentDHCP != nil {
+		return []*config.Device{h.stack.fabric.attachmentDHCP}
+	}
+	dst, ok := netip.AddrFromSlice(ip.DstIP)
+	if !ok {
+		return nil
+	}
+	resolution, resolved := h.stack.fabric.resolveIPv4(dst.Unmap(), pkt.GetDestMAC())
+	if !resolved {
+		pkt.fabricTrace.RouteDecision = "dropped"
+		pkt.fabricTrace.RejectionReason = "no_route"
+		h.stack.stats.mu.Lock()
+		h.stack.stats.FabricDrops++
+		h.stack.stats.mu.Unlock()
+		return nil
+	}
+	pkt.fabricReplySourceMAC = cloneMAC(resolution.replySourceMAC)
+	pkt.fabricTrace.EgressNetwork = resolution.egressNetwork
+	if !resolution.routed {
+		pkt.fabricTrace.RouteDecision = "local"
+		return []*config.Device{resolution.device}
+	}
+	pkt.fabricFirstHopIP = net.IP(resolution.firstHopIP.AsSlice())
+	pkt.fabricFirstHopMAC = cloneMAC(resolution.firstHopMAC)
+	pkt.fabricFirstHopDevice = resolution.firstHopDevice
+	pkt.fabricTrace.RouteDecision = "forwarded"
+	pkt.fabricTrace.Hop = resolution.firstHopDevice.Name + ":" + resolution.routeVia
+	h.stack.stats.mu.Lock()
+	h.stack.stats.FabricForwarded++
+	h.stack.stats.mu.Unlock()
+	return []*config.Device{resolution.device}
 }
 
 func (h *IPHandler) handleFabricTTLTimeout(pkt *Packet, ipLayer *layers.IPv4) bool {

--- a/internal/protocols/packet.go
+++ b/internal/protocols/packet.go
@@ -26,6 +26,17 @@ type Packet struct {
 	fabricFirstHopIP     net.IP
 	fabricFirstHopMAC    net.HardwareAddr
 	fabricFirstHopDevice *config.Device
+	fabricTrace          FabricTrace
+}
+
+// FabricTrace describes the routed-lab decision made for one packet.
+type FabricTrace struct {
+	IngressNetwork  string
+	PhysicalVLAN    uint16
+	RouteDecision   string
+	Hop             string
+	EgressNetwork   string
+	RejectionReason string
 }
 
 // Constants for packet parsing.
@@ -69,6 +80,14 @@ func NewPacket(size int) *Packet {
 	}
 }
 
+// FabricTrace returns a copy of the packet's routed-lab decision metadata.
+func (p *Packet) FabricTrace() FabricTrace {
+	if p == nil {
+		return FabricTrace{}
+	}
+	return p.fabricTrace
+}
+
 // Clone creates a deep copy of the packet.
 func (p *Packet) Clone() *Packet {
 	clone := &Packet{
@@ -84,6 +103,7 @@ func (p *Packet) Clone() *Packet {
 		fabricFirstHopIP:     append(net.IP(nil), p.fabricFirstHopIP...),
 		fabricFirstHopMAC:    cloneMAC(p.fabricFirstHopMAC),
 		fabricFirstHopDevice: p.fabricFirstHopDevice,
+		fabricTrace:          p.fabricTrace,
 	}
 	copy(clone.Buffer, p.Buffer)
 

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -163,6 +163,8 @@ type Statistics struct {
 	DHCPRequests    uint64
 	SNMPQueries     uint64
 	Errors          uint64
+	FabricForwarded uint64
+	FabricDrops     uint64
 }
 
 // NewStack creates a new protocol stack.
@@ -517,6 +519,8 @@ func (s *Stack) GetStats() Statistics {
 		DHCPRequests:    s.stats.DHCPRequests,
 		SNMPQueries:     s.stats.SNMPQueries,
 		Errors:          s.stats.Errors,
+		FabricForwarded: s.stats.FabricForwarded,
+		FabricDrops:     s.stats.FabricDrops,
 	}
 }
 

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -383,6 +383,16 @@ func (s *Stack) Send(pkt *Packet) {
 	select {
 	case s.sendQueue <- pkt:
 	default:
+		if s.fabric != nil && pkt != nil {
+			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
+			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
+			pkt.fabricTrace.RouteDecision = "dropped"
+			pkt.fabricTrace.RejectionReason = "send_queue_full"
+			s.stats.mu.Lock()
+			s.stats.FabricDrops++
+			s.stats.mu.Unlock()
+			s.notifyObservers("tx", pkt)
+		}
 		if s.debugConfig.GetGlobal() >= DebugLevelInfo {
 			_, _ = fmt.Fprintln(os.Stdout, "Send queue full, dropping packet")
 		}

--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -52,7 +52,6 @@ func (s *Stack) receiveAndQueuePacket(buffer []byte) {
 		return
 	}
 
-	s.notifyObservers("rx", pkt)
 	s.queuePacket(pkt)
 }
 
@@ -92,6 +91,16 @@ func (s *Stack) queuePacket(pkt *Packet) {
 	select {
 	case s.recvQueue <- pkt:
 	default:
+		if s.fabric != nil {
+			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
+			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
+			pkt.fabricTrace.RouteDecision = "dropped"
+			pkt.fabricTrace.RejectionReason = "receive_queue_full"
+			s.stats.mu.Lock()
+			s.stats.FabricDrops++
+			s.stats.mu.Unlock()
+		}
+		s.notifyObservers("rx", pkt)
 		if s.debugConfig.GetGlobal() >= DebugLevelInfo {
 			_, _ = fmt.Fprintln(os.Stdout, "Receive queue full, dropping packet")
 		}
@@ -118,6 +127,11 @@ func (s *Stack) decodeThread() {
 func (s *Stack) decodePacket(pkt *Packet) {
 	s.reloadMu.RLock()
 	defer s.reloadMu.RUnlock()
+	defer s.notifyObservers("rx", pkt)
+	if s.fabric != nil {
+		pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
+		pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
+	}
 
 	// Defense in depth: a simulator is exposed to arbitrary, adversarial, and
 	// malformed traffic (discovery tools, scanners, fuzzers). A panic while
@@ -138,6 +152,11 @@ func (s *Stack) decodePacket(pkt *Packet) {
 	}()
 
 	if s.fabric != nil && !s.fabric.acceptsFrame(pkt.VLAN, pkt.VLANTagged) {
+		pkt.fabricTrace.RouteDecision = "dropped"
+		pkt.fabricTrace.RejectionReason = "physical_vlan_rejected"
+		s.stats.mu.Lock()
+		s.stats.FabricDrops++
+		s.stats.mu.Unlock()
 		return
 	}
 
@@ -393,7 +412,19 @@ func (s *Stack) recordSendError(pkt *Packet, err error) {
 	}
 	s.stats.mu.Lock()
 	s.stats.Errors++
+	if s.fabric != nil {
+		s.stats.FabricDrops++
+		if pkt != nil {
+			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
+			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
+			pkt.fabricTrace.RouteDecision = "dropped"
+			pkt.fabricTrace.RejectionReason = "egress_rejected"
+		}
+	}
 	s.stats.mu.Unlock()
+	if s.fabric != nil && pkt != nil {
+		s.notifyObservers("tx", pkt)
+	}
 }
 
 // babbleThread generates periodic network traffic.

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -332,6 +332,7 @@ export interface SimulationStatus {
   deviceCount: number;
   startedAt?: string;
   uptimeSeconds: number;
+  fabric?: import('./fabric-types').SimulationFabricStatus;
 }
 
 /**

--- a/ui/src/api/client.preflight.test.ts
+++ b/ui/src/api/client.preflight.test.ts
@@ -24,7 +24,7 @@ describe('simulation preflight client', () => {
                 attachment: 'tester',
                 interface: 'eth0',
                 mode: 'access',
-                accessVlan: 2,
+                physicalVlan: 2,
                 network: 'lab-access',
                 wireTagged: false,
               },
@@ -47,7 +47,7 @@ describe('simulation preflight client', () => {
     });
 
     expect(report.safe).toBe(true);
-    expect(report.topology.binding.accessVlan).toBe(2);
+    expect(report.topology.binding.physicalVlan).toBe(2);
     expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/simulation/preflight');
     expect(JSON.parse(mockFetch.mock.calls[1][1].body as string)).not.toHaveProperty('dedicated');
   });

--- a/ui/src/api/fabric-types.ts
+++ b/ui/src/api/fabric-types.ts
@@ -9,7 +9,7 @@ export interface FabricBinding {
   attachment: string;
   interface: string;
   mode: 'direct' | 'access';
-  accessVlan?: number;
+  physicalVlan?: number;
   network: string;
   wireTagged: boolean;
 }
@@ -58,4 +58,12 @@ export interface SimulationPreflightReport {
     dhcpScopes: FabricDhcpScope[];
   };
   diagnostics: FabricDiagnostic[];
+}
+
+export interface SimulationFabricStatus {
+  topology: SimulationPreflightReport['topology'];
+  forwarded: number;
+  drops: number;
+  received: number;
+  transmitted: number;
 }

--- a/ui/src/components/PacketDetails.tsx
+++ b/ui/src/components/PacketDetails.tsx
@@ -101,6 +101,20 @@ export const PacketDetails: FC<PacketDetailsProps> = memo(({ packet, onFieldSele
       {/* Protocol dissection tree */}
       <ProtocolTree packet={packet} onFieldSelect={onFieldSelect} />
 
+      {packet.ingressNetwork && (
+        <div className="mt-content rounded-lg bg-bg-base/50 pad-sm border border-surface-border">
+          <DetailRow label={t('packets.inspector.ingressNetwork')} value={packet.ingressNetwork} />
+          <DetailRow label={t('packets.inspector.routeDecision')} value={packet.routeDecision} />
+          <DetailRow label={t('packets.inspector.hop')} value={packet.hop} mono={true} />
+          <DetailRow label={t('packets.inspector.egressNetwork')} value={packet.egressNetwork} />
+          <DetailRow label={t('packets.inspector.physicalVlan')} value={packet.physicalVlan} />
+          <DetailRow
+            label={t('packets.inspector.egressRejectionReason')}
+            value={packet.egressRejectionReason}
+          />
+        </div>
+      )}
+
       {/* Summary */}
       {packet.summary && (
         <div className="mt-heading pt-2 border-t border-surface-border">

--- a/ui/src/components/PacketList.tsx
+++ b/ui/src/components/PacketList.tsx
@@ -21,6 +21,12 @@ export interface Packet {
   summary: string;
   rawData: string; // Hex encoded raw packet data
   headers?: Record<string, unknown>;
+  physicalVlan?: number;
+  ingressNetwork?: string;
+  routeDecision?: string;
+  hop?: string;
+  egressNetwork?: string;
+  egressRejectionReason?: string;
 }
 
 interface PacketListProps {

--- a/ui/src/components/wizard/PreflightStep.test.tsx
+++ b/ui/src/components/wizard/PreflightStep.test.tsx
@@ -18,7 +18,7 @@ const safeReport: SimulationPreflightReport = {
       attachment: 'tester',
       interface: 'eth0',
       mode: 'access',
-      accessVlan: 200,
+      physicalVlan: 200,
       network: 'lab-access',
       wireTagged: false,
     },
@@ -80,6 +80,7 @@ describe('PreflightStep', () => {
     await user.click(screen.getByTestId('wizard-preflight-check'));
 
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('not found'));
+    expect(screen.getByRole('alert')).toHaveTextContent('Unsafe physical attachment');
     expect(preflightSimulation).toHaveBeenCalledWith(
       expect.objectContaining({ attachmentMode: 'direct' }),
     );

--- a/ui/src/components/wizard/PreflightStep.tsx
+++ b/ui/src/components/wizard/PreflightStep.tsx
@@ -119,16 +119,34 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
           </SmallText>
         )}
         {report?.safe && (
-          <SmallText className="text-status-success" role="status">
-            {t('newSimWizard.preflight.safe', { count: report.topology.networks.length })}
-          </SmallText>
+          <div
+            className="rounded-lg border border-status-success/40 bg-status-success/10 pad-sm"
+            role="status"
+          >
+            <SmallText className="text-status-success">
+              {t('newSimWizard.preflight.safe', { count: report.topology.networks.length })}
+            </SmallText>
+            <SmallText className="mt-tight block text-text-secondary">
+              {t('newSimWizard.preflight.physicalVlanSummary', {
+                vlan: report.topology.binding.physicalVlan ?? t('newSimWizard.preflight.untagged'),
+              })}
+            </SmallText>
+          </div>
         )}
         {report && !report.safe && (
-          <ul className="list-disc pl-5 text-sm text-status-error" role="alert">
-            {report.diagnostics.map((diagnostic) => (
-              <li key={`${diagnostic.code}-${diagnostic.field}`}>{diagnostic.message}</li>
-            ))}
-          </ul>
+          <div
+            className="rounded-lg border-2 border-status-error bg-status-error/15 pad-default"
+            role="alert"
+          >
+            <p className="font-semibold text-status-error">
+              {t('newSimWizard.preflight.unsafeTitle')}
+            </p>
+            <ul className="mt-tight list-disc pl-5 text-sm text-status-error">
+              {report.diagnostics.map((diagnostic) => (
+                <li key={`${diagnostic.code}-${diagnostic.field}`}>{diagnostic.message}</li>
+              ))}
+            </ul>
+          </div>
         )}
         <div className="flex gap-default">
           <Button

--- a/ui/src/pages/PacketInspectorPage.test.tsx
+++ b/ui/src/pages/PacketInspectorPage.test.tsx
@@ -5,7 +5,8 @@
  * full unfiltered packet buffer, ignoring whatever display filter the user
  * had dialed in. Export must write exactly the currently filtered packets.
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '../i18n'; // initialise i18next before the page renders (uses t('packets.inspector.*'))
@@ -71,25 +72,27 @@ describe('PacketInspectorPage — filtered export', () => {
     await waitFor(() => expect(capturedOnMessage).toBeTypeOf('function'));
 
     // Push one TCP and one UDP packet through the stream.
-    capturedOnMessage?.({
-      protocol: 'TCP',
-      sourceIp: '10.0.0.1',
-      destIp: '10.0.0.2',
-      sourcePort: 1234,
-      destPort: 80,
-      size: 64,
-      summary: 'tcp packet',
-      rawData: '00112233',
-    });
-    capturedOnMessage?.({
-      protocol: 'UDP',
-      sourceIp: '10.0.0.3',
-      destIp: '10.0.0.4',
-      sourcePort: 53,
-      destPort: 5353,
-      size: 32,
-      summary: 'udp packet',
-      rawData: 'aabbccdd',
+    await act(async () => {
+      capturedOnMessage?.({
+        protocol: 'TCP',
+        sourceIp: '10.0.0.1',
+        destIp: '10.0.0.2',
+        sourcePort: 1234,
+        destPort: 80,
+        size: 64,
+        summary: 'tcp packet',
+        rawData: '00112233',
+      });
+      capturedOnMessage?.({
+        protocol: 'UDP',
+        sourceIp: '10.0.0.3',
+        destIp: '10.0.0.4',
+        sourcePort: 53,
+        destPort: 5353,
+        size: 32,
+        summary: 'udp packet',
+        rawData: 'aabbccdd',
+      });
     });
 
     await waitFor(() => expect(screen.getByText('2 / 2 packets')).toBeInTheDocument());
@@ -119,5 +122,38 @@ describe('PacketInspectorPage — filtered export', () => {
 
     createObjectURLSpy.mockRestore();
     revokeObjectURLSpy.mockRestore();
+  });
+
+  it('shows routed-lab decisions from the packet stream', async () => {
+    render(
+      <MemoryRouter>
+        <PacketInspectorPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(capturedOnMessage).toBeTypeOf('function'));
+
+    await act(async () => {
+      capturedOnMessage?.({
+        protocol: 'IPv4',
+        source_ip: '10.10.200.50',
+        dest_ip: '10.20.0.10',
+        size: 64,
+        raw_data: '00112233',
+        ingress_network: 'access',
+        physical_vlan: 200,
+        route_decision: 'forwarded',
+        hop: 'edge:inside',
+        egress_network: 'servers',
+      });
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: /10\.10\.200\.50/ }));
+
+    expect(screen.getByText('Ingress network')).toBeInTheDocument();
+    expect(screen.getByText('access')).toBeInTheDocument();
+    expect(screen.getByText('forwarded')).toBeInTheDocument();
+    expect(screen.getByText('edge:inside')).toBeInTheDocument();
+    expect(screen.getByText('servers')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
   });
 });

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -181,6 +181,22 @@ export const PacketInspectorPage: FC = () => {
           (incoming.payload as string) ||
           '',
         headers: incoming.headers as Record<string, unknown> | undefined,
+        physicalVlan:
+          (incoming.physicalVlan as number | undefined) ??
+          (incoming.physical_vlan as number | undefined),
+        ingressNetwork:
+          (incoming.ingressNetwork as string | undefined) ??
+          (incoming.ingress_network as string | undefined),
+        routeDecision:
+          (incoming.routeDecision as string | undefined) ??
+          (incoming.route_decision as string | undefined),
+        hop: incoming.hop as string | undefined,
+        egressNetwork:
+          (incoming.egressNetwork as string | undefined) ??
+          (incoming.egress_network as string | undefined),
+        egressRejectionReason:
+          (incoming.egressRejectionReason as string | undefined) ??
+          (incoming.egress_rejection_reason as string | undefined),
       };
 
       setPackets((prev) => {

--- a/ui/src/pages/runtime/RunningSimulationCard.test.tsx
+++ b/ui/src/pages/runtime/RunningSimulationCard.test.tsx
@@ -71,4 +71,53 @@ describe('RunningSimulationCard', () => {
     expect(fetchConfig).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
+
+  it('shows the physical attachment, virtual networks, routes, and counters', () => {
+    render(
+      <MemoryRouter>
+        <RunningSimulationCard
+          simStatus={{
+            ...simStatus,
+            fabric: {
+              topology: {
+                binding: {
+                  attachment: 'tester',
+                  interface: 'eth0',
+                  mode: 'access',
+                  physicalVlan: 200,
+                  network: 'access',
+                  wireTagged: false,
+                },
+                networks: [{ name: 'servers', prefix: '10.20.0.0/24', virtualVlan: 20 }],
+                interfaces: [],
+                routes: [
+                  {
+                    device: 'edge',
+                    destination: '10.20.0.0/24',
+                    via: 'inside',
+                    connected: true,
+                  },
+                ],
+                dhcpScopes: [],
+              },
+              forwarded: 12,
+              drops: 3,
+              received: 20,
+              transmitted: 10,
+            },
+          }}
+          stopping={false}
+          onStop={vi.fn()}
+          message={null}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/Attachment: tester/)).toBeInTheDocument();
+    expect(screen.getByText(/Physical VLAN:.*200/)).toBeInTheDocument();
+    expect(screen.getByText(/Forwarded: 12/)).toBeInTheDocument();
+    expect(screen.getByText(/Drops: 3/)).toBeInTheDocument();
+    expect(screen.getByText(/servers.*10\.20\.0\.0\/24.*Virtual VLAN:.*20/)).toBeInTheDocument();
+    expect(screen.getByText(/edge:.*10\.20\.0\.0\/24.*inside/)).toBeInTheDocument();
+  });
 });

--- a/ui/src/pages/runtime/RunningSimulationCard.tsx
+++ b/ui/src/pages/runtime/RunningSimulationCard.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { fetchConfig } from '../../api/client';
+import type { SimulationStatus } from '../../api/types';
 import { StatBlock } from '../../components/StatBlock';
 import { iconSizes } from '../../constants/sizes';
 import { useErrorToast } from '../../hooks/useErrorToast';
@@ -13,14 +14,16 @@ import { H2, SmallText } from '../../ui/Typography';
 import { formatTime, formatUptime } from '../../utils/format';
 
 export interface RunningSimulationCardProps {
-  simStatus: {
-    interface?: string;
-    configName?: string;
-    configPath?: string;
-    deviceCount: number;
-    uptimeSeconds: number;
-    startedAt?: string;
-  };
+  simStatus: Pick<
+    SimulationStatus,
+    | 'interface'
+    | 'configName'
+    | 'configPath'
+    | 'deviceCount'
+    | 'uptimeSeconds'
+    | 'startedAt'
+    | 'fabric'
+  >;
   stopping: boolean;
   onStop: () => void;
   /** Success-only status text; failures are surfaced as toasts. */
@@ -97,6 +100,59 @@ export const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
             helper={t('runtime.running.startedHelper')}
           />
         </div>
+
+        {simStatus.fabric && (
+          <div className="rounded-lg border border-surface-border bg-bg-base/40 pad-default stack">
+            <div className="flex flex-wrap gap-default text-sm text-text-secondary">
+              <span>
+                {t('runtime.fabric.attachment')}: {simStatus.fabric.topology.binding.attachment}
+              </span>
+              <span>
+                {t('runtime.fabric.physicalVlan')}:{' '}
+                {simStatus.fabric.topology.binding.physicalVlan ?? t('runtime.fabric.untagged')}
+              </span>
+              <span>
+                {t('runtime.fabric.forwarded')}: {simStatus.fabric.forwarded}
+              </span>
+              <span>
+                {t('runtime.fabric.drops')}: {simStatus.fabric.drops}
+              </span>
+              <span>
+                {t('runtime.fabric.received')}: {simStatus.fabric.received}
+              </span>
+              <span>
+                {t('runtime.fabric.transmitted')}: {simStatus.fabric.transmitted}
+              </span>
+            </div>
+            <div className="grid gap-default lg:grid-cols-2">
+              <div>
+                <SmallText className="text-text-muted uppercase">
+                  {t('runtime.fabric.virtualNetworks')}
+                </SmallText>
+                <ul className="mt-tight text-sm text-text-primary">
+                  {simStatus.fabric.topology.networks.map((network) => (
+                    <li key={network.name}>
+                      {network.name} · {network.prefix} · {t('runtime.fabric.virtualVlan')}:{' '}
+                      {network.virtualVlan ?? t('runtime.fabric.none')}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <SmallText className="text-text-muted uppercase">
+                  {t('runtime.fabric.routes')}
+                </SmallText>
+                <ul className="mt-tight text-sm text-text-primary">
+                  {simStatus.fabric.topology.routes.map((route) => (
+                    <li key={`${route.device}-${route.destination}-${route.via}`}>
+                      {route.device}: {route.destination} → {route.via}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
 
         {message && <SmallText className="text-status-success">{message}</SmallText>}
 


### PR DESCRIPTION
## Summary
- expose the active attachment, virtual networks, routes, and routed forwarding/drop counters through simulation status
- add ingress network, physical VLAN, route decision, hop, egress network, and rejection reason to live packet events
- show fabric status in Simulation, routed decisions in Packet Inspector, and a prominent unsafe-attachment block in preflight
- account for send-queue overflow as an observable fabric drop and reject unusable SNMP trap receiver ports

## Linked Issues
Related to #897. Supersedes stacked PR #1030, which GitHub closed when its merged base branch was deleted.

## Testing Evidence
```text
make fmt-check: passed
make lint: 0 issues; frontend clean
make test: passed; Go coverage 64.1%
make security: no Go/npm vulnerabilities; no secrets
make test-e2e: 124 passed, 4 skipped
focused queue-overflow and trap-port regressions: passed
make build: frontend and Go binary built
```

## Security and Release Checklist
- [x] Unsafe physical attachments remain blocked by operator-owned policy validation
- [x] Physical VLAN and virtual VLAN are distinct in API responses and UI labels
- [x] Routed packet drops and rejection reasons are observable without widening access
- [x] Vulnerability, dependency, and secret scans pass
- [x] No release tag or version was created manually

## Review Note
Independent review completed against the full Phase 5/6 stack and again against the final fixes. The two review findings were fixed with regression coverage; the final review found no remaining defects.