### PR TITLE
fix(fabric): account TTL expiry as a drop

### DIFF
--- a/internal/protocols/fabric_forwarding_test.go
+++ b/internal/protocols/fabric_forwarding_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 )
 
-func TestFabricRoutesInternalTargetThroughAttachmentRouter(t *testing.T) {
+func TestFabricResolvesInternalTargetThroughAttachmentRouter(t *testing.T) {
 	cfg, topology, routerMAC := forwardingFixture(t)
 	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
 	stack.ConfigureFabric(topology)
@@ -40,11 +40,11 @@ func TestFabricRoutesInternalTargetThroughAttachmentRouter(t *testing.T) {
 		t.Fatal("resolved fabric endpoint must own its interface address")
 	}
 	trace := pkt.FabricTrace()
-	if trace.RouteDecision != "forwarded" || trace.EgressNetwork != "internal" || trace.Hop != "edge:inside" {
+	if trace.RouteDecision != "" || trace.EgressNetwork != "internal" || trace.Hop != "edge:inside" {
 		t.Fatalf("FabricTrace() = %#v", trace)
 	}
-	if got := stack.GetStats().FabricForwarded; got != 1 {
-		t.Fatalf("FabricForwarded = %d, want 1", got)
+	if got := stack.GetStats().FabricForwarded; got != 0 {
+		t.Fatalf("FabricForwarded = %d before dispatch, want 0", got)
 	}
 }
 
@@ -397,6 +397,18 @@ func TestFabricTTLExpiryUsesAttachmentRouterIdentity(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for routed ICMP time-exceeded")
+	}
+	trace := pkt.FabricTrace()
+	if trace.RouteDecision != "dropped" || trace.RejectionReason != "ttl_expired" {
+		t.Fatalf("FabricTrace() = %#v", trace)
+	}
+	stats := stack.GetStats()
+	if stats.FabricForwarded != 0 || stats.FabricDrops != 1 {
+		t.Fatalf(
+			"fabric counters = forwarded %d drops %d, want forwarded 0 drops 1",
+			stats.FabricForwarded,
+			stats.FabricDrops,
+		)
 	}
 }
 

--- a/internal/protocols/ip.go
+++ b/internal/protocols/ip.go
@@ -74,6 +74,7 @@ func (h *IPHandler) HandlePacket(pkt *Packet) {
 	if h.handleFabricTTLTimeout(pkt, ip) {
 		return
 	}
+	h.recordFabricForwarded(pkt)
 
 	if len(pkt.fabricFirstHopIP) == 0 && h.shouldProcessTTL(ip, devices) && h.handleTTLTimeout(pkt, ip) {
 		return
@@ -143,7 +144,7 @@ func (h *IPHandler) getFabricTarget(ip *layers.IPv4, pkt *Packet) []*config.Devi
 	}
 	resolution, resolved := h.stack.fabric.resolveIPv4(dst.Unmap(), pkt.GetDestMAC())
 	if !resolved {
-		pkt.fabricTrace.RouteDecision = "dropped"
+		pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
 		pkt.fabricTrace.RejectionReason = "no_route"
 		h.stack.stats.mu.Lock()
 		h.stack.stats.FabricDrops++
@@ -159,11 +160,7 @@ func (h *IPHandler) getFabricTarget(ip *layers.IPv4, pkt *Packet) []*config.Devi
 	pkt.fabricFirstHopIP = net.IP(resolution.firstHopIP.AsSlice())
 	pkt.fabricFirstHopMAC = cloneMAC(resolution.firstHopMAC)
 	pkt.fabricFirstHopDevice = resolution.firstHopDevice
-	pkt.fabricTrace.RouteDecision = "forwarded"
 	pkt.fabricTrace.Hop = resolution.firstHopDevice.Name + ":" + resolution.routeVia
-	h.stack.stats.mu.Lock()
-	h.stack.stats.FabricForwarded++
-	h.stack.stats.mu.Unlock()
 	return []*config.Device{resolution.device}
 }
 
@@ -171,11 +168,16 @@ func (h *IPHandler) handleFabricTTLTimeout(pkt *Packet, ipLayer *layers.IPv4) bo
 	if h.stack.fabric == nil || len(pkt.fabricFirstHopIP) == 0 || ipLayer.TTL > 1 {
 		return false
 	}
+	pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
+	pkt.fabricTrace.RejectionReason = fabricRejectionTTLExpired
+	h.stack.stats.mu.Lock()
+	h.stack.stats.FabricDrops++
+	h.stack.stats.mu.Unlock()
 	dstMAC := pkt.GetSourceMAC()
 	if len(dstMAC) == 0 || len(pkt.fabricFirstHopMAC) == 0 {
-		return false
+		return true
 	}
-	err := h.stack.icmpHandler.SendICMPTimeExceeded(
+	_ = h.stack.icmpHandler.SendICMPTimeExceeded(
 		pkt.fabricFirstHopIP,
 		ipLayer.SrcIP,
 		pkt.fabricFirstHopMAC,
@@ -184,7 +186,17 @@ func (h *IPHandler) handleFabricTTLTimeout(pkt *Packet, ipLayer *layers.IPv4) bo
 		pkt.fabricFirstHopDevice,
 		pkt.VLAN,
 	)
-	return err == nil
+	return true
+}
+
+func (h *IPHandler) recordFabricForwarded(pkt *Packet) {
+	if h.stack.fabric == nil || len(pkt.fabricFirstHopIP) == 0 {
+		return
+	}
+	pkt.fabricTrace.RouteDecision = fabricRouteDecisionForwarded
+	h.stack.stats.mu.Lock()
+	h.stack.stats.FabricForwarded++
+	h.stack.stats.mu.Unlock()
 }
 
 // shouldProcessTTL determines if TTL handling should be applied.

--- a/internal/protocols/packet.go
+++ b/internal/protocols/packet.go
@@ -39,6 +39,12 @@ type FabricTrace struct {
 	RejectionReason string
 }
 
+const (
+	fabricRouteDecisionDropped   = "dropped"
+	fabricRouteDecisionForwarded = "forwarded"
+	fabricRejectionTTLExpired    = "ttl_expired"
+)
+
 // Constants for packet parsing.
 const (
 	SizeOfMac           = 6

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -385,7 +385,7 @@ func (s *Stack) Send(pkt *Packet) {
 		if s.fabric != nil && pkt != nil {
 			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
 			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
-			pkt.fabricTrace.RouteDecision = "dropped"
+			pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
 			pkt.fabricTrace.RejectionReason = "send_queue_full"
 			s.stats.mu.Lock()
 			s.stats.FabricDrops++

--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -94,7 +94,7 @@ func (s *Stack) queuePacket(pkt *Packet) {
 		if s.fabric != nil {
 			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
 			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
-			pkt.fabricTrace.RouteDecision = "dropped"
+			pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
 			pkt.fabricTrace.RejectionReason = "receive_queue_full"
 			s.stats.mu.Lock()
 			s.stats.FabricDrops++
@@ -152,7 +152,7 @@ func (s *Stack) decodePacket(pkt *Packet) {
 	}()
 
 	if s.fabric != nil && !s.fabric.acceptsFrame(pkt.VLAN, pkt.VLANTagged) {
-		pkt.fabricTrace.RouteDecision = "dropped"
+		pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
 		pkt.fabricTrace.RejectionReason = "physical_vlan_rejected"
 		s.stats.mu.Lock()
 		s.stats.FabricDrops++
@@ -417,7 +417,7 @@ func (s *Stack) recordSendError(pkt *Packet, err error) {
 		if pkt != nil {
 			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
 			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
-			pkt.fabricTrace.RouteDecision = "dropped"
+			pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
 			pkt.fabricTrace.RejectionReason = "egress_rejected"
 		}
 	}


### PR DESCRIPTION
## Summary

- defer routed-forwarding trace and counter updates until after TTL validation
- classify TTL expiry as a stable `dropped` / `ttl_expired` outcome
- increment fabric drops without incrementing fabric forwarded
- consume the expired packet even when an ICMP Time Exceeded reply cannot be emitted
- centralize repeated routed trace decision literals

## Linked Issue

Closes #1047

## Testing Evidence

```text
make fmt-check
# all formatting checks passed

make lint
# backend: 0 issues; frontend: no issues

make test
# all 41 Go packages and 67 frontend test files passed

make security
# govulncheck, npm audit, and gitleaks passed

go test -race ./internal/protocols -count=1
# affected package passed
```

## Security and Release Checklist

- [x] Expired packets fail closed and cannot reach a protocol handler
- [x] Trace and counters describe the original packet independently of ICMP reply success
- [x] No dependencies or public API endpoints changed
- [x] No suppressions or compatibility shims added
- [x] Full local quality and security gates passed
