### PR TITLE
fix(ci): stop grading private UI as crawlable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
               - 'ui/**'
               - 'internal/i18n/locales/**'
               - 'scripts/i18n/**'
+              - '.lighthouserc.json'
             c:
               - 'src/**'
               - 'include/**'

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -13,7 +13,6 @@
         "categories:performance": ["error", { "minScore": 0.85 }],
         "categories:accessibility": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
-        "categories:seo": ["warn", { "minScore": 0.8 }],
         "first-contentful-paint": ["warn", { "maxNumericValue": 2500 }],
         "largest-contentful-paint": ["warn", { "maxNumericValue": 3000 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }],

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -113,6 +113,7 @@ test-hooks: ## Run repository script regression tests
 	@./scripts/tests/pre-commit-hook-test.sh
 	@./scripts/tests/release-content-integrity-test.sh
 	@./scripts/tests/file-size-gate-test.sh
+	@./scripts/tests/lighthouse-policy-test.sh
 
 # =============================================================================
 # E2E Tests

--- a/scripts/tests/lighthouse-policy-test.sh
+++ b/scripts/tests/lighthouse-policy-test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+config="$repo_root/.lighthouserc.json"
+workflow="$repo_root/.github/workflows/ci.yml"
+
+node -e '
+const config = require(process.argv[1]);
+const assertions = config.ci.assert.assertions;
+
+if ("categories:seo" in assertions) {
+  throw new Error("private NIAC UI must not carry a crawlability-based SEO assertion");
+}
+
+for (const category of [
+  "categories:performance",
+  "categories:accessibility",
+  "categories:best-practices",
+]) {
+  if (assertions[category]?.[0] !== "error") {
+    throw new Error(category + " must remain release-blocking");
+  }
+}
+' "$config"
+
+if ! grep -Fq "              - '.lighthouserc.json'" "$workflow"; then
+  echo ".lighthouserc.json changes must schedule the frontend and Lighthouse jobs"
+  exit 1
+fi
+
+echo "Lighthouse policy regression tests passed"


### PR DESCRIPTION
## Summary

- Remove the crawlability-based SEO category assertion from the private NIAC UI Lighthouse policy.
- Keep performance, accessibility, and best-practices categories release-blocking.
- Add a repository-hook contract test preventing SEO grading from being reintroduced.

## Linked Issue

Closes #1121

## Testing Evidence

```text
./scripts/tests/lighthouse-policy-test.sh: failed before the policy fix, passed after
make test-hooks: passed
shellcheck scripts/tests/lighthouse-policy-test.sh: passed
make fmt-check: passed
PR #1120 Lighthouse report: title, description, robots syntax, and hreflang pass; only intentional is-crawlable=0 reduced SEO
```

## Security and Release Checklist

- [x] The crawler block remains intact.
- [x] Performance, accessibility, and best-practices assertions remain release-blocking.
- [x] No product runtime or dependency changed.
- [x] The policy is covered by a repository-hook regression test.
