### PR TITLE
fix(protocols): route notifications through fabric

### DIFF
--- a/internal/protocols/fabric_runtime.go
+++ b/internal/protocols/fabric_runtime.go
@@ -53,6 +53,12 @@ type fabricResolution struct {
 	routeVia       string
 }
 
+type fabricNotificationEgress struct {
+	device *config.Device
+	source netip.Addr
+	target netip.Addr
+}
+
 func newFabricRuntime(topology *fabric.Topology, cfg *config.Config) *fabricRuntime {
 	if topology == nil || cfg == nil {
 		return nil
@@ -173,6 +179,42 @@ func (r *fabricRuntime) resolveIPv4(dst netip.Addr, ingressMAC net.HardwareAddr)
 		firstHopMAC: cloneMAC(router.mac), firstHopDevice: router.device,
 		egressNetwork: endpoint.network, routeVia: route.via,
 	}, true
+}
+
+func (r *fabricRuntime) notificationEgress(
+	routerDevice *config.Device,
+	destination netip.Addr,
+) (fabricNotificationEgress, bool) {
+	if r == nil || routerDevice == nil || !destination.Is4() {
+		return fabricNotificationEgress{}, false
+	}
+	for i := range r.attachmentRouters {
+		router := &r.attachmentRouters[i]
+		if router.device != routerDevice ||
+			!r.interfaceAvailable(router.device, router.attachmentInterface) {
+			continue
+		}
+		for _, route := range r.routesFor(router) {
+			if !route.connected || route.via != router.attachmentInterface ||
+				!route.destination.Contains(destination) {
+				continue
+			}
+			source, found := r.interfaceAddress(
+				router.device,
+				router.attachmentInterface,
+				router.attachmentIP,
+			)
+			if !found {
+				return fabricNotificationEgress{}, false
+			}
+			return fabricNotificationEgress{
+				device: router.device,
+				source: source,
+				target: destination,
+			}, true
+		}
+	}
+	return fabricNotificationEgress{}, false
 }
 
 func (r *fabricRuntime) interfaceAddress(device *config.Device, name string, fallback netip.Addr) (netip.Addr, bool) {

--- a/internal/protocols/state_notifications.go
+++ b/internal/protocols/state_notifications.go
@@ -44,9 +44,11 @@ type notificationNeighbor struct {
 }
 
 type pendingNotification struct {
-	device                      *config.Device
+	egressDevice                *config.Device
 	vlan                        int
 	source, destination         netip.Addr
+	neighborSource              netip.Addr
+	routed                      bool
 	sourcePort, destinationPort uint16
 	payload                     []byte
 }
@@ -94,17 +96,53 @@ func (s *stackDatagramSender) Send(
 	if !source.IsValid() || len(device.MACAddress) != SizeOfMac {
 		return fmt.Errorf("device %q has no active notification source for %s", device.Name, destination)
 	}
-	destinationMAC, err := s.notificationDestinationMAC(device, vlan, destination, target)
+	egressDevice, neighborSource, target, routed := s.notificationEgress(
+		device,
+		source,
+		destination,
+		target,
+		vlan,
+	)
+	destinationMAC, err := s.notificationDestinationMAC(egressDevice, vlan, destination, target)
 	if err != nil {
 		return err
 	}
 	if destinationMAC == nil {
 		return s.resolveNeighbor(pendingNotification{
-			device: device, vlan: vlan, source: source, destination: destination,
+			egressDevice: egressDevice, vlan: vlan,
+			source: source, destination: destination, neighborSource: neighborSource, routed: routed,
 			sourcePort: sourcePort, destinationPort: port, payload: append([]byte(nil), payload...),
 		}, target)
 	}
-	return s.emitNotification(device, vlan, source, destination, sourcePort, port, destinationMAC, payload)
+	return s.emitNotification(
+		egressDevice,
+		vlan,
+		source,
+		destination,
+		sourcePort,
+		port,
+		destinationMAC,
+		payload,
+		routed,
+	)
+}
+
+func (s *stackDatagramSender) notificationEgress(
+	device *config.Device,
+	source netip.Addr,
+	destination netip.Addr,
+	target netip.Addr,
+	vlan int,
+) (*config.Device, netip.Addr, netip.Addr, bool) {
+	if s.stack.fabric == nil {
+		return device, source, target, false
+	}
+	nextHop := s.notificationTargetDevice(vlan, target)
+	egress, found := s.stack.fabric.notificationEgress(nextHop, destination)
+	if !found {
+		return device, source, target, false
+	}
+	return egress.device, egress.source, egress.target, true
 }
 
 func (s *stackDatagramSender) notificationWireVLAN(vlan int) int {
@@ -292,7 +330,7 @@ func (s *stackDatagramSender) probeNeighbor(key notificationNeighborKey) {
 		slog.Warn("build notification neighbor probe", "target", key.address, "error", err)
 		return
 	}
-	s.queueFrame(notification.device, notification.vlan, frame)
+	s.queueFrame(notification.egressDevice, notification.vlan, frame)
 
 	s.mu.Lock()
 	if current := s.pending[key]; current == resolution {
@@ -309,17 +347,23 @@ func (s *stackDatagramSender) neighborProbeFrame(
 		zeroMAC := net.HardwareAddr{0, 0, 0, 0, 0, 0}
 		return serializeARPPacket(
 			&layers.Ethernet{
-				SrcMAC:       notification.device.MACAddress,
+				SrcMAC:       notification.egressDevice.MACAddress,
 				DstMAC:       net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 				EthernetType: layers.EthernetTypeARP,
 			},
 			buildARPLayer(
-				layers.ARPRequest, notification.device.MACAddress, net.IP(notification.source.AsSlice()),
+				layers.ARPRequest,
+				notification.egressDevice.MACAddress,
+				net.IP(notification.neighborSource.AsSlice()),
 				zeroMAC, net.IP(target.AsSlice()),
 			),
 		)
 	}
-	return serializeNeighborSolicitation(notification.device.MACAddress, notification.source, target)
+	return serializeNeighborSolicitation(
+		notification.egressDevice.MACAddress,
+		notification.neighborSource,
+		target,
+	)
 }
 
 func serializeNeighborSolicitation(sourceMAC net.HardwareAddr, source, target netip.Addr) ([]byte, error) {
@@ -375,8 +419,15 @@ func (s *stackDatagramSender) observeNeighbor(vlan int, address netip.Addr, mac 
 	}
 	for _, notification := range resolution.notifications {
 		if err := s.emitNotification(
-			notification.device, notification.vlan, notification.source, notification.destination,
-			notification.sourcePort, notification.destinationPort, mac, notification.payload,
+			notification.egressDevice,
+			notification.vlan,
+			notification.source,
+			notification.destination,
+			notification.sourcePort,
+			notification.destinationPort,
+			mac,
+			notification.payload,
+			notification.routed,
 		); err != nil {
 			slog.Warn("send resolved management notification", "receiver", notification.destination, "error", err)
 		}
@@ -416,20 +467,25 @@ func (s *stackDatagramSender) notificationTargetDevice(vlan int, target netip.Ad
 }
 
 func (s *stackDatagramSender) emitNotification(
-	device *config.Device,
+	egressDevice *config.Device,
 	vlan int,
 	source, destination netip.Addr,
 	sourcePort, destinationPort uint16,
 	destinationMAC net.HardwareAddr,
 	payload []byte,
+	routed bool,
 ) error {
 	buffer := gopacket.NewSerializeBuffer()
 	udp := &layers.UDP{SrcPort: layers.UDPPort(sourcePort), DstPort: layers.UDPPort(destinationPort)}
 	var network serializableNetworkLayer
 	etherType := layers.EthernetTypeIPv4
 	if source.Is4() {
+		ttl := uint8(ipIPv4TTL)
+		if routed {
+			ttl--
+		}
 		network = &layers.IPv4{
-			Version: ipIPv4Version, IHL: ipIPv4IHL, TTL: ipIPv4TTL, Protocol: layers.IPProtocolUDP,
+			Version: ipIPv4Version, IHL: ipIPv4IHL, TTL: ttl, Protocol: layers.IPProtocolUDP,
 			SrcIP: source.AsSlice(), DstIP: destination.AsSlice(),
 		}
 	} else {
@@ -443,24 +499,37 @@ func (s *stackDatagramSender) emitNotification(
 		return fmt.Errorf("set notification checksum: %w", err)
 	}
 	err := gopacket.SerializeLayers(buffer, gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true},
-		&layers.Ethernet{SrcMAC: device.MACAddress, DstMAC: destinationMAC, EthernetType: etherType},
+		&layers.Ethernet{SrcMAC: egressDevice.MACAddress, DstMAC: destinationMAC, EthernetType: etherType},
 		network, udp, gopacket.Payload(payload))
 	if err != nil {
 		return fmt.Errorf("serialize management notification: %w", err)
 	}
-	s.queueFrame(device, vlan, buffer.Bytes())
+	packet := s.framePacket(egressDevice, vlan, buffer.Bytes())
+	if routed {
+		packet.fabricTrace.PhysicalVLAN = s.stack.fabric.binding.AccessVLAN
+		packet.fabricTrace.RouteDecision = fabricRouteDecisionForwarded
+		packet.fabricTrace.EgressNetwork = s.stack.fabric.attachmentNetwork
+		s.stack.stats.mu.Lock()
+		s.stack.stats.FabricForwarded++
+		s.stack.stats.mu.Unlock()
+	}
+	s.stack.Send(packet)
 	return nil
 }
 
 func (s *stackDatagramSender) queueFrame(device *config.Device, vlan int, frame []byte) {
+	s.stack.Send(s.framePacket(device, vlan, frame))
+}
+
+func (s *stackDatagramSender) framePacket(device *config.Device, vlan int, frame []byte) *Packet {
 	s.stack.mu.Lock()
 	s.stack.serialNumber++
 	serial := s.stack.serialNumber
 	s.stack.mu.Unlock()
-	s.stack.Send(&Packet{
+	return &Packet{
 		Buffer: append([]byte(nil), frame...), Length: len(frame), SerialNumber: serial,
 		Device: device, VLAN: vlan,
-	})
+	}
 }
 
 type stateNotificationRegistration struct {

--- a/internal/protocols/state_notifications_test.go
+++ b/internal/protocols/state_notifications_test.go
@@ -279,6 +279,116 @@ func TestStackDatagramSenderUsesConfiguredNextHopForOffLinkReceiver(t *testing.T
 	}
 }
 
+func TestStackDatagramSenderRoutesThroughFabricToPhysicalCollector(t *testing.T) {
+	routerMAC := mustForwardingMAC(t, "02:00:00:00:00:01")
+	senderMAC := mustForwardingMAC(t, "02:00:00:00:00:10")
+	collectorMAC := mustForwardingMAC(t, "02:00:00:00:00:fe")
+	cfg := &config.Config{
+		Networks: []config.Network{
+			{Name: "attachment", Subnet: "10.10.200.0/24"},
+			{Name: "management", Subnet: "10.20.0.0/24"},
+		},
+		Attachments: []config.LogicalAttachment{{Name: "tester", Network: "attachment"}},
+		Devices: []config.Device{
+			{
+				Name: "edge", Type: "router", MACAddress: routerMAC,
+				Interfaces: []config.Interface{
+					{Name: "outside", Network: "attachment", Address: "10.10.200.1/24"},
+					{Name: "inside", Network: "management", Address: "10.20.0.1/24"},
+				},
+			},
+			{
+				Name: "sender", Type: "server", MACAddress: senderMAC,
+				Interfaces: []config.Interface{{
+					Name: "eth0", Network: "management", Address: "10.20.0.10/24",
+				}},
+				Routes: []config.Route{{
+					Destination: "0.0.0.0/0", Via: "eth0", NextHop: "10.20.0.1",
+				}},
+			},
+		},
+	}
+	report := fabric.Compile(cfg, fabric.Binding{
+		Attachment: "tester", Interface: "eth0", Mode: fabric.ModeAccess, AccessVLAN: 200,
+		PolicyApproved: true,
+	})
+	if !report.Safe {
+		t.Fatalf("Compile() diagnostics = %#v", report.Diagnostics)
+	}
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	stack.ConfigureFabric(&report.Topology)
+	sender := &cfg.Devices[1]
+	datagrams := stack.notifications.sender.(*stackDatagramSender)
+	defer datagrams.reset()
+
+	if err := datagrams.Send(
+		sender, config.UntaggedTag, "10.10.200.100:514", syslogPort, []byte("event"),
+	); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	probe := <-stack.sendQueue
+	assertPhysicalCollectorProbe(t, probe, routerMAC)
+
+	reply, err := serializeARPPacket(
+		&layers.Ethernet{
+			SrcMAC: collectorMAC, DstMAC: routerMAC, EthernetType: layers.EthernetTypeARP,
+		},
+		buildARPLayer(
+			layers.ARPReply, collectorMAC, net.ParseIP("10.10.200.100"),
+			routerMAC, net.ParseIP("10.10.200.1"),
+		),
+	)
+	if err != nil {
+		t.Fatalf("serialize collector ARP reply: %v", err)
+	}
+	stack.arpHandler.HandlePacket(&Packet{Buffer: reply, Length: len(reply), VLAN: config.UntaggedTag})
+
+	notification := <-stack.sendQueue
+	assertPhysicalCollectorNotification(t, notification, routerMAC, collectorMAC)
+	if got := stack.GetStats().FabricForwarded; got != 1 {
+		t.Fatalf("FabricForwarded = %d, want 1", got)
+	}
+}
+
+func assertPhysicalCollectorProbe(t *testing.T, probe *Packet, routerMAC net.HardwareAddr) {
+	t.Helper()
+	probePacket := gopacket.NewPacket(probe.Buffer, layers.LayerTypeEthernet, gopacket.Default)
+	probeEthernet, _ := probePacket.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+	arpRequest, _ := probePacket.Layer(layers.LayerTypeARP).(*layers.ARP)
+	if probeEthernet == nil || arpRequest == nil ||
+		!bytes.Equal(probeEthernet.SrcMAC, routerMAC) ||
+		!net.IP(arpRequest.SourceProtAddress).Equal(net.ParseIP("10.10.200.1")) ||
+		!net.IP(arpRequest.DstProtAddress).Equal(net.ParseIP("10.10.200.100")) {
+		t.Fatalf("physical collector probe = ethernet %#v ARP %#v", probeEthernet, arpRequest)
+	}
+}
+
+func assertPhysicalCollectorNotification(
+	t *testing.T,
+	notification *Packet,
+	routerMAC net.HardwareAddr,
+	collectorMAC net.HardwareAddr,
+) {
+	t.Helper()
+	decoded := gopacket.NewPacket(notification.Buffer, layers.LayerTypeEthernet, gopacket.Default)
+	ethernet, _ := decoded.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+	ipv4, _ := decoded.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+	udp, _ := decoded.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	if ethernet == nil || ipv4 == nil || udp == nil ||
+		!bytes.Equal(ethernet.SrcMAC, routerMAC) ||
+		!bytes.Equal(ethernet.DstMAC, collectorMAC) ||
+		!ipv4.SrcIP.Equal(net.ParseIP("10.20.0.10")) ||
+		!ipv4.DstIP.Equal(net.ParseIP("10.10.200.100")) ||
+		ipv4.TTL != ipIPv4TTL-1 ||
+		string(udp.Payload) != "event" {
+		t.Fatalf("physical collector notification = ethernet %#v IPv4 %#v UDP %#v", ethernet, ipv4, udp)
+	}
+	if trace := notification.FabricTrace(); trace.RouteDecision != fabricRouteDecisionForwarded ||
+		trace.EgressNetwork != "attachment" {
+		t.Fatalf("notification FabricTrace() = %#v", trace)
+	}
+}
+
 func TestStackDatagramSenderResolvesPhysicalNextHopBeforeNotification(t *testing.T) {
 	device := notificationTestDevice()
 	device.VLAN = 200


### PR DESCRIPTION
## Summary

- route off-link management notifications through the compiled routed fabric
- resolve the physical collector from the attachment router identity while preserving the simulated sender IP
- preserve bounded neighbor-resolution queuing and record routed-fabric TTL/telemetry
- add an end-to-end physical collector fixture

## Linked Issue

Closes #1042

## Testing Evidence

```text
go test ./internal/protocols -count=1
PASS

go test -race ./internal/protocols -run ^TestStackDatagramSenderRoutesThroughFabricToPhysicalCollector$ -count=1
PASS

make fmt-check
PASS

make lint
PASS: 0 backend issues; frontend clean

make test
Backend PASS: 41 packages, 65.5% coverage
Frontend PASS: 67 files, 328 tests

make security
PASS: govulncheck found no vulnerabilities; npm audit found 0 vulnerabilities; gitleaks found no leaks
```

## Security and Release Checklist

- [x] No authentication, authorization, CSRF, or credential behavior changed
- [x] No dependency changes
- [x] No customer-facing banned vocabulary added
- [x] Formatting, lint, tests, race test, and security gates pass
- [x] Release notes generated by release-please