### PR TITLE
fix(i18n): refresh runtime catalog extraction

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -643,6 +643,7 @@
     "label": "Simulation",
     "noUsableInterfaces": "No usable interfaces",
     "pickConfigHint": "Pick one below — Start unlocks once you do",
+    "preparingConnectionLabel": "Preparing connection…",
     "preview": {
       "deviceCount_one": "{{count}} device will launch when Start is clicked.",
       "deviceCount_other": "{{count}} devices will launch when Start is clicked.",
@@ -654,6 +655,7 @@
       "previewOnly": "Preview only — Start to launch",
       "selectedPrefix": "Selected:"
     },
+    "reviewConnectionLabel": "Review connection",
     "running": {
       "active": "ACTIVE",
       "configHelper": "Configuration file",
@@ -670,8 +672,6 @@
       "uptimeLabel": "Uptime",
       "viewDevices": "View Devices"
     },
-    "reviewConnectionLabel": "Review connection",
-    "preparingConnectionLabel": "Preparing connection…",
     "startSimulationTitle": "Start Simulation",
     "startSuccess": "Simulation started successfully!",
     "startTitlePickConfig": "Pick a config below first",


### PR DESCRIPTION
## Summary
- refresh the extracted English pages catalog after the Runtime Control preflight labels landed
- restore the i18n catalog drift gate on current main

## Linked Issue
Related to #1034

## Testing Evidence
```
npm run i18n:lint: 7 files checked
npm run i18n:check: passed with no catalog drift
npm run i18n:test: extractor fixture passed; no files updated
vitest i18n parity: 14 tests passed
make fmt-check: all formatting checks passed
make security: govulncheck, npm audit, and gitleaks passed
```

## Security and Release Checklist
- [x] generated catalog ordering only
- [x] no dependencies or runtime behavior changed
- [x] catalog extraction and parity gates passed