### PR TITLE
fix(api): enforce HTTPS-only listeners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       workflows: ${{ steps.filter.outputs.workflows }}
       schema: ${{ steps.filter.outputs.schema }}
+      https: ${{ steps.filter.outputs.https }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -79,6 +80,23 @@ jobs:
             schema:
               - 'docs/schemas/**'
               - 'cmd/niac-schema/**'
+            https:
+              - 'cmd/niac/**'
+              - 'internal/api/**'
+              - 'internal/daemon/**'
+              - 'deploy/macos/build-pkg.sh'
+              - 'deploy/windows/build.ps1'
+              - 'docs/API_EXAMPLES.md'
+              - 'docs/CI_CD.md'
+              - 'docs/FAQ.md'
+              - 'docs/MONITORING.md'
+              - 'docs/PERFORMANCE.md'
+              - 'docs/README.md'
+              - 'docs/WEBUI.md'
+              - 'docs/openapi.yaml'
+              - 'scripts/check-https-only.sh'
+              - 'tests/smoke/run_smoke_tests.sh'
+              - 'ui/vite.config.ts'
 
   # ===========================================================================
   # Backend (Go)
@@ -87,7 +105,7 @@ jobs:
     name: Backend (Go)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.schema == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.schema == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.https == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -138,6 +156,9 @@ jobs:
 
       - name: Output-escaping / XSS gate (#742)
         run: ./scripts/check-output-escaping.sh
+
+      - name: HTTPS-only listener gate (#1037)
+        run: ./scripts/check-https-only.sh
 
       - name: Route-policy gate (capability registry)
         run: ./scripts/check-route-policy.sh

--- a/cmd/niac/cert_dir.go
+++ b/cmd/niac/cert_dir.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func defaultCertDir() string {
+	if dir := os.Getenv("NIAC_CERT_DIR"); dir != "" {
+		return dir
+	}
+	if runtime.GOOS != "windows" {
+		return ""
+	}
+
+	programData := os.Getenv("ProgramData")
+	if programData == "" {
+		programData = `C:\ProgramData`
+	}
+	return filepath.Join(programData, "NiAC", "certs")
+}

--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -19,13 +19,8 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 )
 
-// Daemon listen port defaults. The TLS port is the Wave 1 canonical for
-// niac (mirrors seed:8443 and stem:8444). HTTPS-only — the HTTP port
-// constant remains for the legacy `niac daemon --http` opt-out path so
-// existing deployment scripts keep working until they cut over to TLS.
 const (
 	daemonTLSPort         = 8445
-	daemonHTTPPort        = 8080
 	daemonDefaultListenIP = "127.0.0.1"
 )
 
@@ -35,9 +30,8 @@ type daemonOptions struct {
 	storagePath         string
 	webhookAllowedHosts []string
 	attachmentPolicies  []string
-	// Wave 1 (TLS-by-default) options.
-	certDir  string
-	apiToken string
+	certDir             string
+	apiToken            string
 	// Wave 2 (SIGHUP rotation + scoped tokens) options. tokenFile is the
 	// path to a 0o600 JSON file containing one or more {value, scope}
 	// pairs; preferred over apiToken / NIAC_API_TOKEN. SIGHUP re-reads
@@ -61,8 +55,7 @@ engine, allowing you to:
   - Switch between different configuration files
   - Manage multiple simulation sessions
 
-TLS is enabled by default and the daemon listens on 127.0.0.1:8445.
-The HTTP listener exists only as a 308 redirector. Binding to a
+The daemon serves HTTPS on 127.0.0.1:8445 by default. Binding to a
 non-loopback address (e.g. --listen 0.0.0.0) requires an API token via
 NIAC_API_TOKEN or --api-token.`,
 		Example: `  # Default: HTTPS on 127.0.0.1:8445 (loopback only, no token needed)
@@ -89,7 +82,7 @@ NIAC_API_TOKEN or --api-token.`,
 	}
 
 	daemonCmd.Flags().
-		StringVar(&options.listen, "listen", "", "Address to listen on for API and web UI (default depends on --tls)")
+		StringVar(&options.listen, "listen", "", "Address to listen on for the HTTPS API and web UI (default: 127.0.0.1:8445)")
 	daemonCmd.Flags().
 		StringVar(&options.token, "token", "", "Bearer token for API authentication (DEPRECATED: use NIAC_API_TOKEN env var)")
 	if err := daemonCmd.Flags().MarkDeprecated("token",
@@ -105,8 +98,6 @@ NIAC_API_TOKEN or --api-token.`,
 		StringSliceVar(&options.attachmentPolicies, "attachment-policy", nil,
 			"Operator-approved routed attachment (repeatable): INTERFACE=direct or INTERFACE=access:VLAN")
 
-	// HTTPS is required, no opt-out. The HTTP listener exists only as a
-	// 308 redirector. No --tls or --http flags.
 	daemonCmd.Flags().
 		StringVar(&options.certDir, "cert-dir", "", "Directory holding the self-signed cert and key (default: certs/ relative to CWD; override with NIAC_CERT_DIR)")
 	daemonCmd.Flags().
@@ -129,9 +120,7 @@ func resolveDaemonTokenFile(o *daemonOptions) string {
 	return os.Getenv("NIAC_API_TOKEN_FILE")
 }
 
-// resolveDaemonListen returns the TLS listen address (HTTPS-only; no
-// opt-out is supported) and a true for the legacy tlsOn flag.
-func resolveDaemonListen(o *daemonOptions) (string, bool) {
+func resolveDaemonListen(o *daemonOptions) string {
 	listen := o.listen
 	if listen == "" {
 		listen = os.Getenv("NIAC_LISTEN_ADDR")
@@ -142,17 +131,16 @@ func resolveDaemonListen(o *daemonOptions) (string, bool) {
 	case !strings.Contains(listen, ":"):
 		listen = net.JoinHostPort(listen, strconv.Itoa(daemonTLSPort))
 	}
-	return listen, true
+	return listen
 }
 
 // resolveDaemonCertDir returns the cert-dir to use. Explicit --cert-dir
-// wins; otherwise NIAC_CERT_DIR; otherwise empty (api package picks
-// `certs/`).
+// wins; otherwise NIAC_CERT_DIR; otherwise the platform default.
 func resolveDaemonCertDir(o *daemonOptions) string {
 	if o.certDir != "" {
 		return o.certDir
 	}
-	return os.Getenv("NIAC_CERT_DIR")
+	return defaultCertDir()
 }
 
 // resolveDaemonAPIToken layers --api-token / NIAC_API_TOKEN / --token in
@@ -206,7 +194,7 @@ func parseAttachmentPolicies(values []string) ([]fabric.PhysicalAttachmentPolicy
 func runDaemon(options *daemonOptions, info versionInfo) error {
 	logging.InitColors(true)
 
-	listenAddr, tlsOn := resolveDaemonListen(options)
+	listenAddr := resolveDaemonListen(options)
 	token := resolveDaemonAPIToken(options)
 	tokenFile := resolveDaemonTokenFile(options)
 	certDir := resolveDaemonCertDir(options)
@@ -215,13 +203,8 @@ func runDaemon(options *daemonOptions, info versionInfo) error {
 		return err
 	}
 
-	scheme := "http"
-	if tlsOn {
-		scheme = "https"
-	}
-
 	logging.Infof("Starting NIAC Daemon v%s", info.version)
-	logging.Infof("Web UI will be available at %s://%s", scheme, listenAddr)
+	logging.Infof("Web UI will be available at https://%s", listenAddr)
 	authEnabled := token != "" || tokenFile != ""
 	switch {
 	case tokenFile != "":
@@ -246,7 +229,6 @@ func runDaemon(options *daemonOptions, info versionInfo) error {
 		ReleaseTrain:        info.releaseTrain,
 		UIBuildHash:         info.uiBuildHash,
 		WebhookAllowedHosts: options.webhookAllowedHosts,
-		EnableTLS:           tlsOn,
 		CertDir:             certDir,
 		AttachmentPolicies:  attachmentPolicies,
 	}

--- a/cmd/niac/cmd_service_windows.go
+++ b/cmd/niac/cmd_service_windows.go
@@ -64,13 +64,9 @@ func (p *niacProgram) run() {
 
 	logging.InitColors(false)
 
-	listen := os.Getenv("NIAC_LISTEN")
+	listen := os.Getenv("NIAC_LISTEN_ADDR")
 	if listen == "" {
-		// Wave 1 default-secure: loopback bind so the gate does not trip
-		// when running without an API token. Operators who need external
-		// exposure should set NIAC_LISTEN explicitly and pair it with
-		// NIAC_API_TOKEN.
-		listen = "127.0.0.1:8080"
+		listen = "127.0.0.1:8445"
 	}
 
 	storagePath := os.Getenv("NIAC_STORAGE_PATH")
@@ -90,6 +86,7 @@ func (p *niacProgram) run() {
 		BuildTime:    p.info.date,
 		ReleaseTrain: p.info.releaseTrain,
 		UIBuildHash:  p.info.uiBuildHash,
+		CertDir:      defaultCertDir(),
 	})
 	if err != nil {
 		logging.Errorf("Failed to create daemon: %v", err)

--- a/cmd/niac/commands_test.go
+++ b/cmd/niac/commands_test.go
@@ -389,14 +389,14 @@ func TestNewRootCommand(t *testing.T) {
 	}
 
 	// Verify persistent flags
-	if root.PersistentFlags().Lookup("api-listen") == nil {
-		t.Error("Expected --api-listen persistent flag")
+	if root.PersistentFlags().Lookup("api-listen") != nil {
+		t.Error("obsolete --api-listen persistent flag must not be registered")
 	}
-	if root.PersistentFlags().Lookup("api-token") == nil {
-		t.Error("Expected --api-token persistent flag")
+	if root.PersistentFlags().Lookup("api-token") != nil {
+		t.Error("obsolete global --api-token persistent flag must not be registered")
 	}
-	if root.PersistentFlags().Lookup("metrics-listen") == nil {
-		t.Error("Expected --metrics-listen persistent flag")
+	if root.PersistentFlags().Lookup("metrics-listen") != nil {
+		t.Error("obsolete --metrics-listen persistent flag must not be registered")
 	}
 	if root.PersistentFlags().Lookup("storage-path") == nil {
 		t.Error("Expected --storage-path persistent flag")
@@ -448,11 +448,6 @@ func TestShouldUseLegacyCommand(t *testing.T) {
 		{name: "legacy verbose with value flag", args: []string{"--debug", "2", "en0", "config.yaml"}, want: true},
 		{name: "legacy informational flag", args: []string{"--list-interfaces"}, want: true},
 		{name: "cobra subcommand", args: []string{"run", "en0", "config.yaml"}, want: false},
-		{
-			name: "cobra persistent flag before subcommand",
-			args: []string{"--api-listen", ":8080", "run", "en0", "config.yaml"},
-			want: false,
-		},
 		{name: "help", args: []string{"help"}, want: false},
 		{name: "double dash compatibility", args: []string{"--", "--dry-run", "lo0", "config.yaml"}, want: false},
 		{name: "no args", args: nil, want: false},

--- a/cmd/niac/install_ca.go
+++ b/cmd/niac/install_ca.go
@@ -44,8 +44,7 @@ const (
 // --cert is not given. The lookup honors NIAC_CERT_DIR so an operator can
 // keep certs outside the working directory.
 func defaultInstallCAPath() string {
-	dir := os.Getenv("NIAC_CERT_DIR")
-	cert, _ := api.DefaultCertPaths(dir)
+	cert, _ := api.DefaultCertPaths(defaultCertDir())
 	return cert
 }
 

--- a/cmd/niac/legacy.go
+++ b/cmd/niac/legacy.go
@@ -61,12 +61,7 @@ type legacyFlags struct {
 	debugSNMP    int
 
 	// Service / API flags
-	apiListen             string
-	apiToken              string
-	metricsListen         string
-	storagePath           string
-	alertPacketsThreshold uint64
-	alertWebhook          string
+	storagePath string
 }
 
 // defineLegacyFlags defines all command-line flags for legacy mode.
@@ -275,37 +270,7 @@ func defineDiscoveryProtocolDebugFlags(flagSet *flag.FlagSet, flags *legacyFlags
 }
 
 func defineServiceFlags(flagSet *flag.FlagSet, flags *legacyFlags) {
-	flagSet.StringVar(
-		&flags.apiListen,
-		"api-listen",
-		"",
-		"Expose REST API and Web UI on this address (e.g., :8080)",
-	)
-	flagSet.StringVar(
-		&flags.apiToken,
-		"api-token",
-		"",
-		"Bearer token required for API/Web UI access",
-	)
-	flagSet.StringVar(
-		&flags.metricsListen,
-		"metrics-listen",
-		"",
-		"Expose Prometheus metrics on this address",
-	)
 	flagSet.StringVar(&flags.storagePath, "storage-path", "", "Path to NIAC run history database")
-	flagSet.Uint64Var(
-		&flags.alertPacketsThreshold,
-		"alert-packets-threshold",
-		0,
-		"Trigger alerts when total packet count exceeds this value",
-	)
-	flagSet.StringVar(
-		&flags.alertWebhook,
-		"alert-webhook",
-		"",
-		"Optional webhook URL to notify when alerts fire",
-	)
 }
 
 // processFlags applies flag transformations (verbose/quiet override) and validates flag values.
@@ -323,23 +288,8 @@ func processFlags(flags *legacyFlags) {
 }
 
 func applyLegacyServiceFlags(flags *legacyFlags, services *serviceOptions) {
-	if flags.apiListen != "" {
-		services.apiListen = flags.apiListen
-	}
-	if flags.apiToken != "" {
-		services.apiToken = flags.apiToken
-	}
-	if flags.metricsListen != "" {
-		services.metricsListen = flags.metricsListen
-	}
 	if flags.storagePath != "" {
 		services.storagePath = flags.storagePath
-	}
-	if flags.alertPacketsThreshold > 0 {
-		services.alertPacketsThreshold = flags.alertPacketsThreshold
-	}
-	if flags.alertWebhook != "" {
-		services.alertWebhook = flags.alertWebhook
 	}
 	if services.storagePath == "" {
 		services.storagePath = defaultStoragePath()

--- a/cmd/niac/legacy_helpers_test.go
+++ b/cmd/niac/legacy_helpers_test.go
@@ -7,35 +7,9 @@ import (
 )
 
 func TestApplyLegacyServiceFlags(t *testing.T) {
-	t.Run("all flags set", testLegacyFlagsAllSet)
 	t.Run("no flags set uses defaults", testLegacyFlagsNone)
-	t.Run("partial flags set", testLegacyFlagsPartial)
 	t.Run("does not override existing storagePath", testLegacyFlagsKeepExisting)
 	t.Run("flag storagePath overrides existing", testLegacyFlagsOverrideExisting)
-	t.Run("zero threshold not applied", testLegacyFlagsZeroThreshold)
-}
-
-func testLegacyFlagsAllSet(t *testing.T) {
-	t.Helper()
-	flags := newLegacyFlags()
-	flags.apiListen = ":8080"
-	flags.apiToken = "secret"
-	flags.metricsListen = ":9090"
-	flags.storagePath = "/custom/niac.db"
-	flags.alertPacketsThreshold = 5000
-	flags.alertWebhook = "https://hooks.example.com/alert"
-
-	services := &serviceOptions{}
-	applyLegacyServiceFlags(flags, services)
-
-	assertStrEq(t, "apiListen", services.apiListen, ":8080")
-	assertStrEq(t, "apiToken", services.apiToken, "secret")
-	assertStrEq(t, "metricsListen", services.metricsListen, ":9090")
-	assertStrEq(t, "storagePath", services.storagePath, "/custom/niac.db")
-	if services.alertPacketsThreshold != 5000 {
-		t.Errorf("alertPacketsThreshold = %d, want %d", services.alertPacketsThreshold, 5000)
-	}
-	assertStrEq(t, "alertWebhook", services.alertWebhook, "https://hooks.example.com/alert")
 }
 
 func testLegacyFlagsNone(t *testing.T) {
@@ -44,27 +18,8 @@ func testLegacyFlagsNone(t *testing.T) {
 	services := &serviceOptions{}
 	applyLegacyServiceFlags(flags, services)
 
-	if services.apiListen != "" {
-		t.Errorf("apiListen should be empty, got %q", services.apiListen)
-	}
 	if services.storagePath == "" {
 		t.Error("Expected storagePath to have a default value")
-	}
-}
-
-func testLegacyFlagsPartial(t *testing.T) {
-	t.Helper()
-	flags := newLegacyFlags()
-	flags.apiListen = ":8080"
-	services := &serviceOptions{}
-	applyLegacyServiceFlags(flags, services)
-
-	assertStrEq(t, "apiListen", services.apiListen, ":8080")
-	if services.apiToken != "" {
-		t.Errorf("apiToken should be empty, got %q", services.apiToken)
-	}
-	if services.storagePath == "" {
-		t.Error("Expected storagePath to have default")
 	}
 }
 
@@ -85,19 +40,6 @@ func testLegacyFlagsOverrideExisting(t *testing.T) {
 	applyLegacyServiceFlags(flags, services)
 
 	assertStrEq(t, "storagePath", services.storagePath, "/new/path.db")
-}
-
-func testLegacyFlagsZeroThreshold(t *testing.T) {
-	t.Helper()
-	flags := newLegacyFlags()
-	flags.alertPacketsThreshold = 0
-	services := &serviceOptions{alertPacketsThreshold: 100}
-	applyLegacyServiceFlags(flags, services)
-
-	if services.alertPacketsThreshold != 100 {
-		t.Errorf("alertPacketsThreshold should be preserved when flag is 0, got %d",
-			services.alertPacketsThreshold)
-	}
 }
 
 func assertStrEq(t *testing.T, field, got, want string) {

--- a/cmd/niac/root.go
+++ b/cmd/niac/root.go
@@ -126,23 +126,7 @@ and network discovery without physical hardware.`,
 	)
 
 	rootCmd.PersistentFlags().
-		StringVar(&services.apiListen, "api-listen", "", "Expose the REST API and Web UI on this address (e.g., :8080)")
-	// SECURITY FIX #101: Deprecate --api-token flag in favor of environment variable
-	rootCmd.PersistentFlags().
-		StringVar(&services.apiToken, "api-token", "", "Bearer token required for API/Web UI access (DEPRECATED: use NIAC_API_TOKEN env var)")
-	if err := rootCmd.PersistentFlags().MarkDeprecated("api-token",
-		"the value lands in /proc/<pid>/cmdline and `ps`. Set NIAC_API_TOKEN in the environment instead."); err != nil {
-		// MarkDeprecated only fails for an unknown flag name, which is a programming error.
-		panic(fmt.Errorf("mark --api-token deprecated: %w", err))
-	}
-	rootCmd.PersistentFlags().
-		StringVar(&services.metricsListen, "metrics-listen", "", "Expose Prometheus metrics on this address (defaults to --api-listen)")
-	rootCmd.PersistentFlags().
 		StringVar(&services.storagePath, "storage-path", "", "Path to NIAC run history database (default: ~/.niac/niac.db)")
-	rootCmd.PersistentFlags().
-		Uint64Var(&services.alertPacketsThreshold, "alert-packets-threshold", 0, "Trigger alerts when total packets exceed this value")
-	rootCmd.PersistentFlags().
-		StringVar(&services.alertWebhook, "alert-webhook", "", "Optional webhook URL to notify when alerts fire")
 
 	for _, build := range commandBuilders {
 		build(rootCmd, services)

--- a/cmd/niac/run.go
+++ b/cmd/niac/run.go
@@ -15,8 +15,6 @@ type runOptions struct {
 	quiet      bool
 	noColor    bool
 	tui        bool
-	web        bool
-	webPort    string
 	dryRun     bool
 }
 
@@ -26,24 +24,15 @@ func addRunCommand(root *cobra.Command, services *serviceOptions, info versionIn
 	runCmd := &cobra.Command{
 		Use:   "run <interface> <config-file>",
 		Short: "Run network simulation",
-		Long: `Run NIAC network simulation with optional TUI and/or WebUI.
+		Long: `Run NIAC network simulation with an optional terminal UI.
 
-By default, runs in headless mode. Add --tui for interactive terminal UI,
---web for browser-based UI, or both for full control.`,
+By default, runs in headless mode. Add --tui for interactive terminal UI.
+Use "niac daemon" for the HTTPS web UI and API.`,
 		Example: `  # Headless simulation
   sudo niac run en0 config.yaml
 
   # With Terminal UI (TUI)
   sudo niac run en0 config.yaml --tui
-
-  # With Web UI on port 8080
-  sudo niac run en0 config.yaml --web
-
-  # With both TUI and Web UI
-  sudo niac run en0 config.yaml --tui --web
-
-  # Web UI on custom port
-  sudo niac run en0 config.yaml --web --port 9000
 
   # Validate config without running
   niac run en0 config.yaml --dry-run`,
@@ -58,8 +47,6 @@ By default, runs in headless mode. Add --tui for interactive terminal UI,
 	runCmd.Flags().BoolVarP(&options.quiet, "quiet", "q", false, "Quiet mode (equivalent to -d 0)")
 	runCmd.Flags().BoolVar(&options.noColor, "no-color", false, "Disable colored output")
 	runCmd.Flags().BoolVar(&options.tui, "tui", false, "Enable interactive Terminal UI")
-	runCmd.Flags().BoolVar(&options.web, "web", false, "Enable Web UI")
-	runCmd.Flags().StringVar(&options.webPort, "port", "8080", "Web UI port (used with --web)")
 	runCmd.Flags().BoolVarP(&options.dryRun, "dry-run", "n", false, "Validate config without starting simulation")
 
 	root.AddCommand(runCmd)
@@ -102,11 +89,6 @@ func runSimulation(
 		return nil
 	}
 
-	// Set up API listen address if web is enabled
-	if options.web {
-		services.apiListen = ":" + options.webPort
-	}
-
 	debugConfig := logging.NewDebugConfig(debugLevel)
 
 	// Print banner unless quiet
@@ -114,9 +96,6 @@ func runSimulation(
 		printBanner(info.version)
 		logging.Infof("Interface: %s", interfaceName)
 		logging.Infof("Config: %s (%d devices)", resolvedConfig, len(cfg.Devices))
-		if options.web {
-			logging.Infof("Web UI: http://localhost:%s", options.webPort)
-		}
 		if options.tui {
 			logging.Infof("TUI: Enabled")
 		}

--- a/cmd/niac/run_test.go
+++ b/cmd/niac/run_test.go
@@ -18,10 +18,15 @@ func TestAddRunCommand(t *testing.T) {
 		t.Fatal("Expected run command to be registered")
 	}
 
-	expectedFlags := []string{"debug", "verbose", "quiet", "no-color", "tui", "web", "port", "dry-run"}
+	expectedFlags := []string{"debug", "verbose", "quiet", "no-color", "tui", "dry-run"}
 	for _, flag := range expectedFlags {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("Expected --%s flag on run command", flag)
+		}
+	}
+	for _, obsolete := range []string{"web", "port"} {
+		if cmd.Flags().Lookup(obsolete) != nil {
+			t.Errorf("obsolete --%s flag must not be registered", obsolete)
 		}
 	}
 }
@@ -31,8 +36,6 @@ func TestRunOptionsStruct(t *testing.T) {
 		debugLevel: 2,
 		verbose:    true,
 		tui:        true,
-		web:        true,
-		webPort:    "9000",
 	}
 
 	if opts.debugLevel != 2 {
@@ -43,11 +46,5 @@ func TestRunOptionsStruct(t *testing.T) {
 	}
 	if !opts.tui {
 		t.Error("Expected tui=true")
-	}
-	if !opts.web {
-		t.Error("Expected web=true")
-	}
-	if opts.webPort != "9000" {
-		t.Errorf("webPort = %q, want %q", opts.webPort, "9000")
 	}
 }

--- a/cmd/niac/runtime_services.go
+++ b/cmd/niac/runtime_services.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,12 +15,10 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
 	"github.com/MustardSeedNetworks/niac-go/internal/replay"
 	"github.com/MustardSeedNetworks/niac-go/internal/storage"
-	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
 type runtimeServices struct {
 	storage       *storage.Storage
-	apiServer     *api.Server
 	stack         *protocols.Stack
 	engine        *capture.Engine
 	startTime     time.Time
@@ -46,48 +43,6 @@ func resolveAPIToken(cliToken string) string {
 	}
 
 	return cliToken
-}
-
-// initAPIServer creates and starts the API server with the given configuration.
-func (rs *runtimeServices) initAPIServer(
-	apiAddr, metricsAddr string,
-	stack *protocols.Stack,
-	cfg *config.Config,
-	interfaceName string,
-	services *serviceOptions,
-) error {
-	graph := topology.Build(cfg)
-	info := readVersionInfo()
-	cfgCopy := &api.ServerConfig{
-		Addr:         apiAddr,
-		MetricsAddr:  metricsAddr,
-		Token:        resolveAPIToken(services.apiToken),
-		Stack:        stack,
-		Config:       cfg,
-		ConfigPath:   rs.configPath,
-		Storage:      rs.storage,
-		Interface:    interfaceName,
-		Version:      info.version,
-		Commit:       info.commit,
-		BuildTime:    info.date,
-		ReleaseTrain: info.releaseTrain,
-		UIBuildHash:  info.uiBuildHash,
-		Topology:     graph,
-		Alert: api.AlertConfig{
-			PacketsThreshold: services.alertPacketsThreshold,
-			WebhookURL:       services.alertWebhook,
-		},
-		ApplyConfig: rs.applyConfig,
-		Replay:      rs.replay,
-	}
-
-	rs.apiServer = api.NewServer(*cfgCopy)
-
-	if startErr := rs.apiServer.Start(); startErr != nil {
-		return fmt.Errorf("start API server: %w", startErr)
-	}
-
-	return nil
 }
 
 func startRuntimeServices(
@@ -129,25 +84,6 @@ func startRuntimeServices(
 		rs.replay = newReplayController(engine, stack.GetDebugLevel())
 	}
 
-	apiAddr := services.apiListen
-	metricsAddr := services.metricsListen
-	if apiAddr == "" && metricsAddr != "" {
-		apiAddr = metricsAddr
-		metricsAddr = ""
-	}
-
-	if apiAddr == "" {
-		return rs, nil
-	}
-
-	if initErr := rs.initAPIServer(apiAddr, metricsAddr, stack, cfg, interfaceName, services); initErr != nil {
-		if rs.storage != nil {
-			_ = rs.storage.Close()
-		}
-
-		return nil, initErr
-	}
-
 	return rs, nil
 }
 
@@ -159,16 +95,6 @@ func (rs *runtimeServices) Stop() {
 		_, stopErr := rs.replay.Stop()
 		if stopErr != nil {
 			logger.Error("Error stopping replay during shutdown", "error", stopErr)
-		}
-	}
-
-	if rs.apiServer != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout*time.Second)
-		defer cancel()
-		// SECURITY FIX #106: Log API server shutdown errors
-		err := rs.apiServer.Shutdown(ctx)
-		if err != nil {
-			logger.Error("Error shutting down API server", "error", err)
 		}
 	}
 

--- a/cmd/niac/services.go
+++ b/cmd/niac/services.go
@@ -6,12 +6,7 @@ import (
 )
 
 type serviceOptions struct {
-	apiListen             string
-	apiToken              string
-	metricsListen         string
-	storagePath           string
-	alertPacketsThreshold uint64
-	alertWebhook          string
+	storagePath string
 }
 
 func defaultStoragePath() string {

--- a/cmd/niac/services_test.go
+++ b/cmd/niac/services_test.go
@@ -40,30 +40,10 @@ func TestResolveServiceDefaults(t *testing.T) {
 
 func TestServiceOptionsStruct(t *testing.T) {
 	opts := &serviceOptions{
-		apiListen:             ":8080",
-		apiToken:              "secret-token",
-		metricsListen:         ":9090",
-		storagePath:           "/data/niac.db",
-		alertPacketsThreshold: 1000,
-		alertWebhook:          "https://webhook.example.com",
+		storagePath: "/data/niac.db",
 	}
 
-	if opts.apiListen != ":8080" {
-		t.Errorf("apiListen = %q, want %q", opts.apiListen, ":8080")
-	}
-	if opts.apiToken != "secret-token" {
-		t.Errorf("apiToken = %q, want %q", opts.apiToken, "secret-token")
-	}
-	if opts.metricsListen != ":9090" {
-		t.Errorf("metricsListen = %q, want %q", opts.metricsListen, ":9090")
-	}
 	if opts.storagePath != "/data/niac.db" {
 		t.Errorf("storagePath = %q, want %q", opts.storagePath, "/data/niac.db")
-	}
-	if opts.alertPacketsThreshold != 1000 {
-		t.Errorf("alertPacketsThreshold = %d, want %d", opts.alertPacketsThreshold, 1000)
-	}
-	if opts.alertWebhook != "https://webhook.example.com" {
-		t.Errorf("alertWebhook = %q, want %q", opts.alertWebhook, "https://webhook.example.com")
 	}
 }

--- a/deploy/macos/build-pkg.sh
+++ b/deploy/macos/build-pkg.sh
@@ -99,7 +99,7 @@ mkdir -p /usr/local/niac/data
 launchctl load -w /Library/LaunchDaemons/com.niac.plist 2>/dev/null || true
 
 echo "NiAC installed successfully."
-echo "Web UI: http://localhost:8080"
+echo "Web UI: https://localhost:8445"
 SCRIPT
 chmod 755 "$BUILD_DIR/scripts/postinstall"
 

--- a/deploy/windows/build.ps1
+++ b/deploy/windows/build.ps1
@@ -89,9 +89,9 @@ Write-Host "  Installing Windows service..."
 & "$InstallDir\$BinaryName" service install
 
 # Add firewall rule
-Write-Host "  Adding firewall rule for port 8080..."
+Write-Host "  Adding firewall rule for port 8445..."
 New-NetFirewallRule -DisplayName "NiAC Simulator" `
-    -Direction Inbound -Protocol TCP -LocalPort 8080 `
+    -Direction Inbound -Protocol TCP -LocalPort 8445 `
     -Action Allow -ErrorAction SilentlyContinue | Out-Null
 
 # Start service
@@ -100,7 +100,7 @@ Write-Host "  Starting service..."
 
 Write-Host ""
 Write-Host "Installation complete!" -ForegroundColor Green
-Write-Host "  Web UI: http://localhost:8080"
+Write-Host "  Web UI: https://localhost:8445"
 Write-Host "  Service: $ServiceName"
 Write-Host ""
 Write-Host "Commands:"

--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -365,12 +365,16 @@ print("Replay completed")
 ### Prometheus Metrics Integration
 
 ```python
+import os
 import requests
 from prometheus_client.parser import text_string_to_metric_families
 
 def fetch_metrics():
     """Fetch and parse Prometheus metrics"""
-    response = requests.get("https://localhost:8445/metrics")
+    response = requests.get(
+        "https://localhost:8445/metrics",
+        headers={"Authorization": f"Bearer {os.environ['NIAC_API_TOKEN']}"},
+    )
     response.raise_for_status()
 
     for family in text_string_to_metric_families(response.text):

--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -13,14 +13,22 @@ This document provides practical examples for interacting with the NIAC-Go API u
 
 ## Authentication
 
-All API requests (except `/metrics`) require authentication via Bearer token:
+All API requests, including `/metrics`, require authentication via a bearer token:
 
 ```bash
 # Generate secure token
 export NIAC_API_TOKEN=$(openssl rand -base64 32)
 
-# Start API server
-sudo niac run config.yaml --api :8080
+# Start the HTTPS API server
+niac daemon &
+
+# Wait for first-run certificate generation, then trust it
+for _ in {1..30}; do
+  curl -skf https://localhost:8445/__version >/dev/null && break
+  sleep 1
+done
+curl -skf https://localhost:8445/__version >/dev/null
+sudo niac install-ca
 ```
 
 For state-changing operations (POST/PUT/PATCH/DELETE), you also need a CSRF token:
@@ -28,7 +36,7 @@ For state-changing operations (POST/PUT/PATCH/DELETE), you also need a CSRF toke
 ```bash
 # Get CSRF token
 CSRF_TOKEN=$(curl -s -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/csrf-token | jq -r '.token')
+  https://localhost:8445/api/v1/csrf-token | jq -r '.token')
 ```
 
 ## curl Examples
@@ -37,7 +45,7 @@ CSRF_TOKEN=$(curl -s -H "Authorization: Bearer $NIAC_API_TOKEN" \
 
 ```bash
 curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/stats | jq .
+  https://localhost:8445/api/v1/stats | jq .
 ```
 
 **Response:**
@@ -67,7 +75,7 @@ curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
 
 ```bash
 curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/devices | jq .
+  https://localhost:8445/api/v1/devices | jq .
 ```
 
 **Response:**
@@ -92,7 +100,7 @@ curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
 
 ```bash
 curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/config | jq .
+  https://localhost:8445/api/v1/config | jq .
 ```
 
 ### Update Configuration
@@ -100,7 +108,7 @@ curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
 ```bash
 # Get CSRF token first
 CSRF_TOKEN=$(curl -s -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/csrf-token | jq -r '.token')
+  https://localhost:8445/api/v1/csrf-token | jq -r '.token')
 
 # Update config
 curl -X PUT \
@@ -110,7 +118,7 @@ curl -X PUT \
   -d '{
     "content": "devices:\n  - name: router1\n    type: router\n    ip_addresses:\n      - 192.168.1.1"
   }' \
-  http://localhost:8080/api/v1/config
+  https://localhost:8445/api/v1/config
 ```
 
 ### Start PCAP Replay
@@ -118,7 +126,7 @@ curl -X PUT \
 ```bash
 # Get CSRF token
 CSRF_TOKEN=$(curl -s -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/csrf-token | jq -r '.token')
+  https://localhost:8445/api/v1/csrf-token | jq -r '.token')
 
 # Start replay from file
 curl -X POST \
@@ -130,7 +138,7 @@ curl -X POST \
     "speed": 1.0,
     "loop": false
   }' \
-  http://localhost:8080/api/v1/replay
+  https://localhost:8445/api/v1/replay
 ```
 
 ### Upload and Replay PCAP
@@ -141,7 +149,7 @@ PCAP_DATA=$(base64 -w 0 capture.pcap)
 
 # Get CSRF token
 CSRF_TOKEN=$(curl -s -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/csrf-token | jq -r '.token')
+  https://localhost:8445/api/v1/csrf-token | jq -r '.token')
 
 # Upload and replay
 curl -X POST \
@@ -153,26 +161,26 @@ curl -X POST \
     \"data\": \"$PCAP_DATA\",
     \"speed\": 1.0
   }" \
-  http://localhost:8080/api/v1/replay
+  https://localhost:8445/api/v1/replay
 ```
 
 ### Stop PCAP Replay
 
 ```bash
 CSRF_TOKEN=$(curl -s -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/csrf-token | jq -r '.token')
+  https://localhost:8445/api/v1/csrf-token | jq -r '.token')
 
 curl -X DELETE \
   -H "Authorization: Bearer $NIAC_API_TOKEN" \
   -H "X-CSRF-Token: $CSRF_TOKEN" \
-  http://localhost:8080/api/v1/replay
+  https://localhost:8445/api/v1/replay
 ```
 
 ### Configure Alerts
 
 ```bash
 CSRF_TOKEN=$(curl -s -H "Authorization: Bearer $NIAC_API_TOKEN" \
-  http://localhost:8080/api/v1/csrf-token | jq -r '.token')
+  https://localhost:8445/api/v1/csrf-token | jq -r '.token')
 
 curl -X PUT \
   -H "Authorization: Bearer $NIAC_API_TOKEN" \
@@ -182,7 +190,7 @@ curl -X PUT \
     "packets_threshold": 100000,
     "webhook_url": "http://alertmanager:9093/api/v1/alerts"
   }' \
-  http://localhost:8080/api/v1/alerts
+  https://localhost:8445/api/v1/alerts
 ```
 
 ## Python Examples
@@ -194,7 +202,7 @@ import requests
 import time
 
 # Configuration
-API_URL = "http://localhost:8080"
+API_URL = "https://localhost:8445"
 TOKEN = "your-api-token-here"
 
 headers = {
@@ -226,7 +234,7 @@ if __name__ == "__main__":
 ```python
 import requests
 
-API_URL = "http://localhost:8080"
+API_URL = "https://localhost:8445"
 TOKEN = "your-api-token-here"
 
 headers = {
@@ -283,7 +291,7 @@ import requests
 import base64
 import time
 
-API_URL = "http://localhost:8080"
+API_URL = "https://localhost:8445"
 TOKEN = "your-api-token-here"
 
 headers = {
@@ -362,7 +370,7 @@ from prometheus_client.parser import text_string_to_metric_families
 
 def fetch_metrics():
     """Fetch and parse Prometheus metrics"""
-    response = requests.get("http://localhost:9090/metrics")
+    response = requests.get("https://localhost:8445/metrics")
     response.raise_for_status()
 
     for family in text_string_to_metric_families(response.text):
@@ -377,7 +385,7 @@ fetch_metrics()
 ### Fetch API (Browser/Node.js)
 
 ```javascript
-const API_URL = 'http://localhost:8080';
+const API_URL = 'https://localhost:8445';
 const TOKEN = 'your-api-token-here';
 
 const headers = {
@@ -434,7 +442,7 @@ async function updateConfig(yamlContent) {
 const axios = require('axios');
 
 const api = axios.create({
-  baseURL: 'http://localhost:8080',
+  baseURL: 'https://localhost:8445',
   headers: {
     'Authorization': `Bearer ${process.env.NIAC_API_TOKEN}`
   }
@@ -506,7 +514,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/api/v1/stats", nil)
+	req, _ := http.NewRequest("GET", "https://localhost:8445/api/v1/stats", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	client := &http.Client{}
@@ -538,7 +546,7 @@ $headers = @{
     "Authorization" = "Bearer $token"
 }
 
-$stats = Invoke-RestMethod -Uri "http://localhost:8080/api/v1/stats" -Headers $headers
+$stats = Invoke-RestMethod -Uri "https://localhost:8445/api/v1/stats" -Headers $headers
 Write-Host "Packets Sent: $($stats.stack.packets_sent)"
 Write-Host "Packets Received: $($stats.stack.packets_received)"
 Write-Host "Goroutines: $($stats.goroutines)"
@@ -553,7 +561,7 @@ $headers = @{
 }
 
 # Get CSRF token
-$csrfResponse = Invoke-RestMethod -Uri "http://localhost:8080/api/v1/csrf-token" -Headers $headers
+$csrfResponse = Invoke-RestMethod -Uri "https://localhost:8445/api/v1/csrf-token" -Headers $headers
 $csrfToken = $csrfResponse.token
 
 # Update config
@@ -567,7 +575,7 @@ $body = @{
     content = $configContent
 } | ConvertTo-Json
 
-Invoke-RestMethod -Uri "http://localhost:8080/api/v1/config" `
+Invoke-RestMethod -Uri "https://localhost:8445/api/v1/config" `
     -Method Put `
     -Headers $headersWithCsrf `
     -Body $body
@@ -606,7 +614,7 @@ When rate limited, you'll receive HTTP 429 with retry information in the `X-Requ
 All API responses include an `X-Request-ID` header for debugging:
 
 ```bash
-curl -v -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/stats 2>&1 | grep X-Request-ID
+curl -v -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats 2>&1 | grep X-Request-ID
 # X-Request-ID: a1b2c3d4e5f67890a1b2c3d4e5f67890
 ```
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -21,13 +21,25 @@ jobs:
 
       - name: Start NIAC simulation
         run: |
-          sudo niac run test-network.yaml --api :8080 &
+          NIAC_API_TOKEN=$(openssl rand -base64 32)
+          export NIAC_API_TOKEN
+          echo "NIAC_API_TOKEN=$NIAC_API_TOKEN" >> "$GITHUB_ENV"
+          niac daemon &
           echo $! > niac.pid
           sleep 5
+          CSRF_TOKEN=$(curl -sk \
+            -H "Authorization: Bearer $NIAC_API_TOKEN" \
+            https://localhost:8445/api/v1/csrf-token | jq -r '.token')
+          curl --fail-with-body -sk -X POST \
+            -H "Authorization: Bearer $NIAC_API_TOKEN" \
+            -H "X-CSRF-Token: $CSRF_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg configData "$(cat test-network.yaml)" \
+              '{interface:"eth0", configData:$configData}')" \
+            https://localhost:8445/api/v1/simulation
 
       - name: Run network tests
         run: |
-          export NIAC_API_TOKEN=$(openssl rand -base64 32)
           pytest tests/network_tests.py
 
       - name: Stop NIAC
@@ -42,13 +54,26 @@ jobs:
 network_tests:
   image: ubuntu:22.04
   before_script:
-    - apt-get update && apt-get install -y curl libpcap-dev
+    - apt-get update && apt-get install -y curl jq libpcap-dev
     - curl -L https://github.com/MustardSeedNetworks/niac-go/releases/latest/download/niac-linux-x86_64.tar.gz | tar xz
     - mv niac /usr/local/bin/
     - setcap cap_net_raw,cap_net_admin=eip /usr/local/bin/niac
   script:
-    - niac run test-config.yaml --api :8080 &
+    - export NIAC_API_TOKEN=$(openssl rand -base64 32)
+    - niac daemon &
     - sleep 5
+    - |
+      CSRF_TOKEN=$(curl -sk \
+        -H "Authorization: Bearer $NIAC_API_TOKEN" \
+        https://localhost:8445/api/v1/csrf-token | jq -r '.token')
+      export CSRF_TOKEN
+      curl --fail-with-body -sk -X POST \
+        -H "Authorization: Bearer $NIAC_API_TOKEN" \
+        -H "X-CSRF-Token: $CSRF_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg configData "$(cat test-config.yaml)" \
+          '{interface:"eth0", configData:$configData}')" \
+        https://localhost:8445/api/v1/simulation
     - python3 run_tests.py
     - kill $(pgrep niac)
 ```
@@ -64,21 +89,33 @@ pipeline {
                 sh '''
                     curl -L https://github.com/MustardSeedNetworks/niac-go/releases/latest/download/niac-linux-x86_64.tar.gz | tar xz
                     sudo mv niac /usr/local/bin/
+                    sudo setcap cap_net_raw,cap_net_admin=eip /usr/local/bin/niac
                 '''
             }
         }
         stage('Run Simulation') {
             steps {
                 sh '''
-                    sudo niac run config.yaml --api :8080 &
+                    openssl rand -base64 32 > niac-token
+                    NIAC_API_TOKEN=$(cat niac-token) niac daemon &
                     echo $! > niac.pid
                     sleep 5
+                    CSRF_TOKEN=$(curl -sk \
+                      -H "Authorization: Bearer $(cat niac-token)" \
+                      https://localhost:8445/api/v1/csrf-token | jq -r '.token')
+                    curl --fail-with-body -sk -X POST \
+                      -H "Authorization: Bearer $(cat niac-token)" \
+                      -H "X-CSRF-Token: $CSRF_TOKEN" \
+                      -H "Content-Type: application/json" \
+                      -d "$(jq -n --arg configData "$(cat config.yaml)" \
+                        '{interface:"eth0", configData:$configData}')" \
+                      https://localhost:8445/api/v1/simulation
                 '''
             }
         }
         stage('Test') {
             steps {
-                sh 'pytest tests/'
+                sh 'NIAC_API_TOKEN=$(cat niac-token) pytest tests/'
             }
         }
     }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -165,7 +165,8 @@ curl -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats
 
 **Prometheus Metrics:**
 ```bash
-curl https://localhost:8445/metrics
+curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
+  https://localhost:8445/metrics
 ```
 
 ## Protocols

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -127,7 +127,7 @@ sudo niac run config.yaml
 sudo niac run config.yaml --debug 2
 
 # With API server
-sudo niac run config.yaml --api :8080 --api-token $(openssl rand -base64 32)
+niac daemon --api-token $(openssl rand -base64 32)
 ```
 
 ### How do I stop a running simulation?
@@ -160,12 +160,12 @@ sudo niac run config.yaml
 
 **API:**
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/stats
+curl -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats
 ```
 
 **Prometheus Metrics:**
 ```bash
-curl http://localhost:9090/metrics
+curl https://localhost:8445/metrics
 ```
 
 ## Protocols
@@ -236,12 +236,12 @@ trap_config:
 Set an API token:
 ```bash
 export NIAC_API_TOKEN=$(openssl rand -base64 32)
-sudo niac run config.yaml --api :8080
+niac daemon
 ```
 
 Then include it in requests:
 ```bash
-curl -H "Authorization: Bearer $NIAC_API_TOKEN" http://localhost:8080/api/v1/stats
+curl -H "Authorization: Bearer $NIAC_API_TOKEN" https://localhost:8445/api/v1/stats
 ```
 
 ### What API endpoints are available?
@@ -281,7 +281,7 @@ scrape_configs:
 curl -X PUT -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"webhook_url":"http://alertmanager:9093/api/v1/alerts"}' \
-  http://localhost:8080/api/v1/alerts
+  https://localhost:8445/api/v1/alerts
 ```
 
 ## Troubleshooting
@@ -388,8 +388,8 @@ See `docs/PERFORMANCE.md` for detailed tuning guide. Quick tips:
 
 Start API server, then visit in browser:
 ```bash
-sudo niac run config.yaml --api :8080 --api-token $TOKEN
-# Visit: http://localhost:8080
+niac daemon --api-token $TOKEN
+# Visit: https://localhost:8445
 ```
 
 ### Why is the WebUI slow with many devices?
@@ -417,12 +417,12 @@ token = "your-api-token"
 headers = {"Authorization": f"Bearer {token}"}
 
 # Get stats
-stats = requests.get("http://localhost:8080/api/v1/stats", headers=headers).json()
+stats = requests.get("https://localhost:8445/api/v1/stats", headers=headers).json()
 print(f"Packets sent: {stats['stack']['packets_sent']}")
 
 # Update config
 new_config = {"content": open("new-config.yaml").read()}
-requests.put("http://localhost:8080/api/v1/config", json=new_config, headers=headers)
+requests.put("https://localhost:8445/api/v1/config", json=new_config, headers=headers)
 ```
 
 ### How do I deploy NIAC?

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -30,7 +30,8 @@ first generates its local certificate.
 
 ```bash
 # View raw metrics
-curl https://localhost:8445/metrics
+curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
+  https://localhost:8445/metrics
 
 # Example output:
 # HELP niac_packets_sent_total Total packets sent

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -22,13 +22,15 @@ NIAC-Go exposes comprehensive metrics via a Prometheus-compatible `/metrics` end
 
 ## Prometheus Metrics
 
-The metrics endpoint is available at `http://localhost:8080/metrics` (or your configured API port).
+The metrics endpoint is available on the daemon's HTTPS listener at
+`https://localhost:8445/metrics`. Run `sudo niac install-ca` after the daemon
+first generates its local certificate.
 
 ### Quick Test
 
 ```bash
 # View raw metrics
-curl http://localhost:8080/metrics
+curl https://localhost:8445/metrics
 
 # Example output:
 # HELP niac_packets_sent_total Total packets sent
@@ -72,13 +74,18 @@ global:
 
 scrape_configs:
   - job_name: 'niac-go'
+    scheme: https
+    authorization:
+      credentials_file: /path/to/niac-token
+    tls_config:
+      ca_file: /path/to/niac/certs/server.crt
     static_configs:
-      - targets: ['localhost:8080']
+      - targets: ['localhost:8445']
     metrics_path: '/metrics'
     scrape_interval: 5s
 ```
 
-**Important**: Make sure the `targets` address matches your NIAC-Go API server address.
+**Important**: Make sure the target, token file, and CA file match your NIAC daemon.
 
 ### 3. Start Prometheus
 
@@ -266,7 +273,7 @@ Configure via REST API:
 
 ```bash
 # Set alert threshold
-curl -X PUT http://localhost:8080/api/v1/alert \
+curl -X PUT https://localhost:8445/api/v1/alert \
   -H "Content-Type: application/json" \
   -d '{
     "packets_threshold": 100000,
@@ -274,10 +281,10 @@ curl -X PUT http://localhost:8080/api/v1/alert \
   }'
 
 # Get alert status
-curl http://localhost:8080/api/v1/alert
+curl https://localhost:8445/api/v1/alert
 
 # Disable alerts
-curl -X DELETE http://localhost:8080/api/v1/alert
+curl -X DELETE https://localhost:8445/api/v1/alert
 ```
 
 ## Useful Queries
@@ -325,7 +332,7 @@ niac --config devices.yml
 
 ### Prometheus shows target down
 
-1. Check NIAC-Go is running: `curl http://localhost:8080/api/v1/status`
+1. Check NIAC-Go is running: `curl https://localhost:8445/api/v1/status`
 2. Verify API port in `prometheus.yml` matches your configuration
 3. Check firewall rules
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -201,7 +201,8 @@ sudo ethtool -K eth0 rx off tx off sg off tso off gso off gro off
 
 Prometheus metrics endpoint:
 ```bash
-curl https://localhost:8445/metrics
+curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
+  https://localhost:8445/metrics
 ```
 
 Key metrics:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -117,7 +117,7 @@ Rate limiter automatically cleans up stale entries every 5 minutes. For high-tra
 
 Monitor with:
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/stats | jq .goroutines
+curl -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats | jq .goroutines
 ```
 
 ### Goroutine Limits
@@ -129,7 +129,7 @@ Healthy goroutine counts:
 
 Check goroutines via API:
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/stats | jq .goroutines
+curl -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats | jq .goroutines
 ```
 
 ## CPU Optimization
@@ -201,7 +201,7 @@ sudo ethtool -K eth0 rx off tx off sg off tso off gso off gro off
 
 Prometheus metrics endpoint:
 ```bash
-curl http://localhost:9090/metrics
+curl https://localhost:8445/metrics
 ```
 
 Key metrics:
@@ -248,7 +248,7 @@ niac test error-rate --duration 10s --devices 10
 sudo tcpreplay -i eth0 -M 10 test.pcap
 
 # Monitor processing rate
-watch -n 1 'curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/stats | jq .stack.packets_received'
+watch -n 1 'curl -s -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats | jq .stack.packets_received'
 ```
 
 ## Tuning by Use Case

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,10 +22,8 @@ The installed daemon is HTTPS-only and listens on `127.0.0.1:8445` by default.
 Its API base URL is `https://localhost:8445/api/v1/`; use `-k` only when testing
 with the generated self-signed development certificate.
 
-The ad-hoc `niac run <interface> <config> --web` mode is an explicit plaintext
-mode and defaults to port 8080. Because it binds all interfaces, set
-`NIAC_API_TOKEN` before enabling it. Examples that use
-`http://localhost:8080` apply only to that mode.
+NIAC exposes the API, Web UI, and Prometheus metrics only through the daemon's
+HTTPS listener. The `niac run` command does not open a network service.
 
 Authenticated requests use a bearer token. Mutating requests also require the
 CSRF token returned by `/api/v1/csrf-token`.

--- a/docs/WEBUI.md
+++ b/docs/WEBUI.md
@@ -9,7 +9,14 @@ The NIAC-Go WebUI provides a web-based interface for monitoring and controlling 
 ### Starting the Daemon
 
 ```bash
-niac daemon
+niac daemon &
+# Wait for first-run certificate generation, then trust it
+for _ in {1..30}; do
+  curl -skf https://localhost:8445/__version >/dev/null && break
+  sleep 1
+done
+curl -skf https://localhost:8445/__version >/dev/null
+sudo niac install-ca
 # Open https://localhost:8445
 ```
 
@@ -146,7 +153,7 @@ Configure threshold-based alerting:
 ```bash
 # Export to GraphML
 curl -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:8080/api/v1/topology/export?format=graphml" \
+  "https://localhost:8445/api/v1/topology/export?format=graphml" \
   -o topology.graphml
 ```
 
@@ -223,9 +230,9 @@ View recent protocol errors:
 **Symptoms:** "Failed to fetch" or connection errors
 
 **Solutions:**
-1. Verify API server is running: `curl http://localhost:8080/api/v1/version`
+1. Verify API server is running: `curl https://localhost:8445/api/v1/version`
 2. Check firewall rules
-3. Ensure correct port (default :8080)
+3. Ensure correct port (default :8445)
 4. Try localhost vs 127.0.0.1 vs machine IP
 
 ### Authentication Fails
@@ -418,7 +425,7 @@ server {
     ssl_certificate_key /etc/ssl/private/niac.key;
 
     location / {
-        proxy_pass http://localhost:8080;
+        proxy_pass https://localhost:8445;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -36,8 +36,6 @@ servers:
     description: Installed loopback daemon with bearer authentication configured
   - url: https://niac.example.com/api/v1
     description: Production server (example)
-  - url: http://localhost:8080/api/v1
-    description: Explicit `niac run --web` mode; NIAC_API_TOKEN required
 
 security:
   - BearerAuth: []

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/api/auth"
 	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/sse"
@@ -258,8 +257,7 @@ type ReplayManager interface {
 
 // ServerConfig defines API server options.
 type ServerConfig struct {
-	Addr        string
-	MetricsAddr string
+	Addr string
 	// Token is the legacy Wave 1 single bearer token. When non-empty and
 	// TokenFile is empty, the server seeds its tokenstore.TokenStore with this value
 	// at tokenstore.ScopeReadWrite (back-compat with the pre-Wave-2 contract).
@@ -282,11 +280,6 @@ type ServerConfig struct {
 	UIBuildHash  string
 	Topology     topology.Graph
 	Alert        AlertConfig
-	// EnableTLS controls whether the API listener uses HTTPS. When true,
-	// CertFile/KeyFile (or, when both are empty, the auto-generated
-	// self-signed pair under CertDir) are loaded and the listener serves
-	// TLS 1.3. See internal/api/tls.go.
-	EnableTLS bool
 	// CertDir is the directory the self-signed cert+key default to when
 	// CertFile and KeyFile are not explicitly set. Empty falls back to
 	// `certs/` relative to the working directory.
@@ -366,7 +359,6 @@ type Server struct {
 	cfg               ServerConfig
 	logger            *slog.Logger
 	httpServer        *http.Server
-	metricsServer     *http.Server
 	alertStop         chan struct{}
 	lastAlert         uint64
 	alertMu           sync.RWMutex
@@ -588,7 +580,7 @@ func (s *Server) BoundAddr() string {
 	return s.httpServer.Addr
 }
 
-// Start boots the HTTP listeners.
+// Start boots the HTTPS listener.
 func (s *Server) Start() error {
 	if err := s.checkStartupPreconditions(); err != nil {
 		return err
@@ -603,32 +595,13 @@ func (s *Server) Start() error {
 		}
 	}
 
-	if s.cfg.MetricsAddr != "" && s.cfg.MetricsAddr != s.cfg.Addr {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/metrics", s.recoverMiddleware(auth.Middleware(s.authDeps(), s.handleMetrics)))
-		s.metricsServer = newSecureHTTPServer(s.cfg.MetricsAddr, mux)
-
-		metricsLn, metricsAddr, bindErr := bindWithFallback(context.Background(), s.logger, s.cfg.MetricsAddr)
-		if bindErr != nil {
-			return fmt.Errorf("metrics server bind: %w", bindErr)
-		}
-		s.metricsServer.Addr = metricsAddr
-
-		go func() {
-			if err := s.metricsServer.Serve(metricsLn); err != nil &&
-				!errors.Is(err, http.ErrServerClosed) {
-				s.logger.Error("Metrics server stopped", "error", err)
-			}
-		}()
-	}
-
 	s.startBackgroundTasks()
 	s.updateAlertConfig(s.cfg.Alert)
 
 	return nil
 }
 
-// Shutdown gracefully shuts down the API and metrics servers.
+// Shutdown gracefully shuts down the API server.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.alertMu.Lock()
 
@@ -657,13 +630,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 
 	var errs []error
-
-	if s.metricsServer != nil {
-		if err := s.metricsServer.Shutdown(ctx); err != nil {
-			s.logger.ErrorContext(ctx, "Error shutting down metrics server", "error", err)
-			errs = append(errs, err)
-		}
-	}
 
 	if s.httpServer != nil {
 		if err := s.httpServer.Shutdown(ctx); err != nil {
@@ -750,9 +716,7 @@ func (s *Server) warnIfUnauthenticated() {
 }
 
 // startAPIListener binds the API listener (with port-fallback per #69)
-// and serves either TLS or HTTP per configuration. The redirector is
-// started after the TLS listener so a redirect target exists before
-// the first client can hit :8044.
+// and serves TLS.
 func (s *Server) startAPIListener() error {
 	mux := http.NewServeMux()
 	s.registerAPIRoutes(mux)
@@ -774,30 +738,21 @@ func (s *Server) startAPIListener() error {
 	return nil
 }
 
-// serveAPI starts the API listener in TLS or HTTP mode. The TLS
-// branch resolves cert paths up front and closes the listener on
+// serveAPI starts the API listener in TLS mode. It resolves cert paths
+// up front and closes the listener on
 // resolution failure so we don't leak a half-bound socket back to
 // Start's error path.
 func (s *Server) serveAPI(ln net.Listener) error {
-	if s.cfg.EnableTLS {
-		certFile, keyFile, certErr := s.resolveTLSCertPaths()
-		if certErr != nil {
-			_ = ln.Close()
-			return fmt.Errorf("resolve TLS cert: %w", certErr)
-		}
-		s.httpServer.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS13}
-		go func() {
-			if err := s.httpServer.ServeTLS(ln, certFile, keyFile); err != nil &&
-				!errors.Is(err, http.ErrServerClosed) {
-				s.logger.Error("API server (TLS) stopped", "error", err)
-			}
-		}()
-		return nil
+	certFile, keyFile, certErr := s.resolveTLSCertPaths()
+	if certErr != nil {
+		_ = ln.Close()
+		return fmt.Errorf("resolve TLS cert: %w", certErr)
 	}
+	s.httpServer.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS13}
 	go func() {
-		if err := s.httpServer.Serve(ln); err != nil &&
+		if err := s.httpServer.ServeTLS(ln, certFile, keyFile); err != nil &&
 			!errors.Is(err, http.ErrServerClosed) {
-			s.logger.Error("API server stopped", "error", err)
+			s.logger.Error("API server (TLS) stopped", "error", err)
 		}
 	}()
 	return nil

--- a/internal/api/tls_fingerprint.go
+++ b/internal/api/tls_fingerprint.go
@@ -128,12 +128,8 @@ func formatFingerprint(digest []byte) string {
 	return string(out)
 }
 
-// activeCertPath returns the cert file path the server will use, or "" if
-// the server is running in HTTP mode.
+// activeCertPath returns the cert file path the server will use.
 func (s *Server) activeCertPath() string {
-	if !s.cfg.EnableTLS {
-		return ""
-	}
 	if s.cfg.CertFile != "" {
 		return s.cfg.CertFile
 	}

--- a/internal/api/tls_security_test.go
+++ b/internal/api/tls_security_test.go
@@ -6,10 +6,18 @@ package api
 // poke the Server.Start path with a tiny in-package fixture.
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
+	"io"
 	"log/slog"
+	"net"
+	"net/http"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
 )
@@ -111,6 +119,70 @@ func TestStart_NonLoopbackWithoutTokenRefused(t *testing.T) {
 	const wantSubst = "NIAC_API_TOKEN"
 	if !strings.Contains(err.Error(), wantSubst) {
 		t.Errorf("error must mention %q, got %q", wantSubst, err.Error())
+	}
+}
+
+func TestStartRequiresTLSAndRejectsPlaintext(t *testing.T) {
+	certDir := t.TempDir()
+	s := NewServer(ServerConfig{
+		Addr:                           "127.0.0.1:0",
+		CertDir:                        certDir,
+		SuppressUnauthenticatedWarning: true,
+	})
+	s.SetDaemonController(&nilDaemonController{})
+
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := s.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown() error = %v", err)
+		}
+	})
+
+	certFile, _ := DefaultCertPaths(certDir)
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		t.Fatalf("read generated certificate: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(certPEM) {
+		t.Fatal("generated certificate could not be added to root pool")
+	}
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			RootCAs:    roots,
+		}},
+		Timeout: 2 * time.Second,
+	}
+	_, port, err := net.SplitHostPort(s.BoundAddr())
+	if err != nil {
+		t.Fatalf("split bound address: %v", err)
+	}
+	testAddr := net.JoinHostPort("localhost", port)
+
+	resp, err := client.Get("https://" + testAddr + "/health")
+	if err != nil {
+		t.Fatalf("HTTPS request failed: %v", err)
+	}
+	if _, copyErr := io.Copy(io.Discard, resp.Body); copyErr != nil {
+		t.Errorf("read HTTPS response: %v", copyErr)
+	}
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		t.Errorf("close HTTPS response: %v", closeErr)
+	}
+
+	plainClient := &http.Client{Timeout: 2 * time.Second}
+	plainResp, plainErr := plainClient.Get("http://" + testAddr + "/health")
+	if plainErr != nil {
+		return
+	}
+	defer plainResp.Body.Close()
+	if plainResp.StatusCode >= http.StatusOK && plainResp.StatusCode < http.StatusMultipleChoices {
+		t.Fatalf("plaintext HTTP request returned success status %d", plainResp.StatusCode)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -68,9 +68,6 @@ type Config struct {
 	// admin-managed set of hostnames. Empty = no allowlist (the existing
 	// private-IP / blocked-hostname filters still apply).
 	WebhookAllowedHosts []string
-	// EnableTLS controls whether the daemon's API listener serves HTTPS.
-	// Wave 1 default: true.
-	EnableTLS bool
 	// CertDir is the directory holding the self-signed cert+key when
 	// CertFile/KeyFile are not explicitly set.
 	CertDir string
@@ -153,7 +150,6 @@ func (d *Daemon) Start() error {
 		UIBuildHash:                    d.cfg.UIBuildHash,
 		Storage:                        d.storage,
 		WebhookAllowedHosts:            d.cfg.WebhookAllowedHosts,
-		EnableTLS:                      d.cfg.EnableTLS,
 		CertDir:                        d.cfg.CertDir,
 		CertFile:                       d.cfg.CertFile,
 		KeyFile:                        d.cfg.KeyFile,

--- a/internal/daemon/daemon_coverage_test.go
+++ b/internal/daemon/daemon_coverage_test.go
@@ -245,6 +245,7 @@ func TestStopSimulationLocked_NilFields(t *testing.T) {
 		ListenAddr:  "127.0.0.1:0",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -296,6 +297,7 @@ func TestStartSimulation_NonExistentConfigPath(t *testing.T) {
 		ListenAddr:  "127.0.0.1:0",
 		StoragePath: "disabled",
 		Version:     "test",
+		CertDir:     t.TempDir(),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -335,6 +337,7 @@ func TestStartSimulation_ConfigDataExceedsSize(t *testing.T) {
 		ListenAddr:  "127.0.0.1:0",
 		StoragePath: "disabled",
 		Version:     "test",
+		CertDir:     t.TempDir(),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -375,6 +378,7 @@ func TestStartSimulation_MissingConfigAndPath(t *testing.T) {
 		ListenAddr:  "127.0.0.1:0",
 		StoragePath: "disabled",
 		Version:     "test",
+		CertDir:     t.TempDir(),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -414,6 +418,7 @@ func TestStartSimulation_InvalidInterface(t *testing.T) {
 		ListenAddr:  "127.0.0.1:0",
 		StoragePath: "disabled",
 		Version:     "test",
+		CertDir:     t.TempDir(),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -453,6 +458,7 @@ func TestStartSimulation_InvalidConfigData(t *testing.T) {
 		ListenAddr:  "127.0.0.1:0",
 		StoragePath: "disabled",
 		Version:     "test",
+		CertDir:     t.TempDir(),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -514,6 +520,7 @@ func TestShutdown_WithStorage(t *testing.T) {
 		ListenAddr:  "127.0.0.1:0",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -36,6 +36,7 @@ func TestDaemon_StartupShutdown(t *testing.T) {
 		Token:       "test-token-123",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -83,6 +84,7 @@ func TestDaemon_SimulationLifecycle(t *testing.T) {
 		Token:       "test-token-123",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -160,6 +162,7 @@ func TestDaemon_ErrorRecovery(t *testing.T) {
 		Token:       "test-token-123",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -231,6 +234,7 @@ func TestDaemon_ResourceCleanup(t *testing.T) {
 		Token:       "test-token-123",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -276,6 +280,7 @@ func TestDaemon_ConfigSizeValidation(t *testing.T) {
 		Token:       "test-token-123",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -320,6 +325,7 @@ func TestDaemon_StorageDisabled(t *testing.T) {
 		Token:       "test-token-123",
 		StoragePath: "disabled",
 		Version:     "test",
+		CertDir:     t.TempDir(),
 	}
 
 	daemon, err := NewDaemon(cfg)
@@ -534,6 +540,7 @@ func TestDaemon_MultipleStartStop(t *testing.T) {
 		Token:       "test-token-123",
 		StoragePath: storagePath,
 		Version:     "test",
+		CertDir:     filepath.Join(tmpDir, "certs"),
 	}
 
 	daemon, err := NewDaemon(cfg)

--- a/internal/daemon/sighup_test.go
+++ b/internal/daemon/sighup_test.go
@@ -2,16 +2,20 @@ package daemon
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
 )
 
@@ -38,12 +42,16 @@ func writeTokenFile(t *testing.T, dir, value, scope string) string {
 // status. csrf-token is the cheapest authed endpoint — it returns 200
 // unconditionally and does not require a simulation to be running, so
 // the status reliably reports auth outcome rather than handler state.
-func authedRequest(t *testing.T, addr, token string) int {
+func authedRequest(t *testing.T, client *http.Client, addr, token string) int {
 	t.Helper()
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split bound address: %v", err)
+	}
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodGet,
-		fmt.Sprintf("http://%s/api/v1/csrf-token", addr),
+		fmt.Sprintf("https://localhost:%s/api/v1/csrf-token", port),
 		http.NoBody,
 	)
 	if err != nil {
@@ -52,7 +60,6 @@ func authedRequest(t *testing.T, addr, token string) int {
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("issue request: %v", err)
@@ -66,13 +73,15 @@ func authedRequest(t *testing.T, addr, token string) int {
 // loopback port with the supplied TokenFile. Returns the live daemon
 // and its bound address; registers a t.Cleanup so the test does not
 // need to remember to call Shutdown.
-func newRotationDaemon(t *testing.T, tokenFile string) (*Daemon, string) {
+func newRotationDaemon(t *testing.T, tokenFile string) (*Daemon, string, *http.Client) {
 	t.Helper()
+	certDir := t.TempDir()
 	cfg := Config{
 		ListenAddr:  "127.0.0.1:0",
 		TokenFile:   tokenFile,
 		StoragePath: filepath.Join(t.TempDir(), "rotation.db"),
 		Version:     "test",
+		CertDir:     certDir,
 	}
 	d, err := NewDaemon(cfg)
 	if err != nil {
@@ -92,7 +101,23 @@ func newRotationDaemon(t *testing.T, tokenFile string) (*Daemon, string) {
 	if addr == "" {
 		t.Fatal("apiServer.BoundAddr() returned empty string after Start")
 	}
-	return d, addr
+	certFile, _ := api.DefaultCertPaths(certDir)
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		t.Fatalf("read generated certificate: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(certPEM) {
+		t.Fatal("generated certificate could not be added to root pool")
+	}
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			RootCAs:    roots,
+		}},
+		Timeout: 5 * time.Second,
+	}
+	return d, addr, client
 }
 
 // TestDaemon_ReloadTokens_RotatesTokenFile is the integration test
@@ -115,12 +140,12 @@ func TestDaemon_ReloadTokens_RotatesTokenFile(t *testing.T) {
 	const rotatedToken = "rotated-rw-67890"
 
 	tokenPath := writeTokenFile(t, tmpDir, initialToken, "read-write")
-	d, addr := newRotationDaemon(t, tokenPath)
+	d, addr, client := newRotationDaemon(t, tokenPath)
 
-	if got := authedRequest(t, addr, initialToken); got != http.StatusOK {
+	if got := authedRequest(t, client, addr, initialToken); got != http.StatusOK {
 		t.Errorf("initial token: GET /api/v1/csrf-token = %d, want 200", got)
 	}
-	if got := authedRequest(t, addr, "not-a-real-token"); got != http.StatusUnauthorized {
+	if got := authedRequest(t, client, addr, "not-a-real-token"); got != http.StatusUnauthorized {
 		t.Errorf("bogus token: GET /api/v1/csrf-token = %d, want 401", got)
 	}
 
@@ -141,10 +166,10 @@ func TestDaemon_ReloadTokens_RotatesTokenFile(t *testing.T) {
 		t.Errorf("ReloadTokens returned count %d, want 1", count)
 	}
 
-	if got := authedRequest(t, addr, initialToken); got != http.StatusUnauthorized {
+	if got := authedRequest(t, client, addr, initialToken); got != http.StatusUnauthorized {
 		t.Errorf("rotated-out token: GET /api/v1/csrf-token = %d, want 401", got)
 	}
-	if got := authedRequest(t, addr, rotatedToken); got != http.StatusOK {
+	if got := authedRequest(t, client, addr, rotatedToken); got != http.StatusOK {
 		t.Errorf("rotated-in token: GET /api/v1/csrf-token = %d, want 200", got)
 	}
 }
@@ -163,9 +188,9 @@ func TestDaemon_ReloadTokens_PreservesPreviousTokensOnBadFile(t *testing.T) {
 	const originalToken = "kept-after-bad-reload"
 
 	tokenPath := writeTokenFile(t, tmpDir, originalToken, "read-write")
-	d, addr := newRotationDaemon(t, tokenPath)
+	d, addr, client := newRotationDaemon(t, tokenPath)
 
-	if got := authedRequest(t, addr, originalToken); got != http.StatusOK {
+	if got := authedRequest(t, client, addr, originalToken); got != http.StatusOK {
 		t.Fatalf("pre-reload sanity: GET /api/v1/csrf-token = %d, want 200", got)
 	}
 
@@ -180,7 +205,7 @@ func TestDaemon_ReloadTokens_PreservesPreviousTokensOnBadFile(t *testing.T) {
 		t.Errorf("ReloadTokens returned %v, want ErrTokenFileWorldReadable", err)
 	}
 
-	if got := authedRequest(t, addr, originalToken); got != http.StatusOK {
+	if got := authedRequest(t, client, addr, originalToken); got != http.StatusOK {
 		t.Errorf("post-failed-reload: GET /api/v1/csrf-token = %d, want 200 (prior token must still work)", got)
 	}
 }

--- a/scripts/check-https-only.sh
+++ b/scripts/check-https-only.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+fail=0
+
+report_matches() {
+  local label=$1
+  shift
+  local matches
+  matches=$(rg -n "$@" 2>/dev/null || true)
+  if [ -n "$matches" ]; then
+    printf '%s\n%s\n\n' "$label" "$matches"
+    fail=1
+  fi
+}
+
+report_matches \
+  "Alternate API or metrics listener support found:" \
+  'MetricsAddr|EnableTLS|metricsServer|\.Serve\(' \
+  internal/api/server.go internal/api/tls_fingerprint.go internal/daemon/daemon.go
+
+report_matches \
+  "Obsolete run-mode listener flag found:" \
+  '"(api-listen|metrics-listen)"|--(api-listen|metrics-listen|web)([ =`]|$)|127\.0\.0\.1:8080|os\.Getenv\("NIAC_LISTEN"\)' \
+  --glob '!**/*_test.go' cmd/niac
+
+report_matches \
+  "Plaintext or obsolete API example found in active operator documentation:" \
+  'http://localhost:8080|localhost:9090/metrics|niac run.*--(api|web)' \
+  docs/API_EXAMPLES.md docs/CI_CD.md docs/FAQ.md docs/MONITORING.md \
+  docs/PERFORMANCE.md docs/README.md docs/WEBUI.md docs/openapi.yaml
+
+report_matches \
+  "Plaintext or obsolete API endpoint found in packaging or smoke tests:" \
+  'http://localhost:8080|NIAC_PORT=8080|NIAC_SCHEME="http"|LocalPort 8080' \
+  deploy/macos/build-pkg.sh deploy/windows/build.ps1 tests/smoke/run_smoke_tests.sh
+
+report_matches \
+  "Plaintext development API proxy found:" \
+  'http://localhost:8080' \
+  ui/vite.config.ts
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: HTTPS-only API contract regressed."
+  exit 1
+fi
+
+echo "OK: API, Web UI, and metrics are restricted to the HTTPS listener."

--- a/tests/smoke/run_smoke_tests.sh
+++ b/tests/smoke/run_smoke_tests.sh
@@ -23,8 +23,8 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Configuration
-NIAC_PORT=8080
-NIAC_SCHEME="http"
+NIAC_PORT=8445
+NIAC_SCHEME="https"
 NIAC_HOST="localhost"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -101,7 +101,7 @@ assert_http_status() {
     TESTS_RUN=$((TESTS_RUN + 1))
 
     local status
-    status=$(curl -s $extra_args -o /dev/null -w "%{http_code}" "$url" 2>/dev/null)
+    status=$(curl -sk $extra_args -o /dev/null -w "%{http_code}" "$url" 2>/dev/null)
 
     if [[ "$status" == "$expected" ]]; then
         log_pass "$name (HTTP $status)"
@@ -121,7 +121,7 @@ assert_json_key() {
     TESTS_RUN=$((TESTS_RUN + 1))
 
     local body
-    body=$(curl -s "$url" 2>/dev/null)
+    body=$(curl -sk "$url" 2>/dev/null)
 
     if echo "$body" | grep -q "\"$key\""; then
         log_pass "$name"
@@ -242,7 +242,7 @@ test_api_endpoints() {
     local base_url="${NIAC_SCHEME}://${NIAC_HOST}:${NIAC_PORT}"
 
     # Check if service is reachable
-    if ! curl -s -o /dev/null "${base_url}/" 2>/dev/null; then
+    if ! curl -sk -o /dev/null "${base_url}/" 2>/dev/null; then
         skip_test "API endpoint tests" "Service not reachable at ${base_url}"
         return
     fi
@@ -261,7 +261,7 @@ test_api_endpoints() {
     # Stats returns 503 when no simulation is running (expected behavior)
     TESTS_RUN=$((TESTS_RUN + 1))
     local stats_status
-    stats_status=$(curl -s -o /dev/null -w "%{http_code}" "${base_url}/api/v1/stats" 2>/dev/null)
+    stats_status=$(curl -sk -o /dev/null -w "%{http_code}" "${base_url}/api/v1/stats" 2>/dev/null)
     if [[ "$stats_status" == "200" || "$stats_status" == "503" ]]; then
         log_pass "Stats endpoint responds (HTTP $stats_status)"
         TESTS_PASSED=$((TESTS_PASSED + 1))
@@ -272,7 +272,7 @@ test_api_endpoints() {
 
     log_header "JSON Response Validation"
     local devices_body
-    devices_body=$(curl -s "${base_url}/api/v1/devices" 2>/dev/null)
+    devices_body=$(curl -sk "${base_url}/api/v1/devices" 2>/dev/null)
     TESTS_RUN=$((TESTS_RUN + 1))
     if echo "$devices_body" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
         log_pass "Devices endpoint returns valid JSON"
@@ -283,7 +283,7 @@ test_api_endpoints() {
     fi
 
     local version_body
-    version_body=$(curl -s "${base_url}/api/v1/version" 2>/dev/null)
+    version_body=$(curl -sk "${base_url}/api/v1/version" 2>/dev/null)
     TESTS_RUN=$((TESTS_RUN + 1))
     if echo "$version_body" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
         log_pass "Version endpoint returns valid JSON"
@@ -296,7 +296,7 @@ test_api_endpoints() {
     log_header "SPA Catch-All"
     # NiAC serves the SPA for unknown routes (returns 200 with HTML)
     local unknown_body
-    unknown_body=$(curl -s "${base_url}/api/v1/nonexistent" 2>/dev/null)
+    unknown_body=$(curl -sk "${base_url}/api/v1/nonexistent" 2>/dev/null)
     TESTS_RUN=$((TESTS_RUN + 1))
     if echo "$unknown_body" | grep -q "<!doctype html\|<html"; then
         log_pass "Unknown routes serve SPA (catch-all works)"
@@ -308,7 +308,7 @@ test_api_endpoints() {
 
     log_header "WebUI Assets"
     local html
-    html=$(curl -s "${base_url}/" 2>/dev/null)
+    html=$(curl -sk "${base_url}/" 2>/dev/null)
     assert_contains "$html" "html" "Root serves HTML document"
 }
 
@@ -355,21 +355,21 @@ test_concurrent_requests() {
 
     local base_url="${NIAC_SCHEME}://${NIAC_HOST}:${NIAC_PORT}"
 
-    if ! curl -s -o /dev/null "${base_url}/" 2>/dev/null; then
+    if ! curl -sk -o /dev/null "${base_url}/" 2>/dev/null; then
         skip_test "Concurrent requests" "Service not reachable"
         return
     fi
 
     # Send 20 concurrent requests
     for _ in $(seq 1 20); do
-        curl -s -o /dev/null "${base_url}/api/v1/version" &
+        curl -sk -o /dev/null "${base_url}/api/v1/version" &
     done
     wait
 
     # Verify service still responds
     TESTS_RUN=$((TESTS_RUN + 1))
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" "${base_url}/api/v1/version" 2>/dev/null)
+    status=$(curl -sk -o /dev/null -w "%{http_code}" "${base_url}/api/v1/version" 2>/dev/null)
     if [[ "$status" == "200" ]]; then
         log_pass "Service stable after 20 concurrent requests"
         TESTS_PASSED=$((TESTS_PASSED + 1))

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, loadEnv, type PluginOption } from 'vite';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  const proxyTarget = env.VITE_DEV_API_PROXY || 'http://localhost:8080';
+  const proxyTarget = env.VITE_DEV_API_PROXY || 'https://localhost:8445';
   const analyze = env.ANALYZE === 'true';
 
   return {
@@ -98,6 +98,7 @@ export default defineConfig(({ mode }) => {
         '/api': {
           target: proxyTarget,
           changeOrigin: true,
+          secure: false,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Remove the legacy HTTP API, Web UI, and metrics listeners so all network services use the TLS listener on port 8445.
- Centralize certificate-directory resolution for CLI, daemon, Windows service, and installed service operation.
- Update smoke tests, CI examples, OpenAPI, and operator documentation to the HTTPS-only contract.
- Add a protected-path CI gate that rejects reintroduction of HTTP listener flags or defaults.
- Preserve Apple Silicon as the only macOS release architecture; releases remain GitHub Actions-built and GitHub Releases-distributed.

## Linked Issue

Related to #1053.

Closes #1037.

## Testing Evidence

```text
make lint: 81 Go linters, 0 issues; Biome clean
make fmt-check: pass
make test: Go 41 packages pass, 65.1% coverage; Vitest 63 files pass
make security: govulncheck clean; npm audit 0; gitleaks clean
scripts/check-https-only.sh: pass
Windows amd64 compile-only tests: cmd/niac, internal/api, internal/daemon pass
Post-rebase independent review: HTTPS implementation sound
Follow-up review after metrics-auth fix: no findings
git diff --check: pass
```

## Security and Release Checklist

- [x] API, Web UI, and metrics are served only through TLS 1.3 on the HTTPS listener.
- [x] Existing bearer authentication, CSRF, rate limiting, and scope enforcement remain intact.
- [x] First-run self-signed certificate generation works for daemon and installed-service paths.
- [x] No HTTP fallback or customer-facing insecure listener remains.
- [x] GitHub Actions remains the canonical release builder and GitHub Releases the distribution channel.
- [x] macOS release output remains Apple Silicon only; no Intel macOS artifact is added.
- [x] No secrets or banned customer-facing terminology added.