### PR TITLE
fix(fabric): validate live static route next hops

### DIFF
--- a/internal/devicecli/command_global.go
+++ b/internal/devicecli/command_global.go
@@ -40,13 +40,14 @@ func (s *Session) executeGlobal(fields []string) Response {
 func (s *Session) setStaticRoute(fields []string) Response {
 	destination, destinationErr := netip.ParsePrefix(fields[2])
 	nextHop, nextHopErr := netip.ParseAddr(fields[3])
+	route := devicestate.Route{
+		Destination: destination, Via: fields[4], NextHop: nextHop,
+	}
 	if destinationErr != nil || !destination.Addr().Is4() || nextHopErr != nil || !nextHop.Is4() ||
-		!hasInterface(s.state.Snapshot().Network.Interfaces, fields[4]) {
+		s.validateRoute == nil || !s.validateRoute(route) {
 		return Response{Output: "% Invalid static route"}
 	}
-	s.state.UpsertRoute(devicestate.Route{
-		Destination: destination, Via: fields[4], NextHop: nextHop,
-	})
+	s.state.UpsertRoute(route)
 	return Response{}
 }
 

--- a/internal/devicecli/session.go
+++ b/internal/devicecli/session.go
@@ -13,8 +13,8 @@ const (
 )
 
 // NewSession creates an isolated user-mode command session.
-func NewSession(state *devicestate.Store) *Session {
-	return &Session{state: state, mode: ModeUser}
+func NewSession(state *devicestate.Store, validateRoute RouteValidator) *Session {
+	return &Session{state: state, validateRoute: validateRoute, mode: ModeUser}
 }
 
 // Mode returns the current command mode.

--- a/internal/devicecli/session_test.go
+++ b/internal/devicecli/session_test.go
@@ -132,7 +132,7 @@ func TestSessionSaveReloadAndEraseLifecycle(t *testing.T) {
 		t.Fatal("reload did not restore saved shutdown state")
 	}
 
-	session = devicecli.NewSession(state)
+	session = devicecli.NewSession(state, allowStaticRoute)
 	assertCommand(t, session, "enable", "")
 	assertCommand(t, session, "write erase", "[OK]")
 	if response := session.Execute("reload"); !response.Close {
@@ -367,7 +367,11 @@ func newSession() (*devicecli.Session, *devicestate.Store) {
 			Destination: mustPrefix("10.0.0.0/24"), Via: "Gi0/1", Connected: true,
 		}},
 	})
-	return devicecli.NewSession(state), state
+	return devicecli.NewSession(state, allowStaticRoute), state
+}
+
+func allowStaticRoute(devicestate.Route) bool {
+	return true
 }
 
 func assertCommand(t *testing.T, session *devicecli.Session, command, want string) {

--- a/internal/devicecli/ssh_server.go
+++ b/internal/devicecli/ssh_server.go
@@ -27,8 +27,9 @@ type Credentials struct {
 
 // SSHServer serves isolated command sessions over SSH byte streams.
 type SSHServer struct {
-	state  *devicestate.Store
-	config *ssh.ServerConfig
+	state         *devicestate.Store
+	validateRoute RouteValidator
+	config        *ssh.ServerConfig
 }
 
 // NewSSHServer creates an SSH transport with no default credentials.
@@ -36,9 +37,13 @@ func NewSSHServer(
 	state *devicestate.Store,
 	credentials Credentials,
 	hostSigner ssh.Signer,
+	validateRoute RouteValidator,
 ) (*SSHServer, error) {
 	if state == nil {
 		return nil, errors.New("device state is required")
+	}
+	if validateRoute == nil {
+		return nil, errors.New("route validator is required")
 	}
 	if credentials.Username == "" || credentials.Password == "" {
 		return nil, errors.New("SSH credentials are required")
@@ -51,7 +56,7 @@ func NewSSHServer(
 		MaxAuthTries:     maxSSHAuthAttempts,
 	}
 	config.AddHostKey(hostSigner)
-	return &SSHServer{state: state, config: config}, nil
+	return &SSHServer{state: state, validateRoute: validateRoute, config: config}, nil
 }
 
 func passwordCallback(credentials Credentials) func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) {
@@ -119,7 +124,7 @@ func (s *SSHServer) serveChannel(channel ssh.Channel, requests <-chan *ssh.Reque
 }
 
 func (s *SSHServer) serveShell(channel ssh.Channel) {
-	session := NewSession(s.state)
+	session := NewSession(s.state, s.validateRoute)
 	_, _ = channel.Write([]byte(session.Prompt()))
 	scanner := bufio.NewScanner(channel)
 	scanner.Buffer(nil, maxSSHCommandBytes)

--- a/internal/devicecli/ssh_server_test.go
+++ b/internal/devicecli/ssh_server_test.go
@@ -128,7 +128,7 @@ func newSSHServer(t *testing.T, state *devicestate.Store) *devicecli.SSHServer {
 	}
 	server, err := devicecli.NewSSHServer(state, devicecli.Credentials{
 		Username: "admin", Password: "test-password",
-	}, hostSigner)
+	}, hostSigner, allowStaticRoute)
 	if err != nil {
 		t.Fatalf("NewSSHServer() error = %v", err)
 	}

--- a/internal/devicecli/types.go
+++ b/internal/devicecli/types.go
@@ -21,9 +21,13 @@ type Response struct {
 	Close  bool
 }
 
+// RouteValidator approves one fully parsed static-route mutation.
+type RouteValidator func(devicestate.Route) bool
+
 // Session holds command mode and context for one connection.
 type Session struct {
 	state           *devicestate.Store
+	validateRoute   RouteValidator
 	mode            Mode
 	interfaceName   string
 	vlanID          int

--- a/internal/fabric/compiler_devices.go
+++ b/internal/fabric/compiler_devices.go
@@ -98,37 +98,18 @@ func (c *scenarioCompiler) compileInterface(
 func (c *scenarioCompiler) compileRoutes(device *config.Device, interfaces map[string]Interface) {
 	for i, source := range device.Routes {
 		field := fmt.Sprintf("devices[%s].routes[%d]", device.Name, i)
-		destination, err := parseCanonicalPrefix(source.Destination)
-		if err != nil {
-			c.add(CodeInvalidRoute, field+".destination", err.Error())
+		route, diagnostic := ValidateStaticRoute(
+			StaticRouteSpec{
+				Device: device.Name, Destination: source.Destination,
+				Via: source.Via, NextHop: source.NextHop,
+			},
+			RouteValidationContext{Interfaces: interfaces, AddressOwners: c.addresses},
+		)
+		if diagnostic != nil {
+			c.add(diagnostic.Code, field+"."+diagnostic.Field, diagnostic.Message)
 			continue
 		}
-		iface, exists := interfaces[source.Via]
-		if !exists {
-			c.add(CodeUnknownRouteInterface, field+".via", "route references an unknown interface")
-			continue
-		}
-		nextHop, err := netip.ParseAddr(source.NextHop)
-		if err != nil || !nextHop.Is4() {
-			c.add(CodeInvalidRouteNextHop, field+".next_hop", "next hop must be an IPv4 address")
-			continue
-		}
-		if !iface.Address.Masked().Contains(nextHop) || isReservedEndpoint(iface.Address.Masked(), nextHop) {
-			c.add(CodeRouteNextHopOffLink, field+".next_hop", "next hop must be a usable address on the egress network")
-			continue
-		}
-		owner, assigned := c.addresses[nextHop]
-		if !assigned {
-			c.add(CodeUnknownRouteNextHop, field+".next_hop", "next hop is not assigned to a configured peer")
-			continue
-		}
-		if owner == device.Name {
-			c.add(CodeRouteNextHopSelf, field+".next_hop", "next hop cannot belong to the routed device")
-			continue
-		}
-		c.report.Topology.Routes = append(c.report.Topology.Routes, Route{
-			Device: device.Name, Destination: destination, Via: source.Via, NextHop: nextHop,
-		})
+		c.report.Topology.Routes = append(c.report.Topology.Routes, route)
 	}
 }
 

--- a/internal/fabric/route_validation.go
+++ b/internal/fabric/route_validation.go
@@ -1,0 +1,70 @@
+package fabric
+
+import "net/netip"
+
+// StaticRouteSpec is an authored or runtime-mutated IPv4 static route.
+type StaticRouteSpec struct {
+	Device      string
+	Destination string
+	Via         string
+	NextHop     string
+}
+
+// RouteValidationContext contains the current interfaces and address owners.
+type RouteValidationContext struct {
+	Interfaces    map[string]Interface
+	AddressOwners map[netip.Addr]string
+}
+
+// ValidateStaticRoute applies the canonical routed-scenario invariants.
+func ValidateStaticRoute(spec StaticRouteSpec, context RouteValidationContext) (Route, *Diagnostic) {
+	destination, err := parseCanonicalPrefix(spec.Destination)
+	if err != nil {
+		return Route{}, routeDiagnostic(CodeInvalidRoute, "destination", err.Error())
+	}
+	iface, exists := context.Interfaces[spec.Via]
+	if !exists {
+		return Route{}, routeDiagnostic(
+			CodeUnknownRouteInterface,
+			"via",
+			"route references an unknown interface",
+		)
+	}
+	nextHop, err := netip.ParseAddr(spec.NextHop)
+	if err != nil || !nextHop.Is4() {
+		return Route{}, routeDiagnostic(
+			CodeInvalidRouteNextHop,
+			"next_hop",
+			"next hop must be an IPv4 address",
+		)
+	}
+	if !iface.Address.Masked().Contains(nextHop) || isReservedEndpoint(iface.Address.Masked(), nextHop) {
+		return Route{}, routeDiagnostic(
+			CodeRouteNextHopOffLink,
+			"next_hop",
+			"next hop must be a usable address on the egress network",
+		)
+	}
+	owner, assigned := context.AddressOwners[nextHop]
+	if !assigned {
+		return Route{}, routeDiagnostic(
+			CodeUnknownRouteNextHop,
+			"next_hop",
+			"next hop is not assigned to a configured peer",
+		)
+	}
+	if owner == spec.Device {
+		return Route{}, routeDiagnostic(
+			CodeRouteNextHopSelf,
+			"next_hop",
+			"next hop cannot belong to the routed device",
+		)
+	}
+	return Route{
+		Device: spec.Device, Destination: destination, Via: spec.Via, NextHop: nextHop,
+	}, nil
+}
+
+func routeDiagnostic(code DiagnosticCode, field, message string) *Diagnostic {
+	return &Diagnostic{Code: code, Field: field, Message: message}
+}

--- a/internal/protocols/device_state_integration_test.go
+++ b/internal/protocols/device_state_integration_test.go
@@ -158,7 +158,10 @@ func TestFlatCLIAddressAndShutdownChangePacketDelivery(t *testing.T) {
 	}}}
 	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
 	device := &cfg.Devices[0]
-	session := devicecli.NewSession(stack.deviceStates[device])
+	session := devicecli.NewSession(
+		stack.deviceStates[device],
+		stack.staticRouteValidator(device),
+	)
 	for _, command := range []string{
 		"enable", "configure terminal", "interface Management", "ip address 192.0.2.20/32",
 	} {

--- a/internal/protocols/fabric_forwarding_test.go
+++ b/internal/protocols/fabric_forwarding_test.go
@@ -76,7 +76,10 @@ func TestCLIShutdownChangesFabricDelivery(t *testing.T) {
 	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
 	stack.ConfigureFabric(topology)
 	server := &cfg.Devices[1]
-	session := devicecli.NewSession(stack.deviceStates[server])
+	session := devicecli.NewSession(
+		stack.deviceStates[server],
+		stack.staticRouteValidator(server),
+	)
 	for _, command := range []string{"enable", "configure terminal", "interface eth0", "shutdown"} {
 		if response := session.Execute(command); strings.HasPrefix(response.Output, "%") {
 			t.Fatalf("%q response = %#v", command, response)
@@ -98,7 +101,10 @@ func TestCLIShutdownStopsAttachmentARP(t *testing.T) {
 	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
 	stack.ConfigureFabric(topology)
 	router := &cfg.Devices[0]
-	session := devicecli.NewSession(stack.deviceStates[router])
+	session := devicecli.NewSession(
+		stack.deviceStates[router],
+		stack.staticRouteValidator(router),
+	)
 	for _, command := range []string{"enable", "configure terminal", "interface outside", "shutdown"} {
 		if response := session.Execute(command); strings.HasPrefix(response.Output, "%") {
 			t.Fatalf("%q response = %#v", command, response)
@@ -115,7 +121,10 @@ func TestCLIAddressChangeMovesFabricDelivery(t *testing.T) {
 	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
 	stack.ConfigureFabric(topology)
 	server := &cfg.Devices[1]
-	session := devicecli.NewSession(stack.deviceStates[server])
+	session := devicecli.NewSession(
+		stack.deviceStates[server],
+		stack.staticRouteValidator(server),
+	)
 	for _, command := range []string{
 		"enable", "configure terminal", "interface eth0", "ip address 10.20.0.20/24",
 	} {
@@ -153,17 +162,42 @@ func TestCLIStaticRouteChangesFabricDelivery(t *testing.T) {
 		t.Fatalf("targets before route = %#v", targets)
 	}
 
-	session := devicecli.NewSession(routerState)
-	for _, command := range []string{
-		"enable", "configure terminal", "ip route 10.20.0.0/24 10.10.200.2 inside",
-	} {
+	session := devicecli.NewSession(routerState, stack.staticRouteValidator(router))
+	for _, command := range []string{"enable", "configure terminal"} {
 		if response := session.Execute(command); strings.HasPrefix(response.Output, "%") {
 			t.Fatalf("%q response = %#v", command, response)
 		}
 	}
+	for _, command := range []string{
+		"ip route 10.20.0.1/24 10.20.0.10 inside",
+		"ip route 10.20.0.0/24 203.0.113.99 inside",
+		"ip route 10.20.0.0/24 10.20.0.99 inside",
+		"ip route 10.20.0.0/24 10.20.0.1 inside",
+	} {
+		if response := session.Execute(command); !strings.HasPrefix(response.Output, "%") {
+			t.Fatalf("%q response = %#v, want rejection", command, response)
+		}
+	}
+	const validRoute = "ip route 10.20.0.0/24 10.20.0.10 inside"
+	if response := session.Execute(validRoute); strings.HasPrefix(response.Output, "%") {
+		t.Fatalf("%q response = %#v", validRoute, response)
+	}
+	routes := routerState.Snapshot().Network.Routes
+	if len(routes) != 1 || routes[0].NextHop != netip.MustParseAddr("10.20.0.10") {
+		t.Fatalf("routes after mutation = %#v", routes)
+	}
 	targets := stack.ipHandler.getTargetDevices(destination, pkt, 1, 0)
 	if len(targets) != 1 || targets[0] != &cfg.Devices[1] {
 		t.Fatalf("targets after route = %#v", targets)
+	}
+
+	routerState.UpsertRoute(devicestate.Route{
+		Destination: netip.MustParsePrefix("10.20.0.0/24"),
+		Via:         "inside",
+		NextHop:     netip.MustParseAddr("10.20.0.99"),
+	})
+	if targets = stack.ipHandler.getTargetDevices(destination, pkt, 1, 0); targets != nil {
+		t.Fatalf("targets with unowned next hop = %#v, want nil", targets)
 	}
 }
 

--- a/internal/protocols/fabric_runtime.go
+++ b/internal/protocols/fabric_runtime.go
@@ -38,6 +38,8 @@ type fabricRouter struct {
 type fabricRoute struct {
 	destination netip.Prefix
 	via         string
+	nextHop     netip.Addr
+	connected   bool
 }
 
 type fabricResolution struct {
@@ -125,7 +127,12 @@ func (r *fabricRuntime) indexAttachmentRouters(topology *fabric.Topology) {
 	for _, route := range topology.Routes {
 		router := routers[route.Device]
 		if router != nil {
-			router.routes = append(router.routes, fabricRoute{destination: route.Destination, via: route.Via})
+			router.routes = append(router.routes, fabricRoute{
+				destination: route.Destination,
+				via:         route.Via,
+				nextHop:     route.NextHop,
+				connected:   route.Connected,
+			})
 		}
 	}
 	for i := range r.attachmentRouters {
@@ -231,10 +238,8 @@ func (r *fabricRuntime) routeFor(dst netip.Addr, ingressMAC net.HardwareAddr) (*
 			continue
 		}
 		for _, route := range r.routesFor(router) {
-			if !r.interfaceAvailable(router.device, route.via) {
-				continue
-			}
-			if route.destination.Contains(dst) && route.destination.Bits() > bestBits {
+			if r.routeAvailable(router, route) &&
+				route.destination.Contains(dst) && route.destination.Bits() > bestBits {
 				bestBits = route.destination.Bits()
 				best = router
 				bestRoute = route
@@ -242,6 +247,26 @@ func (r *fabricRuntime) routeFor(dst netip.Addr, ingressMAC net.HardwareAddr) (*
 		}
 	}
 	return best, bestRoute
+}
+
+func (r *fabricRuntime) routeAvailable(router *fabricRouter, route fabricRoute) bool {
+	if !r.interfaceAvailable(router.device, route.via) {
+		return false
+	}
+	if r.deviceStates != nil && !route.connected &&
+		!validateStaticRoute(r.deviceStates, router.device, devicestate.Route{
+			Destination: route.destination,
+			Via:         route.via,
+			NextHop:     route.nextHop,
+		}) {
+		return false
+	}
+	if route.connected {
+		return true
+	}
+	nextHop, exists := r.endpointForAddress(route.nextHop)
+	return exists && nextHop.device != router.device &&
+		r.interfaceAvailable(nextHop.device, nextHop.interfaceName)
 }
 
 func (r *fabricRuntime) routesFor(router *fabricRouter) []fabricRoute {
@@ -255,9 +280,61 @@ func (r *fabricRuntime) routesFor(router *fabricRouter) []fabricRoute {
 	routes := state.Snapshot().Network.Routes
 	result := make([]fabricRoute, 0, len(routes))
 	for _, route := range routes {
-		result = append(result, fabricRoute{destination: route.Destination, via: route.Via})
+		result = append(result, fabricRoute{
+			destination: route.Destination,
+			via:         route.Via,
+			nextHop:     route.NextHop,
+			connected:   route.Connected,
+		})
 	}
 	return result
+}
+
+func (s *Stack) staticRouteValidator(device *config.Device) func(devicestate.Route) bool {
+	return func(route devicestate.Route) bool {
+		return validateStaticRoute(s.deviceStates, device, route)
+	}
+}
+
+func validateStaticRoute(
+	states map[*config.Device]*devicestate.Store,
+	device *config.Device,
+	route devicestate.Route,
+) bool {
+	state := states[device]
+	if state == nil {
+		return false
+	}
+	interfaces := make(map[string]fabric.Interface)
+	for _, iface := range state.Snapshot().Network.Interfaces {
+		interfaces[iface.Name] = fabric.Interface{
+			Device: device.Name, Name: iface.Name, Network: iface.Network, Address: iface.Address,
+		}
+	}
+	owners := make(map[netip.Addr]string)
+	duplicates := make(map[netip.Addr]struct{})
+	for candidate, candidateState := range states {
+		for _, iface := range candidateState.Snapshot().Network.Interfaces {
+			if iface.Address.IsValid() {
+				address := iface.Address.Addr()
+				if _, exists := owners[address]; exists {
+					duplicates[address] = struct{}{}
+				}
+				owners[address] = candidate.Name
+			}
+		}
+	}
+	for address := range duplicates {
+		delete(owners, address)
+	}
+	_, diagnostic := fabric.ValidateStaticRoute(
+		fabric.StaticRouteSpec{
+			Device: device.Name, Destination: route.Destination.String(),
+			Via: route.Via, NextHop: route.NextHop.String(),
+		},
+		fabric.RouteValidationContext{Interfaces: interfaces, AddressOwners: owners},
+	)
+	return diagnostic == nil
 }
 
 func (r *fabricRuntime) bindDeviceStates(states map[*config.Device]*devicestate.Store) {

--- a/internal/protocols/tcp_ssh.go
+++ b/internal/protocols/tcp_ssh.go
@@ -444,6 +444,7 @@ func (h *sshTCPHandler) server(device *config.Device) (*devicecli.SSHServer, err
 		h.stack.deviceStates[device],
 		devicecli.Credentials{Username: device.SSHConfig.Username, Password: password},
 		hostSigner,
+		h.stack.staticRouteValidator(device),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- centralize authored and live static-route validation in the fabric contract
- reject noncanonical, off-link, unowned, and self-owned CLI next hops before mutation
- preserve and resolve live next hops during forwarding, including peer-interface availability
- require the route validator in local and SSH command sessions

## Linked Issue

Closes #1033

## Testing Evidence

```text
make fmt-check
# all formatting checks passed

make lint
# backend: 0 issues; frontend: no issues

make test
# all 41 Go packages and 67 frontend test files passed

make security
# govulncheck, npm audit, and gitleaks passed

go test -race ./internal/fabric ./internal/devicecli ./internal/protocols -count=1
# all affected packages passed
```

## Security and Release Checklist

- [x] Unsafe route mutations fail closed
- [x] Authored and live routes share one validation contract
- [x] No dependencies or public API endpoints changed
- [x] No suppressions, default credentials, or customer-facing vocabulary added
- [x] Full local quality and security gates passed
