### PR TITLE
fix(protocols): validate routed IPv4 ingress

### DIFF
--- a/internal/protocols/fabric_forwarding_test.go
+++ b/internal/protocols/fabric_forwarding_test.go
@@ -71,6 +71,54 @@ func TestFabricRecordsMissingRouteDrop(t *testing.T) {
 	}
 }
 
+func TestFabricRejectsInvalidIPv4HeaderChecksum(t *testing.T) {
+	cfg, topology, routerMAC := forwardingFixture(t)
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	stack.ConfigureFabric(topology)
+	pkt := routedEchoRequest(t, mustForwardingMAC(t, "02:00:00:00:00:fe"), routerMAC)
+	pkt.Buffer[etherHeaderSize+10] ^= 0xff
+
+	stack.ipHandler.HandlePacket(pkt)
+
+	assertFabricIngressRejected(t, stack, pkt, fabricRejectionInvalidIPv4Checksum)
+}
+
+func TestFabricRejectsInvalidAttachmentIPv4Sources(t *testing.T) {
+	for _, source := range []string{"10.99.0.10", "10.10.200.0", "10.10.200.255", "0.0.0.0"} {
+		t.Run(source, func(t *testing.T) {
+			cfg, topology, routerMAC := forwardingFixture(t)
+			stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+			stack.ConfigureFabric(topology)
+			pkt := routedEchoRequestFrom(
+				t,
+				mustForwardingMAC(t, "02:00:00:00:00:fe"),
+				routerMAC,
+				source,
+			)
+
+			stack.ipHandler.HandlePacket(pkt)
+
+			assertFabricIngressRejected(t, stack, pkt, fabricRejectionAttachmentSource)
+		})
+	}
+}
+
+func assertFabricIngressRejected(t *testing.T, stack *Stack, pkt *Packet, reason string) {
+	t.Helper()
+	trace := pkt.FabricTrace()
+	if trace.RouteDecision != fabricRouteDecisionDropped || trace.RejectionReason != reason {
+		t.Fatalf("FabricTrace() = %#v", trace)
+	}
+	if got := stack.GetStats().FabricDrops; got != 1 {
+		t.Fatalf("FabricDrops = %d, want 1", got)
+	}
+	select {
+	case response := <-stack.sendQueue:
+		t.Fatalf("rejected ingress produced response %#v", response)
+	default:
+	}
+}
+
 func TestCLIShutdownChangesFabricDelivery(t *testing.T) {
 	cfg, topology, routerMAC := forwardingFixture(t)
 	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
@@ -617,6 +665,35 @@ func TestFabricBindingsAcceptOnlyUntaggedFrames(t *testing.T) {
 
 func routedEchoRequest(t *testing.T, testerMAC, routerMAC net.HardwareAddr) *Packet {
 	return routedEchoRequestWithTTL(t, testerMAC, routerMAC, 64)
+}
+
+func routedEchoRequestFrom(
+	t *testing.T,
+	testerMAC net.HardwareAddr,
+	routerMAC net.HardwareAddr,
+	source string,
+) *Packet {
+	t.Helper()
+	buffer := gopacket.NewSerializeBuffer()
+	err := gopacket.SerializeLayers(buffer, gopacket.SerializeOptions{
+		FixLengths: true, ComputeChecksums: true,
+	},
+		&layers.Ethernet{SrcMAC: testerMAC, DstMAC: routerMAC, EthernetType: layers.EthernetTypeIPv4},
+		&layers.IPv4{
+			Version: 4, TTL: 64, Protocol: layers.IPProtocolICMPv4,
+			SrcIP: net.ParseIP(source), DstIP: net.ParseIP("10.20.0.10"),
+		},
+		&layers.ICMPv4{TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0), Id: 1},
+		gopacket.Payload([]byte("routed")),
+	)
+	if err != nil {
+		t.Fatalf("SerializeLayers(): %v", err)
+	}
+	pkt, err := ParsePacket(buffer.Bytes(), 1)
+	if err != nil {
+		t.Fatalf("ParsePacket(): %v", err)
+	}
+	return pkt
 }
 
 func routedEchoRequestWithTTL(

--- a/internal/protocols/fabric_runtime.go
+++ b/internal/protocols/fabric_runtime.go
@@ -43,6 +43,8 @@ type fabricRoute struct {
 	connected   bool
 }
 
+const ipv4PointToPointPrefixBits = 30
+
 type fabricResolution struct {
 	device         *config.Device
 	replySourceMAC net.HardwareAddr
@@ -100,6 +102,52 @@ func (r *fabricRuntime) acceptsFrame(vlan int, tagged bool) bool {
 	default:
 		return false
 	}
+}
+
+func (r *fabricRuntime) acceptsIPv4Source(sourceIP, destinationIP net.IP, protocol uint8) bool {
+	if r == nil {
+		return true
+	}
+	source, sourceOK := netip.AddrFromSlice(sourceIP)
+	destination, destinationOK := netip.AddrFromSlice(destinationIP)
+	if !sourceOK || !destinationOK {
+		return false
+	}
+	source = source.Unmap()
+	destination = destination.Unmap()
+	if source == netip.IPv4Unspecified() {
+		return protocol == IPProtocolUDP &&
+			destination == netip.AddrFrom4([4]byte{0xff, 0xff, 0xff, 0xff})
+	}
+	if !source.Is4() || source.IsMulticast() {
+		return false
+	}
+	for _, network := range r.topology.Networks {
+		if network.Name == r.attachmentNetwork {
+			return validAttachmentHost(network.Prefix, source)
+		}
+	}
+	return false
+}
+
+func validAttachmentHost(prefix netip.Prefix, address netip.Addr) bool {
+	if !prefix.IsValid() || !prefix.Addr().Is4() || !prefix.Contains(address) {
+		return false
+	}
+	if prefix.Bits() > ipv4PointToPointPrefixBits {
+		return true
+	}
+	network := prefix.Masked().Addr().As4()
+	host := address.As4()
+	if host == network {
+		return false
+	}
+	mask := net.CIDRMask(prefix.Bits(), address.BitLen())
+	broadcast := network
+	for index := range broadcast {
+		broadcast[index] |= ^mask[index]
+	}
+	return host != broadcast
 }
 
 func (r *fabricRuntime) indexAttachmentDHCP(scopes []fabric.DHCPScope) {

--- a/internal/protocols/ip.go
+++ b/internal/protocols/ip.go
@@ -28,6 +28,7 @@ const (
 	ipIPv4Version = 4  // IPv4 version field
 	ipIPv4IHL     = 5  // IPv4 header length (5 = 20 bytes)
 	ipIPv4TTL     = 64 // IPv4 default TTL
+	ipv4IHLBytes  = 4
 )
 
 // IPHandler handles IP packets.
@@ -51,6 +52,10 @@ func (h *IPHandler) HandlePacket(pkt *Packet) {
 
 	ip := h.parseIPv4Layer(pkt, debugLevel)
 	if ip == nil {
+		return
+	}
+	if h.stack.fabric != nil && !h.stack.fabric.acceptsIPv4Source(ip.SrcIP, ip.DstIP, uint8(ip.Protocol)) {
+		h.rejectFabricIngress(pkt, fabricRejectionAttachmentSource)
 		return
 	}
 
@@ -100,8 +105,25 @@ func (h *IPHandler) parseIPv4Layer(pkt *Packet, debugLevel int) *layers.IPv4 {
 	if !ok {
 		return nil
 	}
+	headerLength := int(ip.IHL) * ipv4IHLBytes
+	if ip.IHL < ipIPv4IHL || len(ip.Contents) < headerLength ||
+		CalculateIPChecksum(ip.Contents[:headerLength]) != 0 {
+		h.rejectFabricIngress(pkt, fabricRejectionInvalidIPv4Checksum)
+		return nil
+	}
 
 	return ip
+}
+
+func (h *IPHandler) rejectFabricIngress(pkt *Packet, reason string) {
+	if h.stack.fabric == nil {
+		return
+	}
+	pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
+	pkt.fabricTrace.RejectionReason = reason
+	h.stack.stats.mu.Lock()
+	h.stack.stats.FabricDrops++
+	h.stack.stats.mu.Unlock()
 }
 
 // getTargetDevices returns devices that should receive this packet, scoped to

--- a/internal/protocols/packet.go
+++ b/internal/protocols/packet.go
@@ -40,9 +40,11 @@ type FabricTrace struct {
 }
 
 const (
-	fabricRouteDecisionDropped   = "dropped"
-	fabricRouteDecisionForwarded = "forwarded"
-	fabricRejectionTTLExpired    = "ttl_expired"
+	fabricRouteDecisionDropped         = "dropped"
+	fabricRouteDecisionForwarded       = "forwarded"
+	fabricRejectionTTLExpired          = "ttl_expired"
+	fabricRejectionInvalidIPv4Checksum = "invalid_ipv4_checksum"
+	fabricRejectionAttachmentSource    = "attachment_source_rejected"
 )
 
 // Constants for packet parsing.


### PR DESCRIPTION
## Summary
- verify IPv4 header checksums before protocol dispatch
- reject invalid routed-attachment source addresses while preserving DHCP bootstrap traffic
- expose stable fabric-drop reasons and counters for rejected ingress

## Linked Issue
Closes #1076

## Testing Evidence
```text
go test ./internal/protocols -count=1
ok github.com/MustardSeedNetworks/niac-go/internal/protocols
make fmt-check && make lint && make test && make security
all gates passed
```

## Security and Release Checklist
- [x] Malformed and spoofed ingress is rejected before dispatch
- [x] DHCP 0.0.0.0 broadcast bootstrap remains supported
- [x] No dependencies or release configuration changed
