### PR TITLE
fix(snmp): project runtime listener tables

### DIFF
--- a/internal/protocols/snmp/device_state.go
+++ b/internal/protocols/snmp/device_state.go
@@ -54,6 +54,7 @@ func (a *Agent) bindDeviceState(state *devicestate.Store) {
 	a.refreshDeviceStateInterfaceMIBs()
 	snapshot := state.Snapshot()
 	a.refreshDeviceStateIPMIBs(snapshot)
+	a.replaceTransportListeners(deviceStateIPv4Addresses(snapshot))
 	a.stateMIBVersion.Store(snapshot.Version)
 }
 
@@ -77,7 +78,18 @@ func (a *Agent) syncDeviceStateMIBs() {
 	}
 	a.refreshDeviceStateInterfaceMIBs()
 	a.refreshDeviceStateIPMIBs(snapshot)
+	a.replaceTransportListeners(deviceStateIPv4Addresses(snapshot))
 	a.stateMIBVersion.Store(snapshot.Version)
+}
+
+func deviceStateIPv4Addresses(snapshot devicestate.Snapshot) []string {
+	result := make([]string, 0, len(snapshot.Network.Interfaces))
+	for _, iface := range snapshot.Network.Interfaces {
+		if iface.Address.IsValid() && iface.Address.Addr().Is4() {
+			result = append(result, iface.Address.Addr().String())
+		}
+	}
+	return result
 }
 
 func authoredInterfaceSpeeds(device *config.Device) map[string]int {

--- a/internal/protocols/snmp/device_state_test.go
+++ b/internal/protocols/snmp/device_state_test.go
@@ -8,6 +8,40 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/devicestate"
 )
 
+func TestAgentTransportTablesTrackSharedDeviceState(t *testing.T) {
+	device := createTestDevice()
+	device.SSHConfig = &config.SSHConfig{Enabled: true}
+	state := devicestate.NewStore(devicestate.Identity{Hostname: device.Name})
+	state.ReplaceNetwork(devicestate.Network{Interfaces: []devicestate.Interface{{
+		Name: "eth0", Address: netip.MustParsePrefix("192.0.2.10/24"),
+		AdminUp: true, OperUp: true,
+	}}})
+	agent := NewAgentWithState(device, state, AgentOptions{Community: "public"})
+
+	assertTransportListener(t, agent, tcpMIBRoot+".13.1.3.192.0.2.10.22.0.0.0.0.0")
+	assertTransportListener(t, agent, udpMIBRoot+".5.1.2.192.0.2.10.161")
+	if err := state.UpdateInterface("eth0", func(iface devicestate.Interface) (devicestate.Interface, error) {
+		iface.Address = netip.MustParsePrefix("192.0.2.20/24")
+		return iface, nil
+	}); err != nil {
+		t.Fatalf("UpdateInterface() error = %v", err)
+	}
+
+	assertTransportListener(t, agent, tcpMIBRoot+".13.1.3.192.0.2.20.22.0.0.0.0.0")
+	assertTransportListener(t, agent, udpMIBRoot+".5.1.2.192.0.2.20.161")
+	if agent.mib.Get(tcpMIBRoot+".13.1.3.192.0.2.10.22.0.0.0.0.0") != nil ||
+		agent.mib.Get(udpMIBRoot+".5.1.2.192.0.2.10.161") != nil {
+		t.Fatal("transport tables retained the previous runtime address")
+	}
+}
+
+func assertTransportListener(t *testing.T, agent *Agent, oid string) {
+	t.Helper()
+	if _, err := agent.HandleGet(oid); err != nil {
+		t.Fatalf("HandleGet(%q) error = %v", oid, err)
+	}
+}
+
 func TestAgentSysNameReadsSharedDeviceState(t *testing.T) {
 	device := &config.Device{Name: "configured-name"}
 	state := devicestate.NewStore(devicestate.Identity{Hostname: "edge-1"})

--- a/internal/protocols/snmp/mib_protocol_groups_test.go
+++ b/internal/protocols/snmp/mib_protocol_groups_test.go
@@ -48,11 +48,12 @@ func TestMIBIIConfiguredListenerTables(t *testing.T) {
 	device.FTPConfig = &config.FTPConfig{Enabled: true}
 	device.NetBIOSConfig = &config.NetBIOSConfig{Enabled: true}
 	device.IPerf3 = &config.IPerf3Config{Enabled: true, Port: 5202}
+	device.SSHConfig = &config.SSHConfig{Enabled: true}
 	device.DHCPConfig = &config.DHCPConfig{}
 	device.DNSConfig = &config.DNSConfig{}
 	agent := NewAgent(device, 0)
 
-	for _, port := range []int{21, 80, 139, 5202} {
+	for _, port := range []int{21, 22, 80, 139, 5202} {
 		index := fmt.Sprintf("192.168.1.1.%d.0.0.0.0.0", port)
 		for column := 1; column <= 5; column++ {
 			oid := fmt.Sprintf("%s.13.1.%d.%s", tcpMIBRoot, column, index)

--- a/internal/protocols/snmp/mib_transport.go
+++ b/internal/protocols/snmp/mib_transport.go
@@ -15,6 +15,7 @@ const (
 	tcpListenState      = 2
 	defaultHTTPPort     = 80
 	defaultFTPPort      = 21
+	defaultSSHPort      = 22
 	defaultSNMPPort     = 161
 	defaultIPerfPort    = 5201
 	dnsListenerPort     = 53
@@ -22,7 +23,9 @@ const (
 	netBIOSNamePort     = 137
 	netBIOSDataPort     = 138
 	netBIOSSessionPort  = 139
-	tcpListenerCapacity = 4
+	tcpListenerCapacity = 5
+	tcpListenerColumns  = 5
+	udpListenerColumns  = 2
 )
 
 func (a *Agent) initializeTransportMIBs() {
@@ -56,17 +59,7 @@ func (a *Agent) initializeTCPMIB() {
 	}
 	a.registerLiveTCPCounters()
 
-	for _, ip := range mibIIIPv4Addresses(a.device.IPAddresses) {
-		for _, port := range a.configuredTCPPorts() {
-			index := ip + "." + strconv.Itoa(port) + ".0.0.0.0.0"
-			entry := tcpMIBRoot + ".13.1"
-			a.mib.Set(entry+".1."+index, &OIDValue{Type: gosnmp.Integer, Value: tcpListenState})
-			a.mib.Set(entry+".2."+index, &OIDValue{Type: gosnmp.IPAddress, Value: ip})
-			a.mib.Set(entry+".3."+index, &OIDValue{Type: gosnmp.Integer, Value: port})
-			a.mib.Set(entry+".4."+index, &OIDValue{Type: gosnmp.IPAddress, Value: "0.0.0.0"})
-			a.mib.Set(entry+".5."+index, &OIDValue{Type: gosnmp.Integer, Value: 0})
-		}
-	}
+	a.replaceTCPListeners(mibIIIPv4Addresses(a.device.IPAddresses))
 }
 
 func (a *Agent) registerLiveTCPCounters() {
@@ -91,14 +84,7 @@ func (a *Agent) initializeUDPMIB() {
 		a.mib.Set(udpMIBRoot+"."+strconv.Itoa(id)+".0", &OIDValue{Type: gosnmp.Counter32, Value: uint32(0)})
 	}
 	a.registerLiveUDPCounters()
-	for _, ip := range mibIIIPv4Addresses(a.device.IPAddresses) {
-		for _, port := range a.configuredUDPPorts() {
-			index := ip + "." + strconv.Itoa(port)
-			entry := udpMIBRoot + ".5.1"
-			a.mib.Set(entry+".1."+index, &OIDValue{Type: gosnmp.IPAddress, Value: ip})
-			a.mib.Set(entry+".2."+index, &OIDValue{Type: gosnmp.Integer, Value: port})
-		}
-	}
+	a.replaceUDPListeners(mibIIIPv4Addresses(a.device.IPAddresses))
 }
 
 func (a *Agent) registerLiveUDPCounters() {
@@ -114,6 +100,9 @@ func (a *Agent) configuredTCPPorts() []int {
 	}
 	if a.device.FTPConfig != nil && a.device.FTPConfig.Enabled {
 		ports = append(ports, defaultFTPPort)
+	}
+	if a.device.SSHConfig != nil && a.device.SSHConfig.Enabled {
+		ports = append(ports, defaultSSHPort)
 	}
 	if a.device.NetBIOSConfig != nil && a.device.NetBIOSConfig.Enabled {
 		ports = append(ports, netBIOSSessionPort)
@@ -142,6 +131,48 @@ func (a *Agent) configuredUDPPorts() []int {
 	}
 
 	return ports
+}
+
+func (a *Agent) replaceTransportListeners(addresses []string) {
+	a.replaceTCPListeners(addresses)
+	a.replaceUDPListeners(addresses)
+}
+
+func (a *Agent) replaceTCPListeners(addresses []string) {
+	const entry = tcpMIBRoot + ".13.1"
+	ports := a.configuredTCPPorts()
+	entries := make(
+		map[string]*OIDValue,
+		len(addresses)*len(ports)*tcpListenerColumns,
+	)
+	for _, ip := range addresses {
+		for _, port := range ports {
+			index := ip + "." + strconv.Itoa(port) + ".0.0.0.0.0"
+			entries[entry+".1."+index] = &OIDValue{Type: gosnmp.Integer, Value: tcpListenState}
+			entries[entry+".2."+index] = &OIDValue{Type: gosnmp.IPAddress, Value: ip}
+			entries[entry+".3."+index] = &OIDValue{Type: gosnmp.Integer, Value: port}
+			entries[entry+".4."+index] = &OIDValue{Type: gosnmp.IPAddress, Value: "0.0.0.0"}
+			entries[entry+".5."+index] = &OIDValue{Type: gosnmp.Integer, Value: 0}
+		}
+	}
+	a.mib.ReplacePrefix(entry, entries)
+}
+
+func (a *Agent) replaceUDPListeners(addresses []string) {
+	const entry = udpMIBRoot + ".5.1"
+	ports := a.configuredUDPPorts()
+	entries := make(
+		map[string]*OIDValue,
+		len(addresses)*len(ports)*udpListenerColumns,
+	)
+	for _, ip := range addresses {
+		for _, port := range ports {
+			index := ip + "." + strconv.Itoa(port)
+			entries[entry+".1."+index] = &OIDValue{Type: gosnmp.IPAddress, Value: ip}
+			entries[entry+".2."+index] = &OIDValue{Type: gosnmp.Integer, Value: port}
+		}
+	}
+	a.mib.ReplacePrefix(entry, entries)
 }
 
 func mibIIIPv4Addresses(addresses []net.IP) []string {


### PR DESCRIPTION
## Summary

- build SNMP TCP and UDP listener rows from authoritative runtime interface addresses
- atomically replace transport rows after shared device-state changes so stale addresses disappear
- expose enabled SSH service on TCP port 22
- extend configured-listener and NewAgentWithState mutation coverage

## Linked Issue

Closes #1045

## Testing Evidence

```text
go test ./internal/protocols/snmp -count=1
PASS

go test -race ./internal/protocols/snmp -run ^TestAgentTransportTablesTrackSharedDeviceState$ -count=1
PASS

make fmt-check
PASS

make lint
PASS: 0 backend issues; frontend clean

make test
Backend PASS: 41 packages, 65.6% coverage
Frontend PASS: 67 files, 328 tests

make security
PASS: govulncheck found no vulnerabilities; npm audit found 0 vulnerabilities; gitleaks found no leaks
```

## Security and Release Checklist

- [x] Transport MIB replacement is atomic
- [x] Runtime addresses are sourced from immutable device-state snapshots
- [x] No dependency, authentication, or authorization changes
- [x] Formatting, lint, tests, race test, and security gates pass
- [x] Release notes generated by release-please