### PR TITLE
fix(daemon): recover active simulation after restart

### DIFF
--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -223,6 +223,7 @@ func runDaemon(options *daemonOptions, info versionInfo) error {
 		Token:               token,
 		TokenFile:           tokenFile,
 		StoragePath:         options.storagePath,
+		RecoveryPath:        daemon.DefaultRecoveryPath(),
 		Version:             info.version,
 		Commit:              info.commit,
 		BuildTime:           info.date,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -42,6 +42,22 @@ brew install libpcap
 The archive includes launchd helper files under `launchd/` for users who want
 NIAC to run as a service.
 
+## Daemon Simulation Recovery
+
+Daemon mode records the active simulation launch intent in
+`<data-root>/state/active-simulation.json`. A graceful service shutdown keeps
+this record, and the next daemon start restores the simulation only after the
+current license grants, attachment policy, host interface, configuration,
+runtime requirements, and routed preflight all pass.
+
+An explicit simulation stop removes the record. If recovery fails, NIAC keeps
+the API available, leaves the simulation stopped, and reports an actionable
+`recovery` object from `GET /api/v1/simulation`. Correct the reported condition
+or remove the named state file before restarting the daemon.
+
+Writes use a synchronized temporary file followed by an atomic replacement.
+An interrupted temporary write is ignored on the next start.
+
 ## Windows
 
 Download the Windows zip for your architecture from the GitHub release and add

--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -62,6 +62,11 @@ func (s *Server) simulationEntitlements() SimulationEntitlements {
 	return entitlements
 }
 
+// SimulationEntitlements returns the currently active simulation grants.
+func (s *Server) SimulationEntitlements() SimulationEntitlements {
+	return s.simulationEntitlements()
+}
+
 func (s *Server) handleSimulation(w http.ResponseWriter, r *http.Request) {
 	if s.daemon == nil {
 		http.Error(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -335,6 +335,14 @@ type SimulationStatus struct {
 	StartedAt     time.Time               `json:"startedAt,omitzero"`
 	UptimeSeconds float64                 `json:"uptimeSeconds"`
 	Fabric        *SimulationFabricStatus `json:"fabric,omitempty"`
+	Recovery      *SimulationRecovery     `json:"recovery,omitempty"`
+}
+
+// SimulationRecovery reports the most recent daemon restart recovery attempt.
+type SimulationRecovery struct {
+	State       string    `json:"state"`
+	Message     string    `json:"message"`
+	AttemptedAt time.Time `json:"attemptedAt"`
 }
 
 // SimulationFabricStatus exposes the active routed topology and its live counters.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -59,6 +59,7 @@ type Config struct {
 	// handler re-reads this path on each signal.
 	TokenFile    string
 	StoragePath  string
+	RecoveryPath string
 	Version      string
 	Commit       string
 	BuildTime    string
@@ -87,6 +88,7 @@ type Daemon struct {
 
 	mu         sync.RWMutex
 	simulation *Simulation
+	recovery   *api.SimulationRecovery
 	// startSimulation is injectable so replacement failure and cleanup are deterministic in tests.
 	startSimulation simulationStarter
 	// capture is the optional standalone packet-capture session that
@@ -193,6 +195,8 @@ func (d *Daemon) Start() error {
 		return fmt.Errorf("start API server: %w", err)
 	}
 
+	d.recoverActiveSimulation(d.apiServer.SimulationEntitlements())
+
 	return nil
 }
 
@@ -250,11 +254,14 @@ func (d *Daemon) TokenScopeCounts() (int, int, int) {
 
 // Shutdown gracefully shuts down the daemon.
 func (d *Daemon) Shutdown(ctx context.Context) error {
-	// Stop simulation if running
-	stopErr := d.StopSimulation()
-	if stopErr != nil {
-		logging.Errorf("Error stopping simulation: %v", stopErr)
+	// Preserve active launch intent across process and host restarts.
+	d.mu.Lock()
+	if d.simulation != nil {
+		if stopErr := d.stopSimulationLocked(false); stopErr != nil {
+			logging.Errorf("Error stopping simulation: %v", stopErr)
+		}
 	}
+	d.mu.Unlock()
 
 	// Stop standalone capture if running. StopCapture is idempotent so
 	// the no-capture case is a fast nil return.
@@ -549,6 +556,14 @@ func (d *Daemon) StartSimulation(req api.SimulationRequest, entitlements api.Sim
 		replay:     resources.replay,
 		cancel:     resources.cancel,
 	}
+	intent := req
+	intent.ConfigPath = configPath
+	intent.ConfigData = ""
+	intent.TemplateName = ""
+	if persistErr := d.persistActiveSimulation(intent); persistErr != nil {
+		resources.stop()
+		return fmt.Errorf("persist active simulation: %w", persistErr)
+	}
 
 	active := d.simulation
 	d.simulation = replacement
@@ -683,12 +698,17 @@ func (d *Daemon) StopSimulation() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	return d.stopSimulationLocked()
+	return d.stopSimulationLocked(true)
 }
 
-func (d *Daemon) stopSimulationLocked() error {
+func (d *Daemon) stopSimulationLocked(clearIntent bool) error {
 	if d.simulation == nil {
 		return ErrNoSimulationRunning
+	}
+	if clearIntent {
+		if clearErr := d.clearActiveSimulation(); clearErr != nil {
+			return fmt.Errorf("clear active simulation: %w", clearErr)
+		}
 	}
 
 	sim := d.simulation
@@ -729,7 +749,8 @@ func (d *Daemon) GetStatus() api.SimulationStatus {
 	defer d.mu.RUnlock()
 
 	status := api.SimulationStatus{
-		Running: d.simulation != nil,
+		Running:  d.simulation != nil,
+		Recovery: d.recovery,
 	}
 
 	if d.simulation != nil {

--- a/internal/daemon/recovery.go
+++ b/internal/daemon/recovery.go
@@ -1,0 +1,181 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/library"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+const (
+	activeSimulationSchemaVersion = 1
+	activeSimulationFileName      = "active-simulation.json"
+	maxActiveSimulationStateSize  = 64 * 1024
+	recoveryFileMode              = 0o600
+	recoveryStateRecovered        = "recovered"
+	recoveryStateFailed           = "failed"
+)
+
+type activeSimulationState struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	Request       api.SimulationRequest `json:"request"`
+	SavedAt       time.Time             `json:"savedAt"`
+}
+
+// DefaultRecoveryPath returns the platform-aware daemon recovery record path.
+func DefaultRecoveryPath() string {
+	return filepath.Join(filepath.Dir(library.DefaultRoot()), "state", activeSimulationFileName)
+}
+
+func (d *Daemon) persistActiveSimulation(request api.SimulationRequest) error {
+	if d.cfg.RecoveryPath == "" {
+		return nil
+	}
+	state := activeSimulationState{
+		SchemaVersion: activeSimulationSchemaVersion,
+		Request:       request,
+		SavedAt:       time.Now().UTC(),
+	}
+	data, marshalErr := json.MarshalIndent(state, "", "  ")
+	if marshalErr != nil {
+		return fmt.Errorf("encode recovery state: %w", marshalErr)
+	}
+	data = append(data, '\n')
+	return writeRecoveryState(d.cfg.RecoveryPath, data)
+}
+
+func writeRecoveryState(path string, data []byte) error {
+	directory := filepath.Dir(path)
+	if mkdirErr := os.MkdirAll(directory, 0o750); mkdirErr != nil {
+		return fmt.Errorf("create recovery directory: %w", mkdirErr)
+	}
+	temp, createErr := os.CreateTemp(directory, ".active-simulation-")
+	if createErr != nil {
+		return fmt.Errorf("create recovery state: %w", createErr)
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+
+	if chmodErr := temp.Chmod(recoveryFileMode); chmodErr != nil {
+		_ = temp.Close()
+		return fmt.Errorf("secure recovery state: %w", chmodErr)
+	}
+	if _, writeErr := temp.Write(data); writeErr != nil {
+		_ = temp.Close()
+		return fmt.Errorf("write recovery state: %w", writeErr)
+	}
+	if syncErr := temp.Sync(); syncErr != nil {
+		_ = temp.Close()
+		return fmt.Errorf("sync recovery state: %w", syncErr)
+	}
+	if closeErr := temp.Close(); closeErr != nil {
+		return fmt.Errorf("close recovery state: %w", closeErr)
+	}
+	if renameErr := os.Rename(tempPath, path); renameErr != nil {
+		return fmt.Errorf("replace recovery state: %w", renameErr)
+	}
+	return nil
+}
+
+func (d *Daemon) clearActiveSimulation() error {
+	if d.cfg.RecoveryPath == "" {
+		return nil
+	}
+	removeErr := os.Remove(d.cfg.RecoveryPath)
+	if removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
+		return removeErr
+	}
+	d.recovery = nil
+	return nil
+}
+
+func (d *Daemon) recoverActiveSimulation(entitlements api.SimulationEntitlements) {
+	if d.cfg.RecoveryPath == "" {
+		return
+	}
+	state, readErr := readRecoveryState(d.cfg.RecoveryPath)
+	if errors.Is(readErr, fs.ErrNotExist) {
+		return
+	}
+	attemptedAt := time.Now().UTC()
+	if readErr != nil {
+		d.setRecoveryFailure(attemptedAt, readErr)
+		return
+	}
+	if startErr := d.StartSimulation(state.Request, entitlements); startErr != nil {
+		d.setRecoveryFailure(attemptedAt, startErr)
+		return
+	}
+	d.mu.Lock()
+	d.recovery = &api.SimulationRecovery{
+		State:       recoveryStateRecovered,
+		Message:     "Active simulation restored from persisted launch intent.",
+		AttemptedAt: attemptedAt,
+	}
+	d.mu.Unlock()
+	logging.Successf("✓ Active simulation recovered on %s", state.Request.Interface)
+}
+
+func (d *Daemon) setRecoveryFailure(attemptedAt time.Time, recoveryErr error) {
+	message := fmt.Sprintf(
+		"Recovery failed: %v. Correct or remove %s before restarting.",
+		recoveryErr,
+		d.cfg.RecoveryPath,
+	)
+	d.mu.Lock()
+	d.recovery = &api.SimulationRecovery{
+		State:       recoveryStateFailed,
+		Message:     message,
+		AttemptedAt: attemptedAt,
+	}
+	d.mu.Unlock()
+	logging.Warningf("%s", message)
+}
+
+func readRecoveryState(path string) (activeSimulationState, error) {
+	info, statErr := os.Lstat(path)
+	if statErr != nil {
+		return activeSimulationState{}, statErr
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return activeSimulationState{}, errors.New("recovery state cannot be a symbolic link")
+	}
+	if !info.Mode().IsRegular() {
+		return activeSimulationState{}, errors.New("recovery state is not a regular file")
+	}
+	if info.Size() > maxActiveSimulationStateSize {
+		return activeSimulationState{}, errors.New("recovery state exceeds the maximum size")
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		return activeSimulationState{}, readErr
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var state activeSimulationState
+	if decodeErr := decoder.Decode(&state); decodeErr != nil {
+		return activeSimulationState{}, fmt.Errorf("decode recovery state: %w", decodeErr)
+	}
+	if trailingErr := decoder.Decode(new(struct{})); !errors.Is(trailingErr, io.EOF) {
+		return activeSimulationState{}, errors.New("recovery state contains trailing data")
+	}
+	if state.SchemaVersion != activeSimulationSchemaVersion {
+		return activeSimulationState{}, fmt.Errorf("unsupported recovery schema version %d", state.SchemaVersion)
+	}
+	if state.Request.Interface == "" || state.Request.ConfigPath == "" {
+		return activeSimulationState{}, errors.New("recovery state is missing interface or configuration path")
+	}
+	if state.Request.ConfigData != "" || state.Request.TemplateName != "" {
+		return activeSimulationState{}, errors.New("recovery state must reference a persisted configuration path")
+	}
+	return state, nil
+}

--- a/internal/daemon/recovery_test.go
+++ b/internal/daemon/recovery_test.go
@@ -1,0 +1,223 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+)
+
+func TestRecoverActiveSimulationAfterDaemonRestart(t *testing.T) {
+	t.Setenv(e2eDryRunEnv, "true")
+	t.Setenv("NIAC_CONFIGS_DIR", t.TempDir())
+	recoveryPath := filepath.Join(t.TempDir(), activeSimulationFileName)
+
+	first := recoveryTestDaemon(t, recoveryPath)
+	request := api.SimulationRequest{
+		Interface:  "recovery0",
+		ConfigData: validRecoveryConfig,
+	}
+	if startErr := first.StartSimulation(request, fullSimulationEntitlements()); startErr != nil {
+		t.Fatalf("StartSimulation() error = %v", startErr)
+	}
+	if _, statErr := os.Stat(recoveryPath); statErr != nil {
+		t.Fatalf("recovery state was not persisted: %v", statErr)
+	}
+
+	first.mu.Lock()
+	if stopErr := first.stopSimulationLocked(false); stopErr != nil {
+		first.mu.Unlock()
+		t.Fatalf("shutdown stop error = %v", stopErr)
+	}
+	first.mu.Unlock()
+
+	second := recoveryTestDaemon(t, recoveryPath)
+	second.recoverActiveSimulation(fullSimulationEntitlements())
+	status := second.GetStatus()
+	if !status.Running || status.Interface != request.Interface {
+		t.Fatalf("recovered status = %#v", status)
+	}
+	if status.Recovery == nil || status.Recovery.State != recoveryStateRecovered {
+		t.Fatalf("recovery status = %#v", status.Recovery)
+	}
+	if stopErr := second.StopSimulation(); stopErr != nil {
+		t.Fatalf("StopSimulation() error = %v", stopErr)
+	}
+	if _, statErr := os.Stat(recoveryPath); !os.IsNotExist(statErr) {
+		t.Fatalf("explicit stop did not clear recovery state: %v", statErr)
+	}
+}
+
+func TestRecoverActiveSimulationFailsClosedForStaleConfig(t *testing.T) {
+	t.Setenv(e2eDryRunEnv, "true")
+	recoveryPath := filepath.Join(t.TempDir(), activeSimulationFileName)
+	state := activeSimulationState{
+		SchemaVersion: activeSimulationSchemaVersion,
+		Request: api.SimulationRequest{
+			Interface:  "recovery0",
+			ConfigPath: filepath.Join(t.TempDir(), "missing.yaml"),
+		},
+		SavedAt: time.Now().UTC(),
+	}
+	writeActiveSimulationFixture(t, recoveryPath, state)
+
+	daemon := recoveryTestDaemon(t, recoveryPath)
+	daemon.recoverActiveSimulation(fullSimulationEntitlements())
+	status := daemon.GetStatus()
+	if status.Running {
+		t.Fatalf("stale state started a simulation: %#v", status)
+	}
+	if status.Recovery == nil || status.Recovery.State != recoveryStateFailed ||
+		!strings.Contains(status.Recovery.Message, "configuration") {
+		t.Fatalf("recovery status = %#v", status.Recovery)
+	}
+}
+
+func TestRecoverActiveSimulationRechecksEntitlements(t *testing.T) {
+	t.Setenv(e2eDryRunEnv, "true")
+	configDir := t.TempDir()
+	t.Setenv("NIAC_CONFIGS_DIR", configDir)
+	configPath := filepath.Join(configDir, "routed.yaml")
+	if writeErr := os.WriteFile(configPath, []byte(routedRecoveryConfig), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	recoveryPath := filepath.Join(t.TempDir(), activeSimulationFileName)
+	writeActiveSimulationFixture(t, recoveryPath, activeSimulationState{
+		SchemaVersion: activeSimulationSchemaVersion,
+		Request: api.SimulationRequest{
+			Interface:  "recovery0",
+			ConfigPath: configPath,
+		},
+		SavedAt: time.Now().UTC(),
+	})
+
+	daemon := recoveryTestDaemon(t, recoveryPath)
+	daemon.recoverActiveSimulation(api.SimulationEntitlements{})
+	status := daemon.GetStatus()
+	if status.Running || status.Recovery == nil ||
+		!strings.Contains(status.Recovery.Message, api.ErrRoutedLabsLicenseRequired.Error()) {
+		t.Fatalf("recovery status = %#v", status)
+	}
+}
+
+func TestRecoverActiveSimulationRechecksAttachmentPolicy(t *testing.T) {
+	t.Setenv(e2eDryRunEnv, "true")
+	configDir := t.TempDir()
+	t.Setenv("NIAC_CONFIGS_DIR", configDir)
+	configPath := filepath.Join(configDir, "routed.yaml")
+	if writeErr := os.WriteFile(configPath, []byte(routedRecoveryConfig), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	recoveryPath := filepath.Join(t.TempDir(), activeSimulationFileName)
+	writeActiveSimulationFixture(t, recoveryPath, activeSimulationState{
+		SchemaVersion: activeSimulationSchemaVersion,
+		Request: api.SimulationRequest{
+			Interface:      "recovery0",
+			Attachment:     "tester",
+			AttachmentMode: fabric.ModeDirect,
+			ConfigPath:     configPath,
+		},
+		SavedAt: time.Now().UTC(),
+	})
+
+	daemon := recoveryTestDaemon(t, recoveryPath)
+	daemon.recoverActiveSimulation(fullSimulationEntitlements())
+	status := daemon.GetStatus()
+	if status.Running || status.Recovery == nil ||
+		!strings.Contains(status.Recovery.Message, ErrUnsafeTopology.Error()) {
+		t.Fatalf("recovery status = %#v", status)
+	}
+}
+
+func TestRecoverActiveSimulationIgnoresInterruptedTempWrite(t *testing.T) {
+	recoveryDir := t.TempDir()
+	recoveryPath := filepath.Join(recoveryDir, activeSimulationFileName)
+	if writeErr := os.WriteFile(
+		filepath.Join(recoveryDir, ".active-simulation-interrupted"),
+		[]byte(`{"schemaVersion":1`),
+		0o600,
+	); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	daemon := recoveryTestDaemon(t, recoveryPath)
+	daemon.recoverActiveSimulation(fullSimulationEntitlements())
+	status := daemon.GetStatus()
+	if status.Running || status.Recovery != nil {
+		t.Fatalf("interrupted temp write affected recovery: %#v", status)
+	}
+}
+
+func TestRecoverActiveSimulationReportsInvalidState(t *testing.T) {
+	recoveryPath := filepath.Join(t.TempDir(), activeSimulationFileName)
+	if writeErr := os.WriteFile(recoveryPath, []byte(`{"schemaVersion":1`), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	daemon := recoveryTestDaemon(t, recoveryPath)
+	daemon.recoverActiveSimulation(fullSimulationEntitlements())
+	status := daemon.GetStatus()
+	if status.Recovery == nil || status.Recovery.State != recoveryStateFailed ||
+		!strings.Contains(status.Recovery.Message, "decode recovery state") {
+		t.Fatalf("recovery status = %#v", status.Recovery)
+	}
+}
+
+func recoveryTestDaemon(t *testing.T, recoveryPath string) *Daemon {
+	t.Helper()
+	daemon, newErr := NewDaemon(Config{
+		StoragePath:  "disabled",
+		RecoveryPath: recoveryPath,
+	})
+	if newErr != nil {
+		t.Fatalf("NewDaemon() error = %v", newErr)
+	}
+	daemon.apiServer = api.NewServer(api.ServerConfig{})
+	t.Cleanup(func() {
+		daemon.mu.Lock()
+		if daemon.simulation != nil {
+			_ = daemon.stopSimulationLocked(false)
+		}
+		daemon.mu.Unlock()
+	})
+	return daemon
+}
+
+func writeActiveSimulationFixture(t *testing.T, path string, state activeSimulationState) {
+	t.Helper()
+	data, marshalErr := json.Marshal(state)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if writeErr := writeRecoveryState(path, data); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+}
+
+const validRecoveryConfig = `devices:
+  - name: recovery-router
+    type: router
+    mac: "02:00:00:00:00:01"
+    ips: ["192.0.2.10"]
+`
+
+const routedRecoveryConfig = `networks:
+  - name: lab
+    subnet: 192.0.2.0/24
+attachments:
+  - name: tester
+    connect: lab
+devices:
+  - name: recovery-router
+    type: router
+    mac: "02:00:00:00:00:01"
+    interfaces:
+      - name: lab0
+        network: lab
+        address: 192.0.2.10/24
+`


### PR DESCRIPTION
## Summary
- persist active simulation launch intent with synchronized atomic replacement
- recover only after current entitlement, attachment policy, interface, configuration, runtime, and routed preflight checks pass
- preserve intent on daemon shutdown, clear it on explicit stop, and expose actionable recovery status

## Linked Issue
Closes #1080

## Testing Evidence
```text
go test -race ./internal/daemon -run TestRecoverActiveSimulation -count=1
ok github.com/MustardSeedNetworks/niac-go/internal/daemon
make fmt-check
all formatting checks passed
make lint
0 issues
make test
backend and frontend tests passed; backend coverage 66.0%
make security
no vulnerabilities, npm vulnerabilities, or leaked secrets found
```

## Security and Release Checklist
- [x] Recovery rechecks current license grants and physical attachment policy
- [x] State file rejects symlinks, unknown fields, stale paths, oversized data, and interrupted temporary writes
- [x] Failure leaves the API available and the simulation stopped
- [x] No dependencies or release configuration changed
