### PR TITLE
fix(snmp): preserve authored physical identity

### DIFF
--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -256,6 +256,7 @@ func (a *Agent) LoadWalkFile(filename string) error {
 	a.registerLiveMIBIIProtocolCounters()
 	a.refreshBridgePortCounters()
 	a.refreshAuthoredInterfaceMIBs()
+	a.refreshAuthoredPhysicalIdentity()
 	a.registerWalkStateFaultCounters()
 	if a.ownsSynthesizedTopology() {
 		a.refreshAuthoredDiscoveryMIBs()

--- a/internal/protocols/snmp/mib_identity.go
+++ b/internal/protocols/snmp/mib_identity.go
@@ -1,0 +1,114 @@
+package snmp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+const (
+	entPhysicalSerialNumber = "1.3.6.1.2.1.47.1.1.1.1.11"
+	locallyAdministeredBit  = byte(0x02)
+	unicastAddressMask      = byte(0xfe)
+)
+
+func (a *Agent) refreshAuthoredPhysicalIdentity() {
+	if a.device == nil || len(a.device.MACAddress) == 0 {
+		return
+	}
+	oids := a.mib.snapshotOIDs()
+	mac := []byte(a.device.MACAddress)
+	if len(mac) == MACAddressOctets {
+		a.refreshPhysicalAddresses(oids, mac)
+		a.mib.Set(dot1dBaseBridgeAddress, &OIDValue{Type: gosnmp.OctetString, Value: mac})
+		a.refreshLLDPChassisIdentity(mac)
+	}
+	for _, oid := range oids {
+		if strings.HasPrefix(oid, entPhysicalSerialNumber+".") {
+			a.refreshPhysicalSerial(oid)
+		}
+	}
+}
+
+func (a *Agent) refreshPhysicalAddresses(oids []string, mac []byte) {
+	identities := [][]byte{
+		oidValueBytes(a.mib.Get(dot1dBaseBridgeAddress)),
+		oidValueBytes(a.mib.Get(lldpLocChassisID)),
+	}
+	lowest := a.lowestPhysicalAddress(oids)
+	for _, oid := range oids {
+		value := oidValueBytes(a.mib.Get(oid))
+		if !strings.HasPrefix(oid, ifPhysAddress+".") ||
+			len(value) != MACAddressOctets || bytes.Equal(value, make([]byte, MACAddressOctets)) {
+			continue
+		}
+		address := derivedPhysicalAddress(mac, oid)
+		if oid == lowest || bytes.Equal(value, identities[0]) || bytes.Equal(value, identities[1]) {
+			address = mac
+		}
+		a.mib.Set(oid, &OIDValue{Type: gosnmp.OctetString, Value: address})
+	}
+}
+
+func (a *Agent) lowestPhysicalAddress(oids []string) string {
+	lowestIndex := int(^uint(0) >> 1)
+	lowestOID := ""
+	for _, oid := range oids {
+		value := oidValueBytes(a.mib.Get(oid))
+		if !strings.HasPrefix(oid, ifPhysAddress+".") ||
+			len(value) != MACAddressOctets || bytes.Equal(value, make([]byte, MACAddressOctets)) {
+			continue
+		}
+		index, err := strconv.Atoi(strings.TrimPrefix(oid, ifPhysAddress+"."))
+		if err == nil && index < lowestIndex {
+			lowestIndex, lowestOID = index, oid
+		}
+	}
+	return lowestOID
+}
+
+func oidValueBytes(value *OIDValue) []byte {
+	if value == nil {
+		return nil
+	}
+	switch typed := value.Value.(type) {
+	case []byte:
+		return typed
+	case string:
+		if parsed, err := net.ParseMAC(typed); err == nil {
+			return parsed
+		}
+		return []byte(typed)
+	default:
+		return nil
+	}
+}
+
+func derivedPhysicalAddress(mac []byte, oid string) []byte {
+	sum := sha256.Sum256(append(append([]byte{}, mac...), oid...))
+	derived := append([]byte{}, sum[:MACAddressOctets]...)
+	derived[0] = (derived[0] | locallyAdministeredBit) & unicastAddressMask
+	return derived
+}
+
+func (a *Agent) refreshLLDPChassisIdentity(mac []byte) {
+	if a.mib.Get(lldpLocChassisID) == nil {
+		return
+	}
+	a.mib.Set(lldpLocChassisIDSubtype, &OIDValue{Type: gosnmp.Integer, Value: ChassisIDSubtypeMAC})
+	a.mib.Set(lldpLocChassisID, &OIDValue{Type: gosnmp.OctetString, Value: mac})
+}
+
+func (a *Agent) refreshPhysicalSerial(oid string) {
+	if oidValueString(a.mib.Get(oid)) == "" {
+		return
+	}
+	mac := strings.ToUpper(strings.ReplaceAll(a.device.MACAddress.String(), ":", ""))
+	index := strings.TrimPrefix(oid, entPhysicalSerialNumber+".")
+	serial := "NIAC-" + mac + "-" + index
+	a.mib.Set(oid, &OIDValue{Type: gosnmp.OctetString, Value: serial})
+}

--- a/internal/protocols/snmp/mib_snapshot.go
+++ b/internal/protocols/snmp/mib_snapshot.go
@@ -1,0 +1,12 @@
+package snmp
+
+func (m *MIB) snapshotOIDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	oids := make([]string, 0, len(m.entries))
+	for oid := range m.entries {
+		oids = append(oids, oid)
+	}
+	return oids
+}

--- a/internal/protocols/snmp/walk_identity_helpers_test.go
+++ b/internal/protocols/snmp/walk_identity_helpers_test.go
@@ -1,0 +1,135 @@
+package snmp
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+type identityFixture struct {
+	agent *Agent
+	mac   net.HardwareAddr
+}
+
+func loadCapturedIdentity(t *testing.T, macText, walkContent string) identityFixture {
+	t.Helper()
+	walk := filepath.Join(t.TempDir(), "identity.walk")
+	if err := os.WriteFile(walk, []byte(walkContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mac, err := net.ParseMAC(macText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	device := createTestDevice()
+	device.MACAddress = mac
+	agent := NewAgent(device, 0)
+	if loadErr := agent.LoadWalkFile(walk); loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	return identityFixture{agent: agent, mac: mac}
+}
+
+func assertAuthoredMAC(t *testing.T, fixture identityFixture) {
+	t.Helper()
+	for _, oid := range []string{dot1dBaseBridgeAddress, ifPhysAddress + ".1", lldpLocChassisID} {
+		value, err := fixture.agent.HandleGet(oid)
+		if err != nil {
+			t.Fatalf("HandleGet(%s): %v", oid, err)
+		}
+		got, ok := value.Value.([]byte)
+		if !ok || !bytes.Equal(got, fixture.mac) {
+			t.Errorf("%s = %v, want %v", oid, value.Value, fixture.mac)
+		}
+	}
+}
+
+func assertAuthoredPhysicalAddress(t *testing.T, fixture identityFixture, index int) {
+	t.Helper()
+	got := physicalAddress(t, fixture.agent, index)
+	if !bytes.Equal(got, fixture.mac) {
+		t.Errorf("physical address %d = %v, want %v", index, got, fixture.mac)
+	}
+}
+
+func assertDistinctPhysicalAddresses(t *testing.T, first, second identityFixture, index int) {
+	t.Helper()
+	firstMAC := physicalAddress(t, first.agent, index)
+	secondMAC := physicalAddress(t, second.agent, index)
+	captured, _ := net.ParseMAC("00:0c:ce:88:23:c8")
+	if bytes.Equal(firstMAC, captured) || bytes.Equal(firstMAC, secondMAC) {
+		t.Errorf("physical address %d was not made device-specific: %v, %v", index, firstMAC, secondMAC)
+	}
+}
+
+func physicalAddress(t *testing.T, agent *Agent, index int) []byte {
+	t.Helper()
+	value, err := agent.HandleGet(ifPhysAddress + "." + strconv.Itoa(index))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := value.Value.([]byte)
+	if !ok {
+		t.Fatalf("physical address %d type = %T, want []byte", index, value.Value)
+	}
+	return got
+}
+
+func assertOIDString(t *testing.T, agent *Agent, oid, want string) {
+	t.Helper()
+	value, err := agent.HandleGet(oid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := oidValueString(value); got != want {
+		t.Errorf("%s = %q, want %q", oid, got, want)
+	}
+}
+
+func assertEmptyPhysicalAddress(t *testing.T, agent *Agent) {
+	t.Helper()
+	value, err := agent.HandleGet(ifPhysAddress + ".2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := value.Value; got != "" {
+		t.Errorf("logical interface physical address = %v, want empty", got)
+	}
+}
+
+func assertPhysicalAddress(t *testing.T, agent *Agent, index int, want string) {
+	t.Helper()
+	assertOIDBytes(t, agent, ifPhysAddress+"."+strconv.Itoa(index), want)
+}
+
+func assertOIDBytes(t *testing.T, agent *Agent, oid, want string) {
+	t.Helper()
+	value, err := agent.HandleGet(oid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBytes, err := net.ParseMAC(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := value.Value.([]byte)
+	if !ok || !bytes.Equal(got, wantBytes) {
+		t.Errorf("%s = %v, want %v", oid, value.Value, wantBytes)
+	}
+}
+
+func oidString(t *testing.T, agent *Agent, oid string) string {
+	t.Helper()
+	value, err := agent.HandleGet(oid)
+	if err != nil {
+		t.Fatalf("HandleGet(%s): %v", oid, err)
+	}
+	got, ok := value.Value.(string)
+	if !ok {
+		t.Fatalf("%s type = %T, want string", oid, value.Value)
+	}
+	return got
+}

--- a/internal/protocols/snmp/walk_identity_test.go
+++ b/internal/protocols/snmp/walk_identity_test.go
@@ -1,0 +1,55 @@
+package snmp
+
+import (
+	"errors"
+	"testing"
+)
+
+const capturedIdentityWalk = `.1.3.6.1.2.1.2.2.1.6.1 = Hex-STRING: 00 0C CE 88 23 C7
+.1.3.6.1.2.1.2.2.1.6.2 = ""
+.1.3.6.1.2.1.2.2.1.6.3 = Hex-STRING: 00 0C CE 88 23 C8
+.1.3.6.1.2.1.2.2.1.6.4 = STRING: "00:0B:FD:D4:6F:DE"
+.1.3.6.1.2.1.17.1.1.0 = Hex-STRING: 00 0B FD D4 6F DE
+.1.3.6.1.2.1.47.1.1.1.1.11.1 = STRING: "FHK0722J116"
+.1.0.8802.1.1.2.1.3.1.0 = INTEGER: 7
+.1.0.8802.1.1.2.1.3.2.0 = Hex-STRING: 00 0B FD D4 6F DE
+`
+
+const physicalSerialOID = "1.3.6.1.2.1.47.1.1.1.1.11"
+
+func TestLoadWalkFilePreservesAuthoredPhysicalIdentity(t *testing.T) {
+	first := loadCapturedIdentity(t, "00:00:0c:00:01:01", capturedIdentityWalk)
+	second := loadCapturedIdentity(t, "00:00:0c:00:01:02", capturedIdentityWalk)
+
+	assertAuthoredMAC(t, first)
+	assertAuthoredMAC(t, second)
+	assertEmptyPhysicalAddress(t, first.agent)
+	assertDistinctPhysicalAddresses(t, first, second, 3)
+	assertAuthoredPhysicalAddress(t, first, 4)
+	assertOIDString(t, first.agent, lldpLocChassisIDSubtype, "4")
+	if len(first.agent.mib.sorted) != 0 {
+		t.Fatal("physical identity refresh built the sorted OID index early")
+	}
+	firstSerial := oidString(t, first.agent, physicalSerialOID+".1")
+	secondSerial := oidString(t, second.agent, physicalSerialOID+".1")
+	if firstSerial == "FHK0722J116" || firstSerial == secondSerial {
+		t.Fatalf("serials did not preserve unique authored identity: %q, %q", firstSerial, secondSerial)
+	}
+}
+
+func TestLoadWalkFileDoesNotPublishNonEthernetMACIdentity(t *testing.T) {
+	fixture := loadCapturedIdentity(t, "00:00:0c:00:01:01:02:03", capturedIdentityWalk)
+
+	assertPhysicalAddress(t, fixture.agent, 1, "00:0c:ce:88:23:c7")
+	assertPhysicalAddress(t, fixture.agent, 3, "00:0c:ce:88:23:c8")
+	assertOIDBytes(t, fixture.agent, dot1dBaseBridgeAddress, "00:0b:fd:d4:6f:de")
+	assertOIDBytes(t, fixture.agent, lldpLocChassisID, "00:0b:fd:d4:6f:de")
+}
+
+func TestLoadWalkFileDoesNotInventLLDPIdentity(t *testing.T) {
+	fixture := loadCapturedIdentity(t, "00:00:0c:00:01:01", `.1.3.6.1.2.1.1.5.0 = STRING: "captured"`)
+	_, err := fixture.agent.HandleGet(lldpLocChassisID)
+	if !errors.Is(err, ErrNoSuchObject) {
+		t.Fatalf("LLDP chassis ID error = %v, want ErrNoSuchObject", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace captured bridge, LLDP chassis, and standard serial identity with authored device identity.
- Derive stable device-specific MACs for additional physical interfaces while preserving empty logical rows.
- Support octet and string walk encodings without forcing non-Ethernet address lengths.

## Linked Issue
Fixes #1127

## Testing Evidence
```text
make fmt-check lint test security build test-e2e
Backend: 43 packages passed; coverage 66.8%
Frontend: 69 test files passed
Playwright: 186 passed, 6 skipped
Authenticated browsers: Chromium, WebKit, Firefox all passed
Node v26.5.0; npm 12.0.1; npm audit 0 vulnerabilities
govulncheck: No vulnerabilities found
gitleaks: no leaks found
```

## Security and Release Checklist
- [x] No secrets or credentials added.
- [x] No authentication, authorization, CSRF, or CORS behavior changed.
- [x] Dependency and vulnerability scans passed.
- [x] Full build and cross-browser E2E passed.
- [x] Release and CT 304 deployment validation will follow merge.