### PR TITLE
fix(snmp): merge authored interfaces into synthesized MIB

### DIFF
--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -91,10 +91,9 @@ func NewAgentWithCommunityAndTelemetry(
 	// Initialize standard MIB-II system objects
 	agent.initializeSystemMIB()
 	agent.initializeSNMPMIB()
-	agent.initializeMIBIIProtocolGroups()
-
-	// Initialize neighbor discovery MIBs (IF-MIB, LLDP-MIB, CDP-MIB)
 	agent.initializeNeighborMIBs()
+	agent.refreshAuthoredInterfaceMIBs()
+	agent.initializeMIBIIProtocolGroups()
 	agent.protocolStats.attachMIB(agent.mib)
 
 	return agent

--- a/internal/protocols/snmp/mib_if.go
+++ b/internal/protocols/snmp/mib_if.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
 
 const (
@@ -19,51 +21,46 @@ const (
 )
 
 func (a *Agent) initializeIFMIB() {
-	logger := slog.Default()
 	device := a.device
-	if device == nil {
+	if device == nil || a.hasWalkContent() {
 		return
 	}
-
-	// A capture walk carries the device's real interface table (ifIndex, names,
-	// counters). Synthesizing a second, sequential ifTable from trunk_ports on
-	// top of it duplicates interfaces under different indices — harmless when a
-	// device has one uplink, but it pollutes the interface list once downstream
-	// access ports are modelled. The walk owns IF-MIB; trunk_ports only drive the
-	// neighbour/forwarding topology (see initializeLLDPRemoteMIB, SynthesizePeerTopology).
-	if a.hasWalkContent() {
-		return
+	names := synthesizedInterfaceNames(device)
+	count := len(names)
+	if count == 0 {
+		count = 1
+		names = []string{"Management"}
 	}
-
-	// Count interfaces from trunk_ports
-	numInterfaces := len(device.TrunkPorts)
-	if numInterfaces == 0 {
-		// If no trunk ports, create at least one management interface
-		numInterfaces = 1
+	a.mib.Set(ifNumber, &OIDValue{Type: gosnmp.Integer, Value: count})
+	for index, name := range names {
+		a.createInterfaceEntry(index+1, name, device.MACAddress.String(), getInterfaceSpeed(name))
 	}
-
-	// ifNumber
-	a.mib.Set(ifNumber, &OIDValue{
-		Type:  gosnmp.Integer,
-		Value: numInterfaces,
-	})
-
-	// Create interface entries
-	if len(device.TrunkPorts) == 0 {
-		// Management interface only
-		a.createInterfaceEntry(1, "Management", device.MACAddress.String(), NanosPerSecond)
-	} else {
-		for idx, trunk := range device.TrunkPorts {
-			ifIdx := idx + 1
-			// Determine speed based on interface name
-			speed := getInterfaceSpeed(trunk.Interface)
-			a.createInterfaceEntry(ifIdx, trunk.Interface, device.MACAddress.String(), speed)
-		}
-	}
-
 	if a.debugLevel >= DebugLevelMinimum {
-		logger.Info("Initialized IF-MIB", "interfaces", numInterfaces, "device", device.Name)
+		slog.Default().Info("Initialized IF-MIB", "interfaces", count, "device", device.Name)
 	}
+}
+
+func synthesizedInterfaceNames(device *config.Device) []string {
+	seen := make(map[string]struct{}, len(device.TrunkPorts)+len(device.Interfaces))
+	names := make([]string, 0, len(seen))
+	for _, trunk := range device.TrunkPorts {
+		appendUniqueInterface(&names, seen, trunk.Interface)
+	}
+	for _, authored := range device.Interfaces {
+		appendUniqueInterface(&names, seen, authored.Name)
+	}
+	return names
+}
+
+func appendUniqueInterface(names *[]string, seen map[string]struct{}, name string) {
+	if name == "" {
+		return
+	}
+	if _, exists := seen[name]; exists {
+		return
+	}
+	seen[name] = struct{}{}
+	*names = append(*names, name)
 }
 
 func (a *Agent) refreshAuthoredInterfaceMIBs() {

--- a/internal/protocols/snmp/mib_if_authored_test.go
+++ b/internal/protocols/snmp/mib_if_authored_test.go
@@ -1,0 +1,47 @@
+package snmp
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+func TestSynthesizedIFMIBMergesAuthoredAndTopologyInterfaces(t *testing.T) {
+	device := createTestDevice()
+	device.Interfaces = []config.Interface{
+		{Name: "Vlan200", Address: "10.0.0.2/24"},
+		{Name: "HundredGigabitEthernet0/0/1", Address: "192.0.2.2/29"},
+	}
+	device.Routes = []config.Route{{
+		Destination: "0.0.0.0/0", Via: "HundredGigabitEthernet0/0/1", NextHop: "192.0.2.1",
+	}}
+	device.TrunkPorts = []config.TrunkPort{{Interface: "HundredGigabitEthernet0/0/2"}}
+	agent := NewAgent(device, 0)
+	for _, name := range []string{"Vlan200", "HundredGigabitEthernet0/0/1", "HundredGigabitEthernet0/0/2"} {
+		if _, ok := agent.InterfaceIndex(name); !ok {
+			t.Errorf("missing synthesized interface %s", name)
+		}
+	}
+	assertMIBValue(t, agent, ipAdEntAddr+".10.0.0.2", "10.0.0.2")
+	assertMIBValue(t, agent, ipRouteNextHop+".0.0.0.0", "192.0.2.1")
+}
+
+func TestSynthesizedIFMIBAppliesAuthoredAttributes(t *testing.T) {
+	device := createTestDevice()
+	device.Interfaces = []config.Interface{{
+		Name: "Vlan200", Address: "10.0.0.2/24", Speed: 100_000,
+		AdminStatus: "up", OperStatus: "down", Duplex: "full", Description: "core SVI",
+	}}
+
+	agent := NewAgent(device, 0)
+	index, ok := agent.InterfaceIndex("Vlan200")
+	if !ok {
+		t.Fatal("missing Vlan200")
+	}
+	suffix := "." + strconv.Itoa(index)
+	assertMIBValue(t, agent, ifHighSpeed+suffix, uint32(100_000))
+	assertMIBValue(t, agent, ifOperStatus+suffix, interfaceStatusDown)
+	assertMIBValue(t, agent, ifAlias+suffix, "core SVI")
+	assertMIBValue(t, agent, dot3StatsDuplexStatus+suffix, DuplexFull)
+}

--- a/internal/protocols/snmp/mib_interface_telemetry_test.go
+++ b/internal/protocols/snmp/mib_interface_telemetry_test.go
@@ -60,8 +60,6 @@ func TestInterfaceFaultCountersAreSNMPObservable(t *testing.T) {
 	}}
 	telemetry := NewProtocolTelemetry()
 	agent := NewAgentWithCommunityAndTelemetry(device, "public", 0, telemetry)
-	seedInterfaceIdentity(t, agent, "GigabitEthernet1/0/5", "10005", "5")
-	agent.refreshAuthoredInterfaceMIBs()
 
 	telemetry.RecordInterfaceCounters("GigabitEthernet1/0/5", InterfaceCounterDelta{
 		InOctets: 1_000, OutOctets: 800,
@@ -73,15 +71,15 @@ func TestInterfaceFaultCountersAreSNMPObservable(t *testing.T) {
 		oid  string
 		want any
 	}{
-		{ifInOctets + ".10005", uint32(1_000)},
-		{ifHCInOctets + ".10005", uint64(1_000)},
-		{ifOutOctets + ".10005", uint32(800)},
-		{ifHCOutOctets + ".10005", uint64(800)},
-		{ifInDiscards + ".10005", uint32(2)},
-		{ifOutDiscards + ".10005", uint32(3)},
-		{ifInErrors + ".10005", uint32(4)},
-		{ifOutErrors + ".10005", uint32(5)},
-		{dot3StatsFCSErrors + ".10005", uint32(6)},
+		{ifInOctets + ".1", uint32(1_000)},
+		{ifHCInOctets + ".1", uint64(1_000)},
+		{ifOutOctets + ".1", uint32(800)},
+		{ifHCOutOctets + ".1", uint64(800)},
+		{ifInDiscards + ".1", uint32(2)},
+		{ifOutDiscards + ".1", uint32(3)},
+		{ifInErrors + ".1", uint32(4)},
+		{ifOutErrors + ".1", uint32(5)},
+		{dot3StatsFCSErrors + ".1", uint32(6)},
 	}
 	for _, test := range tests {
 		t.Run(test.oid, func(t *testing.T) { assertMIBValue(t, agent, test.oid, test.want) })


### PR DESCRIPTION
## Summary

- Synthesize IF-MIB rows from the union of topology and authored interfaces.
- Initialize IF-MIB before IP address and route tables.
- Apply authored speed, status, duplex, and descriptions to synthesized rows.
- Add regression coverage for routes, addresses, counters, and interface attributes.
- Restore complete third-party discovery of routed interfaces and SVIs.

## Linked Issue

Fixes #1131

## Testing Evidence

```text
make fmt-check
PASS

make lint
0 issues

make test
PASS: 43 Go packages and 69 frontend test files

make security
PASS: govulncheck, npm audit, and gitleaks

NIAC routed-fabric preflight
PASS: generated 531-device enterprise scenario compiled for CyberScope on VLAN 200

Independent code review
No findings
```

## Security and Release Checklist

- [x] No new dependencies or secrets.
- [x] No authentication, authorization, CSRF, or CORS behavior changed.
- [x] Walk-backed and synthesized SNMP paths have regression coverage.
- [x] Full lint, test, and security gates passed.
