### PR TITLE
fix(api): enforce device limits on config generation

### DIFF
--- a/internal/api/config_ops.go
+++ b/internal/api/config_ops.go
@@ -81,6 +81,9 @@ func (s *Server) handleConfigMerge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	merged := mergeConfigsByName(base, overlay)
+	if !s.authorizeConfigEntitlements(w, r, merged) {
+		return
+	}
 	yamlBytes, err := config.MarshalConfigYAML(merged)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "marshal_failed",
@@ -141,6 +144,9 @@ func (s *Server) handleConfigImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !s.authorizeConfigEntitlements(w, r, cfg) {
+		return
+	}
 	yamlBytes, err := config.MarshalConfigYAML(cfg)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "marshal_failed",

--- a/internal/api/config_ops_test.go
+++ b/internal/api/config_ops_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -166,4 +167,81 @@ func TestImportConfig_BadFormat(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d, want 400", rec.Code)
 	}
+}
+
+func TestConfigGeneratorsEnforceFreeDeviceLimit(t *testing.T) {
+	server, _ := newTestServer(t)
+	oversized := configYAMLWithDevices(FreeTierDeviceCount + 1)
+
+	tests := []struct {
+		name    string
+		path    string
+		request any
+		handler http.HandlerFunc
+	}{
+		{
+			name: "import",
+			path: "/api/v1/config/import",
+			request: ConfigImportRequest{
+				Format:  "yaml",
+				Content: oversized,
+			},
+			handler: server.handleConfigImport,
+		},
+		{
+			name: "merge",
+			path: "/api/v1/config/merge",
+			request: MergeConfigsRequest{
+				Base:    configYAMLWithDevices(FreeTierDeviceCount),
+				Overlay: configYAMLWithDevicesFrom(FreeTierDeviceCount, 1),
+			},
+			handler: server.handleConfigMerge,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body, err := json.Marshal(test.request)
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+			request := httptest.NewRequest(http.MethodPost, test.path, bytes.NewReader(body))
+			recorder := httptest.NewRecorder()
+
+			test.handler(recorder, request)
+
+			if recorder.Code != http.StatusPaymentRequired {
+				t.Fatalf("status = %d, want 402: %s", recorder.Code, recorder.Body.String())
+			}
+			var response FeatureGateResponse
+			if err = json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.RequiredFeature != "unlimited_devices" {
+				t.Fatalf(
+					"required feature = %q, want unlimited_devices",
+					response.RequiredFeature,
+				)
+			}
+		})
+	}
+}
+
+func configYAMLWithDevices(count int) string {
+	return configYAMLWithDevicesFrom(0, count)
+}
+
+func configYAMLWithDevicesFrom(start, count int) string {
+	var content strings.Builder
+	content.WriteString("devices:\n")
+	for offset := range count {
+		index := start + offset
+		_, _ = fmt.Fprintf(
+			&content,
+			"  - name: device-%d\n    type: host\n    mac: 02:00:00:00:00:%02x\n",
+			index,
+			index,
+		)
+	}
+	return content.String()
 }

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -203,6 +203,19 @@ func (s *Server) handleConfigUpdate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) authorizeConfigReplacement(w http.ResponseWriter, r *http.Request, cfg *config.Config) bool {
+	if !s.authorizeConfigEntitlements(w, r, cfg) {
+		return false
+	}
+	if runtimeErr := config.ValidateRuntimeRequirements(cfg); runtimeErr != nil {
+		writeError(w, r, http.StatusBadRequest, "runtime_requirements_unmet",
+			"Configuration runtime requirements are not met",
+			[]ErrorDetail{{Field: "ssh.passwordEnv", Issue: runtimeErr.Error()}})
+		return false
+	}
+	return true
+}
+
+func (s *Server) authorizeConfigEntitlements(w http.ResponseWriter, r *http.Request, cfg *config.Config) bool {
 	switch err := ValidateConfigEntitlements(cfg, s.simulationEntitlements()); {
 	case errors.Is(err, ErrRoutedLabsLicenseRequired):
 		s.writeFeatureGate(w, r, "routed_labs",
@@ -217,12 +230,6 @@ func (s *Server) authorizeConfigReplacement(w http.ResponseWriter, r *http.Reque
 		writeError(w, r, http.StatusInternalServerError, "config_authorization_failed",
 			"Failed to authorize configuration", nil)
 	default:
-		if runtimeErr := config.ValidateRuntimeRequirements(cfg); runtimeErr != nil {
-			writeError(w, r, http.StatusBadRequest, "runtime_requirements_unmet",
-				"Configuration runtime requirements are not met",
-				[]ErrorDetail{{Field: "ssh.passwordEnv", Issue: runtimeErr.Error()}})
-			return false
-		}
 		return true
 	}
 	return false

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/templates"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
 
 // UseTemplateRequest is the request to create a config from a template.
@@ -114,6 +115,16 @@ func (s *Server) handleTemplateUse(w http.ResponseWriter, r *http.Request) {
 	content, _, err := templates.Load(req.TemplateName)
 	if err != nil {
 		writeError(w, r, http.StatusNotFound, "not_found", err.Error(), nil)
+		return
+	}
+
+	cfg, err := config.LoadYAMLBytes(content)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "invalid_template",
+			"Template contains an invalid configuration", nil)
+		return
+	}
+	if !s.authorizeConfigEntitlements(w, r, cfg) {
 		return
 	}
 

--- a/internal/api/templates_use_test.go
+++ b/internal/api/templates_use_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHandleTemplateUseEnforcesFreeDeviceLimitBeforeSave(t *testing.T) {
+	workDir := t.TempDir()
+	templateDir := filepath.Join(workDir, "templates")
+	if err := os.MkdirAll(templateDir, 0o750); err != nil {
+		t.Fatalf("create template directory: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(templateDir, "oversized.yaml"),
+		[]byte(configYAMLWithDevices(FreeTierDeviceCount+1)),
+		0o600,
+	); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	t.Setenv("NIAC_TEMPLATES_DIR", templateDir)
+	t.Chdir(workDir)
+
+	server, _ := newTestServer(t)
+	body, err := json.Marshal(UseTemplateRequest{TemplateName: "oversized"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/templates/use", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	server.handleTemplateUse(recorder, request)
+
+	if recorder.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402: %s", recorder.Code, recorder.Body.String())
+	}
+	var response FeatureGateResponse
+	if err = json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.RequiredFeature != "unlimited_devices" {
+		t.Fatalf("required feature = %q, want unlimited_devices", response.RequiredFeature)
+	}
+	if _, err = os.Stat(filepath.Join(workDir, "configs", "oversized-config.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("unauthorized template was saved: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- enforce the existing configuration entitlement policy before API import and merge responses are produced
- validate template configurations and reject unauthorized device counts before writing a saved config
- preserve runtime credential validation as a replacement/start-only concern

## Linked Issue

Related to #1053 and the Stage 6 pre-1.0 ten-device acceptance contract.

## Testing Evidence

```text
go test -race ./internal/devicestate ./internal/protocols/snmp ./internal/protocols -run 'Fault|InterfaceFaultCountersAreSNMPObservable|ManagementInterfaceFaultCountersAreObservable|WalkBackedManagementFaultCountersPreserveBaseline' -count=3
ok (all three packages)

make fmt-check
all formatting checks passed

make lint
0 issues

make test (backend)
43 packages passed; coverage 66.3%

make test-frontend test-hooks
68 files / 333 tests passed; hook regressions passed

make security
No Go vulnerabilities; npm audit 0; no secrets

make build
frontend and backend built successfully
```

## Security and Release Checklist

- [x] Mutating routes retain their existing CSRF, rate-limit, and scope policy
- [x] Entitlement failures use the existing structured feature-gate response
- [x] Unauthorized templates are rejected before filesystem mutation
- [x] Formatting, lint, unit, race, hook, security, and build gates pass