### PR TITLE
fix(license): pin Free tier device contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ SLSA provenance to the GitHub release.
 
 ## License
 
+Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000.
+
 [Business Source License 1.1](LICENSE) — free for non-commercial use;
 commercial use requires a license. Converts to Apache-2.0 on the change
 date stated in the LICENSE file. Matches the licensing on seed and stem.

--- a/cmd/niac/help_completeness_test.go
+++ b/cmd/niac/help_completeness_test.go
@@ -106,6 +106,18 @@ func TestCLIHelpCompleteness(t *testing.T) {
 	t.Fatalf("CLI help completeness gaps (%d):\n  %s", len(gaps), strings.Join(gaps, "\n  "))
 }
 
+func TestLicenseHelpStatesDeviceScaleContract(t *testing.T) {
+	root := buildFullRoot()
+	command, _, err := root.Find([]string{"license"})
+	if err != nil {
+		t.Fatalf("find license command: %v", err)
+	}
+	const contract = "Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000."
+	if !strings.Contains(command.Long, contract) {
+		t.Fatalf("license help does not contain device scale contract %q", contract)
+	}
+}
+
 func walkCommands(c *cobra.Command, fn func(*cobra.Command)) {
 	fn(c)
 	for _, sub := range c.Commands() {

--- a/cmd/niac/license.go
+++ b/cmd/niac/license.go
@@ -14,10 +14,13 @@ func addLicenseCommand(root *cobra.Command, _ *serviceOptions) {
 		Use:   "license",
 		Short: "Manage license activation",
 		Long: `The license command handles offline license activation and status
-for NIAC. Without a license, NIAC runs in the Free tier (up to 10
-simulated devices, common protocols). NIAC Pro ($599/yr) unlocks:
+for NIAC.
 
-  • Unlimited simulated devices
+Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000.
+
+NIAC Pro ($599/yr) unlocks:
+
+  • Simulations above the Free tier device cap
   • Advanced protocols: SNMPv3, NetBIOS, FTP, STP
   • Advanced IPv4/IPv6 stack features
   • Error injection (latency, loss, jitter, protocol faults)

--- a/cmd/niac/simulation_entitlements_test.go
+++ b/cmd/niac/simulation_entitlements_test.go
@@ -58,3 +58,32 @@ func TestValidateStoredSimulationConfigUsesCurrentLicenseState(t *testing.T) {
 		t.Fatalf("license state loads = %d, want 1", loads)
 	}
 }
+
+func TestValidateSimulationConfigEnforcesDeviceTier(t *testing.T) {
+	tests := []struct {
+		name    string
+		count   int
+		checker testFeatureChecker
+		wantErr error
+	}{
+		{name: "Free 10", count: 10, checker: testFeatureChecker{}},
+		{
+			name: "Free 11", count: 11, checker: testFeatureChecker{},
+			wantErr: api.ErrUnlimitedDevicesLicenseRequired,
+		},
+		{
+			name: "Pro above Free cap", count: 11,
+			checker: testFeatureChecker{"unlimited_devices": true},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{Devices: make([]config.Device, test.count)}
+			err := validateSimulationConfig(cfg, test.checker)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("validateSimulationConfig() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/api/devices_helpers.go
+++ b/internal/api/devices_helpers.go
@@ -43,8 +43,7 @@ func (s *Server) validateDeviceAddition(
 	if (s.license == nil || !s.license.HasFeature("unlimited_devices")) &&
 		deviceCount >= FreeTierDeviceCount {
 		s.writeFeatureGate(w, r, "unlimited_devices",
-			fmt.Sprintf("Free tier supports up to %d devices. "+
-				"Upgrade to Pro for unlimited devices.", FreeTierDeviceCount))
+			deviceScaleContract+" "+defaultUpgradeMessage)
 		return errValidationFailed
 	}
 

--- a/internal/api/devices_validation.go
+++ b/internal/api/devices_validation.go
@@ -17,6 +17,9 @@ var (
 )
 
 const (
+	deviceScaleContract = "Free: up to 10 simulated devices; Pro removes tier soft cap; " +
+		"absolute ceiling 1000."
+
 	// MaxDeviceCount is the absolute device ceiling enforced for every
 	// tier as a resource-exhaustion guard (security fix #173). Pro
 	// licenses raise the soft cap to this value via the

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -244,7 +244,7 @@ func (s *Server) authorizeConfigReplacement(w http.ResponseWriter, r *http.Reque
 			"Routed virtual labs require the Pro tier. "+defaultUpgradeMessage)
 	case errors.Is(err, ErrUnlimitedDevicesLicenseRequired):
 		s.writeFeatureGate(w, r, "unlimited_devices",
-			"This configuration exceeds the Free tier device cap. "+defaultUpgradeMessage)
+			deviceScaleContract+" "+defaultUpgradeMessage)
 	case errors.Is(err, ErrSimulationDeviceLimitExceeded):
 		writeError(w, r, http.StatusBadRequest, "device_limit_reached",
 			"Configuration exceeds the maximum supported device count", nil)

--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -145,7 +145,7 @@ func (s *Server) handleSimulationStartError(w http.ResponseWriter, r *http.Reque
 			"Routed virtual labs require the Pro tier. "+defaultUpgradeMessage)
 	case errors.Is(err, ErrUnlimitedDevicesLicenseRequired):
 		s.writeFeatureGate(w, r, "unlimited_devices",
-			"This simulation exceeds the Free tier device cap. "+defaultUpgradeMessage)
+			deviceScaleContract+" "+defaultUpgradeMessage)
 	case errors.Is(err, ErrSimulationDeviceLimitExceeded):
 		writeError(w, r, http.StatusBadRequest, "device_limit_reached",
 			"Simulation exceeds the maximum supported device count", nil)

--- a/internal/api/handlers_simulation_entitlements_test.go
+++ b/internal/api/handlers_simulation_entitlements_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+func TestFreeTierDeviceCountMatchesProductContract(t *testing.T) {
+	if FreeTierDeviceCount != 10 {
+		t.Fatalf("FreeTierDeviceCount = %d, want 10", FreeTierDeviceCount)
+	}
+}
+
+func TestValidateConfigEntitlementsDeviceLimits(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          *config.Config
+		entitlements SimulationEntitlements
+		wantErr      error
+	}{
+		{name: "flat Free 10", cfg: flatConfig(10)},
+		{
+			name: "flat Free 11", cfg: flatConfig(11),
+			wantErr: ErrUnlimitedDevicesLicenseRequired,
+		},
+		{
+			name: "flat Pro 11", cfg: flatConfig(11),
+			entitlements: SimulationEntitlements{UnlimitedDevices: true},
+		},
+		{
+			name: "flat Pro 1001", cfg: flatConfig(1001),
+			entitlements: SimulationEntitlements{UnlimitedDevices: true},
+			wantErr:      ErrSimulationDeviceLimitExceeded,
+		},
+		{name: "segmented Free 10", cfg: segmentedConfig(4, 6)},
+		{
+			name: "segmented Free 11", cfg: segmentedConfig(5, 6),
+			wantErr: ErrUnlimitedDevicesLicenseRequired,
+		},
+		{
+			name: "segmented Pro 11", cfg: segmentedConfig(5, 6),
+			entitlements: SimulationEntitlements{UnlimitedDevices: true},
+		},
+		{
+			name: "segmented Pro 1001", cfg: segmentedConfig(500, 501),
+			entitlements: SimulationEntitlements{UnlimitedDevices: true},
+			wantErr:      ErrSimulationDeviceLimitExceeded,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateConfigEntitlements(test.cfg, test.entitlements)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("ValidateConfigEntitlements() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func flatConfig(count int) *config.Config {
+	return &config.Config{Devices: make([]config.Device, count)}
+}
+
+func segmentedConfig(counts ...int) *config.Config {
+	cfg := &config.Config{Segments: make([]config.Segment, len(counts))}
+	for index, count := range counts {
+		cfg.Segments[index] = config.Segment{Tag: index + 1, Devices: make([]config.Device, count)}
+	}
+	return cfg
+}

--- a/internal/api/handlers_simulation_preflight_test.go
+++ b/internal/api/handlers_simulation_preflight_test.go
@@ -152,6 +152,13 @@ func TestHandleSimulationStartRequiresUnlimitedDevicesFeature(t *testing.T) {
 	if response.RequiredFeature != "unlimited_devices" {
 		t.Fatalf("required feature = %q", response.RequiredFeature)
 	}
+	if !strings.Contains(response.UpgradeMessage, deviceScaleContract) {
+		t.Fatalf(
+			"upgrade message = %q, want device scale contract %q",
+			response.UpgradeMessage,
+			deviceScaleContract,
+		)
+	}
 }
 
 func TestHandleSimulationStartRejectsMissingSSHPasswordAsRuntimeRequirement(t *testing.T) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/MustardSeedNetworks/foundation/pkg/csrf"
@@ -238,6 +239,15 @@ func TestHandleConfigUpdateEnforcesEntitlementsBeforeApply(t *testing.T) {
 		_, _ = fmt.Fprintf(&oversized,
 			"  - name: device-%d\n    type: router\n    mac: 02:00:00:00:00:%02x\n", index, index)
 	}
+	var oversizedSegment bytes.Buffer
+	oversizedSegment.WriteString("segments:\n  - tag: 10\n    devices:\n")
+	for index := 0; index <= FreeTierDeviceCount; index++ {
+		_, _ = fmt.Fprintf(&oversizedSegment,
+			"      - name: device-%d\n        type: router\n        mac: 02:00:00:00:00:%02x\n",
+			index,
+			index,
+		)
+	}
 	tests := []struct {
 		name    string
 		content string
@@ -257,6 +267,10 @@ func TestHandleConfigUpdateEnforcesEntitlementsBeforeApply(t *testing.T) {
 			feature: "routed_labs",
 		},
 		{name: "Free device cap", content: oversized.String(), feature: "unlimited_devices"},
+		{
+			name: "segmented Free device cap", content: oversizedSegment.String(),
+			feature: "unlimited_devices",
+		},
 	}
 
 	for _, test := range tests {
@@ -286,6 +300,66 @@ func TestHandleConfigUpdateEnforcesEntitlementsBeforeApply(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleConfigUpdateAllowsSegmentedDeviceEntitlements(t *testing.T) {
+	tests := []struct {
+		name  string
+		count int
+		pro   bool
+	}{
+		{name: "Free 10", count: 10},
+		{name: "Pro 11", count: 11, pro: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, _ := createTestServer(t)
+			if test.pro {
+				server.license = freshManager(t)
+				if result := server.license.StartTrial(); !result.Success {
+					t.Fatalf("StartTrial() = %#v", result)
+				}
+			}
+			applied := false
+			server.cfg.ApplyConfig = func(*config.Config) error {
+				applied = true
+				return nil
+			}
+			body, err := json.Marshal(map[string]string{
+				"content": segmentedConfigUpdate(test.count),
+			})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPut, "/api/v1/config", bytes.NewReader(body))
+
+			server.handleConfig(recorder, request)
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+			}
+			if !applied {
+				t.Fatal("authorized segmented configuration did not reach ApplyConfig")
+			}
+		})
+	}
+}
+
+func segmentedConfigUpdate(count int) string {
+	var content strings.Builder
+	content.WriteString("segments:\n  - tag: 10\n    devices:\n")
+	for index := range count {
+		_, _ = fmt.Fprintf(&content,
+			"      - name: device-%d\n"+
+				"        type: router\n"+
+				"        mac: 02:00:00:00:00:%02x\n",
+			index,
+			index,
+		)
+	}
+	return content.String()
 }
 
 func TestHandleErrors(t *testing.T) {

--- a/internal/daemon/preflight_test.go
+++ b/internal/daemon/preflight_test.go
@@ -192,6 +192,37 @@ func TestLoadAuthorizedSimulationConfigEnforcesFreeDeviceCap(t *testing.T) {
 	}
 }
 
+func TestLoadAuthorizedSegmentedConfigEnforcesDeviceEntitlements(t *testing.T) {
+	tests := []struct {
+		name         string
+		counts       []int
+		entitlements api.SimulationEntitlements
+		wantErr      error
+	}{
+		{name: "Free 10", counts: []int{4, 6}},
+		{
+			name: "Free 11", counts: []int{5, 6},
+			wantErr: api.ErrUnlimitedDevicesLicenseRequired,
+		},
+		{
+			name: "Pro 11", counts: []int{5, 6},
+			entitlements: fullSimulationEntitlements(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := api.SimulationRequest{
+				Interface: "eth0", ConfigData: segmentedSimulationConfig(test.counts...),
+			}
+			_, _, err := loadAuthorizedSimulationConfig(req, test.entitlements)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("loadAuthorizedSimulationConfig() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoadAuthorizedSimulationConfigEnforcesAbsoluteDeviceCap(t *testing.T) {
 	req := api.SimulationRequest{Interface: "eth0", ConfigData: simulationConfigWithDevices(
 		api.MaxDeviceCount + 1,
@@ -212,6 +243,27 @@ func simulationConfigWithDevices(count int) string {
 			"  - name: device-%d\n    type: host\n    mac: 02:00:00:%02x:%02x:%02x\n    ips: [\"198.18.%d.%d\"]\n",
 			index, index>>16, index>>8&0xff, index&0xff, index/254, index%254+1,
 		)
+	}
+	return content.String()
+}
+
+func segmentedSimulationConfig(counts ...int) string {
+	var content strings.Builder
+	content.WriteString("segments:\n")
+	deviceIndex := 0
+	for segmentIndex, count := range counts {
+		_, _ = fmt.Fprintf(&content, "  - tag: %d\n    devices:\n", segmentIndex+1)
+		for range count {
+			_, _ = fmt.Fprintf(&content,
+				"      - name: device-%d\n"+
+					"        type: host\n"+
+					"        mac: 02:00:00:%02x:%02x:%02x\n"+
+					"        ips: [\"198.18.%d.%d\"]\n",
+				deviceIndex, deviceIndex>>16, deviceIndex>>8&0xff, deviceIndex&0xff,
+				deviceIndex/254, deviceIndex%254+1,
+			)
+			deviceIndex++
+		}
 	}
 	return content.String()
 }

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -857,6 +857,7 @@
     "retry": "Retry",
     "devMode": "Development build — license enforcement is off, so every feature is available and no upgrade prompts are shown.",
     "currentTier": "Current tier",
+    "deviceScaleContract": "Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000.",
     "tier": "Tier",
     "activation": "Activation",
     "activated": "Activated",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -857,6 +857,7 @@
     "retry": "Reintentar",
     "devMode": "Compilación de desarrollo: la aplicación de licencia está desactivada, por lo que todas las funciones están disponibles y no se muestran avisos de actualización.",
     "currentTier": "Nivel actual",
+    "deviceScaleContract": "Free: hasta 10 dispositivos simulados; Pro elimina el límite flexible del nivel; límite absoluto de 1000.",
     "tier": "Nivel",
     "activation": "Activación",
     "activated": "Activada",

--- a/internal/license/feature_catalog.go
+++ b/internal/license/feature_catalog.go
@@ -29,7 +29,7 @@ func featureMeta() map[string]FeatureMeta {
 	return map[string]FeatureMeta{
 		"unlimited_devices": {
 			Label:       "Unlimited Devices",
-			Description: "Simulate more than the Free tier's device cap in a single config.",
+			Description: "Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000.",
 		},
 		"routed_labs": {
 			Label:       "Routed Virtual Labs",

--- a/internal/license/feature_catalog.go
+++ b/internal/license/feature_catalog.go
@@ -28,7 +28,7 @@ type FeatureMeta struct {
 func featureMeta() map[string]FeatureMeta {
 	return map[string]FeatureMeta{
 		"unlimited_devices": {
-			Label:       "Unlimited Devices",
+			Label:       "Expanded Device Capacity",
 			Description: "Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000.",
 		},
 		"routed_labs": {

--- a/internal/license/feature_catalog_test.go
+++ b/internal/license/feature_catalog_test.go
@@ -37,6 +37,9 @@ func TestUnlimitedDevicesDescriptionStatesDeviceScaleContract(t *testing.T) {
 	const contract = "Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000."
 	for _, feature := range license.FeatureCatalog() {
 		if feature.ID == "unlimited_devices" {
+			if feature.Label != "Expanded Device Capacity" {
+				t.Fatalf("label = %q, want expanded capacity wording", feature.Label)
+			}
 			if !strings.Contains(feature.Description, contract) {
 				t.Fatalf("description = %q, want device scale contract %q", feature.Description, contract)
 			}

--- a/internal/license/feature_catalog_test.go
+++ b/internal/license/feature_catalog_test.go
@@ -3,6 +3,7 @@
 package license_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/license"
@@ -30,6 +31,19 @@ func TestFeatureCatalogCoversProFeatures(t *testing.T) {
 			t.Errorf("feature %q has an empty Description", f.ID)
 		}
 	}
+}
+
+func TestUnlimitedDevicesDescriptionStatesDeviceScaleContract(t *testing.T) {
+	const contract = "Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000."
+	for _, feature := range license.FeatureCatalog() {
+		if feature.ID == "unlimited_devices" {
+			if !strings.Contains(feature.Description, contract) {
+				t.Fatalf("description = %q, want device scale contract %q", feature.Description, contract)
+			}
+			return
+		}
+	}
+	t.Fatal("unlimited_devices feature missing")
 }
 
 // TestFeatureCatalogIsStable ensures FeatureCatalog() returns a deterministic,

--- a/ui/src/pages/LicensePage.test.tsx
+++ b/ui/src/pages/LicensePage.test.tsx
@@ -67,6 +67,20 @@ function baseStatus(features: LicenseFeature[]): LicenseStatus {
 }
 
 describe('LicensePage', () => {
+  it('states the device scale contract', () => {
+    mockLicense.status = baseStatus([]);
+    mockLicense.loading = false;
+    mockLicense.error = null;
+
+    renderPage();
+
+    expect(
+      screen.getByText(
+        'Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('renders a granted feature by its human-readable label and description, not the raw ID', () => {
     mockLicense.status = baseStatus([bgpFeature]);
     mockLicense.loading = false;

--- a/ui/src/pages/LicensePage.tsx
+++ b/ui/src/pages/LicensePage.tsx
@@ -68,6 +68,9 @@ export const LicensePage: FC = () => {
           </div>
         </CardHeader>
         <CardContent>
+          <p className="mb-comfortable text-sm text-text-secondary">
+            {t('license.deviceScaleContract')}
+          </p>
           <CardRow label={t('license.tier')} value={status.tier} status={tierStatus} />
           <CardRow
             label={t('license.activation')}


### PR DESCRIPTION
## Summary
- make the 10-device Free soft cap and 1,000-device absolute ceiling explicit across CLI, API, UI, and README
- enforce the same entitlement checks for start, import, daemon preflight, and device creation
- describe Pro as expanded capacity instead of contradictory unlimited capacity

## Linked Issue
Related to #1053

## Testing Evidence
```text
make lint: 81 linters, 0 issues; Biome clean
make fmt-check: pass
make test: 41 Go packages and 63 UI files pass; aggregate Go coverage 64.5%
make security: govulncheck clean; npm audit 0; gitleaks clean
focused license/API tests: pass
Codex review: customer-facing capacity-label finding fixed; follow-up review clean
```

## Security and Release Checklist
- [x] Free and nil-license paths fail closed above 10 devices
- [x] Pro removes only the tier soft cap; the 1,000-device resource ceiling remains
- [x] Routed labs remain Pro-only
- [x] No secrets, default credentials, or auth changes
- [x] Release artifacts remain GitHub Actions-only; no local release build or manual tag
- [x] macOS release scope remains Apple Silicon only