### PR TITLE
fix(protocols): bound UDP proxy concurrency

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -179,6 +179,7 @@ The dashboard will display:
 | `niac_packets_received_total` | counter | Total packets received |
 | `niac_devices_total` | gauge | Number of simulated devices |
 | `niac_errors_total` | counter | Total errors |
+| `niac_udp_proxy_overload_drops_total` | counter | UDP `map_to_ip` packets dropped at the 64-operation proxy limit |
 
 ### Protocol-Specific Metrics
 

--- a/internal/api/handlers_metrics.go
+++ b/internal/api/handlers_metrics.go
@@ -43,6 +43,13 @@ func writeBasicMetrics(w io.Writer, stats *protocols.Statistics, deviceCount int
 	writePrometheusMetric(w, "niac_errors_total", "Total errors", "counter", stats.Errors)
 	writePrometheusMetric(
 		w,
+		"niac_udp_proxy_overload_drops_total",
+		"UDP map_to_ip packets dropped at the proxy concurrency limit",
+		"counter",
+		stats.UDPProxyOverloadDrops,
+	)
+	writePrometheusMetric(
+		w,
 		"niac_devices_total",
 		"Number of simulated devices",
 		"gauge",

--- a/internal/api/handlers_metrics_test.go
+++ b/internal/api/handlers_metrics_test.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+)
+
+func TestBasicMetricsIncludesUDPProxyOverloadDrops(t *testing.T) {
+	t.Parallel()
+
+	var output strings.Builder
+	writeBasicMetrics(&output, &protocols.Statistics{UDPProxyOverloadDrops: 3}, 0)
+
+	if !strings.Contains(output.String(), "niac_udp_proxy_overload_drops_total 3\n") {
+		t.Fatalf("metrics missing UDP proxy overload counter:\n%s", output.String())
+	}
+}

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -49,16 +49,17 @@ func (s *Server) handleStats(w http.ResponseWriter, _ *http.Request) {
 		"device_count": deviceCount,
 		"goroutines":   goroutineCount, // FEATURE #119: Monitor goroutine count
 		"stack": map[string]uint64{
-			"packets_sent":     stats.PacketsSent,
-			"packets_received": stats.PacketsReceived,
-			"arp_requests":     stats.ARPRequests,
-			"arp_replies":      stats.ARPReplies,
-			"icmp_requests":    stats.ICMPRequests,
-			"icmp_replies":     stats.ICMPReplies,
-			"dns_queries":      stats.DNSQueries,
-			"dhcp_requests":    stats.DHCPRequests,
-			"snmp_queries":     stats.SNMPQueries,
-			"errors":           stats.Errors,
+			"packets_sent":             stats.PacketsSent,
+			"packets_received":         stats.PacketsReceived,
+			"arp_requests":             stats.ARPRequests,
+			"arp_replies":              stats.ARPReplies,
+			"icmp_requests":            stats.ICMPRequests,
+			"icmp_replies":             stats.ICMPReplies,
+			"dns_queries":              stats.DNSQueries,
+			"dhcp_requests":            stats.DHCPRequests,
+			"snmp_queries":             stats.SNMPQueries,
+			"errors":                   stats.Errors,
+			"udp_proxy_overload_drops": stats.UDPProxyOverloadDrops,
 		},
 	}
 	s.writeJSON(w, payload)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -88,6 +88,16 @@ func TestHandleStats(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
+
+	var response struct {
+		Stack map[string]uint64 `json:"stack"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := response.Stack["udp_proxy_overload_drops"]; !ok {
+		t.Fatal("response missing udp_proxy_overload_drops")
+	}
 }
 
 func TestHandleDevices(t *testing.T) {

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -150,19 +150,20 @@ type PacketObserver interface {
 
 // Statistics holds protocol statistics.
 type Statistics struct {
-	mu              sync.RWMutex
-	PacketsReceived uint64
-	PacketsSent     uint64
-	ARPRequests     uint64
-	ARPReplies      uint64
-	ICMPRequests    uint64
-	ICMPReplies     uint64
-	DNSQueries      uint64
-	DHCPRequests    uint64
-	SNMPQueries     uint64
-	Errors          uint64
-	FabricForwarded uint64
-	FabricDrops     uint64
+	mu                    sync.RWMutex
+	PacketsReceived       uint64
+	PacketsSent           uint64
+	ARPRequests           uint64
+	ARPReplies            uint64
+	ICMPRequests          uint64
+	ICMPReplies           uint64
+	DNSQueries            uint64
+	DHCPRequests          uint64
+	SNMPQueries           uint64
+	Errors                uint64
+	FabricForwarded       uint64
+	FabricDrops           uint64
+	UDPProxyOverloadDrops uint64
 }
 
 // NewStack creates a new protocol stack.
@@ -366,6 +367,7 @@ func (s *Stack) Stop() {
 	s.cdpHandler.Stop()
 	s.edpHandler.Stop()
 	s.fdpHandler.Stop()
+	s.udpHandler.Stop()
 
 	close(s.stopChan)
 	s.notifications.Reset()
@@ -516,19 +518,26 @@ func (s *Stack) GetStats() Statistics {
 
 	// Return copy of data without mutex
 	return Statistics{
-		PacketsReceived: s.stats.PacketsReceived,
-		PacketsSent:     s.stats.PacketsSent,
-		ARPRequests:     s.stats.ARPRequests,
-		ARPReplies:      s.stats.ARPReplies,
-		ICMPRequests:    s.stats.ICMPRequests,
-		ICMPReplies:     s.stats.ICMPReplies,
-		DNSQueries:      s.stats.DNSQueries,
-		DHCPRequests:    s.stats.DHCPRequests,
-		SNMPQueries:     s.stats.SNMPQueries,
-		Errors:          s.stats.Errors,
-		FabricForwarded: s.stats.FabricForwarded,
-		FabricDrops:     s.stats.FabricDrops,
+		PacketsReceived:       s.stats.PacketsReceived,
+		PacketsSent:           s.stats.PacketsSent,
+		ARPRequests:           s.stats.ARPRequests,
+		ARPReplies:            s.stats.ARPReplies,
+		ICMPRequests:          s.stats.ICMPRequests,
+		ICMPReplies:           s.stats.ICMPReplies,
+		DNSQueries:            s.stats.DNSQueries,
+		DHCPRequests:          s.stats.DHCPRequests,
+		SNMPQueries:           s.stats.SNMPQueries,
+		Errors:                s.stats.Errors,
+		FabricForwarded:       s.stats.FabricForwarded,
+		FabricDrops:           s.stats.FabricDrops,
+		UDPProxyOverloadDrops: s.stats.UDPProxyOverloadDrops,
 	}
+}
+
+func (s *Stack) recordUDPProxyOverloadDrop() {
+	s.stats.mu.Lock()
+	s.stats.UDPProxyOverloadDrops++
+	s.stats.mu.Unlock()
 }
 
 func (s *Stack) IncrementStat(stat string) {

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -1,10 +1,13 @@
 package protocols
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"slices"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gopacket/gopacket"
@@ -28,6 +31,9 @@ const (
 	udpBroadcastOctet = 255  // Broadcast IP octet (255.255.255.255)
 	udpProxyTimeoutS  = 30   // Proxy timeout in seconds
 	udpProxyBufSize   = 1500 // Proxy buffer size (MTU)
+	// A fixed process-local limit prevents map_to_ip bursts from exhausting
+	// sockets and goroutines while keeping independent devices responsive.
+	udpProxyConcurrencyLimit = 64
 )
 
 // IP protocol constants for UDP handler.
@@ -60,13 +66,30 @@ const (
 
 // UDPHandler handles UDP packets.
 type UDPHandler struct {
-	stack *Stack
+	stack       *Stack
+	proxyCtx    context.Context
+	cancelProxy context.CancelFunc
+	proxySlots  chan struct{}
+	proxyWG     sync.WaitGroup
+	proxyMu     sync.Mutex
+	proxyConns  map[net.Conn]struct{}
+	stopped     bool
+	dial        func(context.Context, string) (net.Conn, error)
 }
 
 // NewUDPHandler creates a new UDP handler.
 func NewUDPHandler(stack *Stack) *UDPHandler {
+	ctx, cancel := context.WithCancel(context.Background())
+	dialer := &net.Dialer{}
 	return &UDPHandler{
-		stack: stack,
+		stack:       stack,
+		proxyCtx:    ctx,
+		cancelProxy: cancel,
+		proxySlots:  make(chan struct{}, udpProxyConcurrencyLimit),
+		proxyConns:  make(map[net.Conn]struct{}),
+		dial: func(ctx context.Context, address string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "udp", address)
+		},
 	}
 }
 
@@ -200,46 +223,136 @@ func (h *UDPHandler) proxyToMap(device *config.Device, ipLayer *layers.IPv4, udp
 		return
 	}
 
+	srcIP := ipLayer.DstIP.To4()
+	dstIP := ipLayer.SrcIP.To4()
+	if srcIP == nil || dstIP == nil {
+		return
+	}
+
+	request := udpProxyRequest{
+		address: net.JoinHostPort(device.MapToIP.String(), strconv.Itoa(int(udp.DstPort))),
+		payload: slices.Clone(udp.Payload),
+		srcIP:   slices.Clone(srcIP),
+		dstIP:   slices.Clone(dstIP),
+		srcPort: uint16(udp.DstPort),
+		dstPort: uint16(udp.SrcPort),
+		srcMAC:  slices.Clone(identity.source),
+		dstMAC:  slices.Clone(identity.destination),
+		vlan:    identity.vlan,
+	}
+	h.launchProxy(func(ctx context.Context) {
+		h.runProxy(ctx, request)
+	})
+}
+
+type udpProxyRequest struct {
+	address string
+	payload []byte
+	srcIP   []byte
+	dstIP   []byte
+	srcPort uint16
+	dstPort uint16
+	srcMAC  []byte
+	dstMAC  []byte
+	vlan    int
+}
+
+func (h *UDPHandler) launchProxy(work func(context.Context)) bool {
+	h.proxyMu.Lock()
+	if h.stopped {
+		h.proxyMu.Unlock()
+		return false
+	}
+	select {
+	case h.proxySlots <- struct{}{}:
+		h.proxyWG.Add(1)
+		h.proxyMu.Unlock()
+	default:
+		h.proxyMu.Unlock()
+		h.stack.recordUDPProxyOverloadDrop()
+		return false
+	}
+
 	go func() {
-		dstAddr := &net.UDPAddr{IP: device.MapToIP, Port: int(udp.DstPort)}
-
-		conn, err := net.DialUDP("udp", nil, dstAddr)
-		if err != nil {
-			return
-		}
-
-		defer func() { _ = conn.Close() }()
-
-		_ = conn.SetDeadline(time.Now().Add(udpProxyTimeoutS * time.Second))
-
-		_, writeErr := conn.Write(udp.Payload)
-		if writeErr != nil {
-			return
-		}
-
-		buf := make([]byte, udpProxyBufSize)
-
-		n, readErr := conn.Read(buf)
-		if readErr != nil || n <= 0 {
-			return
-		}
-
-		srcIP := ipLayer.DstIP.To4()
-		if srcIP == nil {
-			return
-		}
-
-		_ = h.SendUDP(
-			srcIP,
-			ipLayer.SrcIP.To4(),
-			uint16(udp.DstPort),
-			uint16(udp.SrcPort),
-			buf[:n],
-			[]byte(identity.source),
-			[]byte(identity.destination),
-			identity.vlan,
-		)
+		defer func() {
+			<-h.proxySlots
+			h.proxyWG.Done()
+		}()
+		work(h.proxyCtx)
 	}()
+	return true
+}
+
+func (h *UDPHandler) runProxy(ctx context.Context, request udpProxyRequest) {
+	conn, err := h.dial(ctx, request.address)
+	if err != nil || !h.trackProxyConn(conn) {
+		return
+	}
+	defer func() {
+		h.untrackProxyConn(conn)
+		_ = conn.Close()
+	}()
+
+	_ = conn.SetDeadline(time.Now().Add(udpProxyTimeoutS * time.Second))
+	if _, err = conn.Write(request.payload); err != nil {
+		return
+	}
+
+	buf := make([]byte, udpProxyBufSize)
+	n, err := conn.Read(buf)
+	if err != nil || n <= 0 {
+		return
+	}
+
+	_ = h.SendUDP(
+		request.srcIP,
+		request.dstIP,
+		request.srcPort,
+		request.dstPort,
+		buf[:n],
+		request.srcMAC,
+		request.dstMAC,
+		request.vlan,
+	)
+}
+
+func (h *UDPHandler) trackProxyConn(conn net.Conn) bool {
+	h.proxyMu.Lock()
+	defer h.proxyMu.Unlock()
+	if h.stopped {
+		_ = conn.Close()
+		return false
+	}
+	h.proxyConns[conn] = struct{}{}
+	return true
+}
+
+func (h *UDPHandler) untrackProxyConn(conn net.Conn) {
+	h.proxyMu.Lock()
+	delete(h.proxyConns, conn)
+	h.proxyMu.Unlock()
+}
+
+// Stop cancels proxy dialing, closes in-flight sockets, and waits for all
+// admitted work to release its slot.
+func (h *UDPHandler) Stop() {
+	h.proxyMu.Lock()
+	if h.stopped {
+		h.proxyMu.Unlock()
+		return
+	}
+	h.stopped = true
+	h.cancelProxy()
+	conns := make([]net.Conn, 0, len(h.proxyConns))
+	for conn := range h.proxyConns {
+		conns = append(conns, conn)
+	}
+	h.proxyMu.Unlock()
+
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+	h.proxyWG.Wait()
 }
 
 // SendUDP sends a UDP packet with a default (zero) ToS byte.

--- a/internal/protocols/udp_proxy_test.go
+++ b/internal/protocols/udp_proxy_test.go
@@ -1,0 +1,121 @@
+package protocols
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestUDPProxyConcurrencyIsBoundedAndObservable(t *testing.T) {
+	t.Parallel()
+
+	stack := &Stack{stats: &Statistics{}}
+	handler := NewUDPHandler(stack)
+	started := make(chan struct{}, udpProxyConcurrencyLimit)
+	release := make(chan struct{})
+
+	for range udpProxyConcurrencyLimit {
+		if !handler.launchProxy(func(context.Context) {
+			started <- struct{}{}
+			<-release
+		}) {
+			t.Fatal("proxy work rejected before reaching concurrency limit")
+		}
+	}
+	for range udpProxyConcurrencyLimit {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("proxy work did not start")
+		}
+	}
+
+	if handler.launchProxy(func(context.Context) {}) {
+		t.Fatal("proxy work admitted above concurrency limit")
+	}
+	if got := stack.GetStats().UDPProxyOverloadDrops; got != 1 {
+		t.Fatalf("UDP proxy overload drops = %d, want 1", got)
+	}
+
+	close(release)
+	handler.Stop()
+}
+
+func TestUDPProxyStopClosesBlockedConnection(t *testing.T) {
+	t.Parallel()
+
+	stack := &Stack{stats: &Statistics{}}
+	handler := NewUDPHandler(stack)
+	conn := newBlockingProxyConn()
+	handler.dial = func(context.Context, string) (net.Conn, error) {
+		return conn, nil
+	}
+
+	request := udpProxyRequest{
+		address: "192.0.2.1:9999",
+		payload: []byte("probe"),
+	}
+	if !handler.launchProxy(func(ctx context.Context) {
+		handler.runProxy(ctx, request)
+	}) {
+		t.Fatal("proxy work rejected")
+	}
+
+	select {
+	case <-conn.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("proxy did not block waiting for a reply")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		handler.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("UDP proxy shutdown did not close the blocked connection")
+	}
+}
+
+type blockingProxyConn struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	closeOnce   sync.Once
+}
+
+func newBlockingProxyConn() *blockingProxyConn {
+	return &blockingProxyConn{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (c *blockingProxyConn) Read([]byte) (int, error) {
+	close(c.readStarted)
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingProxyConn) Write(payload []byte) (int, error) {
+	return len(payload), nil
+}
+
+func (c *blockingProxyConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (*blockingProxyConn) LocalAddr() net.Addr              { return nil }
+func (*blockingProxyConn) RemoteAddr() net.Addr             { return nil }
+func (*blockingProxyConn) SetDeadline(time.Time) error      { return nil }
+func (*blockingProxyConn) SetReadDeadline(time.Time) error  { return nil }
+func (*blockingProxyConn) SetWriteDeadline(time.Time) error { return nil }
+
+var _ net.Conn = (*blockingProxyConn)(nil)


### PR DESCRIPTION
## Summary
- cap concurrent UDP `map_to_ip` proxy operations at 64
- drop excess packets and expose the overload counter through stats and Prometheus
- close tracked sockets and wait for admitted proxy work during stack shutdown
- copy packet data before asynchronous processing to avoid buffer reuse races

## Linked Issue
Closes #1041.

## Testing Evidence
```text
go test -race ./internal/protocols ./internal/api -run TestUDPProxy|TestHandleStats|TestBasicMetricsIncludesUDPProxyOverloadDrops -count=20: PASS
make lint: PASS (0 issues)
make fmt-check: PASS
make test: PASS (41 Go packages, 63 frontend files, hooks)
make security: PASS (govulncheck, npm audit, gitleaks)
make build: PASS
codex exec review --base main: PASS
```

## Security and Release Checklist
- [x] Resource exhaustion boundary is explicit and tested
- [x] Shutdown closes in-flight network resources promptly
- [x] Overload is observable in REST stats and Prometheus
- [x] Race, security, lint, formatting, test, and build gates pass
