### PR TITLE
test(web): enforce first-class browser matrix

### DIFF
--- a/.github/workflows/browser-channels.yml
+++ b/.github/workflows/browser-channels.yml
@@ -1,0 +1,90 @@
+name: First-Class Browser Channels
+
+on:
+  schedule:
+    - cron: "17 7 * * 1"
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-channels:
+    name: Installed Chrome and Edge
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install libpcap
+        run: |
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          sudo apt-get update
+          sudo apt-get install -y libpcap-dev
+
+      - name: Install frontend dependencies
+        working-directory: ui
+        run: npm ci
+
+      - name: Build NIAC
+        run: make build
+
+      - name: Install Chrome and Edge channels
+        working-directory: ui
+        run: npx playwright install --with-deps chrome msedge
+
+      - name: Start NIAC
+        env:
+          NIAC_E2E_DRY_RUN_SIMULATION: "1"
+        run: |
+          nohup ./niac daemon --listen 127.0.0.1:8445 --storage disabled > browser-channels-server.log 2>&1 &
+          for i in {1..30}; do
+            if curl -skf https://127.0.0.1:8445/__version >/dev/null; then
+              exit 0
+            fi
+            echo "Waiting for NIAC (attempt $i of 30)"
+            sleep 2
+          done
+          cat browser-channels-server.log
+          exit 1
+
+      - name: Run installed browser journeys
+        working-directory: ui
+        env:
+          E2E_BASE_URL: https://127.0.0.1:8445
+          PLAYWRIGHT_IGNORE_HTTPS_ERRORS: "true"
+        run: npx playwright test --config=playwright.channels.config.ts
+
+      - name: Run installed browser authentication journeys
+        working-directory: ui
+        run: npx playwright test --config=playwright.channels.auth.config.ts
+
+      - name: Upload browser reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: installed-browser-report
+          path: ui/playwright-report/
+          retention-days: 14
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: installed-browser-server-log
+          path: browser-channels-server.log
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -817,9 +817,7 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: ui
-        # Per msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md, every PR
-        # runs Chromium (covers Chrome + Edge) and WebKit (covers Safari).
-        run: npx playwright install --with-deps chromium webkit
+        run: npx playwright install --with-deps chromium webkit firefox
 
       - name: Start backend server
         env:
@@ -854,8 +852,6 @@ jobs:
         env:
           E2E_BASE_URL: https://localhost:8445
           PLAYWRIGHT_IGNORE_HTTPS_ERRORS: "true"
-        # Both chromium and webkit run per E2E_CONVENTIONS — Firefox/mobile/
-        # tablet/visual projects were deleted from playwright.config.ts.
         run: npx playwright test --reporter=html
 
       - name: Run authenticated browser E2E tests
@@ -992,12 +988,9 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    # NOTE: e2e and lighthouse are deliberately excluded from this aggregator.
-    # They were dropped from required-status-checks on main because they're
-    # advisory (flaky / surface real issues that are tracked separately).
-    # Including them here would re-block merge via the dispatcher on the
-    # same flakes. They still run on every PR and surface their own status;
-    # they just don't gate merge.
+    # Browser-engine E2E is release-blocking. Lighthouse remains independent:
+    # it measures performance and accessibility rather than functional browser
+    # compatibility, and its thresholds are enforced by its own job.
     needs:
       - changes
       - backend
@@ -1008,6 +1001,7 @@ jobs:
       - quality
       - docs
       - build
+      - e2e
     if: always()
     steps:
       - name: Verify upstream results

--- a/docs/WEBUI.md
+++ b/docs/WEBUI.md
@@ -193,14 +193,28 @@ View recent protocol errors:
 
 ## Browser Support
 
-**Fully Supported:**
-- Chrome 90+
-- Firefox 88+
-- Safari 14+
-- Edge 90+
+| Support level | Browsers | Acceptance |
+| --- | --- | --- |
+| First-class | Chrome stable, Edge stable, Safari on the current supported macOS release | Critical journeys must pass; failures block release |
+| Compatibility | Firefox current | The Firefox engine suite must pass on relevant changes |
+| Best-effort | Brave current | Run the pre-release privacy smoke checklist; failures are tracked but block only when reproduced in Chrome or Edge |
 
-**Partially Supported:**
-- IE 11 (degraded experience)
+Every relevant pull request runs the critical journey suite in Playwright
+Chromium, WebKit, and Firefox. A weekly workflow and every release-candidate
+pull request run the same journeys in installed Chrome and Edge stable
+channels. WebKit is not treated as proof of Safari compatibility.
+
+Before approving a release candidate in actual Safari:
+
+1. Authenticate over HTTPS and confirm no bearer appears in the URL or browser storage.
+2. Navigate the dashboard, topology, runtime, packet inspector, and offline PCAP pages.
+3. Edit and validate a routed template; start, stop, and restart it.
+4. Confirm live topology/statistics updates and reconnect an interrupted SSE stream.
+5. Exercise packet inspection, downloads, clipboard actions, dialogs, and narrow-width layout.
+6. Record the Safari/macOS versions, result, and screenshots or failure trace in the release.
+
+Before release, repeat authentication, navigation, SSE reconnect, download,
+clipboard, and dialog smoke checks in Brave with default Shields enabled.
 
 ## Performance
 

--- a/ui/playwright.channels.auth.config.ts
+++ b/ui/playwright.channels.auth.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+import authConfig from './playwright.auth.config';
+
+export default defineConfig({
+  ...authConfig,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report/browser-channel-auth' }],
+    ['list'],
+    ['json', { outputFile: 'playwright-report/browser-channel-auth/results.json' }],
+  ],
+  projects: [
+    {
+      name: 'chrome',
+      use: { ...authConfig.use, ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+    {
+      name: 'edge',
+      use: { ...authConfig.use, ...devices['Desktop Edge'], channel: 'msedge' },
+    },
+  ],
+});

--- a/ui/playwright.channels.config.ts
+++ b/ui/playwright.channels.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+export default defineConfig({
+  ...baseConfig,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report/browser-channels' }],
+    ['list'],
+    ['json', { outputFile: 'playwright-report/browser-channels/results.json' }],
+  ],
+  projects: [
+    {
+      name: 'chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+    {
+      name: 'edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
+  ],
+});

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -22,9 +22,9 @@ const baseURL = process.env.E2E_BASE_URL ?? `https://${e2eHost}:${e2ePort}`;
  * - Replay functionality
  * - Network simulation
  *
- * Browsers: Chromium (covers Chrome + Edge) and WebKit (covers Safari).
- * Per msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md, no other browsers
- * or viewports are supported.
+ * Engines: Chromium, WebKit, and Firefox. Installed Chrome and Edge channels
+ * use playwright.channels.config.ts; actual Safari remains a manual release
+ * candidate gate because Playwright controls WebKit rather than Safari.
  */
 export default defineConfig({
   testDir: './e2e',
@@ -67,11 +67,6 @@ export default defineConfig({
     ignoreHTTPSErrors: process.env.PLAYWRIGHT_IGNORE_HTTPS_ERRORS === 'true' || !process.env.CI,
   },
   projects: [
-    // Per msn-docs-internal/05-Engineering/E2E_CONVENTIONS.md, only chromium
-    // (covers Chrome and Edge) and webkit (covers Safari) are supported.
-    // Firefox/mobile/tablet/visual projects were deleted in 2026q2 — they
-    // were configured but never run in CI, and the visual tier's macOS-only
-    // *-darwin.png snapshots couldn't work on Linux CI.
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
@@ -79,6 +74,10 @@ export default defineConfig({
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
     },
   ],
   // Explicit E2E_BASE_URL adopts an operator-managed daemon (CI uses 8445).

--- a/ui/src/test/browserMatrix.test.ts
+++ b/ui/src/test/browserMatrix.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import browserChannelAuthConfig from '../../playwright.channels.auth.config';
+import browserChannelsConfig from '../../playwright.channels.config';
+import criticalConfig from '../../playwright.config';
+
+function projectNames(config: {
+  projects?: Array<{ name?: string }> | readonly { name?: string }[];
+}): string[] {
+  return config.projects?.map((project) => project.name ?? '') ?? [];
+}
+
+describe('browser support matrix', () => {
+  it('gates every critical browser engine', () => {
+    expect(projectNames(criticalConfig)).toEqual(['chromium', 'webkit', 'firefox']);
+  });
+
+  it('tests the installed first-class Chromium browser channels', () => {
+    expect(projectNames(browserChannelsConfig)).toEqual(['chrome', 'edge']);
+    expect(projectNames(browserChannelAuthConfig)).toEqual(['chrome', 'edge']);
+  });
+});


### PR DESCRIPTION
## Summary

- make Chromium, WebKit, and Firefox functional E2E release-blocking
- add scheduled and release-candidate journeys for installed Chrome and Edge stable channels
- run authenticated REST and SSE journeys in installed Chrome and Edge
- publish the first-class, compatibility, and best-effort browser policy plus Safari and Brave evidence checklists
- retain Playwright reports, traces, screenshots, videos, and server logs for diagnosis

## Linked Issue

Closes #1051

## Testing Evidence

```text
npm test -- --run src/test/browserMatrix.test.ts
2 tests passed (regression test first failed because installed-channel configuration did not exist)

npm run typecheck
passed

npm run test:e2e
186 passed across Chromium, WebKit, and Firefox; 6 intentional no-simulation skips

npx playwright test --config=playwright.channels.config.ts
124 passed in installed Chrome and Edge; 4 intentional no-simulation skips

npx playwright test --config=playwright.channels.auth.config.ts
2 passed in installed Chrome and Edge

make fmt-check && make lint
format clean; 81 Go linters and Biome clean

make test && make security
backend coverage 66.2%; 68 frontend test files passed; no Go/npm vulnerabilities or leaked secrets

actionlint .github/workflows/browser-channels.yml
passed
```

Actual Safari launch reached the local HTTPS endpoint; completing its functional checklist requires the operator to accept Safari self-signed-certificate warning. Brave is not installed locally and remains the documented best-effort pre-release check.

## Security and Release Checklist

- [x] first-class engine failures feed the required CI Complete gate
- [x] installed browser workflow uses read-only repository permissions
- [x] authenticated tests verify bearer tokens are not persisted or exposed in URLs
- [x] browser reports and failure artifacts are retained
- [x] no dependencies or secrets added
- [x] full local quality and security gates pass