### PR TITLE
fix(catalog): enforce reproducible semantic sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ devices:
 ## Demo Assets
 
 Large example scenarios, walks, and captures are generated from the shared
-NIAC demo catalog instead of being committed to this repo:
+NIAC demo catalog instead of being committed to this repo. Generation records
+the immutable source commit and validates scenarios and walks before updating
+the local examples:
 
 ```bash
 ./scripts/sync-demo-catalog.sh --sync

--- a/cmd/niac-catalog-sync/main.go
+++ b/cmd/niac-catalog-sync/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/catalogsync"
+)
+
+func main() {
+	if runErr := run(os.Args[1:], os.Stdout); runErr != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", runErr)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, output io.Writer) error {
+	flags := flag.NewFlagSet("niac-catalog-sync", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	mode := flags.String("mode", "", "operation: sync or check")
+	catalogDir := flags.String("catalog-dir", "", "catalog checkout")
+	examplesDir := flags.String("examples-dir", "", "generated examples directory")
+	repository := flags.String("repository", "", "catalog repository URL")
+	commit := flags.String("commit", "", "immutable catalog commit")
+	if parseErr := flags.Parse(args); parseErr != nil {
+		return parseErr
+	}
+
+	if syncErr := catalogsync.Run(catalogsync.Options{
+		Mode:        catalogsync.Mode(*mode),
+		CatalogDir:  *catalogDir,
+		ExamplesDir: *examplesDir,
+		Repository:  *repository,
+		Commit:      *commit,
+	}); syncErr != nil {
+		return syncErr
+	}
+	fmt.Fprintf(output, "OK: catalog %s completed at %s.\n", *mode, *commit)
+	return nil
+}

--- a/cmd/niac-catalog-sync/main_test.go
+++ b/cmd/niac-catalog-sync/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsIncompleteArguments(t *testing.T) {
+	var output bytes.Buffer
+	runErr := run([]string{"-mode", "sync"}, &output)
+	if runErr == nil || !strings.Contains(runErr.Error(), "catalog and examples directories are required") {
+		t.Fatalf("run() error = %v", runErr)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("run() output = %q", output.String())
+	}
+}
+
+func TestRunRejectsUnknownFlag(t *testing.T) {
+	runErr := run([]string{"-unknown"}, new(bytes.Buffer))
+	if runErr == nil {
+		t.Fatal("run() accepted an unknown flag")
+	}
+}

--- a/docs/SHARED_DEMO_CATALOG.md
+++ b/docs/SHARED_DEMO_CATALOG.md
@@ -33,6 +33,17 @@ Check an existing generated `examples/` tree:
 .\scripts\sync-demo-catalog.ps1 -Mode Check
 ```
 
+Both wrappers resolve the selected ref to a clean, immutable Git commit and
+delegate generation to the same Go implementation. Before replacing or
+checking `examples/`, the generator validates every YAML scenario, routed
+attachment, and raw or sanitized SNMP walk. Invalid content fails without
+changing the existing examples.
+
+Each generated tree contains `catalog-source.json` with the catalog repository,
+resolved commit, and sorted SHA-256 digest for every generated file. This
+manifest makes the source revision reproducible and is included in drift
+checks.
+
 ## Generated Layout
 
 | Catalog path | Go generated path |
@@ -52,7 +63,7 @@ Check an existing generated `examples/` tree:
 - `NIAC_DEMO_CATALOG_REF`: catalog branch, tag, or commit. Defaults to `main`.
 - `NIAC_DEMO_CATALOG_DIR`: existing catalog checkout. Defaults to `.catalog/niac-demo-catalog`.
 - `NIAC_GO_EXAMPLES_DIR`: generated output path. Defaults to `examples`.
-- `NIAC_DEMO_CATALOG_OFFLINE=1`: require an existing local catalog and skip `git fetch`.
+- `NIAC_DEMO_CATALOG_OFFLINE=1`: require a clean local Git checkout and skip `git fetch`.
 
 Do not add shared demo assets directly to this repo. Add or update them in
 `niac-demo-catalog`, then regenerate `examples/`.

--- a/internal/catalogsync/catalogsync.go
+++ b/internal/catalogsync/catalogsync.go
@@ -1,0 +1,499 @@
+package catalogsync
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp"
+)
+
+const ManifestName = "catalog-source.json"
+
+const (
+	directoryMode               = 0o750
+	fileMode                    = 0o600
+	executableMode              = 0o700
+	maxReportedValidationErrors = 20
+	maxValidationErrorLines     = 3
+)
+
+type Mode string
+
+const (
+	ModeSync  Mode = "sync"
+	ModeCheck Mode = "check"
+)
+
+type Options struct {
+	Mode        Mode
+	CatalogDir  string
+	ExamplesDir string
+	Repository  string
+	Commit      string
+}
+
+type manifest struct {
+	SchemaVersion int            `json:"schema_version"`
+	Repository    string         `json:"repository"`
+	Commit        string         `json:"commit"`
+	Files         []manifestFile `json:"files"`
+}
+
+type manifestFile struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+type mapping struct {
+	source      string
+	destination string
+	optional    bool
+}
+
+type stagedWalk struct {
+	path   string
+	strict bool
+}
+
+var commitPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$`)
+
+func Run(options Options) error {
+	if err := validateOptions(options); err != nil {
+		return err
+	}
+
+	examplesDir, resolveErr := filepath.Abs(options.ExamplesDir)
+	if resolveErr != nil {
+		return fmt.Errorf("resolve examples directory: %w", resolveErr)
+	}
+	if filepath.Dir(examplesDir) == examplesDir {
+		return errors.New("examples directory cannot be a filesystem root")
+	}
+	if mkdirErr := os.MkdirAll(filepath.Dir(examplesDir), directoryMode); mkdirErr != nil {
+		return fmt.Errorf("create examples parent: %w", mkdirErr)
+	}
+
+	stage, stageErr := os.MkdirTemp(filepath.Dir(examplesDir), ".niac-catalog-stage-")
+	if stageErr != nil {
+		return fmt.Errorf("create catalog stage: %w", stageErr)
+	}
+	defer func() { _ = os.RemoveAll(stage) }()
+
+	if populateErr := populateStage(options.CatalogDir, stage); populateErr != nil {
+		return populateErr
+	}
+	if validationErr := validateStage(stage); validationErr != nil {
+		return validationErr
+	}
+	if manifestErr := writeManifest(stage, options.Repository, strings.ToLower(options.Commit)); manifestErr != nil {
+		return manifestErr
+	}
+
+	switch options.Mode {
+	case ModeSync:
+		return replaceTree(stage, examplesDir)
+	case ModeCheck:
+		return compareTrees(stage, examplesDir)
+	default:
+		return fmt.Errorf("unsupported catalog mode %q", options.Mode)
+	}
+}
+
+func validateOptions(options Options) error {
+	if options.Mode != ModeSync && options.Mode != ModeCheck {
+		return fmt.Errorf("mode must be %q or %q", ModeSync, ModeCheck)
+	}
+	if options.CatalogDir == "" || options.ExamplesDir == "" {
+		return errors.New("catalog and examples directories are required")
+	}
+	if strings.TrimSpace(options.Repository) == "" {
+		return errors.New("catalog repository is required")
+	}
+	if !commitPattern.MatchString(options.Commit) {
+		return errors.New("catalog commit must be a full 40- or 64-character hexadecimal revision")
+	}
+	return nil
+}
+
+func populateStage(catalogDir, stage string) error {
+	for _, item := range mappings() {
+		source := filepath.Join(catalogDir, filepath.FromSlash(item.source))
+		destination := filepath.Join(stage, filepath.FromSlash(item.destination))
+		info, statErr := os.Lstat(source)
+		if statErr != nil {
+			if item.optional && errors.Is(statErr, fs.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("catalog source %s: %w", item.source, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("catalog source %s is a symbolic link", item.source)
+		}
+		if info.IsDir() {
+			if copyErr := copyTree(source, destination); copyErr != nil {
+				return fmt.Errorf("copy catalog source %s: %w", item.source, copyErr)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("catalog source %s is not a regular file", item.source)
+		}
+		if copyErr := copyFile(source, destination, info.Mode()); copyErr != nil {
+			return fmt.Errorf("copy catalog source %s: %w", item.source, copyErr)
+		}
+	}
+	return nil
+}
+
+func mappings() []mapping {
+	return []mapping{
+		{source: "scenarios/go-yaml"},
+		{source: "walks/raw", destination: "device_walks"},
+		{source: "walks/sanitized", destination: "device_walks_sanitized"},
+		{source: "captures/shared", destination: "captures"},
+		{source: "captures/go-extra", destination: "pcaps"},
+		{source: "tools/walk-scripts/go", destination: "walk_scripts"},
+		{
+			source:      "tools/walk-scripts/java/run_demo.sh",
+			destination: "walk_scripts/run_demo.sh",
+			optional:    true,
+		},
+		{source: "docs/imported/go-examples"},
+	}
+}
+
+func copyTree(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, relativeErr := filepath.Rel(source, path)
+		if relativeErr != nil {
+			return relativeErr
+		}
+		target := filepath.Join(destination, relative)
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symbolic link", path)
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(target, directoryMode)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%s is not a regular file", path)
+		}
+		return copyFile(path, target, info.Mode())
+	})
+}
+
+func copyFile(source, destination string, mode fs.FileMode) error {
+	if mkdirErr := os.MkdirAll(filepath.Dir(destination), directoryMode); mkdirErr != nil {
+		return mkdirErr
+	}
+	input, openErr := os.Open(source)
+	if openErr != nil {
+		return openErr
+	}
+	defer func() { _ = input.Close() }()
+
+	permissions := fs.FileMode(fileMode)
+	if mode&0o111 != 0 {
+		permissions = executableMode
+	}
+	output, createErr := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, permissions)
+	if createErr != nil {
+		return createErr
+	}
+	if _, copyErr := io.Copy(output, input); copyErr != nil {
+		_ = output.Close()
+		return copyErr
+	}
+	return output.Close()
+}
+
+func validateStage(stage string) error {
+	scenarios, walks, inspectErr := catalogValidationInputs(stage)
+	if inspectErr != nil {
+		return inspectErr
+	}
+	scenarioErrors := validateScenarios(stage, scenarios)
+	if len(scenarioErrors) > 0 {
+		return joinValidationErrors(scenarioErrors)
+	}
+	return joinValidationErrors(validateWalks(stage, walks))
+}
+
+func catalogValidationInputs(stage string) ([]string, []stagedWalk, error) {
+	var scenarios []string
+	var walks []stagedWalk
+	inspectErr := filepath.WalkDir(stage, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, relativeErr := filepath.Rel(stage, path)
+		if relativeErr != nil {
+			return relativeErr
+		}
+		switch {
+		case strings.HasSuffix(relative, ".yaml"), strings.HasSuffix(relative, ".yml"):
+			scenarios = append(scenarios, path)
+		case within(relative, "device_walks_sanitized"):
+			walks = append(walks, stagedWalk{path: path, strict: true})
+		case within(relative, "device_walks"):
+			walks = append(walks, stagedWalk{path: path})
+		}
+		return nil
+	})
+	if inspectErr != nil {
+		return nil, nil, fmt.Errorf("inspect staged catalog: %w", inspectErr)
+	}
+	return scenarios, walks, nil
+}
+
+func validateScenarios(stage string, scenarios []string) []error {
+	var validationErrors []error
+	for _, path := range scenarios {
+		if scenarioErr := validateScenario(path); scenarioErr != nil {
+			relative, _ := filepath.Rel(stage, path)
+			validationErrors = append(validationErrors, fmt.Errorf("%s: %s", relative, summarizeError(scenarioErr)))
+		}
+	}
+	return validationErrors
+}
+
+func validateWalks(stage string, walks []stagedWalk) []error {
+	var validationErrors []error
+	for _, walk := range walks {
+		result, validationErr := snmp.ValidateWalkFile(walk.path)
+		invalid := validationErr != nil ||
+			(walk.strict && !result.Valid) ||
+			(!walk.strict && result.ValidLines == 0)
+		if invalid {
+			relative, _ := filepath.Rel(stage, walk.path)
+			if validationErr != nil {
+				validationErrors = append(
+					validationErrors,
+					fmt.Errorf("%s: %s", relative, summarizeError(validationErr)),
+				)
+			} else {
+				validationErrors = append(validationErrors, fmt.Errorf("%s: walk validation failed", relative))
+			}
+		}
+	}
+	return validationErrors
+}
+
+func summarizeError(err error) string {
+	lines := strings.SplitN(err.Error(), "\n", maxValidationErrorLines)
+	if len(lines) == 1 {
+		return lines[0]
+	}
+	return lines[0] + " " + strings.TrimSpace(lines[1])
+}
+
+func joinValidationErrors(validationErrors []error) error {
+	if len(validationErrors) <= maxReportedValidationErrors {
+		return errors.Join(validationErrors...)
+	}
+	reported := slices.Clone(validationErrors[:maxReportedValidationErrors])
+	reported = append(
+		reported,
+		fmt.Errorf("%d additional validation errors omitted", len(validationErrors)-maxReportedValidationErrors),
+	)
+	return errors.Join(reported...)
+}
+
+func validateScenario(path string) error {
+	cfg, loadErr := config.Load(path)
+	if loadErr != nil {
+		return fmt.Errorf("load scenario: %w", loadErr)
+	}
+	result := config.NewValidator(path).Validate(cfg)
+	if !result.Valid {
+		return fmt.Errorf("scenario validation failed: %s", result.Format())
+	}
+	for _, attachment := range cfg.Attachments {
+		report := fabric.Compile(cfg, fabric.Binding{
+			Mode:           fabric.ModeDirect,
+			Attachment:     attachment.Name,
+			PolicyApproved: true,
+		})
+		if !report.Safe {
+			return fmt.Errorf(
+				"routed scenario validation failed for attachment %q: %v",
+				attachment.Name,
+				report.Diagnostics,
+			)
+		}
+	}
+	return nil
+}
+
+func within(path, directory string) bool {
+	path = filepath.Clean(path)
+	directory = filepath.Clean(directory)
+	return path == directory || strings.HasPrefix(path, directory+string(filepath.Separator))
+}
+
+func writeManifest(stage, repository, commit string) error {
+	files, filesErr := treeFiles(stage)
+	if filesErr != nil {
+		return filesErr
+	}
+	document := manifest{
+		SchemaVersion: 1,
+		Repository:    repository,
+		Commit:        commit,
+		Files:         files,
+	}
+	data, marshalErr := json.MarshalIndent(document, "", "  ")
+	if marshalErr != nil {
+		return fmt.Errorf("encode source manifest: %w", marshalErr)
+	}
+	data = append(data, '\n')
+	if writeErr := os.WriteFile(filepath.Join(stage, ManifestName), data, fileMode); writeErr != nil {
+		return fmt.Errorf("write source manifest: %w", writeErr)
+	}
+	return nil
+}
+
+func treeFiles(root string) ([]manifestFile, error) {
+	var files []manifestFile
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, relativeErr := filepath.Rel(root, path)
+		if relativeErr != nil {
+			return relativeErr
+		}
+		if relative == ManifestName {
+			return nil
+		}
+		sum, hashErr := fileSHA256(path)
+		if hashErr != nil {
+			return hashErr
+		}
+		files = append(files, manifestFile{
+			Path:   filepath.ToSlash(relative),
+			SHA256: sum,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build source manifest: %w", err)
+	}
+	slices.SortFunc(files, func(left, right manifestFile) int {
+		return strings.Compare(left.Path, right.Path)
+	})
+	return files, nil
+}
+
+func fileSHA256(path string) (string, error) {
+	file, openErr := os.Open(path)
+	if openErr != nil {
+		return "", openErr
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if _, copyErr := io.Copy(hash, file); copyErr != nil {
+		return "", copyErr
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func compareTrees(expected, actual string) error {
+	expectedFiles, expectedErr := allTreeFiles(expected)
+	if expectedErr != nil {
+		return fmt.Errorf("read staged catalog: %w", expectedErr)
+	}
+	actualFiles, actualErr := allTreeFiles(actual)
+	if actualErr != nil {
+		return fmt.Errorf("read generated examples: %w", actualErr)
+	}
+	if !slices.Equal(expectedFiles, actualFiles) {
+		return errors.New("generated examples file set does not match the catalog")
+	}
+	for _, relative := range expectedFiles {
+		expectedHash, expectedHashErr := fileSHA256(filepath.Join(expected, relative))
+		if expectedHashErr != nil {
+			return expectedHashErr
+		}
+		actualHash, actualHashErr := fileSHA256(filepath.Join(actual, relative))
+		if actualHashErr != nil {
+			return actualHashErr
+		}
+		if expectedHash != actualHash {
+			return fmt.Errorf("generated example differs from catalog: %s", filepath.ToSlash(relative))
+		}
+	}
+	return nil
+}
+
+func allTreeFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, relativeErr := filepath.Rel(root, path)
+		if relativeErr != nil {
+			return relativeErr
+		}
+		files = append(files, relative)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(files)
+	return files, nil
+}
+
+func replaceTree(stage, destination string) error {
+	backup, backupErr := os.MkdirTemp(filepath.Dir(destination), ".niac-catalog-backup-")
+	if backupErr != nil {
+		return fmt.Errorf("reserve examples backup: %w", backupErr)
+	}
+	if removeErr := os.Remove(backup); removeErr != nil {
+		return fmt.Errorf("prepare examples backup: %w", removeErr)
+	}
+	defer func() { _ = os.RemoveAll(backup) }()
+
+	if _, statErr := os.Stat(destination); statErr == nil {
+		if renameErr := os.Rename(destination, backup); renameErr != nil {
+			return fmt.Errorf("preserve existing examples: %w", renameErr)
+		}
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		return fmt.Errorf("inspect existing examples: %w", statErr)
+	}
+	if renameErr := os.Rename(stage, destination); renameErr != nil {
+		_ = os.Rename(backup, destination)
+		return fmt.Errorf("install generated examples: %w", renameErr)
+	}
+	return nil
+}

--- a/internal/catalogsync/catalogsync_test.go
+++ b/internal/catalogsync/catalogsync_test.go
@@ -1,0 +1,170 @@
+package catalogsync_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/catalogsync"
+)
+
+const testCommit = "0123456789abcdef0123456789abcdef01234567"
+
+type sourceManifest struct {
+	Repository string `json:"repository"`
+	Commit     string `json:"commit"`
+	Files      []struct {
+		Path   string `json:"path"`
+		SHA256 string `json:"sha256"`
+	} `json:"files"`
+}
+
+func TestRunSyncWritesDeterministicManifestAndDetectsDrift(t *testing.T) {
+	catalog := writeCatalogFixture(t, validScenario, validWalk)
+	first := filepath.Join(t.TempDir(), "examples")
+	second := filepath.Join(t.TempDir(), "examples")
+	options := catalogsync.Options{
+		Mode:        catalogsync.ModeSync,
+		CatalogDir:  catalog,
+		ExamplesDir: first,
+		Repository:  "git@example.test:catalog.git",
+		Commit:      testCommit,
+	}
+
+	if runErr := catalogsync.Run(options); runErr != nil {
+		t.Fatalf("Run(sync) error = %v", runErr)
+	}
+	options.ExamplesDir = second
+	if runErr := catalogsync.Run(options); runErr != nil {
+		t.Fatalf("second Run(sync) error = %v", runErr)
+	}
+
+	firstManifest, firstReadErr := os.ReadFile(filepath.Join(first, catalogsync.ManifestName))
+	if firstReadErr != nil {
+		t.Fatal(firstReadErr)
+	}
+	secondManifest, secondReadErr := os.ReadFile(filepath.Join(second, catalogsync.ManifestName))
+	if secondReadErr != nil {
+		t.Fatal(secondReadErr)
+	}
+	if string(firstManifest) != string(secondManifest) {
+		t.Fatalf("manifest is not deterministic:\n%s\n%s", firstManifest, secondManifest)
+	}
+	var got sourceManifest
+	if decodeErr := json.Unmarshal(firstManifest, &got); decodeErr != nil {
+		t.Fatalf("decode manifest: %v", decodeErr)
+	}
+	if got.Commit != testCommit || got.Repository != options.Repository || len(got.Files) == 0 {
+		t.Fatalf("manifest = %#v", got)
+	}
+
+	options.Mode = catalogsync.ModeCheck
+	options.ExamplesDir = first
+	if runErr := catalogsync.Run(options); runErr != nil {
+		t.Fatalf("Run(check) error = %v", runErr)
+	}
+	if writeErr := os.WriteFile(filepath.Join(first, "lab.yaml"), []byte("changed"), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if driftErr := catalogsync.Run(options); driftErr == nil || !strings.Contains(driftErr.Error(), "differs") {
+		t.Fatalf("Run(check drift) error = %v", driftErr)
+	}
+}
+
+func TestRunRejectsInvalidScenarioBeforeSync(t *testing.T) {
+	catalog := writeCatalogFixture(t, "devices: [", validWalk)
+	examples := filepath.Join(t.TempDir(), "examples")
+
+	runErr := catalogsync.Run(catalogsync.Options{
+		Mode:        catalogsync.ModeSync,
+		CatalogDir:  catalog,
+		ExamplesDir: examples,
+		Repository:  "git@example.test:catalog.git",
+		Commit:      testCommit,
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "load scenario") {
+		t.Fatalf("Run() error = %v", runErr)
+	}
+	if _, examplesErr := os.Stat(examples); !errors.Is(examplesErr, os.ErrNotExist) {
+		t.Fatalf("examples created despite invalid scenario: %v", examplesErr)
+	}
+}
+
+func TestRunRejectsInvalidWalkBeforeSync(t *testing.T) {
+	catalog := writeCatalogFixture(t, validScenario, "invalid walk line")
+	examples := filepath.Join(t.TempDir(), "examples")
+
+	runErr := catalogsync.Run(catalogsync.Options{
+		Mode:        catalogsync.ModeSync,
+		CatalogDir:  catalog,
+		ExamplesDir: examples,
+		Repository:  "git@example.test:catalog.git",
+		Commit:      testCommit,
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "walk validation failed") {
+		t.Fatalf("Run() error = %v", runErr)
+	}
+	if _, examplesErr := os.Stat(examples); !errors.Is(examplesErr, os.ErrNotExist) {
+		t.Fatalf("examples created despite invalid walk: %v", examplesErr)
+	}
+}
+
+func TestRunRejectsMutableRevisionIdentifier(t *testing.T) {
+	runErr := catalogsync.Run(catalogsync.Options{
+		Mode:        catalogsync.ModeSync,
+		CatalogDir:  t.TempDir(),
+		ExamplesDir: filepath.Join(t.TempDir(), "examples"),
+		Repository:  "git@example.test:catalog.git",
+		Commit:      "main",
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "full 40- or 64-character") {
+		t.Fatalf("Run() error = %v", runErr)
+	}
+}
+
+func writeCatalogFixture(t *testing.T, scenario, walk string) string {
+	t.Helper()
+	root := t.TempDir()
+	directories := []string{
+		"scenarios/go-yaml",
+		"walks/raw",
+		"walks/sanitized",
+		"captures/shared",
+		"captures/go-extra",
+		"tools/walk-scripts/go",
+		"docs/imported/go-examples",
+	}
+	for _, directory := range directories {
+		if mkdirErr := os.MkdirAll(filepath.Join(root, directory), 0o750); mkdirErr != nil {
+			t.Fatal(mkdirErr)
+		}
+	}
+	writeFixtureFile(t, filepath.Join(root, "scenarios/go-yaml/lab.yaml"), scenario)
+	writeFixtureFile(t, filepath.Join(root, "walks/raw/device.walk"), walk)
+	writeFixtureFile(t, filepath.Join(root, "walks/sanitized/device.walk"), walk)
+	writeFixtureFile(t, filepath.Join(root, "captures/shared/capture.pcap"), "capture")
+	writeFixtureFile(t, filepath.Join(root, "captures/go-extra/extra.pcap"), "extra")
+	writeFixtureFile(t, filepath.Join(root, "tools/walk-scripts/go/run.sh"), "#!/bin/sh\n")
+	writeFixtureFile(t, filepath.Join(root, "docs/imported/go-examples/README.md"), "demo\n")
+	return root
+}
+
+func writeFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if writeErr := os.WriteFile(path, []byte(content), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+}
+
+const validScenario = `devices:
+  - name: test-device
+    type: switch
+    mac: "00:11:22:33:44:55"
+    ips: ["192.0.2.10"]
+`
+
+const validWalk = `.1.3.6.1.2.1.1.5.0 = STRING: "test-device"
+`

--- a/scripts/sync-demo-catalog.ps1
+++ b/scripts/sync-demo-catalog.ps1
@@ -12,33 +12,14 @@ function Require-Command {
     }
 }
 
-function Copy-Directory {
-    param(
-        [string]$Source,
-        [string]$Destination
-    )
-
-    if (-not (Test-Path -LiteralPath $Source -PathType Container)) {
-        throw "Expected catalog directory missing: $Source"
-    }
-
-    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
-    Copy-Item -Path (Join-Path $Source "*") -Destination $Destination -Recurse -Force
-}
-
-function Get-RelativeFiles {
-    param([string]$Root)
-
-    if (-not (Test-Path -LiteralPath $Root -PathType Container)) {
-        return @()
-    }
-
-    Get-ChildItem -LiteralPath $Root -File -Recurse | ForEach-Object {
-        $_.FullName.Substring($Root.Length).TrimStart("\", "/")
-    } | Sort-Object
+function Test-GitCheckout {
+    param([string]$Path)
+    git -C $Path rev-parse --is-inside-work-tree 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
 }
 
 Require-Command git
+Require-Command go
 
 $ProjectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $CatalogUrl = if ($env:NIAC_DEMO_CATALOG_URL) { $env:NIAC_DEMO_CATALOG_URL } else { "git@github.com:MustardSeedNetworks/niac-demo-catalog.git" }
@@ -48,57 +29,44 @@ $ExamplesDir = if ($env:NIAC_GO_EXAMPLES_DIR) { $env:NIAC_GO_EXAMPLES_DIR } else
 $Offline = $env:NIAC_DEMO_CATALOG_OFFLINE -eq "1"
 
 if ($Offline) {
-    if (-not (Test-Path -LiteralPath $CatalogDir -PathType Container)) {
-        throw "NIAC_DEMO_CATALOG_OFFLINE=1 but catalog directory does not exist: $CatalogDir"
+    if (-not (Test-GitCheckout $CatalogDir)) {
+        throw "Offline catalog must be a git checkout: $CatalogDir"
     }
-} elseif (Test-Path -LiteralPath (Join-Path $CatalogDir ".git") -PathType Container) {
+} elseif (Test-GitCheckout $CatalogDir) {
     git -C $CatalogDir fetch --depth 1 origin $CatalogRef
-    git -C $CatalogDir checkout --detach FETCH_HEAD
+    if ($LASTEXITCODE -ne 0) { throw "Catalog fetch failed." }
 } else {
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $CatalogDir) | Out-Null
     git clone --filter=blob:none --no-checkout $CatalogUrl $CatalogDir
+    if ($LASTEXITCODE -ne 0) { throw "Catalog clone failed." }
     git -C $CatalogDir fetch --depth 1 origin $CatalogRef
-    git -C $CatalogDir checkout --detach FETCH_HEAD
+    if ($LASTEXITCODE -ne 0) { throw "Catalog fetch failed." }
 }
 
-$Stage = Join-Path ([System.IO.Path]::GetTempPath()) ("niac-go-demo-catalog-" + [System.Guid]::NewGuid())
-New-Item -ItemType Directory -Force -Path $Stage | Out-Null
+if (-not $Offline) {
+    git -C $CatalogDir checkout --detach FETCH_HEAD
+    if ($LASTEXITCODE -ne 0) { throw "Catalog checkout failed." }
+}
 
+$Dirty = git -C $CatalogDir status --porcelain --untracked-files=normal
+if ($LASTEXITCODE -ne 0) { throw "Could not inspect the catalog checkout." }
+if ($Dirty) { throw "Catalog checkout has uncommitted content: $CatalogDir" }
+
+$SourceCommit = git -C $CatalogDir rev-parse HEAD
+if ($LASTEXITCODE -ne 0) { throw "Could not resolve the catalog commit." }
+$SourceUrl = git -C $CatalogDir remote get-url origin
+if ($LASTEXITCODE -ne 0) { throw "Could not resolve the catalog origin URL." }
+$ModeValue = $Mode.ToLowerInvariant()
+
+Push-Location $ProjectRoot
 try {
-    Copy-Directory (Join-Path $CatalogDir "scenarios/go-yaml") $Stage
-    Copy-Directory (Join-Path $CatalogDir "walks/raw") (Join-Path $Stage "device_walks")
-    Copy-Directory (Join-Path $CatalogDir "walks/sanitized") (Join-Path $Stage "device_walks_sanitized")
-    Copy-Directory (Join-Path $CatalogDir "captures/shared") (Join-Path $Stage "captures")
-    Copy-Directory (Join-Path $CatalogDir "captures/go-extra") (Join-Path $Stage "pcaps")
-    Copy-Directory (Join-Path $CatalogDir "tools/walk-scripts/go") (Join-Path $Stage "walk_scripts")
-    $SharedRunDemo = Join-Path $CatalogDir "tools/walk-scripts/java/run_demo.sh"
-    if (Test-Path -LiteralPath $SharedRunDemo -PathType Leaf) {
-        Copy-Item -LiteralPath $SharedRunDemo -Destination (Join-Path $Stage "walk_scripts/run_demo.sh") -Force
-    }
-    Copy-Directory (Join-Path $CatalogDir "docs/imported/go-examples") $Stage
-
-    if ($Mode -eq "Sync") {
-        if (Test-Path -LiteralPath $ExamplesDir) {
-            Remove-Item -LiteralPath $ExamplesDir -Recurse -Force
-        }
-        New-Item -ItemType Directory -Force -Path $ExamplesDir | Out-Null
-        Copy-Item -Path (Join-Path $Stage "*") -Destination $ExamplesDir -Recurse -Force
-        Write-Host "OK: generated $ExamplesDir from the shared demo catalog."
-    } else {
-        $stageFiles = Get-RelativeFiles $Stage
-        $exampleFiles = Get-RelativeFiles $ExamplesDir
-        if (Compare-Object $stageFiles $exampleFiles) {
-            throw "$ExamplesDir does not match the shared demo catalog. Run scripts/sync-demo-catalog.ps1 -Mode Sync."
-        }
-        foreach ($relative in $stageFiles) {
-            $stageHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $Stage $relative)).Hash
-            $exampleHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $ExamplesDir $relative)).Hash
-            if ($stageHash -ne $exampleHash) {
-                throw "File differs from shared demo catalog: $relative"
-            }
-        }
-        Write-Host "OK: $ExamplesDir matches the shared demo catalog."
-    }
+    go run ./cmd/niac-catalog-sync `
+        -mode $ModeValue `
+        -catalog-dir $CatalogDir `
+        -examples-dir $ExamplesDir `
+        -repository $SourceUrl `
+        -commit $SourceCommit
+    if ($LASTEXITCODE -ne 0) { throw "Catalog $Mode failed." }
 } finally {
-    Remove-Item -LiteralPath $Stage -Recurse -Force -ErrorAction SilentlyContinue
+    Pop-Location
 }

--- a/scripts/sync-demo-catalog.sh
+++ b/scripts/sync-demo-catalog.sh
@@ -5,14 +5,14 @@ usage() {
   cat >&2 <<'USAGE'
 Usage: scripts/sync-demo-catalog.sh --sync|--check
 
-Generates the Go examples/ layout from MustardSeedNetworks/niac-demo-catalog.
+Generates and validates the Go examples/ layout from MustardSeedNetworks/niac-demo-catalog.
 
 Environment:
   NIAC_DEMO_CATALOG_URL      Catalog git URL.
   NIAC_DEMO_CATALOG_REF      Catalog branch, tag, or commit. Defaults to main.
   NIAC_DEMO_CATALOG_DIR      Existing catalog checkout. Defaults to .catalog/niac-demo-catalog.
   NIAC_GO_EXAMPLES_DIR       Generated output path. Defaults to examples.
-  NIAC_DEMO_CATALOG_OFFLINE  Set to 1 to require NIAC_DEMO_CATALOG_DIR and skip git fetch.
+  NIAC_DEMO_CATALOG_OFFLINE  Set to 1 to require a clean local catalog checkout and skip git fetch.
 USAGE
 }
 
@@ -41,23 +41,12 @@ require_command() {
   fi
 }
 
-copy_dir() {
-  local source="$1"
-  local destination="$2"
-
-  if [ ! -d "$source" ]; then
-    echo "ERROR: expected catalog directory missing: $source" >&2
-    exit 1
-  fi
-
-  mkdir -p "$destination"
-  rsync -a "$source"/ "$destination"/
-}
-
-require_command diff
 require_command git
-require_command mktemp
-require_command rsync
+require_command go
+
+is_git_checkout() {
+  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -69,47 +58,34 @@ EXAMPLES_DIR="${NIAC_GO_EXAMPLES_DIR:-$PROJECT_ROOT/examples}"
 OFFLINE="${NIAC_DEMO_CATALOG_OFFLINE:-0}"
 
 if [ "$OFFLINE" = "1" ]; then
-  if [ ! -d "$CATALOG_DIR" ]; then
-    echo "ERROR: NIAC_DEMO_CATALOG_OFFLINE=1 but catalog directory does not exist: $CATALOG_DIR" >&2
+  if ! is_git_checkout "$CATALOG_DIR"; then
+    echo "ERROR: offline catalog must be a git checkout: $CATALOG_DIR" >&2
     exit 1
   fi
 else
-  if [ -d "$CATALOG_DIR/.git" ]; then
+  if is_git_checkout "$CATALOG_DIR"; then
     git -C "$CATALOG_DIR" fetch --depth 1 origin "$CATALOG_REF"
-    git -C "$CATALOG_DIR" checkout --detach FETCH_HEAD
   else
     mkdir -p "$(dirname "$CATALOG_DIR")"
     git clone --filter=blob:none --no-checkout "$CATALOG_URL" "$CATALOG_DIR"
     git -C "$CATALOG_DIR" fetch --depth 1 origin "$CATALOG_REF"
-    git -C "$CATALOG_DIR" checkout --detach FETCH_HEAD
   fi
+  git -C "$CATALOG_DIR" checkout --detach FETCH_HEAD
 fi
 
-STAGE="$(mktemp -d)"
-trap 'rm -rf "$STAGE"' EXIT
-
-copy_dir "$CATALOG_DIR/scenarios/go-yaml" "$STAGE"
-copy_dir "$CATALOG_DIR/walks/raw" "$STAGE/device_walks"
-copy_dir "$CATALOG_DIR/walks/sanitized" "$STAGE/device_walks_sanitized"
-copy_dir "$CATALOG_DIR/captures/shared" "$STAGE/captures"
-copy_dir "$CATALOG_DIR/captures/go-extra" "$STAGE/pcaps"
-copy_dir "$CATALOG_DIR/tools/walk-scripts/go" "$STAGE/walk_scripts"
-if [ -f "$CATALOG_DIR/tools/walk-scripts/java/run_demo.sh" ]; then
-  cp "$CATALOG_DIR/tools/walk-scripts/java/run_demo.sh" "$STAGE/walk_scripts/run_demo.sh"
+if [ -n "$(git -C "$CATALOG_DIR" status --porcelain --untracked-files=normal)" ]; then
+  echo "ERROR: catalog checkout has uncommitted content: $CATALOG_DIR" >&2
+  exit 1
 fi
-copy_dir "$CATALOG_DIR/docs/imported/go-examples" "$STAGE"
 
-case "$MODE" in
-  sync)
-    mkdir -p "$EXAMPLES_DIR"
-    rsync -a --delete "$STAGE"/ "$EXAMPLES_DIR"/
-    echo "OK: generated $EXAMPLES_DIR from the shared demo catalog."
-    ;;
-  check)
-    if ! diff -qr "$STAGE" "$EXAMPLES_DIR"; then
-      echo "ERROR: $EXAMPLES_DIR does not match the shared demo catalog. Run scripts/sync-demo-catalog.sh --sync." >&2
-      exit 1
-    fi
-    echo "OK: $EXAMPLES_DIR matches the shared demo catalog."
-    ;;
-esac
+SOURCE_COMMIT="$(git -C "$CATALOG_DIR" rev-parse HEAD)"
+SOURCE_URL="$(git -C "$CATALOG_DIR" remote get-url origin)"
+(
+  cd "$PROJECT_ROOT"
+  go run ./cmd/niac-catalog-sync \
+    -mode "$MODE" \
+    -catalog-dir "$CATALOG_DIR" \
+    -examples-dir "$EXAMPLES_DIR" \
+    -repository "$SOURCE_URL" \
+    -commit "$SOURCE_COMMIT"
+)


### PR DESCRIPTION
## Summary

- replace the shell-only catalog copy path with one tested Go synchronization engine
- pin catalog imports to immutable commits and record deterministic source plus SHA-256 metadata
- validate NIAC scenario semantics and walk bindings before replacing generated content
- add drift checking and matching shell and PowerShell wrappers

## Linked Issue

Closes #1079

Related: MustardSeedNetworks/niac-demo-catalog#28

## Testing Evidence

```text
go test -race ./internal/catalogsync ./cmd/niac-catalog-sync
ok github.com/MustardSeedNetworks/niac-go/internal/catalogsync
ok github.com/MustardSeedNetworks/niac-go/cmd/niac-catalog-sync

golangci-lint run ./internal/catalogsync/... ./cmd/niac-catalog-sync/...
0 issues.

make fmt-check && make lint
passed

make test && make security
backend coverage: 66.1%; frontend tests passed; govulncheck, npm audit, and gitleaks passed

bash -n scripts/sync-demo-catalog.sh
passed
```

The live catalog was also checked at commit 0041c24e63266568d1eb7a64ab1a0cdf5126fdce. The new validator correctly rejected obsolete scenario schema fields; the source-catalog migration is tracked in MustardSeedNetworks/niac-demo-catalog#28.

## Security and Release Checklist

- [x] synchronization requires a clean catalog checkout and immutable commit
- [x] every copied file is checksummed and symlinks are rejected
- [x] invalid content cannot replace the current generated catalog
- [x] no dependencies or secrets added
- [x] local lint, tests, and security gates pass