### PR TITLE
fix(ui): resolve page metadata interpolation

### DIFF
--- a/ui/src/pageRegistry.test.tsx
+++ b/ui/src/pageRegistry.test.tsx
@@ -1,0 +1,23 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import i18n from './i18n';
+import { usePages } from './pageRegistry';
+
+const unresolvedInterpolation = /\{\{[^}]+}}/;
+
+describe('page registry translations', () => {
+  afterEach(async () => {
+    await act(() => i18n.changeLanguage('en'));
+  });
+
+  it.each(['en', 'es'])('resolves page metadata interpolation in %s', async (language) => {
+    await act(() => i18n.changeLanguage(language));
+    const { result } = renderHook(() => usePages());
+
+    for (const page of result.current) {
+      expect(page.label, `${page.path} label`).not.toMatch(unresolvedInterpolation);
+      expect(page.title, `${page.path} title`).not.toMatch(unresolvedInterpolation);
+      expect(page.description, `${page.path} description`).not.toMatch(unresolvedInterpolation);
+    }
+  });
+});

--- a/ui/src/pageRegistry.tsx
+++ b/ui/src/pageRegistry.tsx
@@ -127,6 +127,7 @@ type PageI18nKey =
 type PageDef = {
   path: string;
   i18nKey: PageI18nKey;
+  interpolation?: Record<string, string>;
   icon: LucideIcon;
   component: ComponentType;
   badge?: string;
@@ -301,6 +302,7 @@ const staticPages: PageDef[] = [
   {
     path: '/topology',
     i18nKey: 'topology',
+    interpolation: { protocols: 'CDP/LLDP/EDP/FDP' },
     icon: Network,
     component: TopologyPage,
     help: (
@@ -358,6 +360,7 @@ const staticPages: PageDef[] = [
   {
     path: '/traffic',
     i18nKey: 'traffic',
+    interpolation: { format: 'PCAP' },
     icon: Zap,
     component: TrafficInjectionPage,
     help: (
@@ -407,6 +410,7 @@ const staticPages: PageDef[] = [
   {
     path: '/packets',
     i18nKey: 'packets',
+    interpolation: { format: 'PCAP' },
     icon: FileBox,
     component: PacketInspectorPage,
     help: (
@@ -429,6 +433,7 @@ const staticPages: PageDef[] = [
   {
     path: '/config-diff',
     i18nKey: 'configDiff',
+    interpolation: { format: 'YAML' },
     icon: GitCompare,
     component: ConfigDiffPage,
     help: (
@@ -452,6 +457,7 @@ const staticPages: PageDef[] = [
   {
     path: '/walk-validator',
     i18nKey: 'walkValidator',
+    interpolation: { protocol: 'SNMP' },
     icon: ShieldCheck,
     component: WalkValidatorPage,
     help: (
@@ -513,6 +519,7 @@ const staticPages: PageDef[] = [
   {
     path: '/library/walks',
     i18nKey: 'libraryWalks',
+    interpolation: { protocol: 'SNMP' },
     icon: Database,
     component: LibraryWalksPage,
     help: (
@@ -533,6 +540,7 @@ const staticPages: PageDef[] = [
   {
     path: '/library/pcaps',
     i18nKey: 'libraryPcaps',
+    interpolation: { format: 'PCAP' },
     icon: FileBox,
     component: LibraryPcapsPage,
     help: (
@@ -586,9 +594,9 @@ export function usePages(): PageConfig[] {
     () =>
       staticPages.map((p) => ({
         path: p.path,
-        label: t(`${p.i18nKey}.label`),
-        title: t(`${p.i18nKey}.title`),
-        description: t(`${p.i18nKey}.description`),
+        label: t(`${p.i18nKey}.label`, p.interpolation),
+        title: t(`${p.i18nKey}.title`, p.interpolation),
+        description: t(`${p.i18nKey}.description`, p.interpolation),
         icon: p.icon,
         component: p.component,
         badge: p.badge,


### PR DESCRIPTION
## Summary

- Supply page-specific static interpolation values through the central page registry.
- Resolve raw format/protocol placeholders in English and Spanish page metadata.
- Add a regression guard covering every page label, title, and description.

## Linked Issue

Closes #1119

## Testing Evidence

```text
make fmt-check: passed
make lint: 0 issues; frontend clean
make test: 43 race-enabled Go packages passed (66.4%); 69 frontend files / 335 tests passed
make build: passed on Node 26.5.0 and npm 12.0.1
Actual Safari: HTTPS load, client-side route navigation, and corrected Topology description passed
```

## Security and Release Checklist

- [x] No authentication, authorization, CSRF, CORS, or secret-handling behavior changed.
- [x] No dependency or release-workflow change.
- [x] English and Spanish interpolation regression coverage added.
- [x] Actual Safari evidence captured against the merged-main candidate.
