### PR TITLE
fix(snmp): advertise authored CDP peer addresses

### DIFF
--- a/CODE_INDEX.md
+++ b/CODE_INDEX.md
@@ -34,8 +34,8 @@ parallel implementation. It is intentionally organized by purpose.
 | --- | --- | --- |
 | Walk parsing and validation | `internal/protocols/snmp/walk.go` + `walk_validator.go` | Shared net-snmp syntax, numeric bounds, continuation, and terminal-marker handling |
 | IF-MIB identity resolution | `internal/protocols/snmp/mib_if.go` + `peer_topology.go` | Authored interface metadata and every topology table resolve through the walk's real ifIndex |
-| LLDP/CDP synthesis | `internal/protocols/snmp/mib_discovery.go` | Infrastructure neighbor rows; `fdb_only` attachments are intentionally excluded |
-| Bridge/FDB synthesis | `internal/protocols/snmp/peer_topology.go` | MAC to bridge-port to ifIndex chain used for endpoint placement |
+| LLDP/CDP synthesis | `internal/protocols/snmp/mib_discovery.go` + `peer_topology.go` | Infrastructure neighbor rows with authored peer addresses; `fdb_only` attachments are intentionally excluded |
+| Bridge/FDB synthesis | `internal/protocols/snmp/peer_topology.go` | Fleet-resolved MAC to bridge-port to ifIndex chain used for endpoint placement |
 | IP and route MIB synthesis | `internal/protocols/snmp/mib_ip.go` | MIB-II addresses, routes, ARP, and explicit next-hop identity |
 | Per-device MIB-II and interface telemetry | `internal/protocols/stack_protocol_telemetry.go` + `internal/protocols/snmp/protocol_telemetry.go` | One atomic event source per simulated device and authored interface, shared by its SNMP agents; protocol, IF-MIB, IF-X, and bridge counters advance from packet events |
 

--- a/internal/protocols/snmp/mib_discovery.go
+++ b/internal/protocols/snmp/mib_discovery.go
@@ -278,12 +278,6 @@ func (a *Agent) createCDPCacheEntry(
 		Value: 1,
 	})
 
-	// cdpCacheAddress (placeholder - would be remote device IP)
-	a.mib.Set(entryBase+".4."+indexStr, &OIDValue{
-		Type:  gosnmp.OctetString,
-		Value: []byte{10, 0, 0, 1}, // Placeholder IP
-	})
-
 	// cdpCacheVersion
 	version := cdp.SoftwareVersion
 	if version == "" {

--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -1,16 +1,26 @@
 package snmp
 
 import (
+	"net"
 	"strconv"
 	"strings"
 
 	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
 
-// PeerMACResolver returns the MAC bytes for a device name, and whether it is
-// known. The stack builds it from the full config roster — an agent alone only
-// knows its own device.
-type PeerMACResolver func(deviceName string) ([]byte, bool)
+// PeerIdentity contains the fleet-wide identity needed to synthesize discovery
+// and forwarding topology for a remote device.
+type PeerIdentity struct {
+	MAC     []byte
+	Address net.IP
+}
+
+// PeerResolver returns the identity for a remote device and interface. The
+// stack builds it from the full config roster — an agent alone only knows its
+// own device.
+type PeerResolver func(deviceName, interfaceName string) (PeerIdentity, bool)
 
 // hasWalkContent reports whether this device is backed by a capture walk, which
 // then owns the IF-MIB / BRIDGE-MIB content that construction would otherwise
@@ -23,18 +33,16 @@ func (a *Agent) hasWalkContent() bool {
 	return a.device.SNMPConfig.WalkFile != "" || len(a.device.SNMPConfig.WalkFiles) > 0
 }
 
-// SynthesizePeerTopology fills in the bridge forwarding entries that let a
-// discovery tool answer "which switch/port is this host on" (NetAlly's Nearest
-// Switch). Construction seeds only a self FDB entry because a single agent does
-// not know its neighbours' MACs; here — after the fleet is loaded — each
-// trunk_port whose remote device resolves to a MAC becomes a learned FDB entry
-// on the port's bridge index, mapped through the walk's real ifIndex.
+// SynthesizePeerTopology fills the remote CDP address and bridge forwarding
+// entries that a discovery tool uses to identify and place connected devices.
+// A single agent does not know its neighbours' addresses or MACs; here — after
+// the fleet is loaded — each trunk_port resolves through the complete roster.
 //
 // Ports whose interface name is absent from the device's own walk (e.g. an
 // inter-switch uplink named for a chassis the walk doesn't model) are skipped:
 // those links already show via the CDP/LLDP neighbour tables; the FDB is for
 // attached hosts. Call after all MIB content is loaded, then Reindex.
-func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
+func (a *Agent) SynthesizePeerTopology(resolve PeerResolver) {
 	if a == nil || a.device == nil || resolve == nil {
 		return
 	}
@@ -46,22 +54,31 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 	// table. Sampling per-port would drift as we add rows below.
 	offset, hasOffset := a.basePortOffset()
 
+	cdpIndex := 0
 	for _, trunk := range a.device.TrunkPorts {
-		if trunk.RemoteDevice == "" || trunk.Interface == "" {
+		if trunk.RemoteDevice == "" {
 			continue
 		}
 
-		mac, ok := resolve(trunk.RemoteDevice)
-		if !ok || len(mac) == 0 {
+		if !trunk.FDBOnly {
+			cdpIndex++
+		}
+		peer, ok := resolve(trunk.RemoteDevice, trunk.RemoteInterface)
+		if !ok {
 			continue
 		}
 
+		changed = a.setCDPPeerAddress(trunk, peer.Address, cdpIndex) || changed
+
+		if trunk.Interface == "" || len(peer.MAC) == 0 {
+			continue
+		}
 		bridgePort, ok := a.bridgePortForInterface(trunk.Interface, offset, hasOffset)
 		if !ok {
 			continue
 		}
 
-		a.addLearnedFDBEntry(mac, bridgePort)
+		a.addLearnedFDBEntry(peer.MAC, bridgePort)
 
 		maxPort = max(maxPort, bridgePort)
 
@@ -75,6 +92,24 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerMACResolver) {
 		a.raiseBaseNumPorts(maxPort)
 		a.mib.Reindex()
 	}
+}
+
+func (a *Agent) setCDPPeerAddress(trunk config.TrunkPort, address net.IP, index int) bool {
+	if trunk.FDBOnly || a.device.CDPConfig == nil || !a.device.CDPConfig.Enabled {
+		return false
+	}
+	ipv4 := address.To4()
+	if ipv4 == nil {
+		return false
+	}
+
+	ifIndex := a.discoveryIfIndex(trunk.Interface, index)
+	row := strconv.Itoa(ifIndex) + "." + strconv.Itoa(index)
+	a.mib.Set(cdpCacheTable+".1.4."+row, &OIDValue{
+		Type:  gosnmp.OctetString,
+		Value: []byte(ipv4),
+	})
+	return true
 }
 
 // bridgePortForInterface resolves an interface name (e.g. "FastEthernet0/5") to

--- a/internal/protocols/snmp/peer_topology_test.go
+++ b/internal/protocols/snmp/peer_topology_test.go
@@ -37,11 +37,11 @@ func TestSynthesizePeerTopologyLearnsHostOnPort(t *testing.T) {
 	must(agent.SetOID(dot1dBasePortIfIndex+".5", &OIDValue{Type: gosnmp.Integer, Value: 10005}))
 
 	pc1MAC, _ := net.ParseMAC("aa:bb:cc:00:00:21")
-	resolve := func(name string) ([]byte, bool) {
+	resolve := func(name, _ string) (PeerIdentity, bool) {
 		if name == "PC01" {
-			return pc1MAC, true
+			return PeerIdentity{MAC: pc1MAC}, true
 		}
-		return nil, false // UNKNOWN-DEV is unresolvable
+		return PeerIdentity{}, false // UNKNOWN-DEV is unresolvable
 	}
 
 	agent.SynthesizePeerTopology(resolve)
@@ -94,7 +94,9 @@ func TestAuthoredDiscoveryUsesWalkInterfaceIdentityEndToEnd(t *testing.T) {
 		t.Fatalf("LoadWalkFile: %v", err)
 	}
 	pcMAC, _ := net.ParseMAC("aa:bb:cc:00:00:21")
-	agent.SynthesizePeerTopology(func(string) ([]byte, bool) { return pcMAC, true })
+	agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+		return PeerIdentity{MAC: pcMAC}, true
+	})
 
 	assertMIBValue(t, agent, lldpLocPortTable+".1.3.10005", "FastEthernet0/5")
 	assertMIBValue(t, agent, lldpRemTable+".1.9.0.10005.1", "PC01")
@@ -124,7 +126,9 @@ func TestFDBOnlyAttachmentLearnsMACWithoutInventingNeighbor(t *testing.T) {
 	}}
 	agent := NewAgent(dev, 0)
 	pcMAC, _ := net.ParseMAC("aa:bb:cc:00:00:21")
-	agent.SynthesizePeerTopology(func(string) ([]byte, bool) { return pcMAC, true })
+	agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+		return PeerIdentity{MAC: pcMAC}, true
+	})
 
 	assertMIBValue(t, agent, lldpLocPortTable+".1.3.1", "FastEthernet0/5")
 	assertMIBValue(t, agent, dot1dTpFdbPort+"."+macBytesToOIDIndex(pcMAC), 1)
@@ -174,7 +178,9 @@ func TestSynthesizePeerTopologyDerivesPortWhenWalkSparse(t *testing.T) {
 	}
 
 	mac, _ := net.ParseMAC("aa:bb:cc:00:00:77")
-	agent.SynthesizePeerTopology(func(string) ([]byte, bool) { return mac, true })
+	agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+		return PeerIdentity{MAC: mac}, true
+	})
 
 	port := agent.mib.Get(dot1dTpFdbPort + "." + macBytesToOIDIndex(mac))
 	if port == nil || port.Value.(int) != 7 {

--- a/internal/protocols/snmp_agents.go
+++ b/internal/protocols/snmp_agents.go
@@ -102,10 +102,10 @@ func (g *snmpAgentGroup) ReindexAll() {
 	}
 }
 
-// SynthesizePeerTopologyAll fills each agent's downstream bridge FDB from the
-// resolved fleet MACs (see Agent.SynthesizePeerTopology). Every community agent
-// shares the device's topology, so all get the entries.
-func (g *snmpAgentGroup) SynthesizePeerTopologyAll(resolve snmp.PeerMACResolver) {
+// SynthesizePeerTopologyAll fills each agent's CDP peer addresses and downstream
+// bridge FDB from the resolved fleet identities (see Agent.SynthesizePeerTopology).
+// Every community agent shares the device's topology, so all get the entries.
+func (g *snmpAgentGroup) SynthesizePeerTopologyAll(resolve snmp.PeerResolver) {
 	if g == nil {
 		return
 	}

--- a/internal/protocols/stack_snmp.go
+++ b/internal/protocols/stack_snmp.go
@@ -85,9 +85,9 @@ func (s *Stack) initSNMPAgent(device *config.Device) {
 	// fleet roster (a host MAC on the access port it hangs off) so a scanner can
 	// answer "nearest switch/port" for discovered hosts.
 	if !v2Enabled {
-		baseAgent.SynthesizePeerTopology(s.peerMACResolver())
+		baseAgent.SynthesizePeerTopology(s.peerResolver())
 	}
-	group.SynthesizePeerTopologyAll(s.peerMACResolver())
+	group.SynthesizePeerTopologyAll(s.peerResolver())
 
 	// Every MIB is now fully loaded (walk files, AddMib, topology, peer FDB).
 	// Build the sorted OID indexes eagerly so the first GetNext of a discovery
@@ -120,24 +120,45 @@ func configuredWalkFiles(cfg config.SNMPConfig) []string {
 	return files
 }
 
-// peerMACResolver returns a lookup from device name to MAC over the whole config
-// roster. An SNMP agent knows only its own device, so cross-device MAC
-// resolution (for FDB / neighbour synthesis) has to come from the stack.
-func (s *Stack) peerMACResolver() snmp.PeerMACResolver {
-	byName := make(map[string][]byte, len(s.config.Devices))
+// peerResolver returns topology identity over the whole config roster. An SNMP
+// agent knows only its own device, so cross-device resolution has to come from
+// the stack.
+func (s *Stack) peerResolver() snmp.PeerResolver {
+	byName := make(map[string]*config.Device, len(s.config.Devices))
 
 	for i := range s.config.Devices {
 		dev := &s.config.Devices[i]
-		if len(dev.MACAddress) > 0 {
-			byName[dev.Name] = dev.MACAddress
+		byName[dev.Name] = dev
+	}
+
+	return func(name, interfaceName string) (snmp.PeerIdentity, bool) {
+		device, ok := byName[name]
+		if !ok {
+			return snmp.PeerIdentity{}, false
 		}
+
+		return snmp.PeerIdentity{
+			MAC:     device.MACAddress,
+			Address: peerInterfaceAddress(device, interfaceName),
+		}, true
+	}
+}
+
+func peerInterfaceAddress(device *config.Device, interfaceName string) net.IP {
+	for _, iface := range device.Interfaces {
+		if iface.Name != interfaceName {
+			continue
+		}
+		address, _, err := net.ParseCIDR(iface.Address)
+		if err == nil {
+			if ipv4 := address.To4(); ipv4 != nil {
+				return ipv4
+			}
+		}
+		break
 	}
 
-	return func(name string) ([]byte, bool) {
-		mac, ok := byName[name]
-
-		return mac, ok
-	}
+	return firstIPv4Address(device)
 }
 
 // initSNMPv3Engine builds and attaches the device's SNMPv3 authoritative

--- a/internal/protocols/stack_snmp_topology_test.go
+++ b/internal/protocols/stack_snmp_topology_test.go
@@ -1,0 +1,63 @@
+package protocols
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+func TestSNMPTopologyUsesAuthoredCDPPeerAddress(t *testing.T) {
+	cfg := &config.Config{Devices: []config.Device{
+		{
+			Name:        "LAB-EDGE-R1",
+			Type:        "router",
+			MACAddress:  mustTestMAC(t, "00:00:0c:ff:01:01"),
+			IPAddresses: []net.IP{net.ParseIP("10.254.200.1")},
+			Interfaces: []config.Interface{
+				{Name: "GigabitEthernet1/0/48", Address: "10.254.200.1/24"},
+				{Name: "GigabitEthernet1/0/1", Address: "203.0.113.1/30"},
+			},
+			SNMPConfig: config.SNMPConfig{Community: "NetAllyDemo"},
+			CDPConfig:  &config.CDPConfig{Enabled: true},
+			TrunkPorts: []config.TrunkPort{{
+				Interface:       "GigabitEthernet1/0/1",
+				RemoteDevice:    "INET-R1",
+				RemoteInterface: "GigabitEthernet1/0/1",
+			}},
+		},
+		{
+			Name:        "INET-R1",
+			Type:        "router",
+			MACAddress:  mustTestMAC(t, "00:00:0c:00:01:01"),
+			IPAddresses: []net.IP{net.ParseIP("203.0.113.2"), net.ParseIP("8.8.8.8")},
+			Interfaces: []config.Interface{{
+				Name: "GigabitEthernet1/0/1", Address: "203.0.113.2/30",
+			}},
+		},
+	}}
+
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	agent := stack.snmpAgents[&cfg.Devices[0]].baseAgent
+	value, err := agent.HandleGet("1.3.6.1.4.1.9.9.23.1.2.1.1.4.1.1")
+	if err != nil {
+		t.Fatalf("get cdpCacheAddress: %v", err)
+	}
+
+	want := net.ParseIP("203.0.113.2").To4()
+	got, ok := value.Value.([]byte)
+	if !ok || !bytes.Equal(got, want) {
+		t.Fatalf("cdpCacheAddress = %v, want %v", value.Value, want)
+	}
+}
+
+func mustTestMAC(t *testing.T, raw string) net.HardwareAddr {
+	t.Helper()
+	mac, err := net.ParseMAC(raw)
+	if err != nil {
+		t.Fatalf("parse MAC %q: %v", raw, err)
+	}
+	return mac
+}


### PR DESCRIPTION
## Summary

- replace the synthesized CDP `10.0.0.1` placeholder with the authored remote interface/device IPv4 address
- resolve peer MAC and address once through the existing fleet topology path
- add an end-to-end SNMP regression for the LAB-EDGE-R1 to INET-R1 link
- update the capability index

## Linked Issue

Closes #1125

## Testing Evidence

```text
make fmt-check: passed
make lint: 0 issues; frontend checked 329 files
make test: passed; backend coverage 66.7%; frontend and hook suites passed
make security: no Go/npm vulnerabilities; no secrets found
make build: frontend and Go binary built successfully
make schema: generated with no committed schema drift
make test-e2e: 186 passed, 6 skipped; authenticated suite 3 passed across Chromium, WebKit, and Firefox
focused go test -race: protocols and protocols/snmp passed
```

## Security and Release Checklist

- [x] No secrets or credentials added
- [x] `govulncheck`, `npm audit`, and `gitleaks` passed
- [x] Production build includes the frontend and backend
- [x] Cross-browser E2E passed locally
- [ ] Fresh CyberScope Discovery and Link-Live topology acceptance after merged deployment

## Live Defect Evidence

Fresh Link-Live analysis `20260725-075809` showed `LAB-EDGE-R1` connected to both `INET-R1` (`203.0.113.2`) and phantom `10.0.0.1` on `GigabitEthernet1/0/1`. After merge/deployment, acceptance requires a new CyberScope VLAN 200 Discovery, queued Link-Live upload, outbound-profile flush, and topology confirmation.