### PR TITLE
fix(protocols): confine routed discovery egress

### DIFF
--- a/internal/protocols/discovery_capture_test.go
+++ b/internal/protocols/discovery_capture_test.go
@@ -1,0 +1,17 @@
+package protocols
+
+import "net"
+
+type discoveryCapture struct {
+	sources []string
+}
+
+func (*discoveryCapture) ReadPacket([]byte) ([]byte, error) { return nil, nil }
+
+func (c *discoveryCapture) SendPacket(frame []byte) error {
+	c.sources = append(c.sources, net.HardwareAddr(frame[6:12]).String())
+	return nil
+}
+
+func (*discoveryCapture) SetFilter(string) error { return nil }
+func (*discoveryCapture) Filter() string         { return "" }

--- a/internal/protocols/discovery_egress.go
+++ b/internal/protocols/discovery_egress.go
@@ -1,0 +1,63 @@
+package protocols
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+var errDiscoveryOffAttachment = errors.New("discovery advertisement is not on attachment network")
+
+func (s *Stack) validateDiscoveryEgress(pkt *Packet) error {
+	if s.fabric == nil || pkt == nil || !isDiscoveryAdvertisement(pkt.Buffer) {
+		return nil
+	}
+	device, ok := pkt.Device.(*config.Device)
+	if !ok {
+		return fmt.Errorf("discovery advertisement has invalid device identity %T", pkt.Device)
+	}
+	if s.fabric.deviceOnAttachment(device) {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %q",
+		errDiscoveryOffAttachment,
+		device.Name,
+	)
+}
+
+func isDiscoveryAdvertisement(frame []byte) bool {
+	if len(frame) < SizeOfMac {
+		return false
+	}
+	destination := net.HardwareAddr(frame[:SizeOfMac]).String()
+	return strings.EqualFold(destination, LLDPMulticastMAC) ||
+		strings.EqualFold(destination, CDPMulticastMAC) ||
+		strings.EqualFold(destination, EDPMulticastMAC) ||
+		strings.EqualFold(destination, FDPMulticastMAC)
+}
+
+func (r *fabricRuntime) deviceOnAttachment(device *config.Device) bool {
+	for _, iface := range r.topology.Interfaces {
+		if iface.Device == device.Name &&
+			iface.Network == r.attachmentNetwork &&
+			r.interfaceAvailable(device, iface.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Stack) recordDiscoveryEgressDrop(pkt *Packet) {
+	s.stats.mu.Lock()
+	s.stats.FabricDrops++
+	pkt.fabricTrace.IngressNetwork = s.fabric.attachmentNetwork
+	pkt.fabricTrace.PhysicalVLAN = s.fabric.binding.AccessVLAN
+	pkt.fabricTrace.RouteDecision = fabricRouteDecisionDropped
+	pkt.fabricTrace.RejectionReason = "discovery_not_on_attachment"
+	s.stats.mu.Unlock()
+	s.notifyObservers("tx", pkt)
+}

--- a/internal/protocols/discovery_egress_test.go
+++ b/internal/protocols/discovery_egress_test.go
@@ -1,0 +1,141 @@
+package protocols
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/devicestate"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+func TestRoutedDiscoveryAdvertisementsStayOnAttachment(t *testing.T) {
+	for name, advertise := range discoveryAdvertisers() {
+		t.Run(name, func(t *testing.T) {
+			capture, stack := routedDiscoveryStack()
+
+			advertise(stack)
+			drainDiscoveryPackets(stack)
+
+			if len(capture.sources) != 1 || capture.sources[0] != "02:00:00:00:00:01" {
+				t.Fatalf("wire sources = %v, want attachment device only", capture.sources)
+			}
+			stats := stack.GetStats()
+			if stats.Errors != 0 || stats.FabricDrops != 1 {
+				t.Fatalf("Errors = %d, FabricDrops = %d; want 0, 1", stats.Errors, stats.FabricDrops)
+			}
+		})
+	}
+}
+
+func TestFlatDiscoveryAdvertisementsRemainVisible(t *testing.T) {
+	for name, advertise := range discoveryAdvertisers() {
+		t.Run(name, func(t *testing.T) {
+			capture, stack := flatDiscoveryStack()
+
+			advertise(stack)
+			drainDiscoveryPackets(stack)
+
+			if len(capture.sources) != 2 {
+				t.Fatalf("wire sources = %v, want both flat devices", capture.sources)
+			}
+		})
+	}
+}
+
+func TestRoutedDiscoveryChecksEveryAttachmentInterface(t *testing.T) {
+	_, stack := routedDiscoveryStack()
+	edge := &stack.config.Devices[0]
+	stack.fabric.topology.Interfaces = append(
+		[]fabric.Interface{{
+			Device: edge.Name, Name: "unavailable", Network: "attachment",
+			Address: netip.MustParsePrefix("10.10.200.2/24"),
+		}},
+		stack.fabric.topology.Interfaces...,
+	)
+	network := stack.deviceStates[edge].Snapshot().Network
+	network.Interfaces = append(network.Interfaces, devicestate.Interface{
+		Name: "unavailable", Address: netip.MustParsePrefix("10.10.200.2/24"),
+		AdminUp: false, OperUp: false,
+	})
+	stack.deviceStates[edge].ReplaceNetwork(network)
+	destination, _ := net.ParseMAC(LLDPMulticastMAC)
+	frame := make([]byte, ethernetHeaderSize)
+	copy(frame, destination)
+
+	if err := stack.validateDiscoveryEgress(&Packet{Buffer: frame, Device: edge}); err != nil {
+		t.Fatalf("attachment advertisement rejected after unavailable interface: %v", err)
+	}
+}
+
+func TestRoutedDiscoveryRejectsUnknownDeviceIdentity(t *testing.T) {
+	_, stack := routedDiscoveryStack()
+	destination, _ := net.ParseMAC(LLDPMulticastMAC)
+	frame := make([]byte, ethernetHeaderSize)
+	copy(frame, destination)
+
+	err := stack.validateDiscoveryEgress(&Packet{Buffer: frame, Device: "inside"})
+
+	if err == nil {
+		t.Fatal("unknown discovery device identity was allowed onto the attachment")
+	}
+}
+
+func discoveryAdvertisers() map[string]func(*Stack) {
+	return map[string]func(*Stack){
+		"LLDP": func(stack *Stack) { stack.lldpHandler.sendAdvertisements() },
+		"CDP":  func(stack *Stack) { stack.cdpHandler.sendAdvertisements() },
+		"EDP":  func(stack *Stack) { stack.edpHandler.sendAdvertisements() },
+		"FDP":  func(stack *Stack) { stack.fdpHandler.sendAdvertisements() },
+	}
+}
+
+func routedDiscoveryStack() (*discoveryCapture, *Stack) {
+	capture, stack := flatDiscoveryStack()
+	stack.ConfigureFabric(&fabric.Topology{
+		Binding: fabric.CompiledBinding{Network: "attachment"},
+		Interfaces: []fabric.Interface{
+			{
+				Device: "edge", Name: "outside", Network: "attachment",
+				Address: netip.MustParsePrefix("10.10.200.1/24"),
+			},
+			{
+				Device: "inside", Name: "inside", Network: "internal",
+				Address: netip.MustParsePrefix("10.20.0.1/24"),
+			},
+		},
+	})
+	return capture, stack
+}
+
+func flatDiscoveryStack() (*discoveryCapture, *Stack) {
+	capture := &discoveryCapture{}
+	stack := newStack(capture, &config.Config{Devices: discoveryDevices()}, logging.NewDebugConfig(0))
+	return capture, stack
+}
+
+func discoveryDevices() []config.Device {
+	return []config.Device{
+		discoveryDevice("edge", "02:00:00:00:00:01"),
+		discoveryDevice("inside", "02:00:00:00:00:02"),
+	}
+}
+
+func discoveryDevice(name, mac string) config.Device {
+	address, _ := net.ParseMAC(mac)
+	return config.Device{
+		Name: name, Type: "switch", MACAddress: address,
+		LLDPConfig: &config.LLDPConfig{Enabled: true},
+		CDPConfig:  &config.CDPConfig{Enabled: true},
+		EDPConfig:  &config.EDPConfig{Enabled: true},
+		FDPConfig:  &config.FDPConfig{Enabled: true},
+	}
+}
+
+func drainDiscoveryPackets(stack *Stack) {
+	for len(stack.sendQueue) > 0 {
+		stack.sendPacket(<-stack.sendQueue)
+	}
+}

--- a/internal/protocols/stack_threads.go
+++ b/internal/protocols/stack_threads.go
@@ -343,6 +343,10 @@ func (s *Stack) sendThread() {
 func (s *Stack) sendPacket(pkt *Packet) {
 	frame, wireVLAN, err := s.finalizeEgressFrame(pkt)
 	if err != nil {
+		if errors.Is(err, errDiscoveryOffAttachment) {
+			s.recordDiscoveryEgressDrop(pkt)
+			return
+		}
 		s.recordSendError(pkt, err)
 		return
 	}
@@ -383,6 +387,9 @@ func (s *Stack) sendPacket(pkt *Packet) {
 func (s *Stack) finalizeEgressFrame(pkt *Packet) ([]byte, int, error) {
 	if pkt == nil {
 		return nil, -1, errors.New("cannot transmit a nil packet")
+	}
+	if err := s.validateDiscoveryEgress(pkt); err != nil {
+		return nil, -1, err
 	}
 	length := pkt.Length
 	if length == 0 {


### PR DESCRIPTION
## Summary

- Confine routed LLDP, CDP, EDP, and FDP advertisements to devices on the physical attachment network.
- Preserve flat-mode discovery behavior.
- Record expected policy drops without inflating operational errors.
- Cover multi-interface attachment availability and all four discovery protocols.

## Linked Issue

Closes #1123

## Testing Evidence

```text
make fmt-check: passed
make lint: 0 issues
make test: 43 backend packages and 69 frontend test files passed; repository hooks passed
make security: govulncheck found no vulnerabilities; npm audit found 0 vulnerabilities; gitleaks found no leaks
go test -race ./internal/protocols -run 'TestRoutedDiscovery|TestFlatDiscovery' -count=1: passed\ncodex exec review --uncommitted: no remaining findings\n```\n\n## Security and Release Checklist\n\n- [x] No secrets or credentials added.\n- [x] No authentication, authorization, CSRF, CORS, or persistence surfaces changed.\n- [x] Vulnerability and secret scans passed.\n- [x] Routed discovery remains fail-closed for invalid device identity.\n- [ ] Post-merge CyberScope and Link-Live topology acceptance will be recorded from the merged CI artifact before Phase 8 begins.