### PR TITLE
fix(auth): secure browser API sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -858,6 +858,10 @@ jobs:
         # tablet/visual projects were deleted from playwright.config.ts.
         run: npx playwright test --reporter=html
 
+      - name: Run authenticated browser E2E tests
+        working-directory: ui
+        run: npm run test:e2e:auth
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/docs/WEBUI.md
+++ b/docs/WEBUI.md
@@ -242,7 +242,7 @@ View recent protocol errors:
 **Solutions:**
 1. Verify `NIAC_API_TOKEN` is set correctly
 2. Check token was copied completely (no whitespace)
-3. Clear browser localStorage and re-enter token
+3. Reload the page and re-enter the token
 4. Check server logs for token mismatch
 
 ### CSRF Token Errors
@@ -253,7 +253,7 @@ View recent protocol errors:
 1. Refresh page to get new CSRF token
 2. Check browser console for errors
 3. Clear cache and reload
-4. Ensure cookies/localStorage enabled
+4. Ensure browser storage is available for non-sensitive UI preferences
 
 ### Slow Performance
 
@@ -396,7 +396,7 @@ Dark mode support is planned but not yet implemented. Current theme is light onl
 ### Authentication
 
 - API token required for all operations
-- Token stored in browser localStorage
+- Token kept only in the active tab's memory and cleared on page close or reload
 - No session management (stateless)
 - Token transmitted in Authorization header
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -85,6 +85,13 @@ func addSecurityHeaders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 }
 
+func withSecurityHeaders(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		addSecurityHeaders(w, r)
+		next(w, r)
+	}
+}
+
 // recoverMiddleware recovers from panics in HTTP handlers to prevent server crashes
 // SECURITY FIX #2.8.1: Add panic recovery to prevent single malformed request from crashing API.
 func (s *Server) recoverMiddleware(next http.HandlerFunc) http.HandlerFunc {

--- a/internal/api/route_test.go
+++ b/internal/api/route_test.go
@@ -178,3 +178,45 @@ func TestMethodGateRejectsWrongMethod(t *testing.T) {
 		t.Errorf("Allow header = %q, want %q", allow, http.MethodGet)
 	}
 }
+
+func TestSPAIsPublicButAPIRemainsAuthenticated(t *testing.T) {
+	server, _, token := newTestServerWithAuth(t)
+	server.writeLimiter = ratelimit.NewRateLimiter(WriteRateLimit, WriteBurst)
+	mux := http.NewServeMux()
+	server.registerAPIRoutes(mux)
+
+	spaReq := httptest.NewRequest(http.MethodGet, "https://niac.example/", nil)
+	spaRec := httptest.NewRecorder()
+	mux.ServeHTTP(spaRec, spaReq)
+	if spaRec.Code == http.StatusUnauthorized {
+		t.Fatal("GET / without bearer returned 401; the SPA cannot bootstrap its auth prompt")
+	}
+	for _, header := range []string{
+		"Content-Security-Policy",
+		"Strict-Transport-Security",
+		"X-Content-Type-Options",
+		"X-Frame-Options",
+	} {
+		if spaRec.Header().Get(header) == "" {
+			t.Errorf("GET / without bearer omitted %s", header)
+		}
+	}
+
+	apiReq := httptest.NewRequest(http.MethodGet, "/api/v1/auth/scope", nil)
+	apiRec := httptest.NewRecorder()
+	mux.ServeHTTP(apiRec, apiReq)
+	if apiRec.Code != http.StatusUnauthorized {
+		t.Fatalf("GET /api/v1/auth/scope without bearer: status = %d, want 401", apiRec.Code)
+	}
+
+	missingReq := httptest.NewRequest(http.MethodGet, "/api/v1/missing", nil)
+	missingReq.Header.Set("Authorization", "Bearer "+token)
+	missingRec := httptest.NewRecorder()
+	mux.ServeHTTP(missingRec, missingReq)
+	if missingRec.Code != http.StatusNotFound {
+		t.Fatalf("GET unknown /api path with bearer: status = %d, want 404", missingRec.Code)
+	}
+	if got := missingRec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("GET unknown /api path Content-Type = %q, want application/json", got)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -14,7 +14,8 @@ import (
 // CSRF, admin scope, license feature — in one canonical order so a route cannot
 // ship without it. scripts/check-route-policy.sh enforces this. Only the
 // unauthenticated introspection endpoints (/__version, /__capabilities) are
-// registered directly.
+// registered directly. The SPA shell is also public so it can collect a bearer
+// token in browser memory before calling the protected API.
 func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 	// Unauthenticated introspection (no auth wrapper).
 	mux.HandleFunc("/__version", s.recoverMiddleware(s.handleBuildVersion))
@@ -36,12 +37,36 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 	s.registerPcapRoutes(mux)
 	s.registerSSERoutes(mux)
 
-	// Metrics require auth (#172); the SPA is the authenticated catch-all.
+	// Metrics require auth (#172).
 	s.registerAll(mux, []apiRoute{
 		{path: "/metrics", handler: s.handleMetrics, methods: []string{http.MethodGet}},
-		// The SPA serves static assets only; HEAD is honored for asset probes.
-		{path: "/", handler: s.serveSPA(), methods: []string{http.MethodGet, http.MethodHead}},
+		{
+			path:    "/api/",
+			handler: s.handleAPINotFound,
+			methods: []string{
+				http.MethodGet,
+				http.MethodHead,
+				http.MethodPost,
+				http.MethodPut,
+				http.MethodPatch,
+				http.MethodDelete,
+				http.MethodOptions,
+			},
+		},
 	})
+
+	// Static assets contain no privileged data. Serving the shell without auth
+	// lets the browser prompt for a token; all data still comes from protected
+	// /api routes and the token never enters a URL.
+	mux.HandleFunc("/", s.recoverMiddleware(
+		withSecurityHeaders(
+			s.methodGate([]string{http.MethodGet, http.MethodHead}, s.serveSPA()),
+		),
+	))
+}
+
+func (s *Server) handleAPINotFound(w http.ResponseWriter, r *http.Request) {
+	writeError(w, r, http.StatusNotFound, "not_found", "API endpoint not found", nil)
 }
 
 // registerWriteProtectedRoutes registers state-changing routes (write rate

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -21,6 +21,17 @@
     "tagline": "Network protocol simulator and packet inspector",
     "title": "NIAC"
   },
+  "auth": {
+    "checking": "Checking access...",
+    "connect": "Connect",
+    "connectionFailed": "NIAC could not be reached. Check the daemon and try again.",
+    "description": "Enter the API token configured for this NIAC daemon.",
+    "invalidToken": "That API token was rejected.",
+    "memoryOnly": "The token is kept only in this tab's memory and is cleared when the page closes.",
+    "sessionExpired": "Your session is no longer authorized. Enter the API token again.",
+    "title": "Connect to NIAC",
+    "tokenLabel": "API token"
+  },
   "buttons": {
     "add": "Add",
     "apply": "Apply",

--- a/internal/i18n/locales/es/common.json
+++ b/internal/i18n/locales/es/common.json
@@ -5,6 +5,17 @@
     "fullName": "Network In A Can",
     "tagline": "Simulador de protocolos de red e inspector de paquetes"
   },
+  "auth": {
+    "title": "Conectar a NIAC",
+    "description": "Introduzca el token de API configurado para este demonio NIAC.",
+    "tokenLabel": "Token de API",
+    "connect": "Conectar",
+    "checking": "Comprobando el acceso...",
+    "invalidToken": "Ese token de API fue rechazado.",
+    "connectionFailed": "No se pudo acceder a NIAC. Compruebe el demonio e inténtelo de nuevo.",
+    "sessionExpired": "Su sesión ya no está autorizada. Introduzca de nuevo el token de API.",
+    "memoryOnly": "El token se conserva solo en la memoria de esta pestaña y se borra al cerrar la página."
+  },
   "buttons": {
     "save": "Guardar",
     "cancel": "Cancelar",

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -124,6 +124,7 @@ test-e2e: build ## Build and run frontend E2E tests against the HTTPS daemon
 	echo "   📦 Running $$E2E_COUNT spec files..."
 	@echo ""
 	@cd $(UI_DIR) && npm run test:e2e
+	@cd $(UI_DIR) && npm run test:e2e:auth
 	@echo ""
 	@echo "✅ E2E tests complete"
 

--- a/ui/e2e/browser-auth.auth.ts
+++ b/ui/e2e/browser-auth.auth.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+const authToken = 'niac-e2e-browser-auth-token'; // gitleaks:allow — local test fixture
+
+test('authenticates production REST and SSE traffic without persisting the bearer', async ({
+  page,
+}) => {
+  const protectedResponses: Array<{ url: string; status: number }> = [];
+  page.on('response', (response) => {
+    if (response.url().includes('/api/v1/')) {
+      protectedResponses.push({ url: response.url(), status: response.status() });
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.getByTestId('api-token-input')).toBeVisible();
+  await page.getByTestId('api-token-input').fill(authToken);
+  await page.getByRole('button', { name: 'Connect' }).click();
+
+  await expect(page.getByRole('navigation')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect
+    .poll(() =>
+      protectedResponses.some(
+        (response) => response.url.endsWith('/api/v1/auth/scope') && response.status === 200,
+      ),
+    )
+    .toBe(true);
+
+  await page.getByRole('link', { name: /Debug/i }).click();
+  await expect
+    .poll(() =>
+      protectedResponses.some(
+        (response) => response.url.endsWith('/api/v1/stream/logs') && response.status === 200,
+      ),
+    )
+    .toBe(true);
+
+  expect(page.url()).not.toContain(authToken);
+  const persistedValues = await page.evaluate(() => [
+    ...Object.values({ ...localStorage }),
+    ...Object.values({ ...sessionStorage }),
+  ]);
+  expect(persistedValues).not.toContain(authToken);
+});

--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -31,8 +31,7 @@ test.describe('Dashboard', () => {
   test('should have quick access links', async ({ page }) => {
     // Check for navigation links to main pages
     const navLinks = page.locator('a, [role="link"]');
-    const count = await navLinks.count();
-    expect(count).toBeGreaterThan(0);
+    await expect(navLinks.first()).toBeVisible();
   });
 
   // Dropped: "should display device count or empty-state hint". It

--- a/ui/e2e/language-switch.spec.ts
+++ b/ui/e2e/language-switch.spec.ts
@@ -96,7 +96,6 @@ test.describe('Language switching', () => {
     // Either Spanish device-count phrasing should be on the page, OR
     // the noInterface fallback if no simulation is running. Both are
     // valid post-Phase-5 ES outputs.
-    const body = await page.locator('body').textContent();
-    expect(body).toMatch(/dispositivo|Sin interfaz/i);
+    await expect(page.locator('body')).toContainText(/dispositivo|Sin interfaz/i);
   });
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
     "test:watch": "node --disable-warning=DEP0205 ./node_modules/vitest/vitest.mjs --reporter=dot",
     "test:coverage": "node --disable-warning=DEP0205 ./node_modules/vitest/vitest.mjs run --coverage --reporter=verbose",
     "test:e2e": "NO_COLOR= node --disable-warning=DEP0205 ./node_modules/playwright/cli.js test --reporter=list",
+    "test:e2e:auth": "NO_COLOR= node --disable-warning=DEP0205 ./node_modules/playwright/cli.js test --config=playwright.auth.config.ts --reporter=list",
     "test:e2e:fullstack": "NO_COLOR= node --disable-warning=DEP0205 ./node_modules/playwright/cli.js test --config=playwright.fullstack.config.ts --reporter=list",
     "i18n:extract": "i18next-cli extract",
     "i18n:check": "node scripts/check-i18n-extraction.ts",

--- a/ui/playwright.auth.config.ts
+++ b/ui/playwright.auth.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   use: {
     ...baseConfig.use,
     baseURL: `https://127.0.0.1:${authPort}`,
+    ignoreHTTPSErrors: true,
     storageState: undefined,
   },
   webServer: {

--- a/ui/playwright.auth.config.ts
+++ b/ui/playwright.auth.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+const authPort = '18446';
+const authToken = 'niac-e2e-browser-auth-token'; // gitleaks:allow — local test fixture
+
+export default defineConfig({
+  ...baseConfig,
+  testMatch: 'browser-auth.auth.ts',
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    ...baseConfig.use,
+    baseURL: `https://127.0.0.1:${authPort}`,
+    storageState: undefined,
+  },
+  webServer: {
+    command: `cd .. && NIAC_API_TOKEN=${authToken} ./niac daemon --listen 127.0.0.1:${authPort} --storage disabled`,
+    url: `https://127.0.0.1:${authPort}/__version`,
+    reuseExistingServer: false,
+    timeout: 120000,
+    ignoreHTTPSErrors: true,
+  },
+});

--- a/ui/src/api/requestCore.ts
+++ b/ui/src/api/requestCore.ts
@@ -17,6 +17,9 @@ import { ApiError, type ApiErrorDetail, NetworkError, TimeoutError } from './err
 const API_BASE = import.meta.env.VITE_API_BASE ?? '';
 // API_TOKEN is only used in development mode to avoid embedding secrets in production bundles.
 const API_TOKEN = import.meta.env.DEV ? (import.meta.env.VITE_API_TOKEN ?? '') : '';
+export const AUTH_FAILURE_EVENT = 'niac:authentication-required';
+
+let runtimeAPIToken = '';
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   value !== null &&
@@ -82,6 +85,32 @@ const CSRF_TOKEN_PATH = '/api/v1/csrf-token';
 
 let csrfTokenPromise: Promise<string> | null = null;
 
+export function setRuntimeAPIToken(token: string) {
+  runtimeAPIToken = token;
+  csrfTokenPromise = null;
+}
+
+export function clearRuntimeAPIToken() {
+  runtimeAPIToken = '';
+  csrfTokenPromise = null;
+}
+
+function activeAPIToken() {
+  return runtimeAPIToken || API_TOKEN;
+}
+
+export function notifyAuthenticationRequired() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(AUTH_FAILURE_EVENT));
+  }
+}
+
+export function notifyIfAuthenticationFailed(status: number) {
+  if (status === 401) {
+    notifyAuthenticationRequired();
+  }
+}
+
 interface RetryConfig {
   readonly maxRetries: number;
   readonly baseDelay: number;
@@ -105,8 +134,9 @@ async function fetchCSRFToken() {
   csrfTokenPromise = (async () => {
     const headers = new Headers();
     headers.set('Accept', 'application/json');
-    if (API_TOKEN) {
-      headers.set('Authorization', `Bearer ${API_TOKEN}`);
+    const token = activeAPIToken();
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
     }
 
     const response = await fetch(buildUrl(CSRF_TOKEN_PATH), {
@@ -114,6 +144,7 @@ async function fetchCSRFToken() {
       credentials: 'same-origin',
     });
     if (!response.ok) {
+      notifyIfAuthenticationFailed(response.status);
       const text = await response.text();
       throw new ApiError(text || response.statusText, response.status);
     }
@@ -147,14 +178,27 @@ function resetCSRFToken() {
 export async function buildRequestHeaders(path: string, init: RequestInit) {
   const headers = new Headers(init.headers);
   headers.set('Accept', 'application/json');
-  if (API_TOKEN) {
-    headers.set('Authorization', `Bearer ${API_TOKEN}`);
+  const token = activeAPIToken();
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
   }
   if (isStateChangingMethod(init.method) && path !== CSRF_TOKEN_PATH) {
     headers.set('X-Csrf-Token', await fetchCSRFToken());
   }
 
   return headers;
+}
+
+export async function validateRuntimeAuthentication() {
+  const path = '/api/v1/auth/scope';
+  const headers = await buildRequestHeaders(path, { method: 'GET' });
+  const response = await fetch(buildUrl(path), {
+    headers,
+    credentials: 'same-origin',
+  });
+  if (!response.ok) {
+    throw parseApiError(await response.text(), response.status, response.statusText);
+  }
 }
 
 /**
@@ -242,6 +286,7 @@ export async function request<T>(
           continue;
         }
         const text = await response.text();
+        notifyIfAuthenticationFailed(response.status);
         // If the server rejected a stale CSRF token (typically because the
         // daemon was restarted and rotated its in-memory secret), drop the
         // cached token and retry once. Without this the SPA would keep
@@ -336,6 +381,9 @@ export async function requestText(path: string, init: RequestInit = {}): Promise
     });
 
     if (!response.ok) {
+      if (response.status === 401) {
+        notifyAuthenticationRequired();
+      }
       throw parseApiError(await response.text(), response.status, response.statusText);
     }
 

--- a/ui/src/api/requestUpload.test.ts
+++ b/ui/src/api/requestUpload.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearRuntimeAPIToken, setRuntimeAPIToken } from './requestCore';
+import { requestJsonWithProgress } from './requestUpload';
+
+class FakeXMLHttpRequest {
+  static latest: FakeXMLHttpRequest | null = null;
+
+  readonly upload = { onprogress: null as ((event: ProgressEvent) => void) | null };
+  status = 401;
+  statusText = 'Unauthorized';
+  responseText = 'Unauthorized';
+  timeout = 0;
+  withCredentials = false;
+  onabort: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onload: (() => void) | null = null;
+  ontimeout: (() => void) | null = null;
+
+  constructor() {
+    FakeXMLHttpRequest.latest = this;
+  }
+
+  open() {}
+  setRequestHeader() {}
+  abort() {
+    this.onabort?.();
+  }
+  send() {
+    this.onload?.();
+  }
+}
+
+describe('requestJsonWithProgress', () => {
+  beforeEach(() => {
+    clearRuntimeAPIToken();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-token' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    vi.stubGlobal('XMLHttpRequest', FakeXMLHttpRequest);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('raises the authentication event when an upload is unauthorized', async () => {
+    setRuntimeAPIToken('revoked-token');
+    const listener = vi.fn();
+    window.addEventListener('niac:authentication-required', listener);
+
+    await expect(requestJsonWithProgress('/api/v1/uploads', {}, vi.fn())).rejects.toThrow(
+      'Unauthorized',
+    );
+    expect(listener).toHaveBeenCalledOnce();
+
+    window.removeEventListener('niac:authentication-required', listener);
+  });
+});

--- a/ui/src/api/requestUpload.ts
+++ b/ui/src/api/requestUpload.ts
@@ -2,6 +2,7 @@ import { ApiError, NetworkError, TimeoutError } from './errors';
 import {
   buildRequestHeaders,
   buildUrl,
+  notifyIfAuthenticationFailed,
   parseApiError,
   toCamelCase,
   toSnakeCase,
@@ -68,6 +69,7 @@ export function requestJsonWithProgress<T>(
             }
             return;
           }
+          notifyIfAuthenticationFailed(xhr.status);
           reject(parseApiError(xhr.responseText, xhr.status, xhr.statusText));
         };
 

--- a/ui/src/api/runtimeAuth.test.ts
+++ b/ui/src/api/runtimeAuth.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('runtime bearer authentication', () => {
+  beforeEach(async () => {
+    mockFetch.mockReset();
+    const { clearRuntimeAPIToken } = await import('./requestCore');
+    clearRuntimeAPIToken();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('adds the runtime token to REST requests without persistent storage', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ scope: 'admin' }),
+    });
+
+    const { request, setRuntimeAPIToken } = await import('./requestCore');
+    setRuntimeAPIToken('browser-token');
+    await request('/api/v1/auth/scope');
+
+    const headers = mockFetch.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer browser-token');
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it('clears the bearer and cached CSRF token together', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ token: 'old-csrf' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ token: 'new-csrf' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      });
+
+    const { clearRuntimeAPIToken, request, setRuntimeAPIToken } = await import('./requestCore');
+    setRuntimeAPIToken('first-token');
+    await request('/api/v1/alerts', { method: 'PUT' });
+    clearRuntimeAPIToken();
+    setRuntimeAPIToken('second-token');
+    await request('/api/v1/alerts', { method: 'PUT' });
+
+    expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/csrf-token');
+    expect(mockFetch.mock.calls[2][0]).toContain('/api/v1/csrf-token');
+    const secondHeaders = mockFetch.mock.calls[3][1]?.headers as Headers;
+    expect(secondHeaders.get('Authorization')).toBe('Bearer second-token');
+    expect(secondHeaders.get('X-Csrf-Token')).toBe('new-csrf');
+  });
+
+  it('raises the authentication event when CSRF retrieval is unauthorized', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' }),
+    );
+    const listener = vi.fn();
+    window.addEventListener('niac:authentication-required', listener);
+
+    const { request, setRuntimeAPIToken } = await import('./requestCore');
+    setRuntimeAPIToken('revoked-token');
+
+    await expect(request('/api/v1/alerts', { method: 'PUT' })).rejects.toThrow('Unauthorized');
+    expect(listener).toHaveBeenCalledOnce();
+
+    window.removeEventListener('niac:authentication-required', listener);
+  });
+
+  it('does not report session expiry during the initial authentication check', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    const listener = vi.fn();
+    window.addEventListener('niac:authentication-required', listener);
+
+    const { validateRuntimeAuthentication } = await import('./requestCore');
+    await expect(validateRuntimeAuthentication()).rejects.toThrow('Unauthorized');
+    expect(listener).not.toHaveBeenCalled();
+
+    window.removeEventListener('niac:authentication-required', listener);
+  });
+});

--- a/ui/src/components/AuthGate.test.tsx
+++ b/ui/src/components/AuthGate.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '../api/errors';
+
+const { mockValidate, mockSetRuntimeAPIToken, mockClearRuntimeAPIToken, mockT } = vi.hoisted(
+  () => ({
+    mockValidate: vi.fn(),
+    mockSetRuntimeAPIToken: vi.fn(),
+    mockClearRuntimeAPIToken: vi.fn(),
+    mockT: (key: string) => key,
+  }),
+);
+
+vi.mock('../api/requestCore', () => ({
+  AUTH_FAILURE_EVENT: 'niac:authentication-required',
+  clearRuntimeAPIToken: mockClearRuntimeAPIToken,
+  setRuntimeAPIToken: mockSetRuntimeAPIToken,
+  validateRuntimeAuthentication: mockValidate,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}));
+
+import { AuthGate } from './AuthGate';
+
+const renderGate = (children: ReactNode = <div>protected content</div>) =>
+  render(<AuthGate>{children}</AuthGate>);
+
+describe('AuthGate', () => {
+  beforeEach(() => {
+    mockValidate.mockReset();
+    mockSetRuntimeAPIToken.mockReset();
+    mockClearRuntimeAPIToken.mockReset();
+  });
+
+  it('passes through when the daemon permits an unauthenticated loopback session', async () => {
+    mockValidate.mockResolvedValueOnce(undefined);
+    renderGate();
+    expect(await screen.findByText('protected content')).toBeVisible();
+  });
+
+  it('prompts on 401 and validates a bearer token before rendering the app', async () => {
+    mockValidate
+      .mockRejectedValueOnce(new ApiError('Unauthorized', 401))
+      .mockResolvedValueOnce({ scope: 'read-write' });
+    renderGate();
+
+    const input = await screen.findByLabelText('auth.tokenLabel');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    fireEvent.change(input, { target: { value: 'entered-token' } });
+    fireEvent.click(screen.getByRole('button', { name: 'auth.connect' }));
+
+    await waitFor(() => {
+      expect(mockSetRuntimeAPIToken).toHaveBeenCalledWith('entered-token');
+    });
+    expect(await screen.findByText('protected content')).toBeVisible();
+  });
+
+  it('clears a rejected token and keeps the prompt visible', async () => {
+    mockValidate.mockRejectedValue(new ApiError('Unauthorized', 401));
+    renderGate();
+
+    const input = await screen.findByLabelText('auth.tokenLabel');
+    fireEvent.change(input, { target: { value: 'bad-token' } });
+    fireEvent.click(screen.getByRole('button', { name: 'auth.connect' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('auth.invalidToken');
+    expect(mockClearRuntimeAPIToken).toHaveBeenCalled();
+    expect(screen.queryByText('protected content')).not.toBeInTheDocument();
+  });
+
+  it('reports a connection failure without discarding the candidate token', async () => {
+    mockValidate
+      .mockRejectedValueOnce(new ApiError('Unauthorized', 401))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    renderGate();
+
+    const input = await screen.findByLabelText('auth.tokenLabel');
+    fireEvent.change(input, { target: { value: 'valid-token' } });
+    fireEvent.click(screen.getByRole('button', { name: 'auth.connect' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('auth.connectionFailed');
+    expect(mockClearRuntimeAPIToken).not.toHaveBeenCalled();
+    expect(input).toHaveValue('valid-token');
+  });
+});

--- a/ui/src/components/AuthGate.tsx
+++ b/ui/src/components/AuthGate.tsx
@@ -1,0 +1,115 @@
+import { type FormEvent, type ReactElement, type ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ApiError } from '../api/errors';
+import {
+  AUTH_FAILURE_EVENT,
+  clearRuntimeAPIToken,
+  setRuntimeAPIToken,
+  validateRuntimeAuthentication,
+} from '../api/requestCore';
+
+interface AuthGateProps {
+  children: ReactNode;
+}
+
+type AuthState = 'checking' | 'prompt' | 'authenticated';
+
+export function AuthGate({ children }: AuthGateProps): ReactElement {
+  const { t } = useTranslation('common');
+  const [state, setState] = useState<AuthState>('checking');
+  const [token, setToken] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const requireAuthentication = () => {
+      clearRuntimeAPIToken();
+      setState('prompt');
+      setError(t('auth.sessionExpired'));
+    };
+    window.addEventListener(AUTH_FAILURE_EVENT, requireAuthentication);
+    return () => window.removeEventListener(AUTH_FAILURE_EVENT, requireAuthentication);
+  }, [t]);
+
+  useEffect(() => {
+    validateRuntimeAuthentication()
+      .then(() => setState('authenticated'))
+      .catch((err: unknown) => {
+        setState('prompt');
+        if (!(err instanceof ApiError && err.status === 401)) {
+          setError(t('auth.connectionFailed'));
+        }
+      });
+  }, [t]);
+
+  const connect = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const candidate = token.trim();
+    if (!candidate) return;
+
+    setError('');
+    setRuntimeAPIToken(candidate);
+    try {
+      await validateRuntimeAuthentication();
+      setToken('');
+      setState('authenticated');
+    } catch (err: unknown) {
+      if (err instanceof ApiError && err.status === 401) {
+        clearRuntimeAPIToken();
+        setError(t('auth.invalidToken'));
+      } else {
+        setError(t('auth.connectionFailed'));
+      }
+      setState('prompt');
+    }
+  };
+
+  if (state === 'authenticated') {
+    return <>{children}</>;
+  }
+
+  if (state === 'checking') {
+    return (
+      <main className="grid min-h-screen place-items-center bg-surface-base text-text-primary">
+        <p role="status">{t('auth.checking')}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="grid min-h-screen place-items-center bg-surface-base px-4 text-text-primary">
+      <form
+        onSubmit={connect}
+        className="w-full max-w-md rounded-xl border border-surface-border bg-surface-raised p-8 shadow-xl"
+      >
+        <h1 className="font-display text-2xl font-semibold">{t('auth.title')}</h1>
+        <p className="mt-2 text-sm text-text-secondary">{t('auth.description')}</p>
+        <label htmlFor="api-token" className="mt-6 block text-sm font-medium">
+          {t('auth.tokenLabel')}
+        </label>
+        <input
+          id="api-token"
+          data-testid="api-token-input"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          value={token}
+          onChange={(event) => setToken(event.target.value)}
+          className="mt-2 w-full rounded-lg border border-surface-border bg-surface-sunken px-3 py-2 font-mono text-sm outline-none focus:border-brand-primary"
+        />
+        {error && (
+          <p role="alert" className="mt-3 text-sm text-status-error">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={!token.trim()}
+          className="mt-6 w-full rounded-lg bg-brand-primary px-4 py-2 font-medium text-text-inverse disabled:opacity-50"
+        >
+          {t('auth.connect')}
+        </button>
+        <p className="mt-4 text-xs text-text-muted">{t('auth.memoryOnly')}</p>
+      </form>
+    </main>
+  );
+}

--- a/ui/src/hooks/useEventSource.test.ts
+++ b/ui/src/hooks/useEventSource.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearRuntimeAPIToken, setRuntimeAPIToken } from '../api/requestCore';
+import { consumeEventStream } from './useEventSource';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('consumeEventStream', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    clearRuntimeAPIToken();
+  });
+
+  it('authenticates the SSE fetch and parses records split across chunks', async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('event: connected\r\ndata: {"stream":"logs"}\r\n\r'));
+        controller.enqueue(
+          encoder.encode('\ndata: {"type":"log","message":"ready"}\n\ndata: plain text\n\n'),
+        );
+        controller.close();
+      },
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+    );
+    setRuntimeAPIToken('stream-token');
+    const messages: unknown[] = [];
+
+    await consumeEventStream('/api/v1/stream/logs', new AbortController().signal, {
+      onOpen: vi.fn(),
+      onMessage: (message) => messages.push(message),
+    });
+
+    const headers = mockFetch.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer stream-token');
+    expect(headers.get('Accept')).toBe('text/event-stream');
+    expect(messages).toEqual([{ type: 'log', message: 'ready' }, 'plain text']);
+  });
+
+  it('raises the shared authentication event on a 401', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    const listener = vi.fn();
+    window.addEventListener('niac:authentication-required', listener);
+
+    await expect(
+      consumeEventStream('/api/v1/stream/logs', new AbortController().signal, {
+        onOpen: vi.fn(),
+        onMessage: vi.fn(),
+      }),
+    ).rejects.toThrow('Unauthorized');
+
+    expect(listener).toHaveBeenCalledOnce();
+    window.removeEventListener('niac:authentication-required', listener);
+  });
+});

--- a/ui/src/hooks/useEventSource.ts
+++ b/ui/src/hooks/useEventSource.ts
@@ -1,224 +1,185 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  buildRequestHeaders,
+  buildUrl,
+  notifyIfAuthenticationFailed,
+  parseApiError,
+} from '../api/requestCore';
 
-/**
- * Options for configuring the EventSource connection
- */
 export interface UseEventSourceOptions {
-  /** EventSource URL to connect to */
   url: string;
-  /** Callback when a message is received (after JSON parsing) */
   onMessage?: (data: unknown) => void;
-  /** Callback when connection is established */
   onConnect?: () => void;
-  /** Callback when connection is closed/errored */
   onDisconnect?: () => void;
-  /** Callback when an error occurs */
   onError?: (error: Event) => void;
-  /** Whether the connection is enabled (default: true) */
   enabled?: boolean;
 }
 
-/**
- * Result returned by the useEventSource hook
- */
 export interface UseEventSourceResult {
-  /** Last received data (JSON parsed) */
   data: unknown;
-  /** Whether the EventSource is currently connected */
   connected: boolean;
-  /** Last error event, if any */
   error: Event | null;
-  /** Manually close the connection */
   close: () => void;
-  /** Manually reconnect */
   reconnect: () => void;
 }
 
-/**
- * EventSource hook with auto-connect and JSON handling
- *
- * Benefits over WebSocket:
- * - Automatic reconnection built into browser API
- * - Simpler API (server → client only)
- * - Better proxy/CDN compatibility
- * - Works well with HTTP/2 multiplexing
- *
- * @param options - EventSource configuration options
- * @returns EventSource state and control methods
- *
- * @example
- * ```typescript
- * const { data, connected } = useEventSource({
- *   url: '/api/v1/stream/logs',
- *   onMessage: (data) => console.log('Received:', data),
- * });
- * ```
- */
+interface StreamCallbacks {
+  onOpen: () => void;
+  onMessage: (data: unknown) => void;
+}
+
+function parseEventRecord(record: string): unknown | undefined {
+  const lines = record.split(/\r\n|\r|\n/);
+  const event = lines
+    .find((line) => line.startsWith('event:'))
+    ?.slice(6)
+    .trim();
+  if (event && event !== 'message') return undefined;
+
+  const data = lines
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice(5).trimStart())
+    .join('\n');
+  if (!data) return undefined;
+
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+}
+
+export async function consumeEventStream(
+  url: string,
+  signal: AbortSignal,
+  callbacks: StreamCallbacks,
+): Promise<void> {
+  const headers = await buildRequestHeaders(url, { method: 'GET' });
+  headers.set('Accept', 'text/event-stream');
+  const response = await fetch(buildUrl(url), {
+    headers,
+    credentials: 'same-origin',
+    signal,
+  });
+  if (!response.ok) {
+    notifyIfAuthenticationFailed(response.status);
+    throw parseApiError(await response.text(), response.status, response.statusText);
+  }
+  if (!response.body) {
+    throw new Error('Event stream response did not include a body');
+  }
+
+  callbacks.onOpen();
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (!signal.aborted) {
+    const { done, value } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done });
+
+    let boundary = buffer.search(/\r\n\r\n|\r\r|\n\n/);
+    while (boundary >= 0) {
+      const delimiter = buffer.slice(boundary).match(/^(\r\n\r\n|\r\r|\n\n)/)?.[0];
+      if (!delimiter) break;
+      const parsed = parseEventRecord(buffer.slice(0, boundary));
+      if (parsed !== undefined) callbacks.onMessage(parsed);
+      buffer = buffer.slice(boundary + delimiter.length);
+      boundary = buffer.search(/\r\n\r\n|\r\r|\n\n/);
+    }
+    if (done) break;
+  }
+}
+
 export function useEventSource(options: UseEventSourceOptions): UseEventSourceResult {
   const { url, onMessage, onConnect, onDisconnect, onError, enabled = true } = options;
-
   const [data, setData] = useState<unknown>(null);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<Event | null>(null);
-
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
-
-  // Store callbacks in refs to avoid re-creating effects
-  const onMessageRef = useRef(onMessage);
-  const onConnectRef = useRef(onConnect);
-  const onDisconnectRef = useRef(onDisconnect);
-  const onErrorRef = useRef(onError);
+  const callbacksRef = useRef({ onMessage, onConnect, onDisconnect, onError });
 
   useEffect(() => {
-    onMessageRef.current = onMessage;
-  }, [onMessage]);
-  useEffect(() => {
-    onConnectRef.current = onConnect;
-  }, [onConnect]);
-  useEffect(() => {
-    onDisconnectRef.current = onDisconnect;
-  }, [onDisconnect]);
-  useEffect(() => {
-    onErrorRef.current = onError;
-  }, [onError]);
+    callbacksRef.current = { onMessage, onConnect, onDisconnect, onError };
+  }, [onMessage, onConnect, onDisconnect, onError]);
 
-  /**
-   * Connect to the EventSource
-   */
-  const connect = useCallback(() => {
-    if (!url || eventSourceRef.current) {
-      return;
-    }
-
-    try {
-      const es = new EventSource(url);
-      eventSourceRef.current = es;
-
-      es.onopen = () => {
-        if (!mountedRef.current) {
-          return;
-        }
-        setConnected(true);
-        setError(null);
-        onConnectRef.current?.();
-      };
-
-      es.onmessage = (event: MessageEvent) => {
-        if (!mountedRef.current) {
-          return;
-        }
-
-        try {
-          const parsedData = JSON.parse(event.data);
-          setData(parsedData);
-          onMessageRef.current?.(parsedData);
-        } catch {
-          // If JSON parsing fails, use raw data
-          setData(event.data);
-          onMessageRef.current?.(event.data);
-        }
-      };
-
-      es.onerror = (event: Event) => {
-        if (!mountedRef.current) {
-          return;
-        }
-
-        // EventSource automatically reconnects on error
-        // We just update state to reflect disconnection
-        setError(event);
-        setConnected(false);
-        onErrorRef.current?.(event);
-        onDisconnectRef.current?.();
-      };
-
-      // Handle custom 'connected' event from server
-      es.addEventListener('connected', () => {
-        // Event received - connection confirmed
-      });
-    } catch {
-      setError(new Event('error'));
-    }
-  }, [url]);
-
-  /**
-   * Close the EventSource connection
-   */
   const close = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-      setConnected(false);
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
     }
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    setConnected(false);
   }, []);
 
-  /**
-   * Manually reconnect
-   */
+  const connect = useCallback(() => {
+    if (!url || controllerRef.current) return;
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    void consumeEventStream(url, controller.signal, {
+      onOpen: () => {
+        if (!mountedRef.current || controller.signal.aborted) return;
+        setConnected(true);
+        setError(null);
+        callbacksRef.current.onConnect?.();
+      },
+      onMessage: (message) => {
+        if (!mountedRef.current || controller.signal.aborted) return;
+        setData(message);
+        callbacksRef.current.onMessage?.(message);
+      },
+    })
+      .catch(() => {
+        if (!mountedRef.current || controller.signal.aborted) return;
+        const event = new Event('error');
+        setError(event);
+        callbacksRef.current.onError?.(event);
+      })
+      .finally(() => {
+        if (controllerRef.current !== controller) return;
+        controllerRef.current = null;
+        if (!mountedRef.current || controller.signal.aborted) return;
+        setConnected(false);
+        callbacksRef.current.onDisconnect?.();
+        reconnectTimerRef.current = setTimeout(connect, 1_000);
+      });
+  }, [url]);
+
   const reconnect = useCallback(() => {
     close();
-    // Small delay before reconnecting
-    setTimeout(() => {
-      if (mountedRef.current && enabled) {
-        connect();
-      }
+    reconnectTimerRef.current = setTimeout(() => {
+      if (mountedRef.current && enabled) connect();
     }, 100);
   }, [close, connect, enabled]);
 
-  // Connect on mount, cleanup on unmount
   useEffect(() => {
     mountedRef.current = true;
-
-    if (enabled && url) {
-      connect();
-    }
-
+    if (enabled && url) connect();
     return () => {
       mountedRef.current = false;
       close();
     };
   }, [enabled, url, connect, close]);
 
-  return {
-    data,
-    connected,
-    error,
-    close,
-    reconnect,
-  };
+  return { data, connected, error, close, reconnect };
 }
 
-// ============================================================================
-// Specialized Stream Hooks
-// ============================================================================
-
-/**
- * Get the API base URL for streams
- */
 function getStreamBaseUrl(): string {
   return `${window.location.origin}/api/v1/stream`;
 }
 
-/**
- * Options for specialized stream hooks
- */
 export interface StreamHookOptions {
-  /** Callback when a message is received */
   onMessage?: (data: unknown) => void;
-  /** Callback when connection is established */
   onConnect?: () => void;
-  /** Callback when connection is closed */
   onDisconnect?: () => void;
-  /** Callback when an error occurs */
   onError?: (error: Event) => void;
-  /** Whether to auto-connect (default: true) */
   enabled?: boolean;
 }
 
-/**
- * Packet data structure from /api/v1/stream/packets
- */
 export interface PacketData {
   type: 'packet';
   timestamp: string;
@@ -232,23 +193,15 @@ export interface PacketData {
   };
 }
 
-/**
- * Hook for connecting to the packet stream
- */
 export function usePacketStream(options: StreamHookOptions = {}): UseEventSourceResult {
   const { enabled = true, ...restOptions } = options;
-  const url = enabled ? `${getStreamBaseUrl()}/packets` : '';
-
   return useEventSource({
-    url,
+    url: enabled ? `${getStreamBaseUrl()}/packets` : '',
     enabled,
     ...restOptions,
   });
 }
 
-/**
- * Log data structure from /api/v1/stream/logs
- */
 export interface LogData {
   type: 'log';
   timestamp: string;
@@ -256,15 +209,10 @@ export interface LogData {
   message: string;
 }
 
-/**
- * Hook for connecting to the log stream
- */
 export function useLogStream(options: StreamHookOptions = {}): UseEventSourceResult {
   const { enabled = true, ...restOptions } = options;
-  const url = enabled ? `${getStreamBaseUrl()}/logs` : '';
-
   return useEventSource({
-    url,
+    url: enabled ? `${getStreamBaseUrl()}/logs` : '',
     enabled,
     ...restOptions,
   });

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
+import { AuthGate } from './components/AuthGate';
 import { LicenseProvider } from './contexts/LicenseContext';
 import { ScopeProvider } from './contexts/ScopeContext';
 import { initThemeFromStorage } from './hooks/useTheme';
@@ -24,11 +25,13 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <BrowserRouter>
-      <LicenseProvider>
-        <ScopeProvider>
-          <App />
-        </ScopeProvider>
-      </LicenseProvider>
+      <AuthGate>
+        <LicenseProvider>
+          <ScopeProvider>
+            <App />
+          </ScopeProvider>
+        </LicenseProvider>
+      </AuthGate>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/ui/src/ui/ConnectionStatus.tsx
+++ b/ui/src/ui/ConnectionStatus.tsx
@@ -1,4 +1,5 @@
 import { type FC, useCallback, useEffect, useRef, useState } from 'react';
+import { request } from '../api/requestCore';
 
 type Status = 'connected' | 'disconnected' | 'checking';
 
@@ -25,9 +26,9 @@ export const ConnectionStatus: FC = () => {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-      const response = await fetch('/api/v1/version', { signal: controller.signal });
+      await request('/api/v1/version', { signal: controller.signal });
       clearTimeout(timeout);
-      setStatus(response.ok ? 'connected' : 'disconnected');
+      setStatus('connected');
     } catch {
       setStatus('disconnected');
     }


### PR DESCRIPTION
## Summary
- Keep the SPA shell public while protecting every API, metrics, upload, and SSE request with an in-memory bearer.
- Add a browser authentication gate with correct expiry and connection-error handling.
- Preserve browser security headers and authenticated JSON 404s for the API namespace.
- Run production-token E2E coverage in Chromium and WebKit locally and in CI.

## Linked Issue
Closes #1032

## Testing Evidence
```text
make lint: 0 issues; Biome clean
make fmt-check: all formatting checks passed
make test: Go 65.4%; Vitest 67 files / 327 tests passed
make security: govulncheck clean; npm audit 0; gitleaks clean
make build: frontend and backend complete
make test-e2e: 124 passed / 4 skipped; auth Chromium + WebKit 2 passed
```

## Security and Release Checklist
- [x] Bearer remains memory-only and never enters storage or URLs.
- [x] CSRF, upload, REST, and SSE authentication failures are covered.
- [x] CSP, HSTS, frame, and MIME protections remain on the public shell.
- [x] Unknown API paths remain authenticated and return JSON 404 responses.
- [x] No new dependency or vulnerability finding.
- [x] Release notes are not required for this defect PR.