### PR TITLE
docs: retire stale pre-1.0 claims

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -455,7 +455,9 @@ See `CONTRIBUTING.md` for detailed guidelines.
 
 ### Is there commercial support?
 
-NIAC-Go is open source (MIT license). For commercial support or custom development, contact the maintainers through GitHub.
+NIAC is source-available under the Business Source License 1.1. Free supports
+up to 10 simulated devices; Pro licensing and commercial support are available
+through Mustard Seed Networks.
 
 ### How often is NIAC-Go updated?
 

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -170,13 +170,12 @@ Run as Administrator:
 
 ---
 
-## Architecture Support
+## Release Architecture Support
 
 | Architecture | Linux | macOS | Windows |
 |--------------|-------|-------|---------|
-| x86_64 (AMD64) | ✓ | ✓ | ✓ |
-| ARM64 | ✓ | ✓ (Apple Silicon) | - |
-| ARM32 | ✓ | - | - |
+| x86_64 (AMD64) | ✓ | - | ✓ |
+| ARM64 | ✓ | ✓ (Apple Silicon) | ✓ |
 
 ### Cross-Compilation
 
@@ -186,9 +185,6 @@ GOOS=linux GOARCH=amd64 go build -o niac-linux-amd64 ./cmd/niac
 
 # Linux ARM64
 GOOS=linux GOARCH=arm64 go build -o niac-linux-arm64 ./cmd/niac
-
-# macOS AMD64 (Intel)
-GOOS=darwin GOARCH=amd64 go build -o niac-darwin-amd64 ./cmd/niac
 
 # macOS ARM64 (Apple Silicon)
 GOOS=darwin GOARCH=arm64 go build -o niac-darwin-arm64 ./cmd/niac
@@ -232,9 +228,11 @@ All debug flags work across platforms:
 
 ## Release Artifacts
 
-GitHub builds release artifacts on native hosted runners for Linux, macOS, and
-Windows. Local machines should build the host binary for development; the
-release workflow owns the full cross-platform matrix.
+GitHub Actions owns every release build. GoReleaser Cross produces Linux and
+Apple Silicon macOS artifacts on Linux; native GitHub Windows runners produce
+the CGO-enabled Windows artifacts. Local builds are development-only, and Intel
+macOS is not a release target. GitHub Releases is the canonical distribution
+channel.
 
 ---
 

--- a/docs/archive/reports/ARCHITECTURE_AUDIT_2025-01-19.md
+++ b/docs/archive/reports/ARCHITECTURE_AUDIT_2025-01-19.md
@@ -1,5 +1,8 @@
 # Seed / Stem / NIAC Architecture Audit Report
 
+> Archived point-in-time audit. Its licensing, platform, and implementation
+> claims are historical and are not an active backlog.
+
 **Date:** 2025-01-19
 **Auditor:** Claude (Opus 4.5)
 **Role:** Senior Platform Architect, DevOps Lead, Documentation Systems Auditor

--- a/docs/archive/reports/PROJECT_AUDIT_2026-05-07.md
+++ b/docs/archive/reports/PROJECT_AUDIT_2026-05-07.md
@@ -1,9 +1,11 @@
 # Project audit — 2026-05-07
 
+> Archived point-in-time audit. Current work is tracked in GitHub issues and
+> the active pre-1.0 roadmap.
+
 Sweep of the entire repo for best-practice gaps, defects, wiring issues,
-and enhancement opportunities. Companion to
-[SURFACE_MATRIX.md](./SURFACE_MATRIX.md) and
-[CONFIG_COVERAGE.md](./CONFIG_COVERAGE.md).
+and enhancement opportunities. The original companion documents were
+`SURFACE_MATRIX.md` and `CONFIG_COVERAGE.md`; neither remains active.
 
 This is a **point-in-time snapshot.** Items marked **fixed in this PR**
 land alongside this doc; everything else is recorded as a follow-up so


### PR DESCRIPTION
## Summary

- Correct the FAQ from the obsolete MIT/open-source claim to the active source-available BUSL-1.1 and Free/Pro contract.
- Align the platform matrix with GitHub Actions release output: Linux amd64/arm64, Apple Silicon macOS only, and Windows amd64/arm64.
- State that GitHub Releases is the canonical distribution channel and local builds are development-only.
- Move the January and May point-in-time audits into the historical reports archive so their obsolete claims are not an active backlog.
- Reconcile tracking issues #905, #911, #882, and #1004 without touching the active #1032-#1049 defect program.

## Linked Issue

Related to #1053.

## Testing Evidence

```text
git diff --check: pass
changed-document relative-link validation: pass
active-doc stale license/platform search: no matches
independent pre-commit review: no findings
post-rebase full review against origin/main: no findings
```

## Security and Release Checklist

- [x] No production behavior or security boundary changes.
- [x] BUSL-1.1 and the ten-device Free-tier contract match code and README.
- [x] GitHub Actions remains the only release builder.
- [x] GitHub Releases remains the canonical distribution channel.
- [x] Intel macOS is removed from active release documentation.
- [x] Existing active defect issues #1032 through #1049 remain open and untouched.