### PR TITLE
fix(config): resolve segment references at load time

### DIFF
--- a/internal/config/segments_test.go
+++ b/internal/config/segments_test.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
 )
 
 // TestSegmentConfigPathResolution: a segment's `config:` file (a whole demo) is
@@ -55,6 +59,18 @@ segments:
 
 	if segs[1].Tag != 300 || segs[1].Devices[0].Name != "demo2-r1" {
 		t.Errorf("tag-300 inline segment wrong: %+v", segs[1])
+	}
+
+	data, err := MarshalConfigYAML(cfg)
+	if err != nil {
+		t.Fatalf("MarshalConfigYAML() error = %v", err)
+	}
+	var authored converter.Config
+	if err = yaml.Unmarshal(data, &authored); err != nil {
+		t.Fatalf("unmarshal serialized config: %v", err)
+	}
+	if authored.Segments[0].Config != "" || len(authored.Segments[0].Devices) != 1 {
+		t.Fatalf("resolved segment serialized as unresolved reference: %#v", authored.Segments[0])
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -129,13 +129,10 @@ type Route struct {
 // UntaggedTag is the Segment.Tag value for the native/untagged VLAN.
 const UntaggedTag = 0
 
-// Segment binds a device set to a VLAN tag for multi-VLAN playback (ADR 0008).
-// Each segment is served as an isolated network on its tag. Exactly one of
-// Devices (inline) or ConfigPath (a file resolved by the loader) is populated.
+// Segment binds a resolved device set to a VLAN tag for multi-VLAN playback.
 type Segment struct {
-	Tag        int      // UntaggedTag (0) for the native VLAN, else a VLAN id 1..4094
-	Devices    []Device // Inline device set for this segment
-	ConfigPath string   // Path to a config file for this segment (resolved by the loader)
+	Tag     int      // UntaggedTag (0) for the native VLAN, else a VLAN id 1..4094
+	Devices []Device // Resolved device set for this segment
 }
 
 // DeviceCount returns the total number of devices this config describes,

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -216,8 +216,8 @@ func TestValidate_DetectsDuplicateIdentityAcrossSegments(t *testing.T) {
 
 func TestValidate_DetectsDuplicateSegmentTags(t *testing.T) {
 	cfg := &Config{Segments: []Segment{
-		{Tag: UntaggedTag, ConfigPath: "first.yaml"},
-		{Tag: UntaggedTag, ConfigPath: "second.yaml"},
+		{Tag: UntaggedTag},
+		{Tag: UntaggedTag},
 	}}
 
 	result := NewValidator("segments.yaml").Validate(cfg)

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -66,11 +66,8 @@ func segmentsToYAML(segments []Segment) []converter.Segment {
 		if segment.Tag == UntaggedTag {
 			tag = "untagged"
 		}
-		out[i] = converter.Segment{Tag: converter.VLANTag(tag)}
-		if segment.ConfigPath != "" {
-			out[i].Config = segment.ConfigPath
-		} else {
-			out[i].Devices = devicesToYAML(segment.Devices)
+		out[i] = converter.Segment{
+			Tag: converter.VLANTag(tag), Devices: devicesToYAML(segment.Devices),
 		}
 	}
 	return out

--- a/internal/config/yaml_load.go
+++ b/internal/config/yaml_load.go
@@ -194,7 +194,7 @@ func buildSegment(
 		return Segment{}, fmt.Errorf("%w: tag %q", ErrSegmentDevicesXORConfig, ySeg.Tag)
 	}
 
-	seg := Segment{Tag: tag, ConfigPath: ySeg.Config}
+	seg := Segment{Tag: tag}
 
 	if hasConfig {
 		return resolveSegmentConfig(seg, ySeg.Config, configDir, roots)
@@ -265,7 +265,7 @@ func parseSegmentTag(tag string) (int, error) {
 
 func configHasDevices(segments []Segment) bool {
 	return slices.ContainsFunc(segments, func(seg Segment) bool {
-		return len(seg.Devices) > 0 || seg.ConfigPath != ""
+		return len(seg.Devices) > 0
 	})
 }
 

--- a/internal/config/yaml_roundtrip_test.go
+++ b/internal/config/yaml_roundtrip_test.go
@@ -56,7 +56,9 @@ func TestMarshalConfigYAMLPreservesSegments(t *testing.T) {
 		{Tag: UntaggedTag, Devices: []Device{{
 			Name: "native", Type: "router", MACAddress: mustMAC(t, "02:00:00:00:00:01"),
 		}}},
-		{Tag: 200, ConfigPath: "site.yaml"},
+		{Tag: 200, Devices: []Device{{
+			Name: "site", Type: "switch", MACAddress: mustMAC(t, "02:00:00:00:00:02"),
+		}}},
 	}}
 
 	data, err := MarshalConfigYAML(cfg)
@@ -73,8 +75,8 @@ func TestMarshalConfigYAMLPreservesSegments(t *testing.T) {
 	if authored.Segments[0].Tag != "untagged" || len(authored.Segments[0].Devices) != 1 {
 		t.Fatalf("inline segment = %#v", authored.Segments[0])
 	}
-	if authored.Segments[1].Tag != "200" || authored.Segments[1].Config != "site.yaml" {
-		t.Fatalf("referenced segment = %#v", authored.Segments[1])
+	if authored.Segments[1].Tag != "200" || len(authored.Segments[1].Devices) != 1 {
+		t.Fatalf("resolved segment = %#v", authored.Segments[1])
 	}
 }
 

--- a/internal/protocols/stack_init.go
+++ b/internal/protocols/stack_init.go
@@ -79,11 +79,8 @@ func (s *Stack) initializeDevices(cfg *config.Config) {
 // devicesFor can route a frame to the correct "demo" by VLAN tag, even when
 // two segments reuse the same IP addresses.
 //
-// Segments that only set ConfigPath (no inline Devices) are skipped for now —
-// resolving a segment config file is a separate slice — so their VLAN tag
-// ends up with no table and devicesFor(tag) returns nil for it, same as any
-// other unclaimed tag. Duplicate tags are also omitted as defense in depth;
-// configuration validation rejects them before normal stack construction.
+// Duplicate tags are omitted as defense in depth; configuration validation
+// rejects them before normal stack construction.
 func (s *Stack) initializeSegments(cfg *config.Config) {
 	s.segmentTables = make(map[int]*DeviceTable)
 	segments := cfg.NormalizedSegments()
@@ -91,10 +88,6 @@ func (s *Stack) initializeSegments(cfg *config.Config) {
 
 	for _, seg := range segments {
 		if _, duplicate := duplicateTags[seg.Tag]; duplicate {
-			continue
-		}
-		if len(seg.Devices) == 0 {
-			// TODO(slice-2): resolve ConfigPath via config.LoadYAML
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- make runtime segments contain only tags and resolved device sets
- keep YAML `config:` references in the authored DTO and expand them during loading
- serialize loaded runtime configs as canonical inline segment content
- remove the protocol stack's unresolved-reference skip path
- add round-trip evidence that referenced segments are resolved before runtime use

## Linked Issue

Closes #1046

## Testing Evidence

```text
make fmt-check
# all formatting checks passed

make lint
# backend: 0 issues; frontend: no issues

make test
# all 41 Go packages and 67 frontend test files passed

make security
# govulncheck, npm audit, and gitleaks passed

go test -race ./internal/config ./internal/protocols -count=1
# both affected packages passed
```

## Security and Release Checklist

- [x] Unresolved segment paths cannot enter the runtime type
- [x] Managed-root path checks still occur before referenced configs are loaded
- [x] No dependencies or public API endpoints changed
- [x] No compatibility shims or runtime fallbacks added
- [x] Full local quality and security gates passed
