### PR TITLE
docs: add NIAC master closeout plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ NIAC is a source-available network device simulator distributed under the
 - [Monitoring](MONITORING.md)
 - [Configuration schema](schemas/niac.schema.json)
 - [Pre-1.0 roadmap](ROADMAP.md)
+- [Master closeout plan](design/2026-07-niac-master-closeout-plan.md)
 - [Compatibility policy](BREAKING_CHANGES.md)
 
 ## API Modes

--- a/docs/design/2026-07-local-plan-intake.md
+++ b/docs/design/2026-07-local-plan-intake.md
@@ -1,0 +1,145 @@
+# NIAC local-plan intake
+
+**Status:** Reconciled intake
+
+**Date:** 2026-07-23
+
+This tracked record preserves and reconciles five formerly gitignored plans.
+The [master closeout plan](2026-07-niac-master-closeout-plan.md) is their only
+remaining owner.
+
+## Nearest-switch plan
+
+### Delivered
+
+- PR #869 implemented NIAC-side peer topology synthesis.
+- The stack builds the device MAC roster, synthesizes learned remote-MAC FDB
+  entries and LLDP/CDP chassis identifiers, and maps bridge ports to
+  walk-backed interface indexes.
+- Regression tests cover peer FDB and bridge-port behavior.
+
+### Remaining acceptance
+
+- Attach endpoints to realistic access-switch interfaces in the demo catalog.
+- Emit real CDP/LLDP port identifiers and regenerate the catalog manifest.
+- Verify the FDB and bridge-port-to-interface chain by SNMP.
+- Confirm CyberScope reports the expected nearest switch, port, and VLAN.
+
+Stage 5 owns this catalog and live-lab evidence.
+
+## UI architecture and completeness plan
+
+### Delivered
+
+- PRs #812-#813 closed the shortcut, theme ownership, dead template page, and
+  Vite output-contract findings.
+- PRs #921-#925 closed the recorded correctness batch: dead UI, PCAP size
+  handling, auto-scroll, filtered export, decoded-layer boundaries, surfaced
+  failures, corrected copy, password masking, mutation confirmation, and
+  unsaved-change protection.
+- PRs #926-#929, #931-#932, #936-#939, #951-#953, and #955-#957 delivered
+  the naming/IA cleanup, dashboard and simulation status, confirmation and
+  toast consolidation, accessibility disclosures, i18n expansion,
+  template-preview clarification, and shared table behavior.
+- PRs #940, #943-#948, #954, #960-#963, and #965-#967 delivered batch walk
+  validation and the recorded backend/UI enablers, including structured
+  errors, error-injection interfaces, replay progress, batch deletion, guided
+  configuration, sanitize, content management, and upload progress. Commit
+  `abbd929e` carries the BPF error work from closed PR #942.
+
+### Remaining disposition
+
+- Remove the stale `/pcap-analyzer` breadcrumb.
+- Replace the retired botanical reference in `themeModuleColors.ts`.
+- Retain Topology page extraction and spacing cleanup as low, opportunistic
+  maintenance debt unless touched by accepted work.
+- Feature-gate any still-missing MIB archive, template-apply, dump, or
+  packet-analysis parity instead of assuming CLI symmetry is valuable.
+
+Stage 7 owns these final dispositions.
+
+## Modernization plan
+
+### Delivered
+
+- PRs #980, #982, and #983 completed the accepted grouped Go modernization.
+- PR #985 moved content extraction containment to `os.Root`.
+- PRs #987 and #993 made replay opening root-contained and pure Go.
+- PRs #997-#1000 delivered streaming replay, rate modes, bounded loop count,
+  and replay filtering; PRs #1001-#1002 exposed and localized the controls.
+
+### Retired
+
+- Issues #988 and #991 record decisions not to adopt React Compiler or TanStack
+  Query. PRs #989 and #992 removed the unused dependencies.
+- `React.FC`, router, memoization, and sorting-style sweeps remain retired
+  churn unless a new measured defect changes the decision.
+
+### Remaining disposition
+
+- Reverify malformed or truncated replay-packet accounting.
+- Feature-gate endpoint rewrite, VLAN rewrite, expanded throughput reporting,
+  and Inspector export/dissection work.
+
+Stage 7 owns the reliability check. Stage 8 owns feature and market gates for
+optional replay and Inspector expansion.
+
+## Cruft and duplication plan
+
+### Delivered or absorbed
+
+- PR #1012 removed the dead MIB database package and other unused subsystems.
+- PR #921 removed the recorded dead UI components and storage-key leak.
+- The UI cleanup and parity work listed above absorbed the toast, confirmation,
+  polling, i18n, shared-table, and orphan-route findings.
+- Path containment findings are absorbed into #1035 and the delivered
+  `os.Root` work; do not create a parallel security owner.
+
+### Remaining reconciliation
+
+- Reverify and remove dead scripts, config parsing exports, placeholders, and
+  stale comments, including `apply_history_changes.py` and the generated-types
+  placeholder.
+- Decide whether each unowned helper script is a supported tool or dead
+  migration residue, then wire or remove it.
+- Reverify duplicated OID, safe-conversion, packet-serialization, MAC-format,
+  and hex-format helpers; refactor only current duplication.
+- Reverify API dispatch, error-envelope, JSON-writing, and path-field
+  duplication without weakening the existing security wrappers.
+- Decide whether generated Go-to-TypeScript device types warrant a separate
+  epic; retire the empty placeholder if not.
+- Fold file naming and package extraction into accepted internal API work
+  instead of a rename-only sweep.
+- Make the file-size gate honest after triaging current red flags, or remove
+  it; do not preserve a non-blocking gate as false assurance.
+
+Stage 7 owns this maintenance reconciliation. Any unique high or medium defect
+must become an accepted issue before implementation.
+
+## Replay positioning plan
+
+### Delivered
+
+- Replay streaming, topspeed/pps/Mbps modes, loop count, and replay filtering
+  satisfy four of the five original credibility gates.
+- The catalog, live responders, UI controls, and root-contained replay path are
+  real product capabilities and may be described accurately.
+
+### Remaining positioning and capability work
+
+- Close the malformed/truncated replay accounting gate before making parity
+  claims.
+- Reconcile internal strategy and marketing documents so NIAC is described as
+  a test target, not a test instrument, and replay is represented without
+  displacing NIAC's simulator charter.
+- Correct protocol-count and CLI-surface claims against the shipping product.
+- Keep comparisons to tcpreplay bounded to delivered rate, loop, filtering,
+  timing, catalog, and interactivity behavior.
+- Feature-gate packet rewrite, VLAN rewrite, completion statistics, explicit
+  pcapng/nanosecond coverage, Inspector export, protocol-specific filters and
+  dissection, and conversation statistics.
+- Retire dual-interface bridging, line-rate acceleration, true TCP reassembly,
+  expert analysis, and broad Wireshark parity absent a concrete buyer need.
+
+Stage 7 owns truthful documentation alignment. Stage 8 owns optional capability
+and market decisions.

--- a/docs/design/2026-07-niac-master-closeout-ledger.md
+++ b/docs/design/2026-07-niac-master-closeout-ledger.md
@@ -4,7 +4,7 @@
 
 **Updated:** 2026-07-23
 
-**Baseline:** `main` at `90ad10b9` after HTTPS and stale-document closeout
+**Baseline:** `main` at `185a180e` after the v0.94.11 release merge
 
 This ledger prevents duplicate ownership while the
 [master closeout plan](2026-07-niac-master-closeout-plan.md) is executed.
@@ -15,9 +15,10 @@ Update it when work merges or a disposition changes.
 | Item | State | Next action |
 | --- | --- | --- |
 | v0.94.10 core artifacts | Verified | Release workflow, checksum, Cosign bundle, SLSA attestation, and macOS artifact passed |
-| v0.94.10 content packages | Integrity metadata missing | Fix accepted medium defect #1068 before the next release |
+| v0.94.10-v0.94.11 content packages | Integrity metadata missing | Tracked by accepted medium defect #1068 |
+| v0.94.11 core artifacts | Verified | Workflow, checksum, Cosign bundle, SLSA attestation, and macOS artifact passed |
 | Master plan PR #1064 | Draft; rebased on current `main` | Complete review, mark ready, and merge |
-| Latest published release | v0.94.10 | Preserve as the baseline with #1068 explicitly open |
+| Next release after v0.94.11 | Blocked by #1068 | Add content-package integrity metadata before publication |
 
 ## Worktree ownership
 
@@ -107,6 +108,7 @@ new issue until reproduction confirms that the contract remains open.
 - [x] Current worktrees have explicit owners.
 - [x] Former follow-up commits are confirmed present in merged squash commits.
 - [x] v0.94.10 core artifacts are verified; content integrity is tracked in #1068.
+- [x] v0.94.11 publication is complete and its core artifacts are verified.
 - [ ] PR #1064 is merged.
 - [x] PR #1063 is merged or explicitly handed off.
 - [ ] Every #1053 `needs-info` issue has a current reproduction.

--- a/docs/design/2026-07-niac-master-closeout-ledger.md
+++ b/docs/design/2026-07-niac-master-closeout-ledger.md
@@ -24,8 +24,8 @@ Update it when work merges or a disposition changes.
 | --- | --- | --- |
 | Primary `docs/master-plan-closeout` | Clean; PR #1064 | Owns plan and ledger only |
 | `fix/https-only-contract` | Clean; PR #1063 | Owns #1037; do not duplicate listener work |
-| `fix/fault-telemetry` | Clean; base landed as #1059 | Preserve follow-ups `72d2aca5` and `55aae24f`; rebase into a focused follow-up PR |
-| `fix/free-tier-contract` | Clean; base landed as #1062 | Preserve `e1dc2b2c`; rebase into a focused wording PR |
+| `fix/fault-telemetry` | Clean; all patches landed in squash #1059 | Eligible for local cleanup after final verification |
+| `fix/free-tier-contract` | Clean; all patches landed in squash #1062 | Eligible for local cleanup after final verification |
 
 ## Epic #1053 implementation queue
 
@@ -101,7 +101,7 @@ new issue until reproduction confirms that the contract remains open.
 
 - [x] One master plan and ledger exist.
 - [x] Current worktrees have explicit owners.
-- [x] Hidden follow-up commits are identified and preserved.
+- [x] Former follow-up commits are confirmed present in merged squash commits.
 - [ ] v0.94.10 release artifacts and provenance are verified.
 - [ ] PR #1064 is merged.
 - [ ] PR #1063 is merged or explicitly handed off.

--- a/docs/design/2026-07-niac-master-closeout-ledger.md
+++ b/docs/design/2026-07-niac-master-closeout-ledger.md
@@ -4,7 +4,7 @@
 
 **Updated:** 2026-07-23
 
-**Baseline:** `main` at `b2201f3d` after the v0.94.10 release PR merge
+**Baseline:** `main` at `90ad10b9` after HTTPS and stale-document closeout
 
 This ledger prevents duplicate ownership while the
 [master closeout plan](2026-07-niac-master-closeout-plan.md) is executed.
@@ -14,16 +14,19 @@ Update it when work merges or a disposition changes.
 
 | Item | State | Next action |
 | --- | --- | --- |
-| v0.94.10 release PR #1061 | Merged; all PR checks passed | Verify tag, release workflow, assets, attestations, and signatures |
-| Master plan PR #1064 | Draft; CI running | Complete review, mark ready, merge, and update `main` |
-| Latest published release | v0.94.9 | Replace only after v0.94.10 publication is verified |
+| v0.94.10 core artifacts | Verified | Release workflow, checksum, Cosign bundle, SLSA attestation, and macOS artifact passed |
+| v0.94.10 content packages | Integrity metadata missing | Fix accepted medium defect #1068 before the next release |
+| Master plan PR #1064 | Draft; rebased on current `main` | Complete review, mark ready, and merge |
+| Latest published release | v0.94.10 | Preserve as the baseline with #1068 explicitly open |
 
 ## Worktree ownership
 
 | Worktree | State | Disposition |
 | --- | --- | --- |
 | Primary `docs/master-plan-closeout` | Clean; PR #1064 | Owns plan and ledger only |
-| `fix/https-only-contract` | Clean; PR #1063 | Owns #1037; do not duplicate listener work |
+| `fix/precommit-fail-closed` | Clean; draft PR #1067 | Corrected body-lint rerun passed; stale failed context still blocks |
+| `fix/https-only-contract` | Merged in #1063 | Eligible for local cleanup after final verification |
+| `docs/pre1-closeout` | Merged in #1065 | Eligible for local cleanup after final verification |
 | `fix/fault-telemetry` | Clean; all patches landed in squash #1059 | Eligible for local cleanup after final verification |
 | `fix/free-tier-contract` | Clean; all patches landed in squash #1062 | Eligible for local cleanup after final verification |
 
@@ -36,7 +39,7 @@ Update it when work merges or a disposition changes.
 | #1034 routed Runtime Control | High | Needs reproduction | Stage 3 |
 | #1035 nested path containment | High | Needs reproduction | Stage 2 first |
 | #1036 Packet Inspector SSE envelope | High | Needs reproduction | Stage 4 |
-| #1037 HTTPS-only listeners | High | PR #1063 open | HTTPS worktree |
+| #1037 HTTPS-only listeners | High | Delivered in #1063 | Stage 2 evidence retained |
 | #1041 bounded UDP proxy | High | Needs reproduction | Stage 2 |
 | #1042 off-link notifications | High | Needs reproduction | Stage 3 after fault handoff |
 | #1051 first-class browsers | High | Accepted | Stages 1 and 4 |
@@ -51,7 +54,8 @@ Update it when work merges or a disposition changes.
 | #1048 offline PCAP access | Medium | Needs reproduction | Stage 4 |
 | #1049 capture-exit recovery | Medium | Needs reproduction | Stage 4 |
 | #1052 i18next migration | Medium | Accepted | Stage 4 |
-| #1057 fail-closed hooks | Medium | Accepted | Stage 1 first |
+| #1057 fail-closed hooks | Medium | Draft PR #1067 | Stage 1 active |
+| #1068 content-package integrity | Medium | Accepted | Stage 1 before release |
 
 ## Defect-register reconciliation
 
@@ -102,9 +106,9 @@ new issue until reproduction confirms that the contract remains open.
 - [x] One master plan and ledger exist.
 - [x] Current worktrees have explicit owners.
 - [x] Former follow-up commits are confirmed present in merged squash commits.
-- [ ] v0.94.10 release artifacts and provenance are verified.
+- [x] v0.94.10 core artifacts are verified; content integrity is tracked in #1068.
 - [ ] PR #1064 is merged.
-- [ ] PR #1063 is merged or explicitly handed off.
+- [x] PR #1063 is merged or explicitly handed off.
 - [ ] Every #1053 `needs-info` issue has a current reproduction.
 - [ ] Unique high/medium prose-only findings have accepted GitHub issues.
 - [ ] Duplicate findings are marked absorbed.

--- a/docs/design/2026-07-niac-master-closeout-ledger.md
+++ b/docs/design/2026-07-niac-master-closeout-ledger.md
@@ -60,7 +60,7 @@ Update it when work merges or a disposition changes.
 
 ## Defect-register reconciliation
 
-These entries still require a current-v0.94.10 disposition. Do not create a
+These entries still require a current-v0.94.11 disposition. Do not create a
 new issue until reproduction confirms that the contract remains open.
 
 | Finding | Current evidence | Candidate disposition |
@@ -96,8 +96,6 @@ new issue until reproduction confirms that the contract remains open.
 | Defect-hunting plan/register | Active evidence source; close after reconciliation |
 | [Local-plan intake](2026-07-local-plan-intake.md) | Five local plans reconciled; catalog, stale UI references, replay accounting/positioning, cruft, and optional gates remain |
 | Multi-VLAN epic #882 | Reconcile delivered architecture in Stage 7 |
-| Library issue #905 | Fix unsafe default; gate curation separately |
-| License issue #911 | External counsel decision required |
 | Fleet-drift epic #1004 | Reconcile Renovate/foundation delivery and remaining shared CI |
 
 ## Stage 0 exit checklist

--- a/docs/design/2026-07-niac-master-closeout-ledger.md
+++ b/docs/design/2026-07-niac-master-closeout-ledger.md
@@ -55,7 +55,7 @@ Update it when work merges or a disposition changes.
 | #1048 offline PCAP access | Medium | Needs reproduction | Stage 4 |
 | #1049 capture-exit recovery | Medium | Needs reproduction | Stage 4 |
 | #1052 i18next migration | Medium | Accepted | Stage 4 |
-| #1057 fail-closed hooks | Medium | Draft PR #1067 | Stage 1 active |
+| #1057 fail-closed hooks | Medium | Draft PR #1067 | Stage 0 prerequisite active |
 | #1068 content-package integrity | Medium | Accepted | Stage 1 before release |
 
 ## Defect-register reconciliation
@@ -94,9 +94,7 @@ new issue until reproduction confirms that the contract remains open.
 | Routed virtual-lab plan | Phases 0-6 delivered; Phase 7 acceptance active |
 | Remediation plan/execution guide | Active implementation queue under #1053 |
 | Defect-hunting plan/register | Active evidence source; close after reconciliation |
-| Nearest-switch local plan | NIAC synthesis delivered; catalog/live evidence remains |
-| UI architecture local plan | Re-audit after #1053; absorb or retire each item |
-| Modernization local plan | Deferred to Stage 8 gates |
+| [Local-plan intake](2026-07-local-plan-intake.md) | Five local plans reconciled; catalog, stale UI references, replay accounting/positioning, cruft, and optional gates remain |
 | Multi-VLAN epic #882 | Reconcile delivered architecture in Stage 7 |
 | Library issue #905 | Fix unsafe default; gate curation separately |
 | License issue #911 | External counsel decision required |
@@ -111,6 +109,7 @@ new issue until reproduction confirms that the contract remains open.
 - [x] v0.94.11 publication is complete and its core artifacts are verified.
 - [ ] PR #1064 is merged.
 - [x] PR #1063 is merged or explicitly handed off.
+- [ ] PR #1067 is merged before defect reproductions begin.
 - [ ] Every #1053 `needs-info` issue has a current reproduction.
 - [ ] Unique high/medium prose-only findings have accepted GitHub issues.
 - [ ] Duplicate findings are marked absorbed.

--- a/docs/design/2026-07-niac-master-closeout-ledger.md
+++ b/docs/design/2026-07-niac-master-closeout-ledger.md
@@ -1,0 +1,110 @@
+# NIAC master closeout ledger
+
+**Status:** Active
+
+**Updated:** 2026-07-23
+
+**Baseline:** `main` at `b2201f3d` after the v0.94.10 release PR merge
+
+This ledger prevents duplicate ownership while the
+[master closeout plan](2026-07-niac-master-closeout-plan.md) is executed.
+Update it when work merges or a disposition changes.
+
+## Release and publication
+
+| Item | State | Next action |
+| --- | --- | --- |
+| v0.94.10 release PR #1061 | Merged; all PR checks passed | Verify tag, release workflow, assets, attestations, and signatures |
+| Master plan PR #1064 | Draft; CI running | Complete review, mark ready, merge, and update `main` |
+| Latest published release | v0.94.9 | Replace only after v0.94.10 publication is verified |
+
+## Worktree ownership
+
+| Worktree | State | Disposition |
+| --- | --- | --- |
+| Primary `docs/master-plan-closeout` | Clean; PR #1064 | Owns plan and ledger only |
+| `fix/https-only-contract` | Clean; PR #1063 | Owns #1037; do not duplicate listener work |
+| `fix/fault-telemetry` | Clean; base landed as #1059 | Preserve follow-ups `72d2aca5` and `55aae24f`; rebase into a focused follow-up PR |
+| `fix/free-tier-contract` | Clean; base landed as #1062 | Preserve `e1dc2b2c`; rebase into a focused wording PR |
+
+## Epic #1053 implementation queue
+
+| Issue | Priority | Current state | Stage or owner |
+| --- | --- | --- | --- |
+| #1032 browser authentication | High | Needs reproduction | Stage 2 after HTTPS |
+| #1033 live static-route validation | High | Needs reproduction | Stage 3 |
+| #1034 routed Runtime Control | High | Needs reproduction | Stage 3 |
+| #1035 nested path containment | High | Needs reproduction | Stage 2 first |
+| #1036 Packet Inspector SSE envelope | High | Needs reproduction | Stage 4 |
+| #1037 HTTPS-only listeners | High | PR #1063 open | HTTPS worktree |
+| #1041 bounded UDP proxy | High | Needs reproduction | Stage 2 |
+| #1042 off-link notifications | High | Needs reproduction | Stage 3 after fault handoff |
+| #1051 first-class browsers | High | Accepted | Stages 1 and 4 |
+| #1038 duplicate segment tags | Medium | Needs reproduction | Stage 3 |
+| #1039 stale API topology | Medium | Needs reproduction | Stage 3 |
+| #1040 missing stats publisher | Medium | Needs reproduction | Stage 4 |
+| #1043 partial server startup | Medium | Needs reproduction | Stage 4 |
+| #1044 SSH idle expiry | Medium | Needs reproduction | Stage 4 |
+| #1045 SNMP transport state | Medium | Needs reproduction | Stage 3 |
+| #1046 unresolved ConfigPath | Medium | Needs reproduction | Stage 3 |
+| #1047 TTL accounting | Medium | Needs reproduction | Stage 3 |
+| #1048 offline PCAP access | Medium | Needs reproduction | Stage 4 |
+| #1049 capture-exit recovery | Medium | Needs reproduction | Stage 4 |
+| #1052 i18next migration | Medium | Accepted | Stage 4 |
+| #1057 fail-closed hooks | Medium | Accepted | Stage 1 first |
+
+## Defect-register reconciliation
+
+These entries still require a current-v0.94.10 disposition. Do not create a
+new issue until reproduction confirms that the contract remains open.
+
+| Finding | Current evidence | Candidate disposition |
+| --- | --- | --- |
+| NIAC-DEF-001 | Fix landed; full/live gate pending | Absorb into Stage 5/6 acceptance |
+| NIAC-DEF-002 | Fix landed; direct-mode gate pending | Absorb into Stage 5 |
+| NIAC-DEF-008 | Partial next-hop fix | Reproduce with #1033 |
+| NIAC-DEF-013 | Transactional replacement code-confirmed | Create unique high issue if current |
+| NIAC-DEF-015 | Runtime Control code-confirmed | Absorb into #1034 |
+| NIAC-DEF-017 | Lockfile fixed; full gate pending | Absorb into Stage 6 |
+| NIAC-DEF-019 | IPv4 input validation code-confirmed | Create unique medium issue if current |
+| NIAC-DEF-021 | Stack channel lifecycle code-confirmed | Create unique medium issue if current |
+| NIAC-DEF-025 | DHCP validation code-confirmed | Create unique medium issue if current |
+| NIAC-DEF-027 | Catalog sync integrity code-confirmed | Create unique medium issue if current |
+| NIAC-DEF-028 | Restart recovery code-confirmed | Create unique medium issue if current |
+| NIAC-DEF-029 | Preflight/interface parity code-confirmed | Reproduce with #1034 |
+| NIAC-DEF-031 | Darwin link warning reproduced | Retain as low maintenance debt |
+| NIAC-DEF-032 | UI chunk warning reproduced | Retain as low maintenance debt |
+| NIAC-DEF-035 | Fix landed; live gate pending | Absorb into Stage 5 |
+| NIAC-DEF-036 | Catalog rebuilt; live gate pending | Absorb into Stage 5 |
+| NIAC-DEF-037 | Deprecated extractor reproduced | Absorb into #1052 |
+| NIAC-DEF-038 | Foundation fingerprint race reproduced | Verify foundation status; create high issue if current |
+| NIAC-DEF-046 | MIB-II work landed; live gate pending | Absorb into Stage 5/6 acceptance |
+| NIAC-DEF-050 | Markdown backlog reproduced | Retain as low maintenance debt |
+
+## Remaining plan registry
+
+| Plan or issue | Current disposition |
+| --- | --- |
+| Pre-1.0 roadmap | Active acceptance boundary; Stage 6 |
+| Routed virtual-lab plan | Phases 0-6 delivered; Phase 7 acceptance active |
+| Remediation plan/execution guide | Active implementation queue under #1053 |
+| Defect-hunting plan/register | Active evidence source; close after reconciliation |
+| Nearest-switch local plan | NIAC synthesis delivered; catalog/live evidence remains |
+| UI architecture local plan | Re-audit after #1053; absorb or retire each item |
+| Modernization local plan | Deferred to Stage 8 gates |
+| Multi-VLAN epic #882 | Reconcile delivered architecture in Stage 7 |
+| Library issue #905 | Fix unsafe default; gate curation separately |
+| License issue #911 | External counsel decision required |
+| Fleet-drift epic #1004 | Reconcile Renovate/foundation delivery and remaining shared CI |
+
+## Stage 0 exit checklist
+
+- [x] One master plan and ledger exist.
+- [x] Current worktrees have explicit owners.
+- [x] Hidden follow-up commits are identified and preserved.
+- [ ] v0.94.10 release artifacts and provenance are verified.
+- [ ] PR #1064 is merged.
+- [ ] PR #1063 is merged or explicitly handed off.
+- [ ] Every #1053 `needs-info` issue has a current reproduction.
+- [ ] Unique high/medium prose-only findings have accepted GitHub issues.
+- [ ] Duplicate findings are marked absorbed.

--- a/docs/design/2026-07-niac-master-closeout-plan.md
+++ b/docs/design/2026-07-niac-master-closeout-plan.md
@@ -150,8 +150,6 @@ is reproducible.
 | [Local-plan intake](2026-07-local-plan-intake.md) | Resolve every nearest-switch, UI, modernization, cruft/duplication, and replay-positioning item recorded there |
 | Multi-VLAN epic #882 | Reconcile delivered architecture; issue only the actual remaining UI/catalog/acceptance work |
 | Fleet-drift epic #1004 | Record delivered Renovate/foundation work; finish or separately track shared CI and doc alignment |
-| Library issue #905 | Fix the broken/phone-home default; gate content curation as a separate product decision |
-| License issue #911 | Obtain counsel decision; merge approved wording or close with the decision |
 
 Exit gate: every non-archived plan has a final status and no local-only active
 work remains.

--- a/docs/design/2026-07-niac-master-closeout-plan.md
+++ b/docs/design/2026-07-niac-master-closeout-plan.md
@@ -1,0 +1,197 @@
+# Plan: NIAC master closeout
+
+**Status:** Draft for owner review
+
+**Date:** 2026-07-23
+
+## Outcome
+
+Finish every current NIAC plan without treating every historical idea as a
+commitment to build. Each plan item must end in exactly one state:
+
+1. **Delivered** with merged tests and the required browser, lab, or release
+   evidence.
+2. **Absorbed** into one newer authoritative issue or plan, with the older
+   record closed as superseded.
+3. **Retired** with an explicit reason when the item is stale, duplicated,
+   outside the product boundary, or fails the feature or market gate.
+
+The high/medium remediation epic is the implementation queue. The routed-lab
+plan and pre-1.0 roadmap define acceptance. All other plans are inputs that
+must be reconciled, not parallel backlogs.
+
+## Source-of-truth hierarchy
+
+| Rank | Source | Role |
+| --- | --- | --- |
+| 1 | This master closeout plan | Program order, dependencies, and final ledger |
+| 2 | Epic #1053 and its remediation plan/execution guide | High/medium implementation |
+| 3 | Routed virtual-lab plan | Phase 7 hardware acceptance and Phase 8 boundary |
+| 4 | Pre-1.0 roadmap | Release boundary |
+| 5 | Defect register and local plans | Findings to absorb, verify, or retire |
+| 6 | `docs/archive/**` | Historical evidence only; never an active backlog |
+
+## Stage 0: Establish one accurate ledger
+
+1. Finish and verify the v0.94.10 release from the merged Free-tier contract.
+2. Reconcile the three existing worktrees before overlapping edits:
+   `fix/https-only-contract`, `fix/fault-telemetry`, and
+   `fix/free-tier-contract`.
+3. Map every open GitHub issue, defect-register entry, and local-plan item to
+   one owner and one disposition.
+4. Reproduce all #1053 defects still labeled `status: needs-info`; accept,
+   correct, or close them with evidence.
+5. Create GitHub issues for unique unresolved high/medium defect-register
+   findings that are not already represented by #1053.
+6. Mark duplicate findings as absorbed instead of fixing the same contract
+   twice.
+
+Exit gate: no high or medium finding exists only in prose, and no work item has
+two implementation owners.
+
+## Stage 1: Repair the evidence gate
+
+Complete #1057 first:
+
+- Enforce the repository-pinned Node and npm versions.
+- Propagate every failed child command.
+- Print success only after a zero exit.
+- Prove the hook blocks a deliberately failing frontend command.
+
+Then establish the browser baseline and retained traces for Chromium, WebKit,
+Firefox, installed Chrome, installed Edge, and actual Safari.
+
+Exit gate: later work can rely on local and CI results without masked failures.
+
+## Stage 2: Security and external boundaries
+
+Complete remediation Wave 1 in this order:
+
+1. #1035 nested configuration containment.
+2. #1037 HTTPS-only listeners, incorporating the existing HTTPS worktree.
+3. #1041 bounded UDP proxy resources and shutdown.
+4. #1032 secure browser authentication for SPA, REST, and SSE.
+
+Run adversarial path, plaintext-listener, overload, cancellation,
+credential-leak, authorization, and browser tests before merging.
+
+Exit gate: every network entry point is authenticated as required, TLS-only,
+resource-bounded, and unable to escape managed roots.
+
+## Stage 3: Routed and authoritative-state correctness
+
+Complete remediation Wave 2 after the fault-telemetry worktree lands or has an
+explicit handoff:
+
+- #1033, #1034, #1038, #1039, #1042, #1045, #1046, and #1047.
+- Reconcile unresolved NIAC-DEF-008, 013, 015, 019, 021, 025, 027, 028, and
+  029; create issues for unique contracts and absorb true duplicates.
+- Keep the stack-owned state authoritative for CLI, forwarding, SNMP,
+  topology, discovery, counters, and notifications.
+
+Run focused tests before lab work. Then verify routed discovery, SNMP tables,
+off-link notifications, TTL accounting, and isolation with CyberScope and
+Link-Live.
+
+Exit gate: configuration, runtime, CLI, API, SNMP, and packet behavior project
+one consistent state.
+
+## Stage 4: Streaming, lifecycle, browsers, and i18n
+
+Complete remediation Waves 3 and 4:
+
+- #1036 and #1040: production SSE envelopes and statistics publication.
+- #1048 and #1049: offline PCAP access and capture-exit recovery.
+- #1043 and #1044: transactional server startup and SSH expiry.
+- #1051: Chrome, Edge, and Safari first-class release gates; Firefox
+  compatibility and Brave best-effort smoke evidence.
+- #1052: fixture-first migration from `i18next-parser` to `i18next-cli`
+  without catalog loss.
+
+Exit gate: the critical browser journey passes, lifecycle cleanup is
+deterministic, and translation validation is maintained and non-mutating.
+
+## Stage 5: Finish routed-lab Phase 7
+
+Treat already-recorded access-mode work as evidence, not work to repeat.
+Complete and retain the missing acceptance:
+
+1. Run the reference scenario through the dedicated direct cable.
+2. Confirm DHCP, routing, SNMP, SSH, topology, and discovery match access mode.
+3. Verify nearest-switch switch/port/VLAN placement; the NIAC synthesis appears
+   implemented, so finish catalog generation and live proof rather than
+   rebuilding it.
+4. Capture CT `eth0` and the Proxmox bridge for 24 hours and prove isolation.
+5. Run a fresh CyberScope discovery and compare Link-Live with NIAC authored
+   truth.
+6. Record discrepancies as defects and return them to the appropriate earlier
+   stage.
+
+Exit gate: every routed-plan completion criterion has attached evidence.
+
+## Stage 6: Close the pre-1.0 roadmap
+
+- Confirm injected faults through IF-MIB and EtherLike-MIB counters.
+- Confirm the ten-device Free-tier limit across CLI, API, UI, import, template,
+  and runtime entry paths.
+- Remove stale compatibility, licensing, deployment, and roadmap claims.
+- Pass formatting, lint, unit, race, integration, browser, security, package,
+  install, deployment, and version validation from release-built artifacts.
+- Run the final touched-area defect review and file every new high/medium
+  finding before release.
+
+Exit gate: all five roadmap checkboxes are complete and the release candidate
+is reproducible.
+
+## Stage 7: Close or replace every remaining plan
+
+| Plan or issue | Required disposition |
+| --- | --- |
+| Defect-hunting plan/register | Close delivered findings; move unique debt to issues; archive the working register |
+| Nearest-switch plan | Close after catalog and CyberScope evidence |
+| Multi-VLAN epic #882 | Reconcile delivered architecture; issue only the actual remaining UI/catalog/acceptance work |
+| Fleet-drift epic #1004 | Record delivered Renovate/foundation work; finish or separately track shared CI and doc alignment |
+| Library issue #905 | Fix the broken/phone-home default; gate content curation as a separate product decision |
+| License issue #911 | Obtain counsel decision; merge approved wording or close with the decision |
+| UI architecture plan | Re-audit correctness items; absorb defects; retire low-value parity and speculative UI work |
+| Modernization plan | Re-baseline landed `os.Root` work; approve only changes with measurable security, reliability, or maintenance value |
+
+Exit gate: every non-archived plan has a final status and no local-only active
+work remains.
+
+## Stage 8: Post-stabilization expansion gates
+
+Do not automatically implement Phase 8 or discretionary modernization merely
+because it appears in an old plan. Run the feature and market gates separately
+for:
+
+1. OSPF, using the authoritative forwarding table first.
+2. BGP only if a distinct accepted workflow remains after OSPF.
+3. IPv6 forwarding and DHCPv6 relay.
+4. Route policy and simulated ACLs.
+5. Multiple external attachments with a separate threat model.
+6. Replay expansion, React Compiler, TanStack Query, and remaining UI parity.
+
+For each, record **build**, **reshape smaller**, or **retire**, then create a
+bounded implementation plan only for approved work.
+
+## Program controls
+
+- One root-cause contract per PR where practical.
+- Shared-state changes land before projections and UI.
+- Security changes remain isolated from broad refactors.
+- Stacked PRs land one at a time and rebase after each merge.
+- Browser and lab evidence is attached to the issue that owns the contract.
+- The master ledger is updated when work merges, not at the end of the program.
+- A stage cannot close with an untracked high or medium defect.
+
+## Definition of complete
+
+- Epic #1053 is closed with every child delivered or invalidated by evidence.
+- Routed Phase 7 and all pre-1.0 exit criteria pass.
+- Every active plan and planning issue has a delivered, absorbed, or retired
+  disposition.
+- Optional work has an explicit owner decision rather than an indefinite
+  backlog state.
+- Main, local branches, remote branches, and worktrees contain no abandoned or
+  ambiguous NIAC work.

--- a/docs/design/2026-07-niac-master-closeout-plan.md
+++ b/docs/design/2026-07-niac-master-closeout-plan.md
@@ -61,19 +61,19 @@ Complete #1057 first:
 - Print success only after a zero exit.
 - Prove the hook blocks a deliberately failing frontend command.
 
-Then establish the browser baseline and retained traces for Chromium, WebKit,
-Firefox, installed Chrome, installed Edge, and actual Safari.
+Close #1068 before the next release. Then retain browser traces for Chromium,
+WebKit, Firefox, installed Chrome, installed Edge, and actual Safari.
 
 Exit gate: later work can rely on local and CI results without masked failures.
 
 ## Stage 2: Security and external boundaries
 
-Complete remediation Wave 1 in this order:
+Treat #1037 as delivered by PR #1063, then complete remediation Wave 1 in
+this order:
 
 1. #1035 nested configuration containment.
-2. #1037 HTTPS-only listeners, incorporating the existing HTTPS worktree.
-3. #1041 bounded UDP proxy resources and shutdown.
-4. #1032 secure browser authentication for SPA, REST, and SSE.
+2. #1041 bounded UDP proxy resources and shutdown.
+3. #1032 secure browser authentication for SPA, REST, and SSE.
 
 Run adversarial path, plaintext-listener, overload, cancellation,
 credential-leak, authorization, and browser tests before merging.

--- a/docs/design/2026-07-niac-master-closeout-plan.md
+++ b/docs/design/2026-07-niac-master-closeout-plan.md
@@ -61,8 +61,9 @@ Complete #1057 first:
 - Print success only after a zero exit.
 - Prove the hook blocks a deliberately failing frontend command.
 
-Close #1068 before the next release. Then retain browser traces for Chromium,
-WebKit, Firefox, installed Chrome, installed Edge, and actual Safari.
+Verify the already-started v0.94.11 publication, then close #1068 before the
+following release. Retain browser traces for Chromium, WebKit, Firefox,
+installed Chrome, installed Edge, and actual Safari.
 
 Exit gate: later work can rely on local and CI results without masked failures.
 

--- a/docs/design/2026-07-niac-master-closeout-plan.md
+++ b/docs/design/2026-07-niac-master-closeout-plan.md
@@ -1,6 +1,6 @@
 # Plan: NIAC master closeout
 
-**Status:** Draft for owner review
+**Status:** Active
 
 **Date:** 2026-07-23
 
@@ -32,6 +32,9 @@ must be reconciled, not parallel backlogs.
 | 6 | `docs/archive/**` | Historical evidence only; never an active backlog |
 
 ## Stage 0: Establish one accurate ledger
+
+Track current ownership and disposition in the
+[master closeout ledger](2026-07-niac-master-closeout-ledger.md).
 
 1. Finish and verify the v0.94.10 release from the merged Free-tier contract.
 2. Reconcile the three existing worktrees before overlapping edits:

--- a/docs/design/2026-07-niac-master-closeout-plan.md
+++ b/docs/design/2026-07-niac-master-closeout-plan.md
@@ -28,7 +28,7 @@ must be reconciled, not parallel backlogs.
 | 2 | Epic #1053 and its remediation plan/execution guide | High/medium implementation |
 | 3 | Routed virtual-lab plan | Phase 7 hardware acceptance and Phase 8 boundary |
 | 4 | Pre-1.0 roadmap | Release boundary |
-| 5 | Defect register and local plans | Findings to absorb, verify, or retire |
+| 5 | Defect register and [local-plan intake](2026-07-local-plan-intake.md) | Findings to absorb, verify, or retire |
 | 6 | `docs/archive/**` | Historical evidence only; never an active backlog |
 
 ## Stage 0: Establish one accurate ledger
@@ -40,26 +40,21 @@ Track current ownership and disposition in the
 2. Reconcile the three existing worktrees before overlapping edits:
    `fix/https-only-contract`, `fix/fault-telemetry`, and
    `fix/free-tier-contract`.
-3. Map every open GitHub issue, defect-register entry, and local-plan item to
+3. Complete #1057 so failed frontend commands cannot produce trusted-looking
+   reproduction evidence.
+4. Map every open GitHub issue, defect-register entry, and local-plan item to
    one owner and one disposition.
-4. Reproduce all #1053 defects still labeled `status: needs-info`; accept,
+5. Reproduce all #1053 defects still labeled `status: needs-info`; accept,
    correct, or close them with evidence.
-5. Create GitHub issues for unique unresolved high/medium defect-register
+6. Create GitHub issues for unique unresolved high/medium defect-register
    findings that are not already represented by #1053.
-6. Mark duplicate findings as absorbed instead of fixing the same contract
+7. Mark duplicate findings as absorbed instead of fixing the same contract
    twice.
 
 Exit gate: no high or medium finding exists only in prose, and no work item has
 two implementation owners.
 
-## Stage 1: Repair the evidence gate
-
-Complete #1057 first:
-
-- Enforce the repository-pinned Node and npm versions.
-- Propagate every failed child command.
-- Print success only after a zero exit.
-- Prove the hook blocks a deliberately failing frontend command.
+## Stage 1: Extend the evidence gate
 
 Verify the already-started v0.94.11 publication, then close #1068 before the
 following release. Retain browser traces for Chromium, WebKit, Firefox,
@@ -152,13 +147,11 @@ is reproducible.
 | Plan or issue | Required disposition |
 | --- | --- |
 | Defect-hunting plan/register | Close delivered findings; move unique debt to issues; archive the working register |
-| Nearest-switch plan | Close after catalog and CyberScope evidence |
+| [Local-plan intake](2026-07-local-plan-intake.md) | Resolve every nearest-switch, UI, modernization, cruft/duplication, and replay-positioning item recorded there |
 | Multi-VLAN epic #882 | Reconcile delivered architecture; issue only the actual remaining UI/catalog/acceptance work |
 | Fleet-drift epic #1004 | Record delivered Renovate/foundation work; finish or separately track shared CI and doc alignment |
 | Library issue #905 | Fix the broken/phone-home default; gate content curation as a separate product decision |
 | License issue #911 | Obtain counsel decision; merge approved wording or close with the decision |
-| UI architecture plan | Re-audit correctness items; absorb defects; retire low-value parity and speculative UI work |
-| Modernization plan | Re-baseline landed `os.Root` work; approve only changes with measurable security, reliability, or maintenance value |
 
 Exit gate: every non-archived plan has a final status and no local-only active
 work remains.
@@ -174,7 +167,7 @@ for:
 3. IPv6 forwarding and DHCPv6 relay.
 4. Route policy and simulated ACLs.
 5. Multiple external attachments with a separate threat model.
-6. Replay expansion, React Compiler, TanStack Query, and remaining UI parity.
+6. Replay, Inspector, and remaining UI parity expansion.
 
 For each, record **build**, **reshape smaller**, or **retire**, then create a
 bounded implementation plan only for approved work.


### PR DESCRIPTION
## Summary

Adds one authoritative closeout plan and live ledger that sequence the
remediation epic, routed-lab acceptance, pre-1.0 roadmap, legacy defect
register, local plans, worktree handoffs, and remaining planning issues. Every
item must be delivered, absorbed into a newer owner, or explicitly retired.

## Linked Issue

Related to #1053

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [x] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
markdownlint-cli2 --no-globs docs/README.md docs/design/2026-07-niac-master-closeout-plan.md docs/design/2026-07-niac-master-closeout-ledger.md
Summary: 0 error(s)

git diff --cached --check
Passed with no output.

wc -l docs/design/2026-07-niac-master-closeout-plan.md
200 lines (within the 200-line file limit).

wc -l docs/design/2026-07-niac-master-closeout-ledger.md
110 lines (within the 200-line file limit).

Pre-commit checks
Passed: secret detection, file-size reporting, sensitive-file check.
Existing warning-only size debt was reported separately.
```

No code behavior changed, so unit, browser, build, and deployment suites were
not run for this documentation-only PR.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding
  were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior
  changed.
