### PR TITLE
fix(config): confine nested segment configurations

### DIFF
--- a/internal/config/segments_test.go
+++ b/internal/config/segments_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,6 +54,69 @@ segments:
 
 	if segs[1].Tag != 300 || segs[1].Devices[0].Name != "demo2-r1" {
 		t.Errorf("tag-300 inline segment wrong: %+v", segs[1])
+	}
+}
+
+func TestLoadYAMLManagedConfinesSegmentConfigs(t *testing.T) {
+	base := t.TempDir()
+	managedRoot := filepath.Join(base, "networks")
+	if err := os.Mkdir(managedRoot, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	childYAML := []byte(`
+devices:
+  - name: child
+    mac: "02:00:00:00:02:01"
+    ips: ["10.0.0.1"]
+`)
+	managedChild := filepath.Join(managedRoot, "child.yaml")
+	if err := os.WriteFile(managedChild, childYAML, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outsideChild := filepath.Join(base, "outside.yaml")
+	if err := os.WriteFile(outsideChild, childYAML, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlinkChild := filepath.Join(managedRoot, "escape.yaml")
+	if err := os.Symlink(outsideChild, symlinkChild); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		childPath string
+		wantErr   bool
+	}{
+		{name: "managed child", childPath: managedChild},
+		{name: "absolute escape", childPath: outsideChild, wantErr: true},
+		{name: "relative escape", childPath: "../outside.yaml", wantErr: true},
+		{name: "symlink escape", childPath: symlinkChild, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := filepath.Join(managedRoot, tt.name+".yaml")
+			parentYAML := fmt.Sprintf(`
+segments:
+  - tag: 200
+    config: %q
+`, tt.childPath)
+			if err := os.WriteFile(parent, []byte(parentYAML), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			_, _, err := LoadYAMLManaged(parent, []string{managedRoot})
+			if tt.wantErr {
+				if !errors.Is(err, ErrPathOutsideManagedRoots) {
+					t.Fatalf("LoadYAMLManaged() error = %v, want ErrPathOutsideManagedRoots", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadYAMLManaged() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/config/yaml_load.go
+++ b/internal/config/yaml_load.go
@@ -12,12 +12,28 @@ import (
 )
 
 func LoadYAML(filename string) (*Config, error) {
+	return loadYAML(filename, nil)
+}
+
+// LoadYAMLManaged loads a configuration while confining it and every nested
+// segment configuration to the supplied managed roots.
+func LoadYAMLManaged(filename string, roots []string) (*Config, string, error) {
+	managedPath, err := ResolveManagedConfigPath(filename, roots)
+	if err != nil {
+		return nil, "", err
+	}
+
+	cfg, err := loadYAML(managedPath, roots)
+	return cfg, managedPath, err
+}
+
+func loadYAML(filename string, roots []string) (*Config, error) {
 	yamlConfig, err := loadYAMLFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	return buildConfigFromYAML(yamlConfig, filepath.Dir(filepath.Clean(filename)))
+	return buildConfigFromYAML(yamlConfig, filepath.Dir(filepath.Clean(filename)), roots)
 }
 
 // LoadYAMLBytes builds a runtime config from in-memory YAML data.
@@ -27,7 +43,19 @@ func LoadYAMLBytes(data []byte) (*Config, error) {
 		return nil, err
 	}
 
-	return buildConfigFromYAML(yamlConfig, "")
+	return buildConfigFromYAML(yamlConfig, "", nil)
+}
+
+// LoadYAMLBytesManaged builds an in-memory configuration while resolving
+// nested segment configurations relative to configDir and confining them to
+// the supplied managed roots.
+func LoadYAMLBytesManaged(data []byte, configDir string, roots []string) (*Config, error) {
+	yamlConfig, err := loadYAMLBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildConfigFromYAML(yamlConfig, configDir, roots)
 }
 
 // loadYAMLFile loads and validates a YAML configuration file.
@@ -58,7 +86,7 @@ func validateYAMLConfig(yamlConfig *converter.Config) (*converter.Config, error)
 	return yamlConfig, nil
 }
 
-func buildConfigFromYAML(yamlConfig *converter.Config, configDir string) (*Config, error) {
+func buildConfigFromYAML(yamlConfig *converter.Config, configDir string, roots []string) (*Config, error) {
 	var registry *oui.Registry
 	if usesVendorIdentity(yamlConfig) {
 		var err error
@@ -79,7 +107,7 @@ func buildConfigFromYAML(yamlConfig *converter.Config, configDir string) (*Confi
 		cfg.Devices = append(cfg.Devices, device)
 	}
 
-	segments, err := buildSegments(yamlConfig, cfg.IncludePath, configDir, registry)
+	segments, err := buildSegments(yamlConfig, cfg.IncludePath, configDir, roots, registry)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +139,7 @@ func usesVendorIdentity(cfg *converter.Config) bool {
 func buildSegments(
 	yamlConfig *converter.Config,
 	includePath, configDir string,
+	roots []string,
 	registry *oui.Registry,
 ) ([]Segment, error) {
 	if len(yamlConfig.Segments) == 0 {
@@ -124,7 +153,7 @@ func buildSegments(
 	segments := make([]Segment, 0, len(yamlConfig.Segments))
 
 	for _, ySeg := range yamlConfig.Segments {
-		seg, err := buildSegment(ySeg, includePath, configDir, registry)
+		seg, err := buildSegment(ySeg, includePath, configDir, roots, registry)
 		if err != nil {
 			return nil, err
 		}
@@ -138,6 +167,7 @@ func buildSegments(
 func buildSegment(
 	ySeg converter.Segment,
 	includePath, configDir string,
+	roots []string,
 	registry *oui.Registry,
 ) (Segment, error) {
 	tag, err := parseSegmentTag(string(ySeg.Tag))
@@ -155,7 +185,7 @@ func buildSegment(
 	seg := Segment{Tag: tag, ConfigPath: ySeg.Config}
 
 	if hasConfig {
-		return resolveSegmentConfig(seg, ySeg.Config, configDir)
+		return resolveSegmentConfig(seg, ySeg.Config, configDir, roots)
 	}
 
 	for _, yamlDevice := range ySeg.Devices {
@@ -174,12 +204,20 @@ func buildSegment(
 // its devices as the segment's device set. The path is relative to the parent
 // config's directory. A segment config that itself declares segments is
 // rejected — nesting demos is out of scope.
-func resolveSegmentConfig(seg Segment, path, configDir string) (Segment, error) {
+func resolveSegmentConfig(seg Segment, path, configDir string, roots []string) (Segment, error) {
 	if !filepath.IsAbs(path) && configDir != "" {
 		path = filepath.Join(configDir, path)
 	}
 
-	loaded, err := LoadYAML(path)
+	var (
+		loaded *Config
+		err    error
+	)
+	if len(roots) > 0 {
+		loaded, _, err = LoadYAMLManaged(path, roots)
+	} else {
+		loaded, err = LoadYAML(path)
+	}
 	if err != nil {
 		return Segment{}, fmt.Errorf("segment tag %d config %q: %w", seg.Tag, path, err)
 	}

--- a/internal/daemon/config_path_test.go
+++ b/internal/daemon/config_path_test.go
@@ -71,6 +71,50 @@ func TestLoadSimulationConfigRestrictsPathsToManagedRoots(t *testing.T) {
 	}
 }
 
+func TestLoadSimulationConfigRestrictsInlineSegmentPathsToManagedRoots(t *testing.T) {
+	base := t.TempDir()
+	configsDir := filepath.Join(base, "configs")
+	if err := os.Mkdir(configsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NIAC_LIBRARY_ROOT", filepath.Join(base, "library"))
+	t.Setenv("NIAC_CONFIGS_DIR", configsDir)
+
+	managed := writeManagedPathTestConfig(t, configsDir, "managed.yaml")
+	outside := writeManagedPathTestConfig(t, base, "outside.yaml")
+	escape := filepath.Join(configsDir, "escape.yaml")
+	if err := os.Symlink(outside, escape); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		childPath string
+		ok        bool
+	}{
+		{name: "managed absolute path", childPath: managed, ok: true},
+		{name: "absolute outside root", childPath: outside},
+		{name: "relative escape", childPath: "../outside.yaml"},
+		{name: "symlink escape", childPath: escape},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configData := "segments:\n  - tag: 200\n    config: " + tt.childPath + "\n"
+			_, _, err := loadSimulationConfig(api.SimulationRequest{ConfigData: configData}, false)
+			if tt.ok {
+				if err != nil {
+					t.Fatalf("loadSimulationConfig() error = %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, config.ErrPathOutsideManagedRoots) {
+				t.Fatalf("error = %v, want ErrPathOutsideManagedRoots", err)
+			}
+		})
+	}
+}
+
 func writeManagedPathTestConfig(t *testing.T, dir, name string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -287,11 +287,11 @@ func loadSimulationConfig(req api.SimulationRequest, persistInline bool) (*confi
 		if templatePath == "" {
 			return nil, "", fmt.Errorf("%w: %s", ErrTemplateNotFound, req.TemplateName)
 		}
-		cfg, err := config.Load(templatePath)
+		cfg, managedPath, err := config.LoadYAMLManaged(templatePath, simulationConfigRoots())
 		if err != nil {
 			return nil, "", fmt.Errorf("load template %q: %w", req.TemplateName, err)
 		}
-		return cfg, templatePath, nil
+		return cfg, managedPath, nil
 	case req.ConfigData != "":
 		if len(req.ConfigData) > maxSimulationConfigSize {
 			return nil, "", fmt.Errorf(
@@ -301,7 +301,15 @@ func loadSimulationConfig(req api.SimulationRequest, persistInline bool) (*confi
 				len(req.ConfigData),
 			)
 		}
-		cfg, err := config.LoadYAMLBytes([]byte(req.ConfigData))
+		configDir, err := inlineConfigDir()
+		if err != nil {
+			return nil, "", fmt.Errorf("load configuration: %w", err)
+		}
+		cfg, err := config.LoadYAMLBytesManaged(
+			[]byte(req.ConfigData),
+			configDir,
+			simulationConfigRoots(),
+		)
 		if err != nil {
 			return nil, "", fmt.Errorf("load configuration: %w", err)
 		}
@@ -318,11 +326,8 @@ func loadSimulationConfig(req api.SimulationRequest, persistInline bool) (*confi
 		}
 		return cfg, path, nil
 	case req.ConfigPath != "":
-		managedPath, err := config.ResolveManagedConfigPath(req.ConfigPath, simulationConfigRoots())
-		if err != nil {
-			return nil, "", fmt.Errorf("load configuration: %w", err)
-		}
-		cfg, err := config.Load(managedPath)
+		roots := simulationConfigRoots()
+		cfg, managedPath, err := config.LoadYAMLManaged(req.ConfigPath, roots)
 		if err != nil {
 			return nil, "", fmt.Errorf("load configuration: %w", err)
 		}
@@ -425,6 +430,25 @@ const inlineConfigName = "_running.inline.yaml"
 // daemon has a real configPath to operate on. Returns the absolute path
 // it was written to.
 func persistInlineConfig(content string) (string, error) {
+	cleanDir, dirErr := inlineConfigDir()
+	if dirErr != nil {
+		return "", dirErr
+	}
+	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
+		return "", fmt.Errorf("create configs dir: %w", err)
+	}
+	path := filepath.Join(cleanDir, inlineConfigName)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return "", fmt.Errorf("write inline config: %w", err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path, nil //nolint:nilerr // best-effort abs path; relative is fine too
+	}
+	return abs, nil
+}
+
+func inlineConfigDir() (string, error) {
 	rawDir := os.Getenv("NIAC_CONFIGS_DIR")
 	if rawDir == "" {
 		// Prefer $HOME/.niac/configs over CWD so daemon restarts find it.
@@ -442,18 +466,7 @@ func persistInlineConfig(content string) (string, error) {
 	if strings.Contains(cleanDir, "..") {
 		return "", fmt.Errorf("configs dir must not contain '..' components: %s", rawDir)
 	}
-	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
-		return "", fmt.Errorf("create configs dir: %w", err)
-	}
-	path := filepath.Join(cleanDir, inlineConfigName)
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		return "", fmt.Errorf("write inline config: %w", err)
-	}
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return path, nil //nolint:nilerr // best-effort abs path; relative is fine too
-	}
-	return abs, nil
+	return cleanDir, nil
 }
 
 func e2eDryRunSimulation() bool {


### PR DESCRIPTION
## Summary

- carry managed configuration roots through recursive segment loading
- confine file, template, and inline daemon requests to the same authorized roots
- reject absolute, relative, and symlink escapes with `ErrPathOutsideManagedRoots`
- add configuration-loader and daemon regression coverage

## Linked Issue

Closes #1035

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [x] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

## Testing Evidence

```text
go test ./internal/config ./internal/daemon ./internal/api
PASS

make fmt-check
PASS

make lint
PASS

make test
PASS

make security
PASS: no reachable Go vulnerabilities, no npm vulnerabilities, no secrets

golangci-lint run ./internal/config/... ./internal/daemon/...
PASS: 0 issues

pre-commit checks
PASS: formatting, lint, gosec, race tests, file-size advisory, sensitive-file scan

codex exec review --uncommitted
PASS: no actionable findings reported
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. No operator documentation change is required; valid managed configurations retain their behavior and escaped nested paths now fail closed.
