### PR TITLE
fix(release): cover content packages with integrity metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,9 @@ jobs:
               - 'ui/vite.config.ts'
             hooks:
               - '.husky/**'
+              - '.goreleaser.content.yml'
               - 'scripts/tests/pre-commit-hook-test.sh'
+              - 'scripts/tests/release-content-integrity-test.sh'
 
   # ===========================================================================
   # Backend (Go)
@@ -538,6 +540,9 @@ jobs:
 
       - name: Test pre-commit hook
         run: ./scripts/tests/pre-commit-hook-test.sh
+
+      - name: Test release content integrity contract
+        run: ./scripts/tests/release-content-integrity-test.sh
 
       - name: Check for sensitive files
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
     name: goreleaser ${{ github.event_name == 'workflow_dispatch' && '(snapshot)' || '(release)' }}
     if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
-    needs: [build-ui, build-windows]
+    needs: [build-ui, build-windows, niac-content]
     container:
       # Docker Hub tag scheme: <go-version>-<goreleaser-version>. Pin so
       # behaviour stays reproducible; bump via dependabot when newer revs
@@ -294,6 +294,13 @@ jobs:
         with:
           pattern: niac-windows-*
           path: windows-raw/
+
+      - name: Download prebuilt niac-content packages
+        if: needs.niac-content.outputs.has_content == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: niac-content-packages
+          path: content-packages/
 
       - name: Install Syft (SBOM) inside container
         env:
@@ -395,12 +402,23 @@ jobs:
             rm -rf "${stage}"
           done
 
-      - name: SBOM, sign, and publish Windows archives
+      - name: Add prebuilt niac-content packages
+        if: needs.niac-content.outputs.has_content == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          packages=(content-packages/*.deb content-packages/*.rpm)
+          if [ "${#packages[@]}" -ne 2 ]; then
+            echo "::error::expected one niac-content DEB and one RPM, found ${#packages[@]}"
+            exit 1
+          fi
+          cp "${packages[@]}" dist/
+
+      - name: SBOM, sign, and publish supplemental artifacts
         # Mirrors what goreleaser's sboms/signs/checksum config does for the
-        # linux/darwin archives (same syft args, same cosign invocation),
-        # then appends to the checksums.txt the goreleaser step above
-        # already uploaded to the release and re-signs + re-uploads it so
-        # it stays the single authoritative manifest for every platform.
+        # linux/darwin artifacts, then replaces the checksum manifest once
+        # after both native Windows archives and optional content packages
+        # have been added.
         if: ${{ github.event_name == 'push' }}
         shell: bash
         env:
@@ -410,21 +428,54 @@ jobs:
           set -euo pipefail
           version="${REF_NAME#v}"
           cd dist
-          for goarch in amd64 arm64; do
-            artifact="niac-${version}-windows-${goarch}.zip"
+          artifacts=(
+            "niac-${version}-windows-amd64.zip"
+            "niac-${version}-windows-arm64.zip"
+          )
+          content_packages=(niac-content*.deb niac-content*.rpm)
+          if [ -e "${content_packages[0]}" ]; then
+            if [ "${#content_packages[@]}" -ne 2 ]; then
+              echo "::error::expected one niac-content DEB and one RPM, found ${#content_packages[@]}"
+              exit 1
+            fi
+            artifacts+=("${content_packages[@]}")
+          fi
+          for artifact in "${artifacts[@]}"; do
             SYFT_FILE_METADATA_CATALOGER_ENABLED=true \
               syft "${artifact}" --output "spdx-json=${artifact}.sbom.json"
             cosign sign-blob --yes --bundle "${artifact}.cosign.bundle" "${artifact}"
+            cosign sign-blob --yes --bundle "${artifact}.sbom.json.cosign.bundle" "${artifact}.sbom.json"
             sha256sum "${artifact}" >> checksums.txt
+            sha256sum "${artifact}.sbom.json" >> checksums.txt
           done
-          # checksums.txt now covers every platform; the entries goreleaser
-          # signed already point at stale content, so re-sign + re-upload
-          # the merged file rather than leaving two conflicting bundles.
+          # GoReleaser signed its earlier manifest before supplemental
+          # artifacts existed. Replace that bundle with one signature over
+          # the final authoritative manifest.
           cosign sign-blob --yes --bundle checksums.txt.cosign.bundle checksums.txt
-          gh release upload "${REF_NAME}" --clobber --repo "${GITHUB_REPOSITORY}" \
-            "niac-${version}-windows-amd64.zip" "niac-${version}-windows-amd64.zip.sbom.json" "niac-${version}-windows-amd64.zip.cosign.bundle" \
-            "niac-${version}-windows-arm64.zip" "niac-${version}-windows-arm64.zip.sbom.json" "niac-${version}-windows-arm64.zip.cosign.bundle" \
-            checksums.txt checksums.txt.cosign.bundle
+          uploads=(checksums.txt checksums.txt.cosign.bundle)
+          for artifact in "${artifacts[@]}"; do
+            uploads+=("${artifact}" "${artifact}.sbom.json" "${artifact}.cosign.bundle" "${artifact}.sbom.json.cosign.bundle")
+          done
+          gh release upload "${REF_NAME}" --clobber --repo "${GITHUB_REPOSITORY}" "${uploads[@]}"
+
+      - name: Verify content package integrity coverage
+        if: ${{ github.event_name == 'push' && needs.niac-content.outputs.has_content == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          packages=(niac-content*.deb niac-content*.rpm)
+          if [ "${#packages[@]}" -ne 2 ]; then
+            echo "::error::expected one niac-content DEB and one RPM, found ${#packages[@]}"
+            exit 1
+          fi
+          for artifact in "${packages[@]}"; do
+            grep -Fq "  ${artifact}" checksums.txt
+            grep -Fq "  ${artifact}.sbom.json" checksums.txt
+            test -s "${artifact}.sbom.json"
+            test -s "${artifact}.cosign.bundle"
+            test -s "${artifact}.sbom.json.cosign.bundle"
+          done
 
       - name: Capture artifact hashes for SLSA provenance
         if: ${{ github.event_name == 'push' }}
@@ -435,8 +486,8 @@ jobs:
           # exactly the slsa-github-generator subject-checksums format —
           # and by this point in the job includes the Windows archives
           # appended above alongside goreleaser's own linux/darwin
-          # archives and Linux packages, so this is the full, final
-          # subject list for the release.
+          # archives, Linux packages, and optional content packages, so this
+          # is the full, final subject list for the release.
           set -euo pipefail
           echo "hashes=$(base64 -w0 dist/checksums.txt)" >> "$GITHUB_OUTPUT"
 
@@ -455,22 +506,20 @@ jobs:
   # CONTENT_REPO_DEPLOY_KEY secret (a read-only deploy key on that repo) is
   # set.
   #
-  # RESILIENCE: every real step is gated on HAS_CONTENT_KEY. With no key the
-  # whole job is a green no-op, so the core release (the `goreleaser` job
-  # above) is entirely unaffected — you simply don't get a niac-content
-  # package. It runs its own .goreleaser.content.yml with release.mode=append,
-  # so on a real release it adds packages to the release the core job already
-  # created; it never touches the core artifacts.
+  # RESILIENCE: every build step is gated on HAS_CONTENT_KEY. With no key the
+  # job is a green no-op, so the core release remains standalone. With a key,
+  # this job builds but never publishes; the core job consumes the packages
+  # and finalizes one integrity set for the complete release.
   #
-  # UNVALIDATED end-to-end until a release runs with the key set. The nfpm
-  # deb/rpm build itself is validated; the corpus deploy-key checkout and the
-  # append-to-release upload run for the first time in CI here.
+  # The nfpm build is validated locally. The deploy-key checkout and package
+  # handoff remain release-CI concerns.
   # =========================================================================
   niac-content:
     name: niac-content package
     if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
-    needs: [goreleaser]
+    outputs:
+      has_content: ${{ steps.availability.outputs.has_content }}
     container:
       # Reuse the pinned goreleaser-cross image so goreleaser is already
       # present at the exact version the core job uses. No cross toolchain is
@@ -484,7 +533,9 @@ jobs:
       HAS_CONTENT_KEY: ${{ secrets.CONTENT_REPO_DEPLOY_KEY != '' }}
     steps:
       - name: Report whether the content deploy key is present
+        id: availability
         run: |
+          echo "has_content=$HAS_CONTENT_KEY" >> "$GITHUB_OUTPUT"
           if [ "$HAS_CONTENT_KEY" = "true" ]; then
             echo "CONTENT_REPO_DEPLOY_KEY present — building niac-content."
           else
@@ -535,19 +586,20 @@ jobs:
         if: ${{ env.HAS_CONTENT_KEY == 'true' && github.event_name == 'workflow_dispatch' }}
         run: goreleaser release --config .goreleaser.content.yml --snapshot --clean --skip=publish,sign,announce
 
-      - name: Build + append niac-content packages (release)
+      - name: Build niac-content packages (release)
         if: ${{ env.HAS_CONTENT_KEY == 'true' && github.event_name == 'push' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: goreleaser release --config .goreleaser.content.yml --clean
+        run: goreleaser release --config .goreleaser.content.yml --clean --skip=publish,sign,announce
 
-      - name: Upload dry-run niac-content packages for inspection
-        if: ${{ env.HAS_CONTENT_KEY == 'true' && github.event_name == 'workflow_dispatch' }}
+      - name: Upload niac-content packages for the core release
+        if: env.HAS_CONTENT_KEY == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: niac-content-dryrun-${{ github.run_id }}
-          path: dist/
-          retention-days: 14
+          name: niac-content-packages
+          path: |
+            dist/*.deb
+            dist/*.rpm
+          if-no-files-found: error
+          retention-days: 1
 
   # =========================================================================
   # SLSA provenance backfill — recomputes the subject list from a tag's

--- a/.goreleaser.content.yml
+++ b/.goreleaser.content.yml
@@ -15,8 +15,8 @@
 # somehow absent.
 #
 # meta: true → no Go build, this config only assembles the tarball into a
-# deb/rpm. On a real release it appends the packages to the existing GitHub
-# release created by the core `goreleaser` job (release.mode: append).
+# deb/rpm. The workflow passes those packages to the core release job, which
+# owns all publication and integrity metadata.
 #
 # Tested against goreleaser v2.x.
 # =============================================================================
@@ -71,20 +71,14 @@ nfpms:
         file_info:
           mode: 0o644
 
-# The core release owns checksums.txt; don't emit a second one that would
-# clobber it when appending to the same GitHub release.
+# The core release owns the final checksum manifest.
 checksum:
   disable: true
 
 release:
-  github:
-    owner: MustardSeedNetworks
-    name: niac-go
-  # Append to the release the core `goreleaser` job already created for this
-  # tag — never recreate or replace its artifacts.
-  mode: append
-  draft: false
-  prerelease: auto
+  # Content packages are an input to the core release job and must never
+  # create or mutate an SCM release independently.
+  disable: true
 
 # Don't regenerate release notes — the core job already set the body.
 changelog:

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -109,8 +109,9 @@ test-frontend-quiet:
 		exit $$STATUS; \
 	fi
 
-test-hooks: ## Run repository hook regression tests
+test-hooks: ## Run repository script regression tests
 	@./scripts/tests/pre-commit-hook-test.sh
+	@./scripts/tests/release-content-integrity-test.sh
 
 # =============================================================================
 # E2E Tests

--- a/scripts/tests/release-content-integrity-test.sh
+++ b/scripts/tests/release-content-integrity-test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+CONTENT_CONFIG="$REPO_ROOT/.goreleaser.content.yml"
+
+job_block() {
+  local job=$1
+  awk -v job="$job" '
+    $0 == "  " job ":" { active = 1 }
+    active && $0 ~ /^  [a-z0-9_-]+:$/ && $0 != "  " job ":" { exit }
+    active { print }
+  ' "$WORKFLOW"
+}
+
+require_text() {
+  local haystack=$1
+  local needle=$2
+  local message=$3
+  if ! grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "$message"
+    exit 1
+  fi
+}
+
+CONTENT_JOB=$(job_block "niac-content")
+GORELEASER_JOB=$(job_block "goreleaser")
+
+if grep -Fq "needs: [goreleaser]" <<<"$CONTENT_JOB"; then
+  echo "content packages must be built before the core release finalizes integrity metadata"
+  exit 1
+fi
+
+require_text "$CONTENT_JOB" \
+  "goreleaser release --config .goreleaser.content.yml --clean --skip=publish,sign,announce" \
+  "content release builds must disable independent publishing and signing"
+require_text "$CONTENT_JOB" \
+  "name: niac-content-packages" \
+  "content packages must cross the job boundary as a workflow artifact"
+require_text "$GORELEASER_JOB" \
+  "needs: [build-ui, build-windows, niac-content]" \
+  "the core release must wait for the content build"
+require_text "$GORELEASER_JOB" \
+  "name: niac-content-packages" \
+  "the core release must download the content packages"
+require_text "$GORELEASER_JOB" \
+  "Verify content package integrity coverage" \
+  "the release must fail closed when content integrity companions are incomplete"
+require_text "$GORELEASER_JOB" \
+  "grep -Fq \"  \${artifact}.sbom.json\" checksums.txt" \
+  "content verification must require each SBOM in the final manifest"
+require_text "$GORELEASER_JOB" \
+  "test -s \"\${artifact}.sbom.json.cosign.bundle\"" \
+  "content verification must require each SBOM signature bundle"
+require_text "$GORELEASER_JOB" \
+  "artifacts+=(\"\${content_packages[@]}\")" \
+  "content packages must enter the integrity-processing artifact list"
+require_text "$GORELEASER_JOB" \
+  "for artifact in \"\${artifacts[@]}\"; do" \
+  "the processed artifact list must also drive the release upload list"
+require_text "$GORELEASER_JOB" \
+  "cosign sign-blob --yes --bundle \"\${artifact}.sbom.json.cosign.bundle\" \"\${artifact}.sbom.json\"" \
+  "generated SBOMs must receive their own keyless signature bundles"
+require_text "$GORELEASER_JOB" \
+  "sha256sum \"\${artifact}.sbom.json\" >> checksums.txt" \
+  "generated SBOMs must enter the final signed manifest and SLSA subject list"
+require_text "$GORELEASER_JOB" \
+  "uploads+=(\"\${artifact}\" \"\${artifact}.sbom.json\" \"\${artifact}.cosign.bundle\" \"\${artifact}.sbom.json.cosign.bundle\")" \
+  "each processed artifact and its integrity companions must enter the upload list"
+
+for command in "syft \"\${artifact}\"" \
+  "cosign sign-blob --yes --bundle \"\${artifact}.cosign.bundle\"" \
+  "sha256sum \"\${artifact}\" >> checksums.txt"; do
+  require_text "$GORELEASER_JOB" "$command" \
+    "the final release job is missing required content integrity command: $command"
+done
+
+VERIFY_LINE=$(grep -n "Verify content package integrity coverage" "$WORKFLOW" | cut -d: -f1)
+HASH_LINE=$(grep -n "Capture artifact hashes for SLSA provenance" "$WORKFLOW" | cut -d: -f1)
+if [ -z "$VERIFY_LINE" ] || [ -z "$HASH_LINE" ] || [ "$VERIFY_LINE" -ge "$HASH_LINE" ]; then
+  echo "content integrity verification must complete before SLSA subjects are captured"
+  exit 1
+fi
+
+if grep -Fq "mode: append" "$CONTENT_CONFIG"; then
+  echo "the content configuration must not retain an append-to-release path"
+  exit 1
+fi
+
+if ! awk '
+  /^release:$/ { release = 1; next }
+  release && /^[^ ]/ { exit }
+  release && $0 == "  disable: true" { found = 1 }
+  END { exit(found ? 0 : 1) }
+' "$CONTENT_CONFIG"; then
+  echo "the content GoReleaser configuration must disable SCM publication"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- build optional niac-content packages before the core release finalizes its artifact set
- include content packages and supplemental SBOMs in the signed checksum manifest, keyless signature coverage, uploads, and SLSA subjects
- add a fail-closed release workflow regression test and run it in CI

## Linked Issue

Closes #1068

## Testing Evidence

```text
./scripts/tests/release-content-integrity-test.sh
make test-hooks
shellcheck scripts/tests/release-content-integrity-test.sh
actionlint with the three documented pre-existing warnings filtered
goreleaser check .goreleaser.yml
goreleaser check .goreleaser.content.yml
real content-package dry run: exactly one DEB and one RPM produced
make lint
make fmt-check
make test
make security
make build
codex exec review --uncommitted: no actionable regressions
```

All listed gates passed. The local build retained the separately tracked Node/npm pin warning and existing bundle/native-library warnings.

## Security and Release Checklist

- [x] final checksums manifest covers content DEB/RPM files and generated supplemental SBOMs
- [x] content packages and SBOMs receive Cosign bundles
- [x] final manifest drives SLSA subjects
- [x] release fails closed when content integrity companions are incomplete
- [x] independent review completed with no actionable findings