### PR TITLE
fix(ui): keep offline PCAP analysis accessible

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -120,7 +120,10 @@ function AppShell() {
             <Route path="/templates" element={<Navigate to="/runtime" replace={true} />} />
             <Route path="/neighbors" element={<Navigate to="/topology" replace={true} />} />
             <Route path="/analysis" element={<Navigate to="/traffic" replace={true} />} />
-            <Route path="/pcap-analyzer" element={<Navigate to="/packets" replace={true} />} />
+            <Route
+              path="/pcap-analyzer"
+              element={<Navigate to="/packets?view=files" replace={true} />}
+            />
             <Route path="*" element={<Navigate to="/" replace={true} />} />
           </Routes>
         </Suspense>

--- a/ui/src/pages/PacketInspectorPage.test.tsx
+++ b/ui/src/pages/PacketInspectorPage.test.tsx
@@ -203,4 +203,34 @@ describe('PacketInspectorPage — filtered export', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/Unknown.*Unknown/)).not.toBeInTheDocument();
   });
+
+  it('opens offline PCAP analysis when no live stream is active', async () => {
+    fetchCaptureStatus.mockResolvedValue({ running: false });
+
+    render(
+      <MemoryRouter>
+        <PacketInspectorPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(await screen.findByRole('tab', { name: 'PCAP files' }));
+
+    expect(screen.getByText('Drag & drop PCAP file')).toBeInTheDocument();
+  });
+
+  it('opens a bookmarked offline PCAP view directly', async () => {
+    fetchCaptureStatus.mockResolvedValue({ running: false });
+
+    render(
+      <MemoryRouter initialEntries={['/packets?view=files']}>
+        <PacketInspectorPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Drag & drop PCAP file')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'PCAP files' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
 });

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react';
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   fetchCaptureStatus,
   fetchUsableInterfaces,
@@ -95,7 +95,8 @@ export const PacketInspectorPage: FC = () => {
   const { t } = useTranslation('pages');
   const { t: tCommon } = useTranslation('common');
   const navigate = useNavigate();
-  const [view, setView] = useState<'live' | 'files'>('live');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = searchParams.get('view') === 'files' ? 'files' : 'live';
   // The page streams from /api/v1/stream/packets, which the daemon
   // populates from either a running simulation OR a standalone capture
   // session. Polling both lets us pick whichever is producing traffic
@@ -296,19 +297,6 @@ export const PacketInspectorPage: FC = () => {
     return `${selectedPacket.sourceIp}:${selectedPacket.sourcePort ?? 0}`;
   }, [selectedPacket]);
 
-  if (!streamActive) {
-    return (
-      <StandaloneCaptureStarter
-        onStarted={() => {
-          // Force an immediate status refresh so the page transitions
-          // out of the empty state without waiting for the poll tick.
-          refetchCapture();
-        }}
-        navigateToSim={() => navigate('/runtime')}
-      />
-    );
-  }
-
   return (
     <div className="stack-xl">
       {/* Live / PCAP Files tab control */}
@@ -321,7 +309,7 @@ export const PacketInspectorPage: FC = () => {
           type="button"
           role="tab"
           aria-selected={view === 'live'}
-          onClick={() => setView('live')}
+          onClick={() => setSearchParams({}, { replace: true })}
           className={`flex items-center gap-1.5 rounded px-3 py-compact-md text-xs font-medium transition-colors ${
             view === 'live'
               ? 'bg-brand-primary/20 text-brand-accent'
@@ -335,7 +323,7 @@ export const PacketInspectorPage: FC = () => {
           type="button"
           role="tab"
           aria-selected={view === 'files'}
-          onClick={() => setView('files')}
+          onClick={() => setSearchParams({ view: 'files' }, { replace: true })}
           className={`flex items-center gap-1.5 rounded px-3 py-compact-md text-xs font-medium transition-colors ${
             view === 'files'
               ? 'bg-brand-primary/20 text-brand-accent'
@@ -350,8 +338,17 @@ export const PacketInspectorPage: FC = () => {
       {/* PCAP Files tab — renders the standalone analyzer */}
       {view === 'files' && <PcapAnalyzerPage />}
 
+      {view === 'live' && !streamActive && (
+        <StandaloneCaptureStarter
+          onStarted={() => {
+            refetchCapture();
+          }}
+          navigateToSim={() => navigate('/runtime')}
+        />
+      )}
+
       {/* Live capture content (everything below is the original page) */}
-      {view === 'live' && (
+      {view === 'live' && streamActive && (
         <>
           {/* Header with controls */}
           <Card className="border-surface-border bg-bg-surface/70">


### PR DESCRIPTION
## Summary
- keep the Files tab available when live capture is inactive
- support direct offline-analysis bookmarks with `?view=files`
- redirect the legacy PCAP analyzer route to the supported offline view

## Linked Issue
Closes #1048

## Testing Evidence
```text
make fmt-check  # passed
make lint       # passed, 0 issues
make test       # passed, backend coverage 66.2%; frontend 68 files
make security   # passed, 0 Go/npm vulnerabilities and no leaked secrets
```

## Security and Release Checklist
- [x] No authentication or authorization behavior changed
- [x] No dependencies added
- [x] Offline and live packet flows covered by regression tests
- [x] Full formatting, lint, test, and security gates passed
