### PR TITLE
fix(tooling): fail pre-commit checks closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       workflows: ${{ steps.filter.outputs.workflows }}
       schema: ${{ steps.filter.outputs.schema }}
       https: ${{ steps.filter.outputs.https }}
+      hooks: ${{ steps.filter.outputs.hooks }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -97,6 +98,9 @@ jobs:
               - 'scripts/check-https-only.sh'
               - 'tests/smoke/run_smoke_tests.sh'
               - 'ui/vite.config.ts'
+            hooks:
+              - '.husky/**'
+              - 'scripts/tests/pre-commit-hook-test.sh'
 
   # ===========================================================================
   # Backend (Go)
@@ -523,7 +527,7 @@ jobs:
     name: Quality Checks
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.c == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.c == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.hooks == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -531,6 +535,9 @@ jobs:
         run: |
           chmod +x scripts/check-file-size.sh
           ./scripts/check-file-size.sh
+
+      - name: Test pre-commit hook
+        run: ./scripts/tests/pre-commit-hook-test.sh
 
       - name: Check for sensitive files
         run: |

--- a/.husky/check-frontend
+++ b/.husky/check-frontend
@@ -1,0 +1,64 @@
+#!/usr/bin/env sh
+
+FAILED=0
+
+EXPECTED_NODE=$(cat .nvmrc)
+EXPECTED_NPM=$(sed -n 's/.*"packageManager": "npm@\([^"]*\)".*/\1/p' package.json)
+
+if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+  echo "❌ Node.js and npm are required for frontend checks."
+  exit 1
+fi
+
+ACTUAL_NODE=$(node --version)
+ACTUAL_NPM=$(npm --version)
+if [ "$ACTUAL_NODE" != "v$EXPECTED_NODE" ] || [ "$ACTUAL_NPM" != "$EXPECTED_NPM" ]; then
+  echo "❌ Frontend toolchain mismatch."
+  echo "   Required: Node.js v$EXPECTED_NODE, npm $EXPECTED_NPM"
+  echo "   Current:  Node.js $ACTUAL_NODE, npm $ACTUAL_NPM"
+  exit 1
+fi
+
+if [ ! -d "ui/node_modules" ]; then
+  echo "❌ Frontend dependencies not installed. Run: cd ui && npm ci"
+  exit 1
+fi
+
+cd ui || exit 1
+
+UI_FILES=$(printf '%s\n' "$STAGED_TS_FILES" | grep '^ui/' | sed 's|^ui/||' || true)
+if [ -n "$UI_FILES" ]; then
+  echo "Running Biome lint..."
+  BIOME_FAILED=0
+  while IFS= read -r UI_FILE; do
+    if ! ./node_modules/.bin/biome check --no-errors-on-unmatched "$UI_FILE" 2>/dev/null; then
+      BIOME_FAILED=1
+    fi
+  done <<EOF
+$UI_FILES
+EOF
+  if [ "$BIOME_FAILED" -ne 0 ]; then
+    echo "❌ Biome check failed! Run: npm run lint:fix"
+    FAILED=1
+  else
+    echo "✓ Biome check passed"
+  fi
+fi
+
+echo "Running TypeScript check..."
+if ! sh ../.husky/run-tailed npm run typecheck; then
+  echo "❌ TypeScript errors!"
+  FAILED=1
+else
+  echo "✓ TypeScript check passed"
+fi
+
+echo "Running frontend tests..."
+if ! sh ../.husky/run-tailed npm run test; then
+  echo "❌ Frontend tests failed!"
+  FAILED=1
+else
+  echo "✓ Frontend tests passed"
+fi
+
+exit "$FAILED"

--- a/.husky/check-go
+++ b/.husky/check-go
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+
+FAILED=0
+
+GOLANGCI_LINT=""
+if command -v golangci-lint >/dev/null 2>&1; then
+  GOLANGCI_LINT="golangci-lint"
+elif [ -x "$HOME/go/bin/golangci-lint" ]; then
+  GOLANGCI_LINT="$HOME/go/bin/golangci-lint"
+elif [ -x "$(go env GOPATH)/bin/golangci-lint" ]; then
+  GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint"
+fi
+
+echo "Checking go fmt..."
+GOFMT_OUTPUT=""
+while IFS= read -r GO_FILE; do
+  FILE_OUTPUT=$(gofmt -l "$GO_FILE" 2>/dev/null || true)
+  if [ -n "$FILE_OUTPUT" ]; then
+    GOFMT_OUTPUT="${GOFMT_OUTPUT}${GOFMT_OUTPUT:+
+}${FILE_OUTPUT}"
+  fi
+done <<EOF
+$STAGED_GO_FILES
+EOF
+if [ -n "$GOFMT_OUTPUT" ]; then
+  echo "❌ Go formatting issues:"
+  echo "$GOFMT_OUTPUT"
+  echo "Run: gofmt -w <files>"
+  FAILED=1
+else
+  echo "✓ Go formatting OK"
+fi
+
+if [ -n "$GOLANGCI_LINT" ]; then
+  echo "Running golangci-lint..."
+  if ! "$GOLANGCI_LINT" run --new-from-rev=HEAD~1 2>/dev/null; then
+    echo "❌ Go linting failed!"
+    FAILED=1
+  else
+    echo "✓ Go linting passed"
+  fi
+else
+  echo "⚠ golangci-lint not installed, skipping"
+fi
+
+if command -v gosec >/dev/null 2>&1; then
+  echo "Running gosec security scan..."
+  GOSEC_FAILED=0
+  while IFS= read -r GO_FILE; do
+    if ! gosec -quiet "$GO_FILE" 2>/dev/null; then
+      GOSEC_FAILED=1
+    fi
+  done <<EOF
+$STAGED_GO_FILES
+EOF
+  if [ "$GOSEC_FAILED" -ne 0 ]; then
+    echo "❌ Security issues found in staged files!"
+    FAILED=1
+  else
+    echo "✓ Security scan passed"
+  fi
+else
+  echo "⚠ gosec not installed, skipping security scan"
+fi
+
+echo "Running Go tests..."
+if ! sh .husky/run-tailed go test -short -race ./...; then
+  echo "❌ Go tests failed!"
+  FAILED=1
+else
+  echo "✓ Go tests passed"
+fi
+
+exit "$FAILED"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -61,62 +61,8 @@ if [ -n "$STAGED_GO_FILES" ]; then
   echo "│ 2/6 Go Backend Checks                │"
   echo "└──────────────────────────────────────┘"
 
-  # Find golangci-lint
-  GOLANGCI_LINT=""
-  if command -v golangci-lint >/dev/null 2>&1; then
-    GOLANGCI_LINT="golangci-lint"
-  elif [ -x "$HOME/go/bin/golangci-lint" ]; then
-    GOLANGCI_LINT="$HOME/go/bin/golangci-lint"
-  elif [ -x "$(go env GOPATH)/bin/golangci-lint" ]; then
-    GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint"
-  fi
-
-  # Go formatting check
-  echo "Checking go fmt..."
-  GOFMT_OUTPUT=$(gofmt -l $STAGED_GO_FILES 2>/dev/null || true)
-  if [ -n "$GOFMT_OUTPUT" ]; then
-    echo "❌ Go formatting issues:"
-    echo "$GOFMT_OUTPUT"
-    echo "Run: gofmt -w <files>"
+  if ! STAGED_GO_FILES="$STAGED_GO_FILES" sh .husky/check-go; then
     FAILED=1
-  else
-    echo "✓ Go formatting OK"
-  fi
-
-  # Go linting
-  if [ -n "$GOLANGCI_LINT" ]; then
-    echo "Running golangci-lint..."
-    if ! $GOLANGCI_LINT run --new-from-rev=HEAD~1 2>/dev/null; then
-      echo "❌ Go linting failed!"
-      FAILED=1
-    else
-      echo "✓ Go linting passed"
-    fi
-  else
-    echo "⚠ golangci-lint not installed, skipping"
-  fi
-
-  # Go security check (gosec) - only scan staged files
-  if command -v gosec >/dev/null 2>&1; then
-    echo "Running gosec security scan..."
-    # Only scan staged Go files, not entire codebase (golangci-lint already covers full gosec)
-    if ! gosec -quiet $STAGED_GO_FILES 2>/dev/null; then
-      echo "❌ Security issues found in staged files!"
-      FAILED=1
-    else
-      echo "✓ Security scan passed"
-    fi
-  else
-    echo "⚠ gosec not installed, skipping security scan"
-  fi
-
-  # Go tests (short mode)
-  echo "Running Go tests..."
-  if ! go test -short -race ./... 2>&1 | tail -10; then
-    echo "❌ Go tests failed!"
-    FAILED=1
-  else
-    echo "✓ Go tests passed"
   fi
 fi
 
@@ -129,50 +75,8 @@ if [ -n "$STAGED_UI_FILES" ]; then
   echo "│ 3/6 Frontend Checks (Biome)          │"
   echo "└──────────────────────────────────────┘"
 
-  if [ ! -d "ui/node_modules" ]; then
-    echo "❌ Frontend dependencies not installed. Run: cd ui && npm ci"
+  if ! STAGED_TS_FILES="$STAGED_TS_FILES" sh .husky/check-frontend; then
     FAILED=1
-  else
-    cd ui
-
-    # Biome lint and format check
-    if [ -f "node_modules/.bin/biome" ] || command -v biome >/dev/null 2>&1; then
-      echo "Running Biome lint..."
-
-      # Get ui-relative paths for staged files
-      UI_FILES=$(echo "$STAGED_TS_FILES" | grep '^ui/' | sed 's|^ui/||' || true)
-
-      if [ -n "$UI_FILES" ]; then
-        if ! npx biome check --no-errors-on-unmatched $UI_FILES 2>/dev/null; then
-          echo "❌ Biome check failed! Run: npm run lint:fix"
-          FAILED=1
-        else
-          echo "✓ Biome check passed"
-        fi
-      fi
-    else
-      echo "⚠ Biome not installed, skipping lint"
-    fi
-
-    # TypeScript check
-    echo "Running TypeScript check..."
-    if ! npx tsc --noEmit 2>&1 | tail -10; then
-      echo "❌ TypeScript errors!"
-      FAILED=1
-    else
-      echo "✓ TypeScript check passed"
-    fi
-
-    # Frontend tests
-    echo "Running frontend tests..."
-    if ! npm test -- --passWithNoTests 2>&1 | tail -10; then
-      echo "❌ Frontend tests failed!"
-      FAILED=1
-    else
-      echo "✓ Frontend tests passed"
-    fi
-
-    cd ..
   fi
 fi
 
@@ -204,7 +108,15 @@ if [ -n "$STAGED_MD_FILES" ]; then
   # Use markdownlint if available
   if command -v markdownlint >/dev/null 2>&1; then
     echo "Running markdownlint..."
-    if ! markdownlint $STAGED_MD_FILES 2>/dev/null; then
+    MARKDOWN_FAILED=0
+    while IFS= read -r MARKDOWN_FILE; do
+      if ! markdownlint "$MARKDOWN_FILE" 2>/dev/null; then
+        MARKDOWN_FAILED=1
+      fi
+    done <<EOF
+$STAGED_MD_FILES
+EOF
+    if [ "$MARKDOWN_FAILED" -ne 0 ]; then
       echo "❌ Markdown issues found!"
       FAILED=1
     else

--- a/.husky/run-tailed
+++ b/.husky/run-tailed
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+OUTPUT_FILE=$(mktemp)
+trap 'rm -f "$OUTPUT_FILE"' EXIT HUP INT TERM
+
+"$@" >"$OUTPUT_FILE" 2>&1
+STATUS=$?
+tail -10 "$OUTPUT_FILE"
+
+exit "$STATUS"

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -11,7 +11,7 @@
 # =============================================================================
 
 .PHONY: test test-all test-backend test-backend-quiet test-frontend test-frontend-quiet \
-        test-e2e test-e2e-ui test-e2e-install test-coverage
+        test-hooks test-e2e test-e2e-ui test-e2e-install test-coverage
 
 # =============================================================================
 # Main Test Targets
@@ -19,27 +19,31 @@
 
 test: ## Run unit tests (backend + frontend)
 	@printf "$(BOLD)$(CYAN)┌─ Unit Tests ─────────────────────────────────────────────────────────────────┐$(RESET)\n"
-	@printf "$(CYAN)│$(RESET) $(BOLD)[1/2]$(RESET) Backend (Go)                                                          $(CYAN)│$(RESET)\n"
+	@printf "$(CYAN)│$(RESET) $(BOLD)[1/3]$(RESET) Backend (Go)                                                          $(CYAN)│$(RESET)\n"
 	$(call timer-start,test-backend)
 	@$(MAKE) --no-print-directory test-backend-quiet
 	$(call timer-end,test-backend,Backend tests)
-	@printf "$(CYAN)│$(RESET) $(BOLD)[2/2]$(RESET) Frontend (Vitest)                                                      $(CYAN)│$(RESET)\n"
+	@printf "$(CYAN)│$(RESET) $(BOLD)[2/3]$(RESET) Frontend (Vitest)                                                      $(CYAN)│$(RESET)\n"
 	$(call timer-start,test-frontend)
 	@$(MAKE) --no-print-directory test-frontend-quiet
 	$(call timer-end,test-frontend,Frontend tests)
+	@printf "$(CYAN)│$(RESET) $(BOLD)[3/3]$(RESET) Repository hooks                                                      $(CYAN)│$(RESET)\n"
+	@$(MAKE) --no-print-directory test-hooks
 	@printf "$(CYAN)└──────────────────────────────────────────────────────────────────────────────┘$(RESET)\n"
 
 test-all: ## Run ALL tests (unit + E2E)
 	@printf "$(BOLD)$(CYAN)┌─ Full Test Suite ────────────────────────────────────────────────────────────┐$(RESET)\n"
-	@printf "$(CYAN)│$(RESET) $(BOLD)[1/3]$(RESET) Backend unit tests                                                    $(CYAN)│$(RESET)\n"
+	@printf "$(CYAN)│$(RESET) $(BOLD)[1/4]$(RESET) Backend unit tests                                                    $(CYAN)│$(RESET)\n"
 	$(call timer-start,test-backend)
 	@$(MAKE) --no-print-directory test-backend-quiet
 	$(call timer-end,test-backend,Backend tests)
-	@printf "$(CYAN)│$(RESET) $(BOLD)[2/3]$(RESET) Frontend unit tests                                                   $(CYAN)│$(RESET)\n"
+	@printf "$(CYAN)│$(RESET) $(BOLD)[2/4]$(RESET) Frontend unit tests                                                   $(CYAN)│$(RESET)\n"
 	$(call timer-start,test-frontend)
 	@$(MAKE) --no-print-directory test-frontend-quiet
 	$(call timer-end,test-frontend,Frontend tests)
-	@printf "$(CYAN)│$(RESET) $(BOLD)[3/3]$(RESET) E2E tests (Playwright)                                                $(CYAN)│$(RESET)\n"
+	@printf "$(CYAN)│$(RESET) $(BOLD)[3/4]$(RESET) Repository hooks                                                      $(CYAN)│$(RESET)\n"
+	@$(MAKE) --no-print-directory test-hooks
+	@printf "$(CYAN)│$(RESET) $(BOLD)[4/4]$(RESET) E2E tests (Playwright)                                                $(CYAN)│$(RESET)\n"
 	$(call timer-start,test-e2e)
 	@$(MAKE) --no-print-directory test-e2e
 	$(call timer-end,test-e2e,E2E tests)
@@ -104,6 +108,9 @@ test-frontend-quiet:
 		echo "$$OUTPUT" | tail -60; \
 		exit $$STATUS; \
 	fi
+
+test-hooks: ## Run repository hook regression tests
+	@./scripts/tests/pre-commit-hook-test.sh
 
 # =============================================================================
 # E2E Tests

--- a/scripts/tests/pre-commit-hook-test.sh
+++ b/scripts/tests/pre-commit-hook-test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TEST_REPO=$(mktemp -d)
+trap 'rm -rf "$TEST_REPO"' EXIT
+
+mkdir -p "$TEST_REPO/.husky" "$TEST_REPO/bin" "$TEST_REPO/ui/node_modules"
+cp "$REPO_ROOT/.husky/pre-commit" "$REPO_ROOT/.husky/check-frontend" \
+  "$REPO_ROOT/.husky/run-tailed" "$TEST_REPO/.husky/"
+cp "$REPO_ROOT/.nvmrc" "$REPO_ROOT/package.json" "$TEST_REPO/"
+
+git -C "$TEST_REPO" init -q
+git -C "$TEST_REPO" config user.email "hook-test@example.invalid"
+git -C "$TEST_REPO" config user.name "Hook Test"
+printf 'export const value = 1;\n' >"$TEST_REPO/ui/app.ts"
+git -C "$TEST_REPO" add ui/app.ts
+
+cat >"$TEST_REPO/bin/gitleaks" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+
+cat >"$TEST_REPO/bin/node" <<'EOF'
+#!/usr/bin/env sh
+if [ "${1:-}" = "--version" ]; then
+  echo "v26.5.0"
+  exit 0
+fi
+exit 0
+EOF
+
+cat >"$TEST_REPO/bin/npm" <<'EOF'
+#!/usr/bin/env sh
+if [ "${1:-}" = "--version" ]; then
+  echo "12.0.1"
+  exit 0
+fi
+if [ "${1:-}" = "run" ] && [ "${2:-}" = "typecheck" ]; then
+  exit 0
+fi
+echo "simulated frontend test startup failure" >&2
+exit 23
+EOF
+
+cat >"$TEST_REPO/bin/npx" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+
+chmod +x "$TEST_REPO/bin/"*
+mkdir -p "$TEST_REPO/ui/node_modules/.bin"
+cat >"$TEST_REPO/ui/node_modules/.bin/biome" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+chmod +x "$TEST_REPO/ui/node_modules/.bin/biome"
+
+set +e
+OUTPUT=$(
+  cd "$TEST_REPO"
+  CI='' PATH="$TEST_REPO/bin:$PATH" sh .husky/pre-commit 2>&1
+)
+STATUS=$?
+set -e
+
+if [ "$STATUS" -eq 0 ]; then
+  echo "expected the pre-commit hook to reject a failed frontend test command"
+  echo "$OUTPUT"
+  exit 1
+fi
+
+if printf '%s\n' "$OUTPUT" | grep -q "Frontend tests passed"; then
+  echo "hook reported frontend success after the test command failed"
+  echo "$OUTPUT"
+  exit 1
+fi
+
+printf '%s\n' "$OUTPUT" | grep -q "Frontend tests failed"
+
+cat >"$TEST_REPO/bin/node" <<'EOF'
+#!/usr/bin/env sh
+if [ "${1:-}" = "--version" ]; then
+  echo "v26.4.0"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$TEST_REPO/bin/node"
+
+set +e
+OUTPUT=$(
+  cd "$TEST_REPO"
+  CI='' PATH="$TEST_REPO/bin:$PATH" sh .husky/pre-commit 2>&1
+)
+STATUS=$?
+set -e
+
+if [ "$STATUS" -eq 0 ]; then
+  echo "expected the pre-commit hook to reject the wrong Node.js version"
+  echo "$OUTPUT"
+  exit 1
+fi
+
+printf '%s\n' "$OUTPUT" | grep -q "Frontend toolchain mismatch"
+if printf '%s\n' "$OUTPUT" | grep -q "Frontend tests passed"; then
+  echo "hook ran frontend tests with the wrong Node.js version"
+  echo "$OUTPUT"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- preserve command failures while showing the final ten output lines
- reject Node.js and npm versions that do not match repository pins
- use the tsgo-backed typecheck and standard Vitest scripts
- run the hook regression through `make test` and required CI quality checks

## Linked Issue

Closes #1057

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
RED: scripts/tests/pre-commit-hook-test.sh
expected the pre-commit hook to reject a failed frontend test command
simulated frontend test startup failure
Frontend tests passed
ALL PRE-COMMIT CHECKS PASSED

GREEN: make test-hooks
exit 0

make fmt-check
All formatting checks passed

make lint
0 issues; frontend Biome clean

make test
41 Go packages passed; coverage 64.5%
63 frontend test files / 316 tests passed
repository hook regression passed

shellcheck .husky/pre-commit .husky/check-go .husky/check-frontend \
  .husky/run-tailed scripts/tests/pre-commit-hook-test.sh
exit 0

Independent staged-diff review
No actionable regressions found
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were not changed.
- [x] Dependencies were not changed.
- [x] Operator-visible failure messages identify the required and current toolchain.
