### PR TITLE
fix(daemon): recover from capture loop exit

### DIFF
--- a/internal/api/handlers_capture.go
+++ b/internal/api/handlers_capture.go
@@ -23,6 +23,7 @@ type CaptureStatus struct {
 	Interface string `json:"interface,omitempty"`
 	Filter    string `json:"filter,omitempty"`
 	StartedAt string `json:"startedAt,omitempty"`
+	LastError string `json:"lastError,omitempty"`
 	// Packets is the running count of packets the capture has observed
 	// since it started. Updated by the capture loop.
 	Packets uint64 `json:"packets"`

--- a/internal/daemon/capture.go
+++ b/internal/daemon/capture.go
@@ -2,16 +2,25 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/gopacket/gopacket"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api"
-	"github.com/MustardSeedNetworks/niac-go/internal/capture"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 )
+
+var errCaptureLoopExited = errors.New("capture loop exited unexpectedly")
+
+type captureEngine interface {
+	SetFilter(string) error
+	StartCaptureContext(context.Context, func(gopacket.Packet)) error
+	Close()
+}
 
 // standaloneCapture is the runtime state for a /api/v1/capture session.
 // Distinct from the Simulation type because no protocols.Stack is
@@ -23,9 +32,10 @@ type standaloneCapture struct {
 	iface     string
 	filter    string
 	startedAt time.Time
-	engine    *capture.Engine
+	engine    captureEngine
 	cancel    context.CancelFunc
 	packets   atomic.Uint64
+	stopOnce  sync.Once
 }
 
 // StartCapture spins up a capture session on req.Interface, optionally
@@ -44,11 +54,11 @@ func (d *Daemon) StartCapture(req api.CaptureRequest) error {
 		return api.ErrCaptureAlreadyRunning
 	}
 
-	if !capture.InterfaceExists(req.Interface) {
+	if !d.captureInterfaceExists(req.Interface) {
 		return fmt.Errorf("%w: %s", api.ErrCaptureInterfaceNotFound, req.Interface)
 	}
 
-	engine, err := capture.New(req.Interface, DefaultDebugLevel)
+	engine, err := d.newCaptureEngine(req.Interface, DefaultDebugLevel)
 	if err != nil {
 		return fmt.Errorf("create capture engine: %w", err)
 	}
@@ -69,6 +79,9 @@ func (d *Daemon) StartCapture(req api.CaptureRequest) error {
 		cancel:    cancel,
 	}
 
+	d.capture = session
+	d.captureLastError = ""
+
 	// Drive the capture in its own goroutine so the API call returns
 	// promptly. StartCaptureContext blocks until ctx is cancelled or
 	// the engine errors out, and invokes our handler synchronously
@@ -76,7 +89,6 @@ func (d *Daemon) StartCapture(req api.CaptureRequest) error {
 	// counter bump + non-blocking SSE broadcast.
 	go d.runStandaloneCapture(ctx, session)
 
-	d.capture = session
 	logging.Successf("✓ Standalone capture started on %s", req.Interface)
 	return nil
 }
@@ -94,8 +106,35 @@ func (d *Daemon) runStandaloneCapture(ctx context.Context, c *standaloneCapture)
 		}
 	}
 
-	if err := c.engine.StartCaptureContext(ctx, handler); err != nil && ctx.Err() == nil {
-		logging.Errorf("standalone capture loop exited with error: %v", err)
+	err := d.captureRunner(ctx, c.engine, handler)
+	if ctx.Err() != nil {
+		d.completeStandaloneCapture(c, nil)
+		return
+	}
+	if err == nil {
+		err = errCaptureLoopExited
+	}
+	d.completeStandaloneCapture(c, err)
+}
+
+func (d *Daemon) completeStandaloneCapture(session *standaloneCapture, terminalErr error) {
+	d.mu.Lock()
+	current := d.capture == session
+	if current {
+		session.stop()
+		d.capture = nil
+		if terminalErr != nil {
+			d.captureLastError = terminalErr.Error()
+		}
+	}
+	d.mu.Unlock()
+
+	if !current {
+		session.stop()
+		return
+	}
+	if terminalErr != nil {
+		logging.Errorf("standalone capture loop exited with error: %v", terminalErr)
 	}
 }
 
@@ -104,17 +143,23 @@ func (d *Daemon) runStandaloneCapture(ctx context.Context, c *standaloneCapture)
 func (d *Daemon) StopCapture() error {
 	d.mu.Lock()
 	session := d.capture
-	d.capture = nil
-	d.mu.Unlock()
-
 	if session == nil {
+		d.mu.Unlock()
 		return nil
 	}
 
-	session.cancel()
-	session.engine.Close()
+	session.stop()
+	d.capture = nil
+	d.mu.Unlock()
 	logging.Successf("✓ Standalone capture stopped on %s", session.iface)
 	return nil
+}
+
+func (c *standaloneCapture) stop() {
+	c.stopOnce.Do(func() {
+		c.cancel()
+		c.engine.Close()
+	})
 }
 
 // GetCaptureStatus returns a snapshot of the capture session. Safe to
@@ -125,7 +170,7 @@ func (d *Daemon) GetCaptureStatus() api.CaptureStatus {
 	defer d.mu.RUnlock()
 
 	if d.capture == nil {
-		return api.CaptureStatus{Running: false}
+		return api.CaptureStatus{Running: false, LastError: d.captureLastError}
 	}
 	return api.CaptureStatus{
 		Running:   true,

--- a/internal/daemon/capture_test.go
+++ b/internal/daemon/capture_test.go
@@ -3,8 +3,12 @@ package daemon
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/gopacket/gopacket"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api"
 )
@@ -111,6 +115,124 @@ func TestGetCaptureStatus_NoSession(t *testing.T) {
 	}
 }
 
+func TestStandaloneCaptureUnexpectedExitClearsSessionAndAllowsRestart(t *testing.T) {
+	d := newTestDaemon(t)
+	d.captureInterfaceExists = func(string) bool { return true }
+	var engines []*fakeCaptureEngine
+	d.newCaptureEngine = func(string, int) (captureEngine, error) {
+		engine := &fakeCaptureEngine{}
+		engines = append(engines, engine)
+		return engine, nil
+	}
+	var runs atomic.Int32
+	d.captureRunner = func(
+		ctx context.Context,
+		_ captureEngine,
+		_ func(gopacket.Packet),
+	) error {
+		if runs.Add(1) == 1 {
+			return errors.New("packet source closed")
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	if err := d.StartCapture(api.CaptureRequest{Interface: "test0"}); err != nil {
+		t.Fatalf("first StartCapture() error = %v", err)
+	}
+	waitForCaptureStatus(t, d, false)
+
+	status := d.GetCaptureStatus()
+	if !strings.Contains(status.LastError, "packet source closed") {
+		t.Fatalf("LastError = %q, want terminal runner error", status.LastError)
+	}
+	if got := engines[0].closes.Load(); got != 1 {
+		t.Fatalf("failed engine Close() calls = %d, want 1", got)
+	}
+
+	if err := d.StartCapture(api.CaptureRequest{Interface: "test0"}); err != nil {
+		t.Fatalf("restart StartCapture() error = %v", err)
+	}
+	waitForCaptureStatus(t, d, true)
+	if status = d.GetCaptureStatus(); status.LastError != "" {
+		t.Fatalf("LastError after restart = %q, want cleared", status.LastError)
+	}
+	if err := d.StopCapture(); err != nil {
+		t.Fatalf("StopCapture() error = %v", err)
+	}
+	if got := engines[1].closes.Load(); got != 1 {
+		t.Fatalf("replacement engine Close() calls = %d, want 1", got)
+	}
+}
+
+func TestStandaloneCaptureOldRunnerCannotClearReplacement(t *testing.T) {
+	d := newTestDaemon(t)
+	d.captureInterfaceExists = func(string) bool { return true }
+	d.newCaptureEngine = func(string, int) (captureEngine, error) {
+		return &fakeCaptureEngine{}, nil
+	}
+	oldRelease := make(chan struct{})
+	var runs atomic.Int32
+	d.captureRunner = func(
+		ctx context.Context,
+		_ captureEngine,
+		_ func(gopacket.Packet),
+	) error {
+		if runs.Add(1) == 1 {
+			<-oldRelease
+			return errors.New("old capture failed")
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	if err := d.StartCapture(api.CaptureRequest{Interface: "old0"}); err != nil {
+		t.Fatalf("first StartCapture() error = %v", err)
+	}
+	if err := d.StopCapture(); err != nil {
+		t.Fatalf("StopCapture() error = %v", err)
+	}
+	if err := d.StartCapture(api.CaptureRequest{Interface: "new0"}); err != nil {
+		t.Fatalf("replacement StartCapture() error = %v", err)
+	}
+	close(oldRelease)
+	waitForCaptureStatus(t, d, true)
+
+	status := d.GetCaptureStatus()
+	if status.Interface != "new0" || status.LastError != "" {
+		t.Fatalf("replacement status = %#v", status)
+	}
+	if err := d.StopCapture(); err != nil {
+		t.Fatalf("replacement StopCapture() error = %v", err)
+	}
+}
+
+type fakeCaptureEngine struct {
+	closes atomic.Int32
+}
+
+func (f *fakeCaptureEngine) SetFilter(string) error { return nil }
+
+func (f *fakeCaptureEngine) StartCaptureContext(context.Context, func(gopacket.Packet)) error {
+	return nil
+}
+
+func (f *fakeCaptureEngine) Close() {
+	f.closes.Add(1)
+}
+
+func waitForCaptureStatus(t *testing.T, d *Daemon, running bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if d.GetCaptureStatus().Running == running {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("capture Running did not become %v", running)
+}
+
 // newTestDaemon builds a Daemon with the minimum scaffolding needed to
 // exercise StartCapture / StopCapture / GetCaptureStatus. Storage is
 // disabled and there's no API server attached — these tests only care
@@ -124,6 +246,3 @@ func newTestDaemon(t *testing.T) *Daemon {
 	}
 	return d
 }
-
-// silence the unused-import warning if a future cleanup drops context.
-var _ = context.Background

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gopacket/gopacket"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/api"
 	"github.com/MustardSeedNetworks/niac-go/internal/api/templates"
 	"github.com/MustardSeedNetworks/niac-go/internal/api/tokenstore"
@@ -95,7 +97,11 @@ type Daemon struct {
 	// runs without a simulation. Mutually exclusive with simulation
 	// because both want exclusive ownership of the same libpcap
 	// interface handle; see internal/daemon/capture.go.
-	capture *standaloneCapture
+	capture                *standaloneCapture
+	captureLastError       string
+	captureInterfaceExists func(string) bool
+	newCaptureEngine       func(string, int) (captureEngine, error)
+	captureRunner          func(context.Context, captureEngine, func(gopacket.Packet)) error
 }
 
 // Simulation represents a running NIAC simulation.
@@ -130,8 +136,19 @@ type simulationStarter func(
 // NewDaemon creates a new daemon instance.
 func NewDaemon(cfg Config) (*Daemon, error) {
 	daemon := &Daemon{
-		cfg:             cfg,
-		startSimulation: startSimulationResources,
+		cfg:                    cfg,
+		startSimulation:        startSimulationResources,
+		captureInterfaceExists: capture.InterfaceExists,
+		newCaptureEngine: func(name string, debugLevel int) (captureEngine, error) {
+			return capture.New(name, debugLevel)
+		},
+		captureRunner: func(
+			ctx context.Context,
+			engine captureEngine,
+			handler func(gopacket.Packet),
+		) error {
+			return engine.StartCaptureContext(ctx, handler)
+		},
 	}
 
 	// Open storage if enabled

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -350,6 +350,7 @@ export interface StandaloneCaptureStatus {
   interface?: string;
   filter?: string;
   startedAt?: string;
+  lastError?: string;
   packets: number;
 }
 


### PR DESCRIPTION
## Summary
- register capture sessions before their runner starts so immediate exits cannot leave stuck state
- clear only the matching session and prevent delayed runners from clearing replacements
- cancel and close each capture engine exactly once across stop, failure, and shutdown races
- expose the terminal runner failure in capture status and clear it after a successful restart

## Linked Issue
Closes #1049

## Testing Evidence
```text
go test -race ./internal/daemon -run '^TestStandaloneCapture(UnexpectedExitClearsSessionAndAllowsRestart|OldRunnerCannotClearReplacement)$' -count=10  # passed
go test -race ./internal/daemon  # passed
npm run typecheck                # passed
make fmt-check  # passed
make lint       # passed, 0 issues
make test       # passed, backend coverage 66.4%; frontend 68 files
make security   # passed, 0 Go/npm vulnerabilities and no leaked secrets
```

## Security and Release Checklist
- [x] No authentication or authorization behavior changed
- [x] No dependencies added
- [x] Session completion is identity-safe
- [x] Engine cleanup is exactly once
- [x] Terminal failures remain observable through the status API
- [x] Full formatting, lint, test, and security gates passed
