### PR TITLE
fix(fabric): validate DHCP leases and options

### DIFF
--- a/internal/fabric/compiler.go
+++ b/internal/fabric/compiler.go
@@ -12,11 +12,12 @@ import (
 // Compile validates and canonicalizes a routed scenario without side effects.
 func Compile(cfg *config.Config, binding Binding) Report {
 	compiler := scenarioCompiler{
-		cfg:       cfg,
-		binding:   binding,
-		networks:  make(map[string]Network),
-		devices:   make(map[string]struct{}),
-		addresses: make(map[netip.Addr]string),
+		cfg:                cfg,
+		binding:            binding,
+		networks:           make(map[string]Network),
+		devices:            make(map[string]struct{}),
+		addresses:          make(map[netip.Addr]string),
+		dhcpLeaseAddresses: make(map[netip.Addr]string),
 	}
 	compiler.compileBinding()
 	compiler.compileNetworks()
@@ -26,12 +27,14 @@ func Compile(cfg *config.Config, binding Binding) Report {
 }
 
 type scenarioCompiler struct {
-	cfg       *config.Config
-	binding   Binding
-	networks  map[string]Network
-	devices   map[string]struct{}
-	addresses map[netip.Addr]string
-	report    Report
+	cfg                *config.Config
+	binding            Binding
+	networks           map[string]Network
+	devices            map[string]struct{}
+	addresses          map[netip.Addr]string
+	dhcpLeaseAddresses map[netip.Addr]string
+	dhcpLeaseMACs      []dhcpLeaseMAC
+	report             Report
 }
 
 func (c *scenarioCompiler) compileBinding() {

--- a/internal/fabric/compiler_devices.go
+++ b/internal/fabric/compiler_devices.go
@@ -1,9 +1,12 @@
 package fabric
 
 import (
+	"bytes"
 	"fmt"
+	"maps"
 	"net"
 	"net/netip"
+	"slices"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
@@ -11,8 +14,15 @@ import (
 const (
 	bitsPerByte                     = 8
 	maxUsableEndpointPrefixLen      = 30
+	ethernetMACBytes                = 6
 	fullByteMask               byte = 0xff
 )
+
+type dhcpLeaseMAC struct {
+	address net.HardwareAddr
+	mask    net.HardwareAddr
+	device  string
+}
 
 func (c *scenarioCompiler) compileInterfaces(device *config.Device) map[string]Interface {
 	compiled := make(map[string]Interface)
@@ -192,29 +202,248 @@ func (c *scenarioCompiler) appendDHCPScope(device *config.Device, iface Interfac
 		)
 		return
 	}
+	if !c.validateDHCPOptions(device, network) {
+		return
+	}
+	if !c.validateDHCPPoolCollisions(device, iface, start, end) ||
+		!c.validateDHCPLeases(device, network, start, end) {
+		return
+	}
+	c.report.Topology.DHCPScopes = append(c.report.Topology.DHCPScopes, DHCPScope{
+		Device: device.Name, Network: iface.Network, Start: start, End: end, Router: router,
+	})
+}
+
+func (c *scenarioCompiler) validateDHCPPoolCollisions(
+	device *config.Device,
+	iface Interface,
+	start netip.Addr,
+	end netip.Addr,
+) bool {
+	field := "devices." + device.Name + ".dhcp"
 	for address, owner := range c.addresses {
 		if address.Compare(start) >= 0 && address.Compare(end) <= 0 {
 			c.add(
 				CodeDHCPAddressCollision,
-				"devices."+device.Name+".dhcp",
+				field,
 				fmt.Sprintf("DHCP pool contains an interface address assigned to device %s", owner),
 			)
-			return
+			return false
 		}
 	}
 	for _, scope := range c.report.Topology.DHCPScopes {
 		if scope.Network == iface.Network && start.Compare(scope.End) <= 0 && end.Compare(scope.Start) >= 0 {
 			c.add(
 				CodeDHCPAddressCollision,
-				"devices."+device.Name+".dhcp",
+				field,
 				fmt.Sprintf("DHCP pool overlaps the pool assigned to device %s", scope.Device),
 			)
-			return
+			return false
 		}
 	}
-	c.report.Topology.DHCPScopes = append(c.report.Topology.DHCPScopes, DHCPScope{
-		Device: device.Name, Network: iface.Network, Start: start, End: end, Router: router,
-	})
+	for address, owner := range c.dhcpLeaseAddresses {
+		if address.Compare(start) >= 0 && address.Compare(end) <= 0 {
+			c.add(
+				CodeDHCPAddressCollision,
+				field,
+				fmt.Sprintf("DHCP pool contains a lease address assigned by device %s", owner),
+			)
+			return false
+		}
+	}
+	return true
+}
+
+func (c *scenarioCompiler) validateDHCPOptions(device *config.Device, network Network) bool {
+	field := "devices." + device.Name + ".dhcp"
+	for index, server := range device.DHCPConfig.DomainNameServer {
+		address, ok := ipToAddr(server)
+		if !ok || !address.Is4() || !address.IsGlobalUnicast() {
+			c.add(
+				CodeInvalidDHCPOption,
+				fmt.Sprintf("%s.domain_name_server[%d]", field, index),
+				"DHCP DNS server must be a unicast IPv4 address",
+			)
+			return false
+		}
+	}
+	for _, option := range []struct {
+		name    string
+		address net.IP
+	}{
+		{name: "server_identifier", address: device.DHCPConfig.ServerIdentifier},
+		{name: "next_server_ip", address: device.DHCPConfig.NextServerIP},
+	} {
+		if option.address == nil {
+			continue
+		}
+		address, ok := ipToAddr(option.address)
+		if !ok || !address.Is4() || !network.Prefix.Contains(address) ||
+			isReservedEndpoint(network.Prefix, address) {
+			c.add(
+				CodeInvalidDHCPOption,
+				field+"."+option.name,
+				"DHCP server option must be a usable IPv4 address inside its network",
+			)
+			return false
+		}
+	}
+	return true
+}
+
+func (c *scenarioCompiler) validateDHCPLeases(
+	device *config.Device,
+	network Network,
+	poolStart netip.Addr,
+	poolEnd netip.Addr,
+) bool {
+	pendingAddresses := make(map[netip.Addr]string)
+	pendingMACs := make([]dhcpLeaseMAC, 0, len(device.DHCPConfig.ClientLeases))
+	for index, lease := range device.DHCPConfig.ClientLeases {
+		address, mac, ok := c.validateDHCPLease(
+			device,
+			lease,
+			index,
+			network,
+			poolStart,
+			poolEnd,
+			pendingAddresses,
+			pendingMACs,
+		)
+		if !ok {
+			return false
+		}
+		pendingAddresses[address] = device.Name
+		pendingMACs = append(pendingMACs, mac)
+	}
+	maps.Copy(c.dhcpLeaseAddresses, pendingAddresses)
+	c.dhcpLeaseMACs = append(c.dhcpLeaseMACs, pendingMACs...)
+	return true
+}
+
+func (c *scenarioCompiler) validateDHCPLease(
+	device *config.Device,
+	lease config.DHCPLease,
+	index int,
+	network Network,
+	poolStart netip.Addr,
+	poolEnd netip.Addr,
+	pendingAddresses map[netip.Addr]string,
+	pendingMACs []dhcpLeaseMAC,
+) (netip.Addr, dhcpLeaseMAC, bool) {
+	field := fmt.Sprintf("devices.%s.dhcp.client_leases[%d]", device.Name, index)
+	address, ok := ipToAddr(lease.ClientIP)
+	if !ok || !address.Is4() || !network.Prefix.Contains(address) ||
+		isReservedEndpoint(network.Prefix, address) || !validDHCPLeaseMAC(lease) {
+		c.add(CodeInvalidDHCPLease, field, "DHCP lease must use a usable network address and unicast MAC")
+		return netip.Addr{}, dhcpLeaseMAC{}, false
+	}
+	if !c.validateDHCPLeaseAddress(field, address, poolStart, poolEnd, pendingAddresses) {
+		return netip.Addr{}, dhcpLeaseMAC{}, false
+	}
+	if owner, exists := overlappingDHCPLeaseMAC(lease, c.dhcpLeaseMACs); exists {
+		c.add(
+			CodeDHCPAddressCollision,
+			field+".mac",
+			fmt.Sprintf("DHCP lease MAC overlaps an assignment by device %s", owner),
+		)
+		return netip.Addr{}, dhcpLeaseMAC{}, false
+	}
+	if owner, exists := overlappingDHCPLeaseMAC(lease, pendingMACs); exists {
+		c.add(
+			CodeDHCPAddressCollision,
+			field+".mac",
+			fmt.Sprintf("DHCP lease MAC overlaps an assignment by device %s", owner),
+		)
+		return netip.Addr{}, dhcpLeaseMAC{}, false
+	}
+	return address, dhcpLeaseMAC{
+		address: slices.Clone(lease.MACAddress),
+		mask:    slices.Clone(lease.MACMask),
+		device:  device.Name,
+	}, true
+}
+
+func (c *scenarioCompiler) validateDHCPLeaseAddress(
+	field string,
+	address netip.Addr,
+	poolStart netip.Addr,
+	poolEnd netip.Addr,
+	pendingAddresses map[netip.Addr]string,
+) bool {
+	if owner, exists := c.addresses[address]; exists {
+		c.add(
+			CodeDHCPAddressCollision,
+			field+".ip",
+			fmt.Sprintf("DHCP lease address is assigned to device %s", owner),
+		)
+		return false
+	}
+	if address.Compare(poolStart) >= 0 && address.Compare(poolEnd) <= 0 {
+		c.add(CodeDHCPAddressCollision, field+".ip", "DHCP lease address overlaps its dynamic pool")
+		return false
+	}
+	for _, scope := range c.report.Topology.DHCPScopes {
+		if address.Compare(scope.Start) >= 0 && address.Compare(scope.End) <= 0 {
+			c.add(
+				CodeDHCPAddressCollision,
+				field+".ip",
+				fmt.Sprintf("DHCP lease address overlaps the pool assigned to device %s", scope.Device),
+			)
+			return false
+		}
+	}
+	if owner, exists := c.dhcpLeaseAddresses[address]; exists {
+		c.add(
+			CodeDHCPAddressCollision,
+			field+".ip",
+			fmt.Sprintf("DHCP lease address is already assigned by device %s", owner),
+		)
+		return false
+	}
+	if owner, exists := pendingAddresses[address]; exists {
+		c.add(
+			CodeDHCPAddressCollision,
+			field+".ip",
+			fmt.Sprintf("DHCP lease address is already assigned by device %s", owner),
+		)
+		return false
+	}
+	return true
+}
+
+func validDHCPLeaseMAC(lease config.DHCPLease) bool {
+	if len(lease.MACAddress) != ethernetMACBytes || lease.MACAddress[0]&1 != 0 ||
+		bytes.Equal(lease.MACAddress, make(net.HardwareAddr, ethernetMACBytes)) {
+		return false
+	}
+	return len(lease.MACMask) == 0 || len(lease.MACMask) == ethernetMACBytes
+}
+
+func overlappingDHCPLeaseMAC(lease config.DHCPLease, assigned []dhcpLeaseMAC) (string, bool) {
+	for _, candidate := range assigned {
+		if dhcpLeaseMACsOverlap(lease.MACAddress, lease.MACMask, candidate.address, candidate.mask) {
+			return candidate.device, true
+		}
+	}
+	return "", false
+}
+
+func dhcpLeaseMACsOverlap(left, leftMask, right, rightMask net.HardwareAddr) bool {
+	for index := range ethernetMACBytes {
+		leftConstraint := fullByteMask
+		if len(leftMask) != 0 {
+			leftConstraint = leftMask[index]
+		}
+		rightConstraint := fullByteMask
+		if len(rightMask) != 0 {
+			rightConstraint = rightMask[index]
+		}
+		if (left[index]^right[index])&leftConstraint&rightConstraint != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func isReservedEndpoint(prefix netip.Prefix, address netip.Addr) bool {

--- a/internal/fabric/compiler_test.go
+++ b/internal/fabric/compiler_test.go
@@ -340,6 +340,144 @@ func TestCompileRejectsInvalidDHCPSemantics(t *testing.T) {
 			},
 			code: fabric.CodeDHCPAddressCollision,
 		},
+		{
+			name: "lease outside network",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{{
+					ClientIP:   net.ParseIP("192.0.2.10"),
+					MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+				}}
+			},
+			code: fabric.CodeInvalidDHCPLease,
+		},
+		{
+			name: "lease uses reserved address",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{{
+					ClientIP:   net.ParseIP("10.10.200.255"),
+					MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+				}}
+			},
+			code: fabric.CodeInvalidDHCPLease,
+		},
+		{
+			name: "lease has invalid MAC",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{{
+					ClientIP: net.ParseIP("10.10.200.50"), MACAddress: net.HardwareAddr{0x02},
+				}}
+			},
+			code: fabric.CodeInvalidDHCPLease,
+		},
+		{
+			name: "lease has invalid MAC mask",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{{
+					ClientIP:   net.ParseIP("10.10.200.50"),
+					MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+					MACMask:    net.HardwareAddr{0xff},
+				}}
+			},
+			code: fabric.CodeInvalidDHCPLease,
+		},
+		{
+			name: "lease overlaps pool",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{{
+					ClientIP:   net.ParseIP("10.10.200.210"),
+					MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+				}}
+			},
+			code: fabric.CodeDHCPAddressCollision,
+		},
+		{
+			name: "lease collides with interface",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{{
+					ClientIP:   net.ParseIP("10.10.200.1"),
+					MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+				}}
+			},
+			code: fabric.CodeDHCPAddressCollision,
+		},
+		{
+			name: "duplicate lease address",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{
+					{
+						ClientIP:   net.ParseIP("10.10.200.50"),
+						MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+					},
+					{
+						ClientIP:   net.ParseIP("10.10.200.50"),
+						MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x11},
+					},
+				}
+			},
+			code: fabric.CodeDHCPAddressCollision,
+		},
+		{
+			name: "duplicate lease MAC",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{
+					{
+						ClientIP:   net.ParseIP("10.10.200.50"),
+						MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+					},
+					{
+						ClientIP:   net.ParseIP("10.10.200.51"),
+						MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x10},
+					},
+				}
+			},
+			code: fabric.CodeDHCPAddressCollision,
+		},
+		{
+			name: "overlapping masked lease MAC",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{
+					{
+						ClientIP:   net.ParseIP("10.10.200.50"),
+						MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0},
+						MACMask:    net.HardwareAddr{0xff, 0xff, 0xff, 0, 0, 0},
+					},
+					{
+						ClientIP:   net.ParseIP("10.10.200.51"),
+						MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 1},
+						MACMask:    net.HardwareAddr{0xff, 0xff, 0xff, 0, 0, 0},
+					},
+				}
+			},
+			code: fabric.CodeDHCPAddressCollision,
+		},
+		{
+			name: "invalid DNS server address",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.DomainNameServer = []net.IP{nil}
+			},
+			code: fabric.CodeInvalidDHCPOption,
+		},
+		{
+			name: "IPv6 DNS server address",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.DomainNameServer = []net.IP{net.ParseIP("2001:4860:4860::8888")}
+			},
+			code: fabric.CodeInvalidDHCPOption,
+		},
+		{
+			name: "server identifier outside network",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.ServerIdentifier = net.ParseIP("192.0.2.10")
+			},
+			code: fabric.CodeInvalidDHCPOption,
+		},
+		{
+			name: "next server uses reserved address",
+			mutate: func(cfg *config.Config) {
+				cfg.Devices[1].DHCPConfig.NextServerIP = net.ParseIP("10.10.200.0")
+			},
+			code: fabric.CodeInvalidDHCPOption,
+		},
 	}
 
 	for _, tt := range tests {
@@ -352,6 +490,23 @@ func TestCompileRejectsInvalidDHCPSemantics(t *testing.T) {
 			}
 			assertDiagnostic(t, report, tt.code)
 		})
+	}
+}
+
+func TestCompileAcceptsValidDHCPLeasesAndOptions(t *testing.T) {
+	cfg := referenceConfig()
+	cfg.Devices[1].DHCPConfig.ClientLeases = []config.DHCPLease{{
+		ClientIP:   net.ParseIP("10.10.200.50"),
+		MACAddress: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x50},
+	}}
+	cfg.Devices[1].DHCPConfig.DomainNameServer = []net.IP{net.ParseIP("8.8.8.8")}
+	cfg.Devices[1].DHCPConfig.ServerIdentifier = net.ParseIP("10.10.200.2")
+	cfg.Devices[1].DHCPConfig.NextServerIP = net.ParseIP("10.10.200.1")
+
+	report := fabric.Compile(cfg, accessBinding())
+
+	if !report.Safe {
+		t.Fatalf("Compile() diagnostics = %#v, want safe DHCP configuration", report.Diagnostics)
 	}
 }
 

--- a/internal/fabric/types.go
+++ b/internal/fabric/types.go
@@ -42,6 +42,8 @@ const (
 	CodeDHCPPoolOutsideNetwork   DiagnosticCode = "dhcp_pool_outside_network"
 	CodeInvalidDHCPRange         DiagnosticCode = "invalid_dhcp_range"
 	CodeInvalidDHCPRouter        DiagnosticCode = "invalid_dhcp_router"
+	CodeInvalidDHCPLease         DiagnosticCode = "invalid_dhcp_lease"
+	CodeInvalidDHCPOption        DiagnosticCode = "invalid_dhcp_option"
 	CodeReservedDHCPAddress      DiagnosticCode = "reserved_dhcp_address"
 	CodeDHCPAddressCollision     DiagnosticCode = "dhcp_address_collision"
 )


### PR DESCRIPTION
## Summary
- validate static DHCP lease network membership, reserved endpoints, MAC shape, and wildcard-mask uniqueness
- reject collisions across interfaces, dynamic pools, and static leases without leaking invalid scope state into later validation
- validate DHCPv4 DNS, server identifier, and next-server options with stable compiler diagnostics

## Linked Issue
Closes #1078

## Testing Evidence
```
make fmt-check: all formatting checks passed
make lint: backend 0 issues; frontend 328 files checked
make test: 41 Go packages and 67 Vitest files passed; Go coverage 65.5%
make security: govulncheck no vulnerabilities; npm audit 0 vulnerabilities; gitleaks no leaks
go test -race ./internal/fabric -count=1: ok
```

## Security and Release Checklist
- [x] fail-closed compiler behavior preserved
- [x] no dependencies added
- [x] no auth, secret, or release-path changes
- [x] full local quality and security gates passed