### PR TITLE
fix(protocols): enforce single-use stack lifecycle

### DIFF
--- a/internal/protocols/errors.go
+++ b/internal/protocols/errors.go
@@ -48,6 +48,8 @@ var ErrUnsupportedSNMPVersion = errors.New("unsupported SNMP version")
 // Sentinel errors for Stack.
 var (
 	ErrStackAlreadyRunning = errors.New("stack already running")
+	ErrStackStopped        = errors.New("stack is stopped and cannot be reused")
+	ErrSendQueueFull       = errors.New("stack send queue is full")
 	ErrNilConfig           = errors.New("reload config: nil config")
 	ErrUnsafeFabricReload  = errors.New("reload config: unsafe routed topology")
 )

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -110,9 +110,12 @@ type Stack struct {
 	stats *Statistics
 
 	// Control
-	running  atomic.Bool
-	stopChan chan struct{}
-	wg       sync.WaitGroup
+	lifecycleMu sync.RWMutex
+	started     bool
+	running     atomic.Bool
+	stopped     bool
+	stopChan    chan struct{}
+	wg          sync.WaitGroup
 
 	debugConfig     *logging.DebugConfig
 	snmpAgents      map[*config.Device]*snmpAgentGroup
@@ -161,6 +164,7 @@ type Statistics struct {
 	DHCPRequests          uint64
 	SNMPQueries           uint64
 	Errors                uint64
+	RejectedSends         uint64
 	FabricForwarded       uint64
 	FabricDrops           uint64
 	UDPProxyOverloadDrops uint64
@@ -313,12 +317,19 @@ func (s *Stack) allowDHCP() bool {
 	return s.fabric == nil || s.fabric.attachmentDHCP != nil
 }
 
-// AddPacketObserver registers an observer for stack packet events.
-
+// Start begins a single-use protocol stack. A stopped stack cannot be restarted.
 func (s *Stack) Start() error {
-	if !s.running.CompareAndSwap(false, true) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	if s.started {
+		if s.stopped {
+			return ErrStackStopped
+		}
 		return ErrStackAlreadyRunning
 	}
+	s.started = true
+	s.running.Store(true)
 
 	// Start receive thread
 	s.wg.Add(1)
@@ -356,11 +367,16 @@ func (s *Stack) Start() error {
 	return nil
 }
 
-// Stop stops the protocol stack.
+// Stop permanently transitions the protocol stack out of service.
 func (s *Stack) Stop() {
-	if !s.running.CompareAndSwap(true, false) {
+	s.lifecycleMu.Lock()
+	if !s.running.Load() {
+		s.lifecycleMu.Unlock()
 		return
 	}
+	s.running.Store(false)
+	s.stopped = true
+	s.lifecycleMu.Unlock()
 
 	// Stop discovery protocol handlers
 	s.lldpHandler.Stop()
@@ -378,10 +394,38 @@ func (s *Stack) Stop() {
 	}
 }
 
-func (s *Stack) Send(pkt *Packet) {
+func (s *Stack) Send(pkt *Packet) bool {
+	return s.send(pkt) == nil
+}
+
+func (s *Stack) send(pkt *Packet) error {
+	s.lifecycleMu.RLock()
+	if s.stopped {
+		s.lifecycleMu.RUnlock()
+		s.stats.mu.Lock()
+		s.stats.RejectedSends++
+		if s.fabric != nil {
+			s.stats.FabricDrops++
+		}
+		s.stats.mu.Unlock()
+		if s.fabric != nil && pkt != nil {
+			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
+			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
+			pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
+			pkt.fabricTrace.RejectionReason = "stack_stopped"
+			s.notifyObservers("tx", pkt)
+		}
+		return ErrStackStopped
+	}
 	select {
 	case s.sendQueue <- pkt:
+		s.lifecycleMu.RUnlock()
+		return nil
 	default:
+		s.lifecycleMu.RUnlock()
+		s.stats.mu.Lock()
+		s.stats.RejectedSends++
+		s.stats.mu.Unlock()
 		if s.fabric != nil && pkt != nil {
 			pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
 			pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
@@ -395,6 +439,7 @@ func (s *Stack) Send(pkt *Packet) {
 		if s.debugConfig.GetGlobal() >= DebugLevelInfo {
 			_, _ = fmt.Fprintln(os.Stdout, "Send queue full, dropping packet")
 		}
+		return ErrSendQueueFull
 	}
 }
 
@@ -419,9 +464,7 @@ func (s *Stack) SendRawPacketVLAN(data []byte, vlan int) error {
 		VLAN:         vlan,
 	}
 
-	s.Send(pkt)
-
-	return nil
+	return s.send(pkt)
 }
 
 // GetDevices returns the device table.
@@ -528,6 +571,7 @@ func (s *Stack) GetStats() Statistics {
 		DHCPRequests:          s.stats.DHCPRequests,
 		SNMPQueries:           s.stats.SNMPQueries,
 		Errors:                s.stats.Errors,
+		RejectedSends:         s.stats.RejectedSends,
 		FabricForwarded:       s.stats.FabricForwarded,
 		FabricDrops:           s.stats.FabricDrops,
 		UDPProxyOverloadDrops: s.stats.UDPProxyOverloadDrops,

--- a/internal/protocols/stack_lifecycle_test.go
+++ b/internal/protocols/stack_lifecycle_test.go
@@ -1,0 +1,66 @@
+package protocols
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+type lifecycleCapture struct{}
+
+func (lifecycleCapture) ReadPacket([]byte) ([]byte, error) {
+	return nil, errors.New("no packet")
+}
+
+func (lifecycleCapture) SendPacket([]byte) error { return nil }
+func (lifecycleCapture) SetFilter(string) error  { return nil }
+func (lifecycleCapture) Filter() string          { return "" }
+
+func TestStackRejectsSendAfterStop(t *testing.T) {
+	stack := newStack(lifecycleCapture{}, &config.Config{}, logging.NewDebugConfig(0))
+	if err := stack.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	stack.Stop()
+
+	if stack.Send(NewPacket(64)) {
+		t.Fatal("Send() accepted a packet after Stop()")
+	}
+	if err := stack.SendRawPacket([]byte{0x00}); !errors.Is(err, ErrStackStopped) {
+		t.Fatalf("SendRawPacket() error = %v, want %v", err, ErrStackStopped)
+	}
+	if got := stack.GetStats().RejectedSends; got != 2 {
+		t.Fatalf("RejectedSends = %d, want 2", got)
+	}
+	select {
+	case packet := <-stack.sendQueue:
+		t.Fatalf("stopped stack queued packet %#v", packet)
+	default:
+	}
+}
+
+func TestStackIsSingleUseAfterStop(t *testing.T) {
+	stack := newStack(lifecycleCapture{}, &config.Config{}, logging.NewDebugConfig(0))
+	if err := stack.Start(); err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	stack.Stop()
+
+	if err := stack.Start(); !errors.Is(err, ErrStackStopped) {
+		t.Fatalf("second Start() error = %v, want %v", err, ErrStackStopped)
+	}
+}
+
+func TestStackRejectsSecondStartWhileRunning(t *testing.T) {
+	stack := newStack(lifecycleCapture{}, &config.Config{}, logging.NewDebugConfig(0))
+	if err := stack.Start(); err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	defer stack.Stop()
+
+	if err := stack.Start(); !errors.Is(err, ErrStackAlreadyRunning) {
+		t.Fatalf("second Start() error = %v, want %v", err, ErrStackAlreadyRunning)
+	}
+}


### PR DESCRIPTION
## Summary
- define protocol stacks as explicitly single-use after stop
- reject post-stop and queue-full sends with observable results and counters
- serialize start, stop, and send admission so closed lifecycle state cannot be revived

## Linked Issue
Closes #1077

## Testing Evidence
```text
make fmt-check
all formatting checks passed
make lint
0 issues
make test
backend and frontend tests passed; backend coverage 65.9%
make security
no vulnerabilities, npm vulnerabilities, or leaked secrets found
go test -race ./internal/protocols -run lifecycle tests -count=10
ok github.com/MustardSeedNetworks/niac-go/internal/protocols
```

## Security and Release Checklist
- [x] Lifecycle transitions are serialized
- [x] Post-stop delivery fails closed and is counted
- [x] No dependencies or release configuration changed
