### PR TITLE
fix(ui): consume packet SSE envelope

### DIFF
--- a/internal/api/sse/hub.go
+++ b/internal/api/sse/hub.go
@@ -217,10 +217,10 @@ func (h *Hub) Broadcast(stream Stream, data any) {
 
 // BroadcastPacket sends a packet to all packet stream subscribers.
 func (h *Hub) BroadcastPacket(data any) {
-	h.Broadcast(StreamPackets, map[string]any{
-		"type":      "packet",
-		"data":      data,
-		"timestamp": time.Now().UTC(),
+	h.Broadcast(StreamPackets, PacketEvent{
+		Type:      "packet",
+		Data:      data,
+		Timestamp: time.Now().UTC(),
 	})
 }
 

--- a/internal/api/sse/hub_test.go
+++ b/internal/api/sse/hub_test.go
@@ -1,6 +1,8 @@
 package sse
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -250,6 +252,52 @@ func TestSSEHubBroadcastToClients(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Error("did not receive broadcast message")
+	}
+}
+
+func TestSSEHubBroadcastPacketWireEnvelope(t *testing.T) {
+	hub := NewHub(Config{})
+	go hub.Run()
+	defer hub.Stop()
+
+	client := &Client{
+		hub:      hub,
+		send:     make(chan []byte, hub.config.BufferSize),
+		stream:   StreamPackets,
+		clientIP: "127.0.0.1",
+	}
+	hub.register <- client
+
+	hub.BroadcastPacket(map[string]any{
+		"protocol":  "TCP",
+		"source_ip": "192.0.2.10",
+	})
+
+	select {
+	case msg := <-client.send:
+		lines := bytes.Split(msg, []byte("\n"))
+		if len(lines) < 2 || !bytes.HasPrefix(lines[1], []byte("data: ")) {
+			t.Fatalf("unexpected SSE frame: %q", msg)
+		}
+		var event struct {
+			Type      string         `json:"type"`
+			Data      map[string]any `json:"data"`
+			Timestamp time.Time      `json:"timestamp"`
+		}
+		if err := json.Unmarshal(bytes.TrimPrefix(lines[1], []byte("data: ")), &event); err != nil {
+			t.Fatalf("decode packet event: %v", err)
+		}
+		if event.Type != "packet" {
+			t.Errorf("type = %q, want packet", event.Type)
+		}
+		if event.Data["protocol"] != "TCP" || event.Data["source_ip"] != "192.0.2.10" {
+			t.Errorf("data = %#v", event.Data)
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("timestamp is zero")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive packet broadcast")
 	}
 }
 

--- a/internal/api/sse/packet_observer_test.go
+++ b/internal/api/sse/packet_observer_test.go
@@ -1,0 +1,56 @@
+package sse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+)
+
+func TestPacketToWirePreservesSimulationDirection(t *testing.T) {
+	packet := &protocols.Packet{
+		Buffer:       []byte{0x00, 0x11, 0x22, 0x33},
+		Length:       4,
+		SerialNumber: 7,
+		Timestamp:    time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC),
+		VLAN:         -1,
+	}
+
+	for _, direction := range []string{"rx", "tx"} {
+		t.Run(direction, func(t *testing.T) {
+			wire := packetToWire(direction, packet)
+			if wire["direction"] != direction {
+				t.Errorf("direction = %v, want %q", wire["direction"], direction)
+			}
+			if wire["raw_data"] != "00112233" {
+				t.Errorf("raw_data = %v", wire["raw_data"])
+			}
+			if wire["serial"] != 7 {
+				t.Errorf("serial = %v", wire["serial"])
+			}
+		})
+	}
+}
+
+func TestGopacketToWireUsesStandaloneCaptureShape(t *testing.T) {
+	raw := []byte{
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+		0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+		0x08, 0x00,
+	}
+	packet := gopacket.NewPacket(raw, layers.LayerTypeEthernet, gopacket.Default)
+
+	wire := GopacketToWire(packet)
+	if wire["direction"] != "rx" {
+		t.Errorf("direction = %v, want rx", wire["direction"])
+	}
+	if wire["size"] != len(raw) {
+		t.Errorf("size = %v, want %d", wire["size"], len(raw))
+	}
+	if wire["raw_data"] != "00112233445566778899aabb0800" {
+		t.Errorf("raw_data = %v", wire["raw_data"])
+	}
+}

--- a/internal/api/sse/types.go
+++ b/internal/api/sse/types.go
@@ -26,6 +26,7 @@ package sse
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 const (
@@ -84,6 +85,13 @@ type Message struct {
 	Event string `json:"event,omitempty"` // Optional event type
 	Data  any    `json:"data"`
 	ID    string `json:"id,omitempty"` // Optional event ID for Last-Event-ID
+}
+
+// PacketEvent is the wire envelope sent by the packet stream.
+type PacketEvent struct {
+	Type      string    `json:"type"`
+	Data      any       `json:"data"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 // Client is a single connected client's hub-side handle. The hub

--- a/ui/src/hooks/useEventSource.ts
+++ b/ui/src/hooks/useEventSource.ts
@@ -180,17 +180,21 @@ export interface StreamHookOptions {
   enabled?: boolean;
 }
 
-export interface PacketData {
+export interface PacketStreamEvent {
   type: 'packet';
   timestamp: string;
-  data: {
-    sourceIp: string;
-    destIp: string;
-    protocol: string;
-    size: number;
-    payload?: string;
-    [key: string]: unknown;
-  };
+  data: Record<string, unknown>;
+}
+
+export function isPacketStreamEvent(value: unknown): value is PacketStreamEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const event = value as Record<string, unknown>;
+  return (
+    event.type === 'packet' &&
+    typeof event.timestamp === 'string' &&
+    typeof event.data === 'object' &&
+    event.data !== null
+  );
 }
 
 export function usePacketStream(options: StreamHookOptions = {}): UseEventSourceResult {

--- a/ui/src/pages/PacketInspectorPage.test.tsx
+++ b/ui/src/pages/PacketInspectorPage.test.tsx
@@ -28,12 +28,16 @@ vi.mock('../api/client', () => ({
 
 let capturedOnMessage: ((data: unknown) => void) | undefined;
 
-vi.mock('../hooks/useEventSource', () => ({
-  usePacketStream: (options: { onMessage?: (data: unknown) => void }) => {
-    capturedOnMessage = options.onMessage;
-    return { connected: true, reconnect: vi.fn() };
-  },
-}));
+vi.mock('../hooks/useEventSource', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/useEventSource')>();
+  return {
+    ...actual,
+    usePacketStream: (options: { onMessage?: (data: unknown) => void }) => {
+      capturedOnMessage = options.onMessage;
+      return { connected: true, reconnect: vi.fn() };
+    },
+  };
+});
 
 // The page consumes the shared sim-status poll via useSimulationStatus
 // (useAppState('simStatus') under an AppProvider). Mock the hook so this
@@ -74,24 +78,32 @@ describe('PacketInspectorPage — filtered export', () => {
     // Push one TCP and one UDP packet through the stream.
     await act(async () => {
       capturedOnMessage?.({
-        protocol: 'TCP',
-        sourceIp: '10.0.0.1',
-        destIp: '10.0.0.2',
-        sourcePort: 1234,
-        destPort: 80,
-        size: 64,
-        summary: 'tcp packet',
-        rawData: '00112233',
+        type: 'packet',
+        timestamp: '2026-07-24T12:00:00.000Z',
+        data: {
+          protocol: 'TCP',
+          sourceIp: '10.0.0.1',
+          destIp: '10.0.0.2',
+          sourcePort: 1234,
+          destPort: 80,
+          size: 64,
+          summary: 'tcp packet',
+          rawData: '00112233',
+        },
       });
       capturedOnMessage?.({
-        protocol: 'UDP',
-        sourceIp: '10.0.0.3',
-        destIp: '10.0.0.4',
-        sourcePort: 53,
-        destPort: 5353,
-        size: 32,
-        summary: 'udp packet',
-        rawData: 'aabbccdd',
+        type: 'packet',
+        timestamp: '2026-07-24T12:00:01.000Z',
+        data: {
+          protocol: 'UDP',
+          sourceIp: '10.0.0.3',
+          destIp: '10.0.0.4',
+          sourcePort: 53,
+          destPort: 5353,
+          size: 32,
+          summary: 'udp packet',
+          rawData: 'aabbccdd',
+        },
       });
     });
 
@@ -134,16 +146,20 @@ describe('PacketInspectorPage — filtered export', () => {
 
     await act(async () => {
       capturedOnMessage?.({
-        protocol: 'IPv4',
-        source_ip: '10.10.200.50',
-        dest_ip: '10.20.0.10',
-        size: 64,
-        raw_data: '00112233',
-        ingress_network: 'access',
-        physical_vlan: 200,
-        route_decision: 'forwarded',
-        hop: 'edge:inside',
-        egress_network: 'servers',
+        type: 'packet',
+        timestamp: '2026-07-24T12:00:00.000Z',
+        data: {
+          protocol: 'IPv4',
+          source_ip: '10.10.200.50',
+          dest_ip: '10.20.0.10',
+          size: 64,
+          raw_data: '00112233',
+          ingress_network: 'access',
+          physical_vlan: 200,
+          route_decision: 'forwarded',
+          hop: 'edge:inside',
+          egress_network: 'servers',
+        },
       });
     });
 
@@ -155,5 +171,36 @@ describe('PacketInspectorPage — filtered export', () => {
     expect(screen.getByText('edge:inside')).toBeInTheDocument();
     expect(screen.getByText('servers')).toBeInTheDocument();
     expect(screen.getByText('200')).toBeInTheDocument();
+  });
+
+  it('reads packet fields from the exact SSE wire envelope', async () => {
+    render(
+      <MemoryRouter>
+        <PacketInspectorPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(capturedOnMessage).toBeTypeOf('function'));
+
+    await act(async () => {
+      capturedOnMessage?.({
+        type: 'packet',
+        timestamp: '2026-07-24T12:00:00.000Z',
+        data: {
+          protocol: 'TCP',
+          source_ip: '192.0.2.10',
+          dest_ip: '198.51.100.20',
+          source_port: 49152,
+          dest_port: 443,
+          size: 74,
+          summary: 'TCP 49152 → 443',
+          raw_data: '00112233',
+        },
+      });
+    });
+
+    expect(
+      await screen.findByRole('button', { name: /192\.0\.2\.10.*198\.51\.100\.20/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Unknown.*Unknown/)).not.toBeInTheDocument();
   });
 });

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -34,7 +34,7 @@ import { useApiResource } from '../hooks/useApiResource';
 import { useColoringRules } from '../hooks/useColoringRules';
 import { useDisplayFilter } from '../hooks/useDisplayFilter';
 import { useErrorToast } from '../hooks/useErrorToast';
-import { usePacketStream } from '../hooks/useEventSource';
+import { isPacketStreamEvent, usePacketStream } from '../hooks/useEventSource';
 import { useSimulationStatus } from '../hooks/useSimulationStatus';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
@@ -153,19 +153,15 @@ export const PacketInspectorPage: FC = () => {
         return;
       }
 
-      // Validate incoming data is an object before casting
-      if (typeof data !== 'object' || data === null) {
-        return;
-      }
+      if (!isPacketStreamEvent(data)) return;
 
-      // Transform incoming data to Packet format
-      const incoming = data as Record<string, unknown>;
+      const incoming = data.data;
 
       // SSE payloads bypass the shared toCamelCase converter in client.ts,
       // so fall back to snake_case keys when the camelCase key is missing.
       const packet: Packet = {
         id: generatePacketId(),
-        timestamp: (incoming.timestamp as string) || new Date().toISOString(),
+        timestamp: (incoming.timestamp as string) || data.timestamp,
         protocol: (incoming.protocol as string) || 'Unknown',
         sourceIp: (incoming.sourceIp as string) || (incoming.source_ip as string) || 'Unknown',
         destIp: (incoming.destIp as string) || (incoming.dest_ip as string) || 'Unknown',


### PR DESCRIPTION
## Summary

- define the packet stream envelope explicitly in Go and TypeScript
- unwrap the server-sent event before Packet Inspector maps packet fields
- reject malformed packet events instead of rendering Unknown endpoints
- cover the exact SSE wire frame, simulation receive/transmit direction, and standalone capture shape

## Linked Issue

Closes #1036

## Testing Evidence

```text
npm test -- --run src/pages/PacketInspectorPage.test.tsx
expected regression before implementation: 1 failed, exact wire envelope rendered Unknown endpoints

go test -race ./internal/api/sse
ok github.com/MustardSeedNetworks/niac-go/internal/api/sse

npm test -- --run src/pages/PacketInspectorPage.test.tsx src/hooks/useEventSource.test.ts
2 files passed, 5 tests passed

make fmt-check && make lint && make test && make security
format clean; 81 Go linters and Biome clean; backend coverage 66.1%; frontend tests passed; no Go/npm vulnerabilities or leaked secrets
```

## Security and Release Checklist

- [x] untrusted stream input is checked before field access
- [x] no authentication, authorization, or CSRF behavior changed
- [x] no dependencies or secrets added
- [x] full local quality and security gates pass