### PR TITLE
fix(api): publish authoritative stats stream

### DIFF
--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -54,18 +54,18 @@ curl -H "Authorization: Bearer $NIAC_API_TOKEN" \
   "timestamp": "2025-11-14T12:34:56Z",
   "interface": "eth0",
   "version": "2.6.0",
-  "device_count": 5,
+  "deviceCount": 5,
   "goroutines": 42,
   "stack": {
-    "packets_sent": 12543,
-    "packets_received": 10234,
-    "arp_requests": 523,
-    "arp_replies": 498,
-    "icmp_requests": 1024,
-    "icmp_replies": 1019,
-    "dns_queries": 234,
-    "dhcp_requests": 45,
-    "snmp_queries": 89,
+    "packetsSent": 12543,
+    "packetsReceived": 10234,
+    "arpRequests": 523,
+    "arpReplies": 498,
+    "icmpRequests": 1024,
+    "icmpReplies": 1019,
+    "dnsQueries": 234,
+    "dhcpRequests": 45,
+    "snmpQueries": 89,
     "errors": 3
   }
 }
@@ -219,8 +219,8 @@ def main():
     """Monitor statistics every 5 seconds"""
     while True:
         stats = get_stats()
-        print(f"Packets: sent={stats['stack']['packets_sent']}, "
-              f"received={stats['stack']['packets_received']}, "
+        print(f"Packets: sent={stats['stack']['packetsSent']}, "
+              f"received={stats['stack']['packetsReceived']}, "
               f"errors={stats['stack']['errors']}, "
               f"goroutines={stats['goroutines']}")
         time.sleep(5)
@@ -432,7 +432,7 @@ async function updateConfig(yamlContent) {
 (async () => {
   try {
     const stats = await getStats();
-    console.log('Packets sent:', stats.stack.packets_sent);
+    console.log('Packets sent:', stats.stack.packetsSent);
     console.log('Goroutines:', stats.goroutines);
   } catch (error) {
     console.error('Error:', error);
@@ -502,11 +502,11 @@ type Stats struct {
 	Timestamp   string `json:"timestamp"`
 	Interface   string `json:"interface"`
 	Version     string `json:"version"`
-	DeviceCount int    `json:"device_count"`
+	DeviceCount int    `json:"deviceCount"`
 	Goroutines  int    `json:"goroutines"`
 	Stack       struct {
-		PacketsSent     uint64 `json:"packets_sent"`
-		PacketsReceived uint64 `json:"packets_received"`
+		PacketsSent     uint64 `json:"packetsSent"`
+		PacketsReceived uint64 `json:"packetsReceived"`
 		Errors          uint64 `json:"errors"`
 	} `json:"stack"`
 }
@@ -551,8 +551,8 @@ $headers = @{
 }
 
 $stats = Invoke-RestMethod -Uri "https://localhost:8445/api/v1/stats" -Headers $headers
-Write-Host "Packets Sent: $($stats.stack.packets_sent)"
-Write-Host "Packets Received: $($stats.stack.packets_received)"
+Write-Host "Packets Sent: $($stats.stack.packetsSent)"
+Write-Host "Packets Received: $($stats.stack.packetsReceived)"
 Write-Host "Goroutines: $($stats.goroutines)"
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -419,7 +419,7 @@ headers = {"Authorization": f"Bearer {token}"}
 
 # Get stats
 stats = requests.get("https://localhost:8445/api/v1/stats", headers=headers).json()
-print(f"Packets sent: {stats['stack']['packets_sent']}")
+print(f"Packets sent: {stats['stack']['packetsSent']}")
 
 # Update config
 new_config = {"content": open("new-config.yaml").read()}

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -249,7 +249,7 @@ niac test error-rate --duration 10s --devices 10
 sudo tcpreplay -i eth0 -M 10 test.pcap
 
 # Monitor processing rate
-watch -n 1 'curl -s -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats | jq .stack.packets_received'
+watch -n 1 'curl -s -H "Authorization: Bearer $TOKEN" https://localhost:8445/api/v1/stats | jq .stack.packetsReceived'
 ```
 
 ## Tuning by Use Case

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -25,6 +25,7 @@ Prometheus metrics share the daemon's HTTPS listener at `/metrics`; there is no 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/v1/stats` | Live packet counters, interface info, NIAC version |
+| `GET` | `/api/v1/stream/stats` | Server-sent live statistics stream |
 | `GET` | `/api/v1/devices` | Device inventory (type, IPs, enabled protocols) |
 | `GET` | `/api/v1/history` | Recent runs persisted to BoltDB |
 | `GET` | `/api/v1/config` | Active YAML config plus file metadata |
@@ -42,6 +43,10 @@ Prometheus metrics share the daemon's HTTPS listener at `/metrics`; there is no 
 | `GET` | `/metrics` | Prometheus metrics endpoint (see [Monitoring Guide](MONITORING.md)) |
 
 Include `Authorization: Bearer <token>` or append `?token=<token>` when authentication is enabled.
+
+The statistics stream publishes once per second while a simulation is active
+and at least one client is subscribed. Each `stats` event carries the same
+authoritative snapshot shape as `GET /api/v1/stats`.
 
 ## Web UI
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -417,65 +417,66 @@ components:
           type: string
           format: date-time
           example: "2025-11-14T10:30:00Z"
-        uptime:
-          type: string
-          example: "2h15m30s"
         version:
           type: string
           example: "2.7.0"
         interface:
           type: string
           example: "eth0"
-        device_count:
+        deviceCount:
           type: integer
           example: 50
         goroutines:
           type: integer
           description: Current goroutine count for leak detection
           example: 127
-        packets_sent:
-          type: integer
-          format: int64
-          example: 1000000
-        packets_received:
-          type: integer
-          format: int64
-          example: 950000
-        errors:
-          type: integer
-          format: int64
-          example: 42
-        protocol_stats:
+        stack:
           type: object
           properties:
-            arp_requests:
+            packetsSent:
+              type: integer
+              format: int64
+              example: 1000000
+            packetsReceived:
+              type: integer
+              format: int64
+              example: 950000
+            arpRequests:
               type: integer
               format: int64
               example: 5000
-            arp_replies:
+            arpReplies:
               type: integer
               format: int64
               example: 4950
-            icmp_requests:
+            icmpRequests:
               type: integer
               format: int64
               example: 10000
-            icmp_replies:
+            icmpReplies:
               type: integer
               format: int64
               example: 9800
-            dns_queries:
+            dnsQueries:
               type: integer
               format: int64
               example: 2000
-            dhcp_requests:
+            dhcpRequests:
               type: integer
               format: int64
               example: 50
-            snmp_queries:
+            snmpQueries:
               type: integer
               format: int64
               example: 500
+            errors:
+              type: integer
+              format: int64
+              example: 42
+            udpProxyOverloadDrops:
+              type: integer
+              format: int64
+              example: 0
 
     Device:
       type: object
@@ -678,22 +679,22 @@ components:
     StatsResponse:
       value:
         timestamp: "2025-11-14T10:30:00Z"
-        uptime: "2h15m30s"
         version: "2.7.0"
         interface: "eth0"
-        device_count: 50
+        deviceCount: 50
         goroutines: 127
-        packets_sent: 1000000
-        packets_received: 950000
-        errors: 42
-        protocol_stats:
-          arp_requests: 5000
-          arp_replies: 4950
-          icmp_requests: 10000
-          icmp_replies: 9800
-          dns_queries: 2000
-          dhcp_requests: 50
-          snmp_queries: 500
+        stack:
+          packetsSent: 1000000
+          packetsReceived: 950000
+          arpRequests: 5000
+          arpReplies: 4950
+          icmpRequests: 10000
+          icmpReplies: 9800
+          dnsQueries: 2000
+          dhcpRequests: 50
+          snmpQueries: 500
+          errors: 42
+          udpProxyOverloadDrops: 0
 
     DeviceListResponse:
       value:

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -19,49 +19,13 @@ import (
 )
 
 func (s *Server) handleStats(w http.ResponseWriter, _ *http.Request) {
-	// SECURITY FIX #161: Thread-safe access to all config fields
-	s.configMu.RLock()
-	stack := s.cfg.Stack
-	cfg := s.cfg.Config
-	iface := s.cfg.Interface
-	s.configMu.RUnlock()
-
-	if stack == nil {
+	payload, ok := s.currentStatsPayload()
+	if !ok {
 		http.Error(w, "no simulation running", http.StatusServiceUnavailable)
 
 		return
 	}
 
-	stats := stack.GetStats()
-
-	deviceCount := 0
-	if cfg != nil {
-		deviceCount = len(cfg.Devices)
-	}
-
-	// FEATURE #119: Include goroutine count for debugging and monitoring
-	goroutineCount := runtime.NumGoroutine()
-
-	payload := map[string]any{
-		"timestamp":    time.Now().UTC(),
-		"interface":    iface,
-		"version":      s.cfg.Version,
-		"device_count": deviceCount,
-		"goroutines":   goroutineCount, // FEATURE #119: Monitor goroutine count
-		"stack": map[string]uint64{
-			"packets_sent":             stats.PacketsSent,
-			"packets_received":         stats.PacketsReceived,
-			"arp_requests":             stats.ARPRequests,
-			"arp_replies":              stats.ARPReplies,
-			"icmp_requests":            stats.ICMPRequests,
-			"icmp_replies":             stats.ICMPReplies,
-			"dns_queries":              stats.DNSQueries,
-			"dhcp_requests":            stats.DHCPRequests,
-			"snmp_queries":             stats.SNMPQueries,
-			"errors":                   stats.Errors,
-			"udp_proxy_overload_drops": stats.UDPProxyOverloadDrops,
-		},
-	}
 	s.writeJSON(w, payload)
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -95,8 +95,11 @@ func TestHandleStats(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if _, ok := response.Stack["udp_proxy_overload_drops"]; !ok {
-		t.Fatal("response missing udp_proxy_overload_drops")
+	if _, ok := response.Stack["udpProxyOverloadDrops"]; !ok {
+		t.Fatal("response missing udpProxyOverloadDrops")
+	}
+	if _, ok := response.Stack["udp_proxy_overload_drops"]; ok {
+		t.Fatal("response retained legacy snake_case stats key")
 	}
 }
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -415,6 +415,7 @@ func (s *Server) startBackgroundTasks() {
 
 	// Start SSE hub for real-time streaming
 	go s.sseHub.Run()
+	go s.startStatsPublisher(statsStreamInterval)
 	s.logger.Info("[SSE] Server-Sent Events hub started")
 
 	// Tee slog into the SSE hub so the Protocol Debug Console gets

--- a/internal/api/stats_sse_test.go
+++ b/internal/api/stats_sse_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/sse"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+)
+
+func TestStatsPublisherDeliversCurrentSnapshot(t *testing.T) {
+	cfg := &config.Config{Devices: []config.Device{{Name: "edge-1", Type: "router"}}}
+	server := &Server{
+		cfg: ServerConfig{
+			Stack:     protocols.NewStack(nil, cfg, logging.NewDebugConfig(0)),
+			Config:    cfg,
+			Interface: "en0",
+			Version:   "test",
+		},
+		logger:    slog.Default(),
+		sseHub:    sse.NewHub(sse.Config{}),
+		bgStop:    make(chan struct{}),
+		startTime: time.Now(),
+	}
+	go server.sseHub.Run()
+	go server.startStatsPublisher(10 * time.Millisecond)
+	defer func() {
+		if err := server.Shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown: %v", err)
+		}
+	}()
+
+	httpServer := httptest.NewServer(http.HandlerFunc(server.handleSSEStats))
+	defer httpServer.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	response, err := client.Get(httpServer.URL) // #nosec G107 -- local test server
+	if err != nil {
+		t.Fatalf("subscribe to stats stream: %v", err)
+	}
+	defer response.Body.Close()
+
+	scanner := bufio.NewScanner(response.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event struct {
+			Type string       `json:"type"`
+			Data statsPayload `json:"data"`
+		}
+		if decodeErr := json.Unmarshal(
+			[]byte(strings.TrimPrefix(line, "data: ")),
+			&event,
+		); decodeErr != nil {
+			t.Fatalf("decode stats event: %v", decodeErr)
+		}
+		if event.Type != "stats" {
+			continue
+		}
+		if strings.Contains(line, "device_count") || !strings.Contains(line, `"deviceCount":1`) {
+			t.Fatalf("stats event did not use the camelCase wire contract: %s", line)
+		}
+		if event.Data.Interface != "en0" || event.Data.Version != "test" {
+			t.Errorf("payload identity = %#v", event.Data)
+		}
+		if event.Data.DeviceCount != 1 {
+			t.Errorf("device count = %d, want 1", event.Data.DeviceCount)
+		}
+		return
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		t.Fatalf("read stats stream: %v", scanErr)
+	}
+	t.Fatal("stats stream closed before publishing a snapshot")
+}

--- a/internal/api/stats_stream.go
+++ b/internal/api/stats_stream.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/sse"
+)
+
+const statsStreamInterval = time.Second
+
+type statsPayload struct {
+	Timestamp   time.Time         `json:"timestamp"`
+	Interface   string            `json:"interface"`
+	Version     string            `json:"version"`
+	DeviceCount int               `json:"deviceCount"`
+	Goroutines  int               `json:"goroutines"`
+	Stack       statsStackPayload `json:"stack"`
+}
+
+type statsStackPayload struct {
+	PacketsSent           uint64 `json:"packetsSent"`
+	PacketsReceived       uint64 `json:"packetsReceived"`
+	ARPRequests           uint64 `json:"arpRequests"`
+	ARPReplies            uint64 `json:"arpReplies"`
+	ICMPRequests          uint64 `json:"icmpRequests"`
+	ICMPReplies           uint64 `json:"icmpReplies"`
+	DNSQueries            uint64 `json:"dnsQueries"`
+	DHCPRequests          uint64 `json:"dhcpRequests"`
+	SNMPQueries           uint64 `json:"snmpQueries"`
+	Errors                uint64 `json:"errors"`
+	UDPProxyOverloadDrops uint64 `json:"udpProxyOverloadDrops"`
+}
+
+func (s *Server) currentStatsPayload() (statsPayload, bool) {
+	s.configMu.RLock()
+	stack := s.cfg.Stack
+	cfg := s.cfg.Config
+	iface := s.cfg.Interface
+	version := s.cfg.Version
+	s.configMu.RUnlock()
+
+	if stack == nil {
+		return statsPayload{}, false
+	}
+
+	stats := stack.GetStats()
+	deviceCount := 0
+	if cfg != nil {
+		deviceCount = len(cfg.Devices)
+	}
+
+	return statsPayload{
+		Timestamp:   time.Now().UTC(),
+		Interface:   iface,
+		Version:     version,
+		DeviceCount: deviceCount,
+		Goroutines:  runtime.NumGoroutine(),
+		Stack: statsStackPayload{
+			PacketsSent:           stats.PacketsSent,
+			PacketsReceived:       stats.PacketsReceived,
+			ARPRequests:           stats.ARPRequests,
+			ARPReplies:            stats.ARPReplies,
+			ICMPRequests:          stats.ICMPRequests,
+			ICMPReplies:           stats.ICMPReplies,
+			DNSQueries:            stats.DNSQueries,
+			DHCPRequests:          stats.DHCPRequests,
+			SNMPQueries:           stats.SNMPQueries,
+			Errors:                stats.Errors,
+			UDPProxyOverloadDrops: stats.UDPProxyOverloadDrops,
+		},
+	}, true
+}
+
+func (s *Server) startStatsPublisher(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.bgStop:
+			return
+		case <-ticker.C:
+			if s.sseHub.ClientCount(sse.StreamStats) == 0 {
+				continue
+			}
+			payload, ok := s.currentStatsPayload()
+			if ok {
+				s.sseHub.BroadcastStats(payload)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- publish the documented stats SSE event once per second while clients are subscribed
- derive REST and SSE responses from the same lock-safe typed snapshot
- enforce NIAC's camelCase wire contract across the stats API, stream, tests, and live documentation
- stop publisher work when the daemon shuts down and avoid snapshot work without subscribers

## Linked Issue
Closes #1040

## Testing Evidence
```text
go test -race ./internal/api -run '^(TestHandleStats|TestStatsPublisherDeliversCurrentSnapshot)$' -count=5  # passed
./scripts/check-json-casing.sh  # passed, empty violation baseline
make fmt-check  # passed
make lint       # passed, 0 issues
make test       # backend passed at 66.2% coverage; frontend 333/333 passed
make security   # passed, 0 Go/npm vulnerabilities and no leaked secrets
```

## Security and Release Checklist
- [x] No authentication or authorization behavior changed
- [x] No dependencies added
- [x] REST and SSE use one authoritative camelCase response contract
- [x] Publisher lifecycle, subscription behavior, and wire casing are covered by tests
- [x] Full formatting, lint, test, and security gates passed
