### PR TITLE
fix(protocols): expire idle SSH sessions consistently

### DIFF
--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -359,6 +359,7 @@ func (s *Stack) Start() error {
 	s.edpHandler.Start()
 	s.fdpHandler.Start()
 	s.startNeighborCleanupLoop()
+	s.startSessionCleanupLoop()
 
 	if s.debugConfig.GetGlobal() >= DebugLevelBasic {
 		_, _ = fmt.Fprintln(os.Stdout, "Protocol stack started")

--- a/internal/protocols/stack_sessions.go
+++ b/internal/protocols/stack_sessions.go
@@ -1,0 +1,23 @@
+package protocols
+
+import "time"
+
+func (s *Stack) startSessionCleanupLoop() {
+	if s.tcpHandler == nil || s.tcpHandler.ssh == nil {
+		return
+	}
+
+	s.wg.Go(func() {
+		ticker := time.NewTicker(sshSessionCleanup)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				s.tcpHandler.ssh.cleanupExpired()
+			case <-s.stopChan:
+				return
+			}
+		}
+	})
+}

--- a/internal/protocols/tcp_ssh.go
+++ b/internal/protocols/tcp_ssh.go
@@ -24,6 +24,7 @@ const (
 	sshSegmentPayloadLimit = 1200
 	sshMaxSessions         = 256
 	sshSessionIdleTimeout  = 5 * time.Minute
+	sshSessionCleanup      = time.Minute
 	sshRetransmitTimeout   = 500 * time.Millisecond
 	sshMaxRetransmits      = 4
 )
@@ -261,28 +262,20 @@ func (h *sshTCPHandler) finishServer(session *sshTCPSession) {
 
 func (h *sshTCPHandler) reserveSession(key string) (bool, bool) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	now := h.now()
-	for currentKey, session := range h.sessions {
-		if session == nil {
-			continue
-		}
-		session.mu.Lock()
-		stale := now.Sub(session.lastActivity) >= sshSessionIdleTimeout
-		session.mu.Unlock()
-		if stale {
-			h.close(session)
-			delete(h.sessions, currentKey)
-		}
-	}
+	expired := h.removeExpiredLocked(h.now())
 	if _, exists := h.sessions[key]; exists {
+		h.mu.Unlock()
+		h.closeAll(expired)
 		return false, false
 	}
 	if len(h.sessions) >= sshMaxSessions {
+		h.mu.Unlock()
+		h.closeAll(expired)
 		return false, true
 	}
 	h.sessions[key] = nil
+	h.mu.Unlock()
+	h.closeAll(expired)
 	return true, false
 }
 
@@ -455,8 +448,54 @@ func (h *sshTCPHandler) server(device *config.Device) (*devicecli.SSHServer, err
 
 func (h *sshTCPHandler) session(key string) *sshTCPSession {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-	return h.sessions[key]
+	session := h.sessions[key]
+	if session == nil {
+		h.mu.Unlock()
+		return nil
+	}
+	now := h.now()
+	session.mu.Lock()
+	if now.Sub(session.lastActivity) < sshSessionIdleTimeout {
+		session.lastActivity = now
+		session.mu.Unlock()
+		h.mu.Unlock()
+		return session
+	}
+	delete(h.sessions, key)
+	session.mu.Unlock()
+	h.mu.Unlock()
+	h.close(session)
+	return nil
+}
+
+func (h *sshTCPHandler) cleanupExpired() {
+	h.mu.Lock()
+	expired := h.removeExpiredLocked(h.now())
+	h.mu.Unlock()
+	h.closeAll(expired)
+}
+
+func (h *sshTCPHandler) removeExpiredLocked(now time.Time) []*sshTCPSession {
+	var expired []*sshTCPSession
+	for key, session := range h.sessions {
+		if session == nil {
+			continue
+		}
+		session.mu.Lock()
+		stale := now.Sub(session.lastActivity) >= sshSessionIdleTimeout
+		session.mu.Unlock()
+		if stale {
+			delete(h.sessions, key)
+			expired = append(expired, session)
+		}
+	}
+	return expired
+}
+
+func (h *sshTCPHandler) closeAll(sessions []*sshTCPSession) {
+	for _, session := range sessions {
+		h.close(session)
+	}
 }
 
 func (h *sshTCPHandler) closeSession(key string) {

--- a/internal/protocols/tcp_ssh_test.go
+++ b/internal/protocols/tcp_ssh_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/virtualtcp"
 )
 
@@ -93,6 +94,63 @@ func TestSSHTCPHandlerReplacesIdleSessionForReusedSYN(t *testing.T) {
 	}
 	if reserved, _ := handler.reserveSession("client"); !reserved {
 		t.Fatal("reused tuple could not reserve a fresh session")
+	}
+}
+
+func TestSSHTCPHandlerExpiresIdleSessionBeforeEstablishedTraffic(t *testing.T) {
+	now := time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC)
+	ip := &layers.IPv4{SrcIP: net.ParseIP("10.0.0.2"), DstIP: net.ParseIP("10.0.0.1")}
+	tcp := &layers.TCP{SrcPort: 40000, DstPort: TCPPortSSH, ACK: true, Seq: 100, Ack: 200}
+	key := sshSessionKey(ip, tcp, 0)
+	connection := virtualtcp.NewPacketConn(
+		"10.0.0.1:22", "10.0.0.2:40000",
+		func(context.Context, []byte) error { return nil },
+	)
+	handler := &sshTCPHandler{
+		sessions: map[string]*sshTCPSession{
+			key: {
+				key: key, connection: connection, established: true,
+				lastActivity: now.Add(-sshSessionIdleTimeout),
+			},
+		},
+		now: func() time.Time { return now },
+	}
+
+	handler.HandlePacket(
+		&Packet{},
+		ip,
+		tcp,
+		[]*config.Device{{SSHConfig: &config.SSHConfig{Enabled: true}}},
+	)
+
+	if _, exists := handler.sessions[key]; exists {
+		t.Fatal("idle session remained after established ACK traffic")
+	}
+	if _, err := connection.Write([]byte("closed")); err == nil {
+		t.Fatal("idle connection remained open")
+	}
+}
+
+func TestSSHTCPHandlerCleanupExpiresAbandonedSessions(t *testing.T) {
+	now := time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC)
+	connection := virtualtcp.NewPacketConn(
+		"10.0.0.1:22", "10.0.0.2:40000",
+		func(context.Context, []byte) error { return nil },
+	)
+	handler := &sshTCPHandler{
+		sessions: map[string]*sshTCPSession{
+			"abandoned": {connection: connection, lastActivity: now.Add(-sshSessionIdleTimeout)},
+		},
+		now: func() time.Time { return now },
+	}
+
+	handler.cleanupExpired()
+
+	if _, exists := handler.sessions["abandoned"]; exists {
+		t.Fatal("periodic cleanup retained an abandoned session")
+	}
+	if _, err := connection.Write([]byte("closed")); err == nil {
+		t.Fatal("abandoned connection remained open")
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject and close an expired SSH session before processing any established segment
- refresh active sessions atomically with lookup so cleanup cannot race valid traffic
- reclaim abandoned sessions on a bounded stack-lifecycle cleanup loop
- close expired connections outside the handler registry lock

## Linked Issue
Closes #1044

## Testing Evidence
```text
go test -race ./internal/protocols -run '^TestSSHTCPHandler(ExpiresIdleSessionBeforeEstablishedTraffic|CleanupExpiresAbandonedSessions|ExpiresIdleSessionsBeforeApplyingLimit|ReplacesIdleSessionForReusedSYN)$' -count=5  # passed
make fmt-check  # passed
make lint       # passed, 0 issues
make test       # passed, backend coverage 66.3%; frontend 68 files
make security   # passed, 0 Go/npm vulnerabilities and no leaked secrets
```

## Security and Release Checklist
- [x] No authentication credentials or authorization policy changed
- [x] No dependencies added
- [x] Expiry applies before ACK, payload, FIN, and RST processing
- [x] Abandoned sessions are reclaimed while the stack is running
- [x] Full formatting, lint, test, and security gates passed
