### PR TITLE
fix(daemon): replace simulations transactionally

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -87,6 +87,8 @@ type Daemon struct {
 
 	mu         sync.RWMutex
 	simulation *Simulation
+	// startSimulation is injectable so replacement failure and cleanup are deterministic in tests.
+	startSimulation simulationStarter
 	// capture is the optional standalone packet-capture session that
 	// runs without a simulation. Mutually exclusive with simulation
 	// because both want exclusive ownership of the same libpcap
@@ -109,10 +111,25 @@ type Simulation struct {
 	cancel context.CancelFunc
 }
 
+type simulationResources struct {
+	engine *capture.Engine
+	stack  *protocols.Stack
+	replay api.ReplayManager
+	cancel context.CancelFunc
+}
+
+type simulationStarter func(
+	string,
+	*config.Config,
+	*fabric.Topology,
+	bool,
+) (simulationResources, error)
+
 // NewDaemon creates a new daemon instance.
 func NewDaemon(cfg Config) (*Daemon, error) {
 	daemon := &Daemon{
-		cfg: cfg,
+		cfg:             cfg,
+		startSimulation: startSimulationResources,
 	}
 
 	// Open storage if enabled
@@ -507,59 +524,49 @@ func (d *Daemon) StartSimulation(req api.SimulationRequest, entitlements api.Sim
 		return err
 	}
 	compiled := compiledFabric.topology
+	resources, err := d.startSimulation(req.Interface, cfg, compiled, dryRun)
+	if err != nil {
+		resources.stop()
+		return err
+	}
 	if req.ConfigData != "" {
 		configPath, err = persistInlineConfig(req.ConfigData)
 		if err != nil {
+			resources.stop()
 			return fmt.Errorf("persist inline config: %w", err)
 		}
 	}
-	if d.simulation != nil {
-		if stopErr := d.stopSimulationLocked(); stopErr != nil {
-			return fmt.Errorf("stop existing simulation: %w", stopErr)
-		}
-	}
 
-	var engine *capture.Engine
-	var cancel context.CancelFunc
-	var replay api.ReplayManager
-	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(DefaultDebugLevel))
-	stack.ConfigureFabric(compiled)
-
-	if !dryRun {
-		engine, stack, cancel, err = startSimulationStack(req.Interface, cfg, compiled)
-		if err != nil {
-			return err
-		}
-		replay = newReplayController(engine, stack.GetDebugLevel())
-	} else {
-		_, cancel = context.WithCancel(context.Background())
-	}
-
-	d.simulation = &Simulation{
+	replacement := &Simulation{
 		Interface:  req.Interface,
 		ConfigPath: configPath,
 		ConfigName: filepath.Base(configPath),
 		StartedAt:  time.Now(),
-		engine:     engine,
-		stack:      stack,
+		engine:     resources.engine,
+		stack:      resources.stack,
 		cfg:        cfg,
 		fabric:     compiled,
-		replay:     replay,
-		cancel:     cancel,
+		replay:     resources.replay,
+		cancel:     resources.cancel,
 	}
 
-	d.apiServer.UpdateSimulation(stack, cfg, configPath, req.Interface, replay)
+	active := d.simulation
+	d.simulation = replacement
+	d.apiServer.UpdateSimulation(resources.stack, cfg, configPath, req.Interface, resources.replay)
+	if active != nil {
+		d.stopSimulation(active)
+	}
 
 	logging.Successf("✓ Simulation started on %s with %d devices", req.Interface, len(cfg.Devices))
 
 	// Auto-start PCAP playback if configured. The playback is best-effort —
 	// a failed playback start logs but doesn't fail the simulation, since
 	// the protocol stack is already up and serving devices.
-	if !dryRun && replay != nil &&
+	if !dryRun && resources.replay != nil &&
 		cfg.CapturePlayback != nil &&
 		strings.TrimSpace(cfg.CapturePlayback.FileName) != "" {
 		fileName := resolvePlaybackPath(cfg.CapturePlayback.FileName, configPath)
-		_, replayErr := replay.Start(api.ReplayRequest{
+		_, replayErr := resources.replay.Start(api.ReplayRequest{
 			File:   fileName,
 			LoopMs: cfg.CapturePlayback.LoopTime,
 			Scale:  cfg.CapturePlayback.ScaleTime,
@@ -572,6 +579,46 @@ func (d *Daemon) StartSimulation(req api.SimulationRequest, entitlements api.Sim
 	}
 
 	return nil
+}
+
+func startSimulationResources(
+	iface string,
+	cfg *config.Config,
+	topology *fabric.Topology,
+	dryRun bool,
+) (simulationResources, error) {
+	if dryRun {
+		stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(DefaultDebugLevel))
+		stack.ConfigureFabric(topology)
+		_, cancel := context.WithCancel(context.Background())
+		return simulationResources{stack: stack, cancel: cancel}, nil
+	}
+
+	engine, stack, cancel, err := startSimulationStack(iface, cfg, topology)
+	if err != nil {
+		return simulationResources{}, err
+	}
+	return simulationResources{
+		engine: engine,
+		stack:  stack,
+		replay: newReplayController(engine, stack.GetDebugLevel()),
+		cancel: cancel,
+	}, nil
+}
+
+func (resources simulationResources) stop() {
+	if resources.replay != nil {
+		_, _ = resources.replay.Stop()
+	}
+	if resources.cancel != nil {
+		resources.cancel()
+	}
+	if resources.stack != nil {
+		resources.stack.Stop()
+	}
+	if resources.engine != nil {
+		resources.engine.Close()
+	}
 }
 
 func loadAuthorizedSimulationConfig(
@@ -645,31 +692,25 @@ func (d *Daemon) stopSimulationLocked() error {
 	}
 
 	sim := d.simulation
+	d.simulation = nil
+	d.apiServer.ClearSimulation()
+	d.stopSimulation(sim)
 
-	// Stop replay if running
-	if sim.replay != nil {
-		_, _ = sim.replay.Stop()
-	}
+	logging.Infof("Simulation stopped")
 
-	// Cancel context first to signal shutdown
-	if sim.cancel != nil {
-		sim.cancel()
-	}
+	return nil
+}
 
-	// Stop stack
-	if sim.stack != nil {
-		sim.stack.Stop()
-	}
-
-	// Close engine
-	if sim.engine != nil {
-		sim.engine.Close()
-	}
-
-	// Save run history
-	if d.storage != nil && sim.stack != nil {
+func (d *Daemon) stopSimulation(sim *Simulation) {
+	simulationResources{
+		engine: sim.engine,
+		stack:  sim.stack,
+		replay: sim.replay,
+		cancel: sim.cancel,
+	}.stop()
+	if d.storage != nil && sim.stack != nil && sim.cfg != nil {
 		stats := sim.stack.GetStats()
-		record := storage.RunRecord{
+		_ = d.storage.AddRun(storage.RunRecord{
 			StartedAt:       sim.StartedAt,
 			Duration:        time.Since(sim.StartedAt),
 			Interface:       sim.Interface,
@@ -678,18 +719,8 @@ func (d *Daemon) stopSimulationLocked() error {
 			PacketsSent:     stats.PacketsSent,
 			PacketsReceived: stats.PacketsReceived,
 			Errors:          stats.Errors,
-		}
-		_ = d.storage.AddRun(record)
+		})
 	}
-
-	d.simulation = nil
-
-	// Clear simulation from API server
-	d.apiServer.ClearSimulation()
-
-	logging.Infof("Simulation stopped")
-
-	return nil
 }
 
 // GetStatus returns the current simulation status.

--- a/internal/daemon/replacement_test.go
+++ b/internal/daemon/replacement_test.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+)
+
+func TestFailedSimulationReplacementPreservesActiveRun(t *testing.T) {
+	t.Setenv(e2eDryRunEnv, "true")
+	t.Setenv("NIAC_CONFIGS_DIR", t.TempDir())
+	daemon := replacementTestDaemon(t)
+	startReplacementTestSimulation(t, daemon, "active-router")
+
+	active := daemon.simulation
+	activeStatus := daemon.GetStatus()
+	activeYAML, err := os.ReadFile(active.ConfigPath)
+	if err != nil {
+		t.Fatalf("ReadFile(active config) error = %v", err)
+	}
+	cleanupCalls := 0
+	daemon.startSimulation = func(
+		string,
+		*config.Config,
+		*fabric.Topology,
+		bool,
+	) (simulationResources, error) {
+		return simulationResources{cancel: func() { cleanupCalls++ }}, errors.New("injected startup failure")
+	}
+
+	err = daemon.StartSimulation(replacementRequest("replacement-router"), fullSimulationEntitlements())
+	if err == nil || !strings.Contains(err.Error(), "injected startup failure") {
+		t.Fatalf("StartSimulation() error = %v, want injected startup failure", err)
+	}
+	if daemon.simulation != active {
+		t.Fatal("failed replacement changed the active simulation")
+	}
+	if got := daemon.GetStatus(); got.Interface != activeStatus.Interface ||
+		got.ConfigPath != activeStatus.ConfigPath ||
+		got.ConfigName != activeStatus.ConfigName ||
+		got.DeviceCount != activeStatus.DeviceCount ||
+		!reflect.DeepEqual(got.Fabric, activeStatus.Fabric) {
+		t.Fatalf("status after failed replacement = %#v, want %#v", got, activeStatus)
+	}
+	persisted, readErr := os.ReadFile(active.ConfigPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(active config after failure) error = %v", readErr)
+	}
+	if string(persisted) != string(activeYAML) {
+		t.Fatalf("active inline config changed after failed replacement:\n%s", persisted)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("partial replacement cleanup calls = %d, want 1", cleanupCalls)
+	}
+}
+
+func TestSuccessfulSimulationReplacementPublishesThenStopsOldRun(t *testing.T) {
+	t.Setenv(e2eDryRunEnv, "true")
+	t.Setenv("NIAC_CONFIGS_DIR", t.TempDir())
+	daemon := replacementTestDaemon(t)
+	startReplacementTestSimulation(t, daemon, "active-router")
+
+	active := daemon.simulation
+	oldStopped := false
+	active.cancel = func() {
+		oldStopped = true
+		if daemon.simulation == active {
+			t.Error("old simulation stopped before replacement was published")
+		}
+	}
+
+	if err := daemon.StartSimulation(
+		replacementRequest("replacement-router"),
+		fullSimulationEntitlements(),
+	); err != nil {
+		t.Fatalf("StartSimulation(replacement) error = %v", err)
+	}
+
+	if !oldStopped {
+		t.Fatal("successful replacement did not stop the old simulation")
+	}
+	if daemon.simulation == active {
+		t.Fatal("successful replacement did not publish a new simulation")
+	}
+	status := daemon.GetStatus()
+	if !status.Running || status.Interface != "replacement0" || status.DeviceCount != 1 ||
+		status.Fabric == nil ||
+		len(status.Fabric.Topology.Interfaces) != 1 ||
+		status.Fabric.Topology.Interfaces[0].Device != "replacement-router" {
+		t.Fatalf("replacement status = %#v", status)
+	}
+	persisted, err := os.ReadFile(status.ConfigPath)
+	if err != nil {
+		t.Fatalf("ReadFile(replacement config) error = %v", err)
+	}
+	if !strings.Contains(string(persisted), "replacement-router") {
+		t.Fatalf("replacement config = %q", persisted)
+	}
+}
+
+func replacementTestDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	daemon, err := NewDaemon(Config{
+		StoragePath: "disabled",
+		AttachmentPolicies: []fabric.PhysicalAttachmentPolicy{{
+			Interface: "replacement0", Mode: fabric.ModeAccess, AccessVLAN: 200,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewDaemon() error = %v", err)
+	}
+	daemon.apiServer = api.NewServer(api.ServerConfig{})
+	t.Cleanup(func() {
+		if daemon.simulation != nil {
+			_ = daemon.StopSimulation()
+		}
+	})
+	return daemon
+}
+
+func startReplacementTestSimulation(t *testing.T, daemon *Daemon, name string) {
+	t.Helper()
+	if err := daemon.StartSimulation(replacementRequest(name), fullSimulationEntitlements()); err != nil {
+		t.Fatalf("StartSimulation(%s) error = %v", name, err)
+	}
+}
+
+func replacementRequest(name string) api.SimulationRequest {
+	return api.SimulationRequest{
+		Interface:      "replacement0",
+		Attachment:     "tester",
+		AttachmentMode: fabric.ModeAccess,
+		AccessVLAN:     200,
+		ConfigData: "networks:\n" +
+			"  - name: lab-access\n" +
+			"    subnet: 192.0.2.0/24\n" +
+			"attachments:\n" +
+			"  - name: tester\n" +
+			"    connect: lab-access\n" +
+			"devices:\n" +
+			"  - name: " + name + "\n" +
+			"    type: router\n" +
+			"    mac: \"02:00:00:00:00:01\"\n" +
+			"    interfaces:\n" +
+			"      - name: outside\n" +
+			"        network: lab-access\n" +
+			"        address: 192.0.2.10/24\n",
+	}
+}


### PR DESCRIPTION
## Summary
- prepare and start replacement runtime resources before changing the active simulation
- publish the replacement stack, config, fabric, replay, and API state as one locked transition, then retire the old run
- clean partially acquired replacement resources and preserve the active inline config/status when startup fails

## Linked Issue
Closes #1075

## Testing Evidence
```
make fmt-check: all formatting checks passed
make lint: backend 0 issues; frontend 328 files checked
make test: 41 Go packages and 67 Vitest files passed; Go coverage 65.5%, daemon coverage 68.3%
make security: govulncheck no vulnerabilities; npm audit 0 vulnerabilities; gitleaks no leaks
go test -race ./internal/daemon -run Test(Failed|Successful)SimulationReplacement -count=1: passed
post-rebase focused daemon tests and backend lint: passed
```

## Security and Release Checklist
- [x] failed replacement leaves the active run and API status intact
- [x] partial replacement resources are cleaned
- [x] successful replacement publishes before old-run shutdown
- [x] no dependencies added
- [x] full local quality and security gates passed