### PR TITLE
fix(config): reject duplicate segment tags

### DIFF
--- a/internal/config/segments_test.go
+++ b/internal/config/segments_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -186,6 +187,42 @@ segments:
 
 	if segs[1].Devices[0].Name != "evt" {
 		t.Errorf("segment 1 device = %q, want evt", segs[1].Devices[0].Name)
+	}
+}
+
+func TestSegmentsRejectDuplicateNormalizedTags(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		firstTag  string
+		secondTag string
+	}{
+		{name: "numeric", firstTag: "200", secondTag: "\"200\""},
+		{name: "untagged", firstTag: "untagged", secondTag: "UNTAGGED"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			yamlConfig := fmt.Sprintf(`
+segments:
+  - tag: %s
+    devices:
+      - name: first
+        mac: "02:00:00:00:00:01"
+        ips: ["10.0.0.1"]
+  - tag: %s
+    devices:
+      - name: second
+        mac: "02:00:00:00:00:02"
+        ips: ["10.0.0.2"]
+`, test.firstTag, test.secondTag)
+			_, err := LoadYAMLBytes([]byte(yamlConfig))
+			if !errors.Is(err, ErrDuplicateSegmentTag) {
+				t.Fatalf("LoadYAMLBytes() error = %v, want duplicate segment tag", err)
+			}
+			for _, location := range []string{"segments[0].tag", "segments[1].tag"} {
+				if !strings.Contains(err.Error(), location) {
+					t.Fatalf("LoadYAMLBytes() error = %q, want location %q", err, location)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -13,6 +13,7 @@ var (
 	ErrSegmentsAndTopLevelDevices = errors.New("use either top-level devices or segments, not both")
 	ErrSegmentDevicesXORConfig    = errors.New("segment must set exactly one of devices or config")
 	ErrInvalidSegmentTag          = errors.New("invalid segment tag")
+	ErrDuplicateSegmentTag        = errors.New("duplicate segment tag")
 	ErrInvalidMapToIP             = errors.New("invalid map_to_ip")
 	ErrInvalidTTLIP               = errors.New("invalid ttl ip")
 	ErrInvalidTTLMask             = errors.New("invalid ttl mask")
@@ -164,6 +165,20 @@ func (c *Config) NormalizedSegments() []Segment {
 	}
 
 	return []Segment{{Tag: UntaggedTag, Devices: c.Devices}}
+}
+
+// DuplicateSegmentTags returns every tag mapped to its conflicting segment indices.
+func DuplicateSegmentTags(segments []Segment) map[int][]int {
+	indices := make(map[int][]int, len(segments))
+	for index, segment := range segments {
+		indices[segment.Tag] = append(indices[segment.Tag], index)
+	}
+	for tag, locations := range indices {
+		if len(locations) == 1 {
+			delete(indices, tag)
+		}
+	}
+	return indices
 }
 
 // RateMode selects how replay paces its packet sends. ScaleTime applies only

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -74,6 +74,7 @@ func (v *Validator) Validate(cfg *Config) *ListError {
 		return v.errors
 	}
 
+	v.validateSegmentTags(cfg.Segments)
 	for i := range cfg.Segments {
 		for j := range cfg.Segments[i].Devices {
 			knownDeviceNames[cfg.Segments[i].Devices[j].Name] = true
@@ -93,6 +94,37 @@ func (v *Validator) Validate(cfg *Config) *ListError {
 	}
 
 	return v.errors
+}
+
+func (v *Validator) validateSegmentTags(segments []Segment) {
+	conflicts := DuplicateSegmentTags(segments)
+	reported := make(map[int]struct{}, len(conflicts))
+	for _, segment := range segments {
+		indices, duplicate := conflicts[segment.Tag]
+		if !duplicate {
+			continue
+		}
+		if _, done := reported[segment.Tag]; done {
+			continue
+		}
+		reported[segment.Tag] = struct{}{}
+		fields := make([]string, len(indices))
+		for index, location := range indices {
+			fields[index] = fmt.Sprintf("segments[%d].tag", location)
+		}
+		for index, field := range fields {
+			others := append([]string(nil), fields[:index]...)
+			others = append(others, fields[index+1:]...)
+			v.addError(
+				field,
+				fmt.Sprintf(
+					"duplicate segment tag %d also used by %s",
+					segment.Tag,
+					strings.Join(others, ", "),
+				),
+			)
+		}
+	}
 }
 
 // validateDevice validates a single device configuration.

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -214,6 +214,28 @@ func TestValidate_DetectsDuplicateIdentityAcrossSegments(t *testing.T) {
 	}
 }
 
+func TestValidate_DetectsDuplicateSegmentTags(t *testing.T) {
+	cfg := &Config{Segments: []Segment{
+		{Tag: UntaggedTag, ConfigPath: "first.yaml"},
+		{Tag: UntaggedTag, ConfigPath: "second.yaml"},
+	}}
+
+	result := NewValidator("segments.yaml").Validate(cfg)
+
+	if result.Valid {
+		t.Fatal("Validate() valid = true, want duplicate segment tag errors")
+	}
+	fields := make(map[string]bool)
+	for _, validationErr := range result.Errors {
+		fields[validationErr.Field] = true
+	}
+	for _, field := range []string{"segments[0].tag", "segments[1].tag"} {
+		if !fields[field] {
+			t.Fatalf("errors = %#v, want field %q", result.Errors, field)
+		}
+	}
+}
+
 func TestValidate_ResolvesForwardTopologyReference(t *testing.T) {
 	cfg := &Config{Devices: []Device{
 		{

--- a/internal/config/yaml_load.go
+++ b/internal/config/yaml_load.go
@@ -151,9 +151,25 @@ func buildSegments(
 	}
 
 	segments := make([]Segment, 0, len(yamlConfig.Segments))
+	segmentTags := make(map[int]int, len(yamlConfig.Segments))
 
-	for _, ySeg := range yamlConfig.Segments {
-		seg, err := buildSegment(ySeg, includePath, configDir, roots, registry)
+	for index, ySeg := range yamlConfig.Segments {
+		tag, err := parseSegmentTag(string(ySeg.Tag))
+		if err != nil {
+			return nil, err
+		}
+		if first, duplicate := segmentTags[tag]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: segments[%d].tag and segments[%d].tag normalize to %d",
+				ErrDuplicateSegmentTag,
+				first,
+				index,
+				tag,
+			)
+		}
+		segmentTags[tag] = index
+
+		seg, err := buildSegment(ySeg, tag, includePath, configDir, roots, registry)
 		if err != nil {
 			return nil, err
 		}
@@ -166,15 +182,11 @@ func buildSegments(
 
 func buildSegment(
 	ySeg converter.Segment,
+	tag int,
 	includePath, configDir string,
 	roots []string,
 	registry *oui.Registry,
 ) (Segment, error) {
-	tag, err := parseSegmentTag(string(ySeg.Tag))
-	if err != nil {
-		return Segment{}, err
-	}
-
 	hasInline := len(ySeg.Devices) > 0
 	hasConfig := ySeg.Config != ""
 

--- a/internal/protocols/segment_demux_test.go
+++ b/internal/protocols/segment_demux_test.go
@@ -60,6 +60,21 @@ func TestSegmentDemuxIsolatesReusedIP(t *testing.T) {
 	}
 }
 
+func TestSegmentDemuxFailsClosedForDuplicateTags(t *testing.T) {
+	cfg := &config.Config{
+		Segments: []config.Segment{
+			{Tag: 200, Devices: []config.Device{segDevice("first", "02:00:00:00:02:00", "10.0.0.1")}},
+			{Tag: 200, Devices: []config.Device{segDevice("second", "02:00:00:00:03:00", "10.0.0.2")}},
+		},
+	}
+
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+
+	if table := stack.devicesFor(200); table != nil {
+		t.Fatalf("devicesFor(200) = %#v, want no table for duplicate tag", table)
+	}
+}
+
 // TestFlatModeUnchanged: a config with no segments stays in flat mode —
 // devicesFor returns the single global table for every VLAN.
 func TestFlatModeUnchanged(t *testing.T) {

--- a/internal/protocols/stack_init.go
+++ b/internal/protocols/stack_init.go
@@ -82,11 +82,17 @@ func (s *Stack) initializeDevices(cfg *config.Config) {
 // Segments that only set ConfigPath (no inline Devices) are skipped for now —
 // resolving a segment config file is a separate slice — so their VLAN tag
 // ends up with no table and devicesFor(tag) returns nil for it, same as any
-// other unclaimed tag.
+// other unclaimed tag. Duplicate tags are also omitted as defense in depth;
+// configuration validation rejects them before normal stack construction.
 func (s *Stack) initializeSegments(cfg *config.Config) {
 	s.segmentTables = make(map[int]*DeviceTable)
+	segments := cfg.NormalizedSegments()
+	duplicateTags := config.DuplicateSegmentTags(segments)
 
-	for _, seg := range cfg.NormalizedSegments() {
+	for _, seg := range segments {
+		if _, duplicate := duplicateTags[seg.Tag]; duplicate {
+			continue
+		}
 		if len(seg.Devices) == 0 {
 			// TODO(slice-2): resolve ConfigPath via config.LoadYAML
 			continue


### PR DESCRIPTION
## Summary

- reject duplicate normalized segment tags during YAML loading before referenced configs are resolved
- report every conflicting semantic-validation field, including duplicate untagged segments
- share duplicate detection with the protocol stack and fail closed if invalid programmatic input bypasses validation
- add parser, validator, and runtime demultiplex regression coverage

## Linked Issue

Closes #1038

## Testing Evidence

```text
make fmt-check
# all formatting checks passed

make lint
# backend: 0 issues; frontend: no issues

make test
# all 41 Go packages and 67 frontend test files passed

make security
# govulncheck, npm audit, and gitleaks passed

go test -race ./internal/config ./internal/protocols -count=1
# both affected packages passed
```

## Security and Release Checklist

- [x] Duplicate tags fail before runtime construction
- [x] Runtime bypasses fail closed without exposing either colliding segment
- [x] No dependencies or public API endpoints changed
- [x] No suppressions or compatibility shims added
- [x] Full local quality and security gates passed
