### PR TITLE
chore(deps): refresh current dependency metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/leodido/go-urn v1.5.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
-	github.com/mattn/go-isatty v0.0.23 // indirect
+	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy0/jY=
 github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
-github.com/mattn/go-isatty v0.0.23 h1:cYwCQTQf3HB6xUC+BtyCLZNr7IzbOmoZbmssVNzSyiQ=
-github.com/mattn/go-isatty v0.0.23/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
+github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
+github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2926,7 +2926,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "10.5.3"
+        "storybook": "^10.5.3"
       }
     },
     "node_modules/@storybook/addon-docs": {
@@ -2950,7 +2950,7 @@
       },
       "peerDependencies": {
         "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "10.5.3"
+        "storybook": "^10.5.3"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2969,7 +2969,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "10.5.3"
+        "storybook": "^10.5.3"
       }
     },
     "node_modules/@storybook/addon-vitest": {
@@ -2990,7 +2990,7 @@
         "@vitest/browser": "^3.0.0 || ^4.0.0",
         "@vitest/browser-playwright": "^4.0.0",
         "@vitest/runner": "^3.0.0 || ^4.0.0",
-        "storybook": "10.5.3",
+        "storybook": "^10.5.3",
         "vitest": "^3.0.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -3111,7 +3111,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "10.5.3",
+        "storybook": "^10.5.3",
         "typescript": ">= 4.9.x",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },


### PR DESCRIPTION
## Summary

- update the used `github.com/mattn/go-isatty` indirect dependency from v0.0.23 to v0.0.24
- regenerate current Storybook peer metadata in the npm lockfile with Node 26.5.0/npm 12.0.1
- leave deprecated `i18next-parser` replacement scoped to #1052

## Linked Issue

Closes #1056
Related to #1052 and #1057

## Testing Evidence

```text
make fmt-check
All formatting checks passed

make lint
Backend: 0 issues
Frontend: 323 files checked; no fixes applied

make test
Go: 42 packages passed; coverage 64.1%
Frontend: 63 test files passed

make security
govulncheck: No vulnerabilities found
npm audit: found 0 vulnerabilities
gitleaks: no leaks found

go mod verify
all modules verified

Independent review
No behavioral regressions identified; dependency and lockfile updates are internally consistent
```

## Security and Release Checklist

- [x] Exact dependency versions retained
- [x] No new dependency introduced
- [x] Vulnerability, package audit, and secret scan pass
- [x] Full tests pass under pinned Node 26.5.0/npm 12.0.1
- [x] Independent pre-commit review found no actionable defect
