### PR TITLE
fix(release): keep content handoff outside checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,11 +296,14 @@ jobs:
           path: windows-raw/
 
       - name: Download prebuilt niac-content packages
+        # Download before publication so transfer failures cannot leave a
+        # partial public release, but keep the files outside the checkout so
+        # GoReleaser's clean-worktree validation remains authoritative.
         if: needs.niac-content.outputs.has_content == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: niac-content-packages
-          path: content-packages/
+          path: ${{ runner.temp }}/niac-content-packages/
 
       - name: Install Syft (SBOM) inside container
         env:
@@ -407,7 +410,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          packages=(content-packages/*.deb content-packages/*.rpm)
+          packages=("${RUNNER_TEMP}"/niac-content-packages/*.deb "${RUNNER_TEMP}"/niac-content-packages/*.rpm)
           if [ "${#packages[@]}" -ne 2 ]; then
             echo "::error::expected one niac-content DEB and one RPM, found ${#packages[@]}"
             exit 1

--- a/scripts/tests/release-content-integrity-test.sh
+++ b/scripts/tests/release-content-integrity-test.sh
@@ -84,6 +84,13 @@ if [ -z "$VERIFY_LINE" ] || [ -z "$HASH_LINE" ] || [ "$VERIFY_LINE" -ge "$HASH_L
   exit 1
 fi
 
+require_text "$GORELEASER_JOB" \
+  "path: \${{ runner.temp }}/niac-content-packages/" \
+  "content packages must be downloaded outside the repository checkout"
+require_text "$GORELEASER_JOB" \
+  "packages=(\"\${RUNNER_TEMP}\"/niac-content-packages/*.deb \"\${RUNNER_TEMP}\"/niac-content-packages/*.rpm)" \
+  "the core release must consume content packages from runner temporary storage"
+
 if grep -Fq "mode: append" "$CONTENT_CONFIG"; then
   echo "the content configuration must not retain an append-to-release path"
   exit 1


### PR DESCRIPTION
## Summary

- download prebuilt content packages into runner temporary storage before publication
- preserve GoReleaser clean-worktree validation without creating a partial-release transfer failure window
- extend the release contract test to enforce the checkout-external handoff

## Linked Issue

Closes #1068

## Testing Evidence

```text
v0.94.12 release run 30051925078 reproduced the dirty-worktree failure
./scripts/tests/release-content-integrity-test.sh
make test-hooks
shellcheck scripts/tests/release-content-integrity-test.sh
actionlint with documented pre-existing warnings filtered
make lint
make fmt-check
make test
make security
make build
codex exec review --uncommitted: no actionable regressions
```

All listed gates passed.

## Security and Release Checklist

- [x] content transfer completes before public release publication
- [x] downloaded content remains outside the Git checkout
- [x] GoReleaser clean-worktree validation remains fail-closed
- [x] downstream integrity and provenance processing still consumes both content packages
- [x] independent review completed with no actionable findings