### PR TITLE
fix(api): project live simulation topology

### DIFF
--- a/internal/api/config_state.go
+++ b/internal/api/config_state.go
@@ -119,9 +119,14 @@ func (s *Server) currentConfig() *config.Config {
 
 func (s *Server) currentTopology() topology.Graph {
 	s.configMu.RLock()
-	defer s.configMu.RUnlock()
+	stack := s.cfg.Stack
+	cached := s.cfg.Topology
+	s.configMu.RUnlock()
 
-	return s.cfg.Topology
+	if stack != nil {
+		return stack.RuntimeTopology()
+	}
+	return cached
 }
 
 func (s *Server) replaceConfig(cfg *config.Config) {

--- a/internal/api/config_state_test.go
+++ b/internal/api/config_state_test.go
@@ -128,6 +128,50 @@ func TestCurrentTopology(t *testing.T) {
 	}
 }
 
+func TestCurrentTopologyReadsRuntimeStackProjection(t *testing.T) {
+	cfg := mustLoadConfig(t, baseConfigYAML)
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	server := &Server{
+		cfg: ServerConfig{
+			Stack:    stack,
+			Topology: topology.Build(cfg),
+		},
+		logger: slog.Default(),
+	}
+	updated := mustLoadConfig(t, updatedConfigYAML)
+	if err := stack.ReloadConfig(updated); err != nil {
+		t.Fatalf("ReloadConfig() error = %v", err)
+	}
+
+	got := server.currentTopology()
+	if len(got.Nodes) != 1 || got.Nodes[0].Name != "core2" {
+		t.Fatalf("currentTopology() = %#v", got)
+	}
+}
+
+func TestClearSimulationClearsAllSimulationState(t *testing.T) {
+	cfg := mustLoadConfig(t, baseConfigYAML)
+	server := &Server{
+		cfg: ServerConfig{
+			Stack:      protocols.NewStack(nil, cfg, logging.NewDebugConfig(0)),
+			Config:     cfg,
+			ConfigPath: "/tmp/active.yaml",
+			Interface:  "eth0",
+			Replay:     &stubReplay{},
+			Topology:   topology.Build(cfg),
+		},
+		logger: slog.Default(),
+	}
+
+	server.ClearSimulation()
+
+	if server.currentStack() != nil || server.currentConfig() != nil ||
+		server.configPath() != "" || server.currentInterface() != "" ||
+		server.cfg.Replay != nil || len(server.currentTopology().Nodes) != 0 {
+		t.Fatalf("simulation state was not cleared: %#v", server.cfg)
+	}
+}
+
 func TestReplaceConfig(t *testing.T) {
 	server := &Server{
 		cfg: ServerConfig{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -842,5 +842,8 @@ func (s *Server) ClearSimulation() {
 
 	s.cfg.Stack = nil
 	s.cfg.Config = nil
+	s.cfg.ConfigPath = ""
+	s.cfg.Interface = ""
 	s.cfg.Replay = nil
+	s.cfg.Topology = topology.Graph{}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -742,10 +742,14 @@ func (d *Daemon) GetStatus() api.SimulationStatus {
 		if d.simulation.cfg != nil {
 			status.DeviceCount = d.simulation.cfg.DeviceCount()
 		}
-		if d.simulation.fabric != nil {
+		if d.simulation.fabric != nil && d.simulation.stack != nil {
 			stats := d.simulation.stack.GetStats()
+			topology, ok := d.simulation.stack.RuntimeFabricTopology()
+			if !ok {
+				topology = *d.simulation.fabric
+			}
 			status.Fabric = &api.SimulationFabricStatus{
-				Topology:    *d.simulation.fabric,
+				Topology:    topology,
 				Forwarded:   stats.FabricForwarded,
 				Drops:       stats.FabricDrops,
 				Received:    stats.PacketsReceived,

--- a/internal/protocols/fabric_runtime.go
+++ b/internal/protocols/fabric_runtime.go
@@ -12,6 +12,7 @@ import (
 
 type fabricRuntime struct {
 	binding           fabric.CompiledBinding
+	topology          fabric.Topology
 	attachmentNetwork string
 	devicesByName     map[string]*config.Device
 	interfacesByAddr  map[netip.Addr]fabricEndpoint
@@ -65,7 +66,14 @@ func newFabricRuntime(topology *fabric.Topology, cfg *config.Config) *fabricRunt
 	}
 
 	runtime := &fabricRuntime{
-		binding:           topology.Binding,
+		binding: topology.Binding,
+		topology: fabric.Topology{
+			Binding:    topology.Binding,
+			Networks:   append([]fabric.Network(nil), topology.Networks...),
+			Interfaces: append([]fabric.Interface(nil), topology.Interfaces...),
+			Routes:     append([]fabric.Route(nil), topology.Routes...),
+			DHCPScopes: append([]fabric.DHCPScope(nil), topology.DHCPScopes...),
+		},
 		attachmentNetwork: topology.Binding.Network,
 		devicesByName:     make(map[string]*config.Device, len(cfg.Devices)),
 		interfacesByAddr:  make(map[netip.Addr]fabricEndpoint, len(topology.Interfaces)),

--- a/internal/protocols/stack_topology.go
+++ b/internal/protocols/stack_topology.go
@@ -1,0 +1,101 @@
+package protocols
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
+)
+
+// RuntimeTopology projects the current device state into the UI topology model.
+func (s *Stack) RuntimeTopology() topology.Graph {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	cfg := s.currentConfig()
+	if cfg == nil {
+		return topology.Graph{}
+	}
+	projected := *cfg
+	projected.Devices = append([]config.Device(nil), cfg.Devices...)
+	for index := range projected.Devices {
+		source := &cfg.Devices[index]
+		device := &projected.Devices[index]
+		device.Interfaces = append([]config.Interface(nil), source.Interfaces...)
+		state := s.deviceStates[source]
+		if state == nil {
+			continue
+		}
+		snapshot := state.Snapshot()
+		for interfaceIndex := range device.Interfaces {
+			for _, current := range snapshot.Network.Interfaces {
+				if current.Name != device.Interfaces[interfaceIndex].Name {
+					continue
+				}
+				if current.Address.IsValid() {
+					device.Interfaces[interfaceIndex].Address = current.Address.String()
+				} else {
+					device.Interfaces[interfaceIndex].Address = ""
+				}
+				device.Interfaces[interfaceIndex].AdminStatus = interfaceStatus(current.AdminUp)
+				device.Interfaces[interfaceIndex].OperStatus = interfaceStatus(current.OperUp)
+				break
+			}
+		}
+	}
+	return topology.Build(&projected)
+}
+
+// RuntimeFabricTopology projects authoritative interface and route state into
+// the active compiled fabric contract.
+func (s *Stack) RuntimeFabricTopology() (fabric.Topology, bool) {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	cfg := s.currentConfig()
+	if cfg == nil || s.fabric == nil {
+		return fabric.Topology{}, false
+	}
+	result := s.fabric.topology
+	result.Interfaces = append([]fabric.Interface(nil), result.Interfaces...)
+	result.Routes = make([]fabric.Route, 0, len(result.Routes))
+	interfaces := make(map[string]map[string]int, len(result.Interfaces))
+	for index, current := range result.Interfaces {
+		if interfaces[current.Device] == nil {
+			interfaces[current.Device] = make(map[string]int)
+		}
+		interfaces[current.Device][current.Name] = index
+	}
+	result.Routes = result.Routes[:0]
+	devices := make(map[string]*config.Device, len(s.deviceStates))
+	for device := range s.deviceStates {
+		devices[device.Name] = device
+	}
+	for _, name := range slices.Sorted(maps.Keys(devices)) {
+		device := devices[name]
+		state := s.deviceStates[device]
+		snapshot := state.Snapshot()
+		for _, current := range snapshot.Network.Interfaces {
+			index, found := interfaces[device.Name][current.Name]
+			if found {
+				result.Interfaces[index].Address = current.Address
+			}
+		}
+		for _, current := range snapshot.Network.Routes {
+			result.Routes = append(result.Routes, fabric.Route{
+				Device: device.Name, Destination: current.Destination,
+				Via: current.Via, NextHop: current.NextHop, Connected: current.Connected,
+			})
+		}
+	}
+	return result, true
+}
+
+func interfaceStatus(up bool) string {
+	if up {
+		return "up"
+	}
+	return "down"
+}

--- a/internal/protocols/stack_topology_test.go
+++ b/internal/protocols/stack_topology_test.go
@@ -1,0 +1,94 @@
+package protocols
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/devicecli"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+func TestRuntimeFabricTopologyTracksCLIState(t *testing.T) {
+	cfg, compiled := runtimeTopologyFixture(t)
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	stack.ConfigureFabric(compiled)
+	router := &cfg.Devices[0]
+	session := devicecli.NewSession(stack.deviceStates[router], stack.staticRouteValidator(router))
+	for _, command := range []string{
+		"enable",
+		"configure terminal",
+		"interface inside",
+		"ip address 10.30.0.1/24",
+	} {
+		if response := session.Execute(command); strings.HasPrefix(response.Output, "%") {
+			t.Fatalf("%q output = %q", command, response.Output)
+		}
+	}
+
+	topology, ok := stack.RuntimeFabricTopology()
+	if !ok {
+		t.Fatal("RuntimeFabricTopology() unavailable")
+	}
+	wantAddress := netip.MustParsePrefix("10.30.0.1/24")
+	if topology.Interfaces[1].Address != wantAddress {
+		t.Fatalf("inside address = %s, want %s", topology.Interfaces[1].Address, wantAddress)
+	}
+	if topology.Routes[1].Destination != netip.MustParsePrefix("10.30.0.0/24") {
+		t.Fatalf("connected route = %s, want 10.30.0.0/24", topology.Routes[1].Destination)
+	}
+}
+
+func TestRuntimeTopologyTracksCLIInterfaceShutdown(t *testing.T) {
+	cfg := &config.Config{Devices: []config.Device{
+		{
+			Name: "left", Type: "switch",
+			Interfaces: []config.Interface{{Name: "Gi0/1", AdminStatus: "up", OperStatus: "up"}},
+			TrunkPorts: []config.TrunkPort{{Interface: "Gi0/1", RemoteDevice: "right", RemoteInterface: "Gi0/1"}},
+		},
+		{
+			Name: "right", Type: "switch",
+			Interfaces: []config.Interface{{Name: "Gi0/1", AdminStatus: "up", OperStatus: "up"}},
+		},
+	}}
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	session := devicecli.NewSession(stack.deviceStates[&cfg.Devices[0]], nil)
+	for _, command := range []string{"enable", "configure terminal", "interface Gi0/1", "shutdown"} {
+		if response := session.Execute(command); strings.HasPrefix(response.Output, "%") {
+			t.Fatalf("%q output = %q", command, response.Output)
+		}
+	}
+
+	graph := stack.RuntimeTopology()
+	if len(graph.Links) != 1 || graph.Links[0].Status != "down" {
+		t.Fatalf("RuntimeTopology() links = %#v", graph.Links)
+	}
+}
+
+func runtimeTopologyFixture(t *testing.T) (*config.Config, *fabric.Topology) {
+	t.Helper()
+	cfg := &config.Config{
+		Networks: []config.Network{
+			{Name: "attachment", Subnet: "10.10.200.0/24"},
+			{Name: "inside", Subnet: "10.20.0.0/24"},
+		},
+		Attachments: []config.LogicalAttachment{{Name: "tester", Network: "attachment"}},
+		Devices: []config.Device{{
+			Name: "edge", Type: "router", MACAddress: mustForwardingMAC(t, "02:00:00:00:00:01"),
+			Interfaces: []config.Interface{
+				{Name: "outside", Network: "attachment", Address: "10.10.200.1/24"},
+				{Name: "inside", Network: "inside", Address: "10.20.0.1/24"},
+			},
+		}},
+	}
+	report := fabric.Compile(cfg, fabric.Binding{
+		Attachment: "tester", Interface: "eth0", Mode: fabric.ModeAccess, AccessVLAN: 200,
+		PolicyApproved: true,
+	})
+	if !report.Safe {
+		t.Fatalf("Compile() diagnostics = %#v", report.Diagnostics)
+	}
+	return cfg, &report.Topology
+}


### PR DESCRIPTION
## Summary

- project API topology and routed-fabric status from authoritative runtime device state
- reflect CLI interface address, route, and link-state mutations without recompiling authored config
- atomically clear stack, config, path, interface, replay, and topology state when a simulation stops
- add CLI-mutation, runtime projection, stop cleanup, and race tests

## Linked Issue

Closes #1039

## Testing Evidence

```text
go test ./internal/protocols ./internal/api ./internal/daemon -count=1
PASS

go test -race ./internal/protocols -run ^TestRuntime -count=1
PASS

go test -race ./internal/api -run ^(TestCurrentTopologyReadsRuntimeStackProjection|TestClearSimulationClearsAllSimulationState)$ -count=1
PASS

make fmt-check
PASS

make lint
PASS: 0 backend issues; frontend clean

make test
Backend PASS: 41 packages, 65.6% coverage
Frontend PASS: 67 files, 328 tests

make security
PASS: govulncheck found no vulnerabilities; npm audit found 0 vulnerabilities; gitleaks found no leaks
```

## Security and Release Checklist

- [x] Simulation-scoped state is cleared under one lock
- [x] Runtime projections are immutable copies
- [x] No dependency or authentication changes
- [x] Formatting, lint, tests, race tests, and security gates pass
- [x] Release notes generated by release-please