### PR TITLE
fix(deps): update foundation to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MustardSeedNetworks/niac-go
 go 1.26.5
 
 require (
-	github.com/MustardSeedNetworks/foundation v0.2.0
+	github.com/MustardSeedNetworks/foundation v0.2.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/MustardSeedNetworks/foundation v0.2.0 h1:YUXlbT2PmxvXSF/v9Yjym1K/AgGlUXjtASwhWBAMaCY=
-github.com/MustardSeedNetworks/foundation v0.2.0/go.mod h1:AV8k4d1dRdr9s8abBh+pYze24UceV5A6fXwWBn7RH1k=
+github.com/MustardSeedNetworks/foundation v0.2.1 h1:VeGrgs27rDh3WI5tQPSrd003TDmVshb7KH5OI5c3YYg=
+github.com/MustardSeedNetworks/foundation v0.2.1/go.mod h1:AV8k4d1dRdr9s8abBh+pYze24UceV5A6fXwWBn7RH1k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=


### PR DESCRIPTION
## Summary
- consume foundation v0.2.1
- stabilize hardware fingerprints across concurrent and consecutive license managers
- retain activation state across manager reloads

## Linked Issue
Related to #1053. Delivers [foundation#2](https://github.com/MustardSeedNetworks/foundation/issues/2).

## Testing Evidence
```text
go test -race -count=20 ./internal/license -run TestActivationLifecycle|TestPersistedProStateUsesCurrentFeaturePolicy: PASS
make lint: PASS (0 issues)
make fmt-check: PASS
make test: PASS (41 Go packages, 63 frontend files, hooks)
make security: PASS (govulncheck, npm audit, gitleaks)
make build: PASS
codex exec review --uncommitted: PASS
```

## Security and Release Checklist
- [x] No secrets or credentials changed
- [x] Shared security-core release is pinned exactly
- [x] Race and vulnerability gates pass
- [x] No customer-facing behavior or release assets changed
