### PR TITLE
feat(snmp): simulate realistic interface telemetry

### DIFF
--- a/docs/schemas/niac.schema.json
+++ b/docs/schemas/niac.schema.json
@@ -783,11 +783,17 @@
         "name": {
           "type": "string"
         },
+        "type": {
+          "type": "string"
+        },
         "network": {
           "type": "string"
         },
         "address": {
           "type": "string"
+        },
+        "mtu": {
+          "type": "integer"
         },
         "speed": {
           "type": "integer"
@@ -803,6 +809,12 @@
         },
         "description": {
           "type": "string"
+        },
+        "in_utilization": {
+          "type": "number"
+        },
+        "out_utilization": {
+          "type": "number"
         },
         "vlans": {
           "items": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -383,15 +383,19 @@ type DNSRecord struct {
 
 // Interface represents a network interface on a device.
 type Interface struct {
-	Name        string
-	Network     string
-	Address     string
-	Speed       int // Mbps
-	Duplex      string
-	AdminStatus string // up, down
-	OperStatus  string // up, down, testing
-	Description string
-	VLANs       []int
+	Name           string
+	Type           string
+	Network        string
+	Address        string
+	MTU            int
+	Speed          int // Mbps
+	Duplex         string
+	AdminStatus    string // up, down, testing
+	OperStatus     string // up, down, testing
+	Description    string
+	InUtilization  float64 // percentage of interface capacity
+	OutUtilization float64 // percentage of interface capacity
+	VLANs          []int
 }
 
 // SNMPConfig holds SNMP configuration.

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -129,9 +129,11 @@ func interfacesToYAML(interfaces []Interface) []converter.Interface {
 	out := make([]converter.Interface, len(interfaces))
 	for i, iface := range interfaces {
 		out[i] = converter.Interface{
-			Name: iface.Name, Network: iface.Network, Address: iface.Address,
-			Speed: iface.Speed, Duplex: iface.Duplex, AdminStatus: iface.AdminStatus,
-			OperStatus: iface.OperStatus, Description: iface.Description, VLANs: iface.VLANs,
+			Name: iface.Name, Type: iface.Type, Network: iface.Network, Address: iface.Address,
+			MTU: iface.MTU, Speed: iface.Speed, Duplex: iface.Duplex,
+			AdminStatus: iface.AdminStatus, OperStatus: iface.OperStatus,
+			Description: iface.Description, InUtilization: iface.InUtilization,
+			OutUtilization: iface.OutUtilization, VLANs: iface.VLANs,
 		}
 	}
 	return out

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -61,15 +61,19 @@ func convertInterfaces(in []converter.Interface) []Interface {
 	out := make([]Interface, len(in))
 	for i, iface := range in {
 		out[i] = Interface{
-			Name:        iface.Name,
-			Network:     iface.Network,
-			Address:     iface.Address,
-			Speed:       iface.Speed,
-			Duplex:      iface.Duplex,
-			AdminStatus: iface.AdminStatus,
-			OperStatus:  iface.OperStatus,
-			Description: iface.Description,
-			VLANs:       iface.VLANs,
+			Name:           iface.Name,
+			Type:           iface.Type,
+			Network:        iface.Network,
+			Address:        iface.Address,
+			MTU:            iface.MTU,
+			Speed:          iface.Speed,
+			Duplex:         iface.Duplex,
+			AdminStatus:    iface.AdminStatus,
+			OperStatus:     iface.OperStatus,
+			Description:    iface.Description,
+			InUtilization:  iface.InUtilization,
+			OutUtilization: iface.OutUtilization,
+			VLANs:          iface.VLANs,
 		}
 	}
 	return out

--- a/internal/config/yaml_roundtrip_test.go
+++ b/internal/config/yaml_roundtrip_test.go
@@ -87,8 +87,9 @@ func completeRoundTripDevice(walk string, enabled *bool) Device {
 		Babble: true, VLAN: 200, Properties: map[string]string{"vendor": "Cisco"},
 		TTLConfig: &TTLConfig{TTL: 2, IP: net.ParseIP("10.240.0.1"), Mask: net.CIDRMask(24, 32)},
 		Interfaces: []Interface{{
-			Name: "Gi0/0", Network: "access", Address: "10.254.200.1/24", Speed: 1000,
-			Duplex: "full", AdminStatus: "up", OperStatus: "up", VLANs: []int{200},
+			Name: "Gi0/0", Type: "ethernet", Network: "access", Address: "10.254.200.1/24",
+			MTU: 9000, Speed: 1000, Duplex: "full", AdminStatus: "up", OperStatus: "up",
+			InUtilization: 12.5, OutUtilization: 7.25, VLANs: []int{200},
 		}},
 		Routes: []Route{{Destination: "10.240.0.0/16", Via: "Gi0/0", NextHop: "10.254.200.2"}},
 		SNMPConfig: SNMPConfig{

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -166,11 +166,15 @@ devices:
     mac: "00:11:22:33:44:55"
     interfaces:
       - name: "Ethernet1/1"
+        type: "ethernet"
+        mtu: 9000
         speed: 1000
         duplex: "full"
         admin_status: "up"
         oper_status: "down"
         description: "uplink"
+        in_utilization: 12.5
+        out_utilization: 7.25
         vlans: [10, 20]
 `
 	tmpfile := createTempYAML(t, yaml)
@@ -191,6 +195,12 @@ devices:
 	if iface.Name != "Ethernet1/1" || iface.Speed != 1000 || iface.Duplex != "full" {
 		t.Fatalf("interface not loaded correctly: %+v", iface)
 	}
+	if iface.Type != "ethernet" || iface.MTU != 9000 {
+		t.Fatalf("interface type/MTU not loaded correctly: %+v", iface)
+	}
+	if iface.InUtilization != 12.5 || iface.OutUtilization != 7.25 {
+		t.Fatalf("interface utilization not loaded correctly: %+v", iface)
+	}
 	if iface.AdminStatus != "up" || iface.OperStatus != "down" || iface.Description != "uplink" {
 		t.Fatalf("interface status/description not loaded correctly: %+v", iface)
 	}
@@ -208,10 +218,14 @@ func TestMarshalConfigYAML_Interfaces(t *testing.T) {
 				MACAddress: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
 				Interfaces: []Interface{
 					{
-						Name:        "Ethernet1/1",
-						Speed:       1000,
-						Duplex:      "full",
-						AdminStatus: "up",
+						Name:           "Ethernet1/1",
+						Type:           "ethernet",
+						MTU:            9000,
+						Speed:          1000,
+						Duplex:         "full",
+						AdminStatus:    "up",
+						InUtilization:  12.5,
+						OutUtilization: 7.25,
 					},
 				},
 			},
@@ -229,6 +243,38 @@ func TestMarshalConfigYAML_Interfaces(t *testing.T) {
 	iface := roundTrip.Devices[0].Interfaces[0]
 	if iface.Name != "Ethernet1/1" || iface.Speed != 1000 || iface.Duplex != "full" {
 		t.Fatalf("round-trip interface = %+v", iface)
+	}
+	if iface.Type != "ethernet" || iface.MTU != 9000 ||
+		iface.InUtilization != 12.5 || iface.OutUtilization != 7.25 {
+		t.Fatalf("round-trip interface realism = %+v", iface)
+	}
+}
+
+func TestLoadYAMLRejectsInvalidInterfaceRealism(t *testing.T) {
+	template := `
+devices:
+  - name: switch-a
+    type: switch
+    mac: "00:11:22:33:44:55"
+    interfaces:
+      - name: Ethernet1/1
+        %s
+`
+	for _, test := range []struct {
+		name  string
+		field string
+	}{
+		{name: "type", field: "type: serial"},
+		{name: "mtu", field: "mtu: 575"},
+		{name: "in utilization", field: "in_utilization: 101"},
+		{name: "out utilization", field: "out_utilization: -1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			yaml := strings.Replace(template, "%s", test.field, 1)
+			if _, err := LoadYAMLBytes([]byte(yaml)); err == nil {
+				t.Fatalf("LoadYAMLBytes accepted invalid interface %s", test.field)
+			}
+		})
 	}
 }
 

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -141,9 +141,9 @@ type Device struct {
 	OSFingerprint *OSFingerprintConfig `yaml:"os_fingerprint,omitempty"` // v1.24.0
 	SSH           *SSHConfig           `yaml:"ssh,omitempty"`
 	Syslog        *SyslogConfig        `yaml:"syslog,omitempty"`
-	IPerf3        *IPerf3Config        `yaml:"iperf3,omitempty"`     // v1.25.0
-	Reflector     *ReflectorConfig     `yaml:"reflector,omitempty"`  // v0.94.0 — NetAlly UDP reflector endpoint
-	Interfaces    []Interface          `yaml:"interfaces,omitempty"` // Device interface metadata
+	IPerf3        *IPerf3Config        `yaml:"iperf3,omitempty"`                                   // v1.25.0
+	Reflector     *ReflectorConfig     `yaml:"reflector,omitempty"`                                // v0.94.0 — NetAlly UDP reflector endpoint
+	Interfaces    []Interface          `yaml:"interfaces,omitempty"     validate:"omitempty,dive"` // Device interface metadata
 	Routes        []Route              `yaml:"routes,omitempty"         validate:"omitempty,dive"`
 	TrunkPorts    []TrunkPort          `yaml:"trunk_ports,omitempty"`   // v1.23.0 — topology link declarations
 	PortChannels  []PortChannel        `yaml:"port_channels,omitempty"` // v1.23.0 — LAG bundling
@@ -201,15 +201,19 @@ func addEnabledRequirements(schema *jsonschema.Schema, required ...string) {
 
 // Interface represents configured metadata for a device interface.
 type Interface struct {
-	Name        string `yaml:"name"`
-	Network     string `yaml:"network,omitempty"`
-	Address     string `yaml:"address,omitempty"      validate:"omitempty,cidr"`
-	Speed       int    `yaml:"speed,omitempty"` // Mbps
-	Duplex      string `yaml:"duplex,omitempty"`
-	AdminStatus string `yaml:"admin_status,omitempty"`
-	OperStatus  string `yaml:"oper_status,omitempty"`
-	Description string `yaml:"description,omitempty"`
-	VLANs       []int  `yaml:"vlans,omitempty"`
+	Name           string  `yaml:"name"`
+	Type           string  `yaml:"type,omitempty"            validate:"omitempty,oneof=ethernet l2vlan loopback tunnel other"`
+	Network        string  `yaml:"network,omitempty"`
+	Address        string  `yaml:"address,omitempty"         validate:"omitempty,cidr"`
+	MTU            int     `yaml:"mtu,omitempty"             validate:"omitempty,gte=576,lte=65535"`
+	Speed          int     `yaml:"speed,omitempty"` // Mbps
+	Duplex         string  `yaml:"duplex,omitempty"          validate:"omitempty,oneof=full half"`
+	AdminStatus    string  `yaml:"admin_status,omitempty"    validate:"omitempty,oneof=up down testing"`
+	OperStatus     string  `yaml:"oper_status,omitempty"     validate:"omitempty,oneof=up down testing"`
+	Description    string  `yaml:"description,omitempty"`
+	InUtilization  float64 `yaml:"in_utilization,omitempty"  validate:"omitempty,gte=0,lte=100"`
+	OutUtilization float64 `yaml:"out_utilization,omitempty" validate:"omitempty,gte=0,lte=100"`
+	VLANs          []int   `yaml:"vlans,omitempty"`
 }
 
 // Route declares an IPv4 static route through a named device interface.

--- a/internal/protocols/snmp/mib_bridge.go
+++ b/internal/protocols/snmp/mib_bridge.go
@@ -219,11 +219,11 @@ func (a *Agent) registerDot1dTpPortEntry(portIdx int) {
 	a.mib.Set(dot1dTpPort+"."+portStr, &OIDValue{Type: gosnmp.Integer, Value: portIdx})
 	a.mib.Set(dot1dTpPortMaxInfo+"."+portStr, &OIDValue{Type: gosnmp.Integer, Value: DefaultMTU})
 	a.mib.SetDynamic(dot1dTpPortInFrames+"."+portStr, func() *OIDValue {
-		stats := a.protocolStats.interfaceSnapshot(a.interfaceNameForBridgePort(portStr))
+		stats := a.interfaceSnapshot(a.interfaceNameForBridgePort(portStr))
 		return &OIDValue{Type: gosnmp.Counter32, Value: safeUint32FromUint64(stats.inUcast + stats.inNUcast)}
 	})
 	a.mib.SetDynamic(dot1dTpPortOutFrames+"."+portStr, func() *OIDValue {
-		stats := a.protocolStats.interfaceSnapshot(a.interfaceNameForBridgePort(portStr))
+		stats := a.interfaceSnapshot(a.interfaceNameForBridgePort(portStr))
 		return &OIDValue{Type: gosnmp.Counter32, Value: safeUint32FromUint64(stats.outUcast + stats.outNUcast)}
 	})
 	a.mib.Set(

--- a/internal/protocols/snmp/mib_if.go
+++ b/internal/protocols/snmp/mib_if.go
@@ -18,6 +18,15 @@ const (
 	interfaceStatusDown    = 2
 	interfaceStatusTesting = 3
 	duplexHalf             = 2
+	interfaceTypeOther     = 1
+	interfaceTypeEthernet  = 6
+	interfaceTypeLoopback  = 24
+	interfaceTypeTunnel    = 131
+	interfaceTypeL2VLAN    = 135
+	averageFrameOctets     = 900
+	bitsPerOctet           = 8
+	nonUnicastPacketRatio  = 20
+	broadcastPacketRatio   = 100
 )
 
 func (a *Agent) initializeIFMIB() {
@@ -78,6 +87,20 @@ func (a *Agent) refreshAuthoredInterfaceMIBs() {
 				Type: gosnmp.Gauge32, Value: safeUint32FromUint64(uint64(iface.Speed)),
 			})
 		}
+		if iface.MTU > 0 {
+			a.mib.Set(ifMtu+"."+index, &OIDValue{Type: gosnmp.Integer, Value: iface.MTU})
+		}
+		ifTypeValue := interfaceTypeFor(iface.Name, iface.Type)
+		a.mib.Set(ifType+"."+index, &OIDValue{Type: gosnmp.Integer, Value: ifTypeValue})
+		connector := TruthValueTrue
+		if ifTypeValue != interfaceTypeEthernet {
+			connector = TruthValueFalse
+			a.mib.Delete(dot3StatsDuplexStatus + "." + index)
+		}
+		a.mib.Set(
+			ifConnectorPresent+"."+index,
+			&OIDValue{Type: gosnmp.Integer, Value: connector},
+		)
 		if status := interfaceStatus(iface.AdminStatus); status != 0 {
 			a.mib.Set(ifAdminStatus+"."+index, &OIDValue{Type: gosnmp.Integer, Value: status})
 		}
@@ -92,20 +115,55 @@ func (a *Agent) refreshAuthoredInterfaceMIBs() {
 		}
 		a.registerIfTableCounters(iface.Name, index)
 		a.registerIfXTablePacketCounters(iface.Name, index)
-		switch strings.ToLower(iface.Duplex) {
-		case "half":
-			a.mib.Set(
-				dot3StatsDuplexStatus+"."+index,
-				&OIDValue{Type: gosnmp.Integer, Value: duplexHalf},
-			)
-		case "full":
-			a.mib.Set(
-				dot3StatsDuplexStatus+"."+index,
-				&OIDValue{Type: gosnmp.Integer, Value: DuplexFull},
-			)
+		if ifTypeValue == interfaceTypeEthernet {
+			switch strings.ToLower(iface.Duplex) {
+			case "half":
+				a.mib.Set(
+					dot3StatsDuplexStatus+"."+index,
+					&OIDValue{Type: gosnmp.Integer, Value: duplexHalf},
+				)
+			case "full":
+				a.mib.Set(
+					dot3StatsDuplexStatus+"."+index,
+					&OIDValue{Type: gosnmp.Integer, Value: DuplexFull},
+				)
+			}
 		}
 	}
 	a.refreshDeviceStateInterfaceMIBs()
+}
+
+func configuredInterfaceType(interfaceType string) int {
+	switch strings.ToLower(interfaceType) {
+	case "ethernet":
+		return interfaceTypeEthernet
+	case "l2vlan":
+		return interfaceTypeL2VLAN
+	case "loopback":
+		return interfaceTypeLoopback
+	case "tunnel":
+		return interfaceTypeTunnel
+	case "other":
+		return interfaceTypeOther
+	default:
+		return 0
+	}
+}
+
+func interfaceTypeFor(name, configured string) int {
+	if configuredType := configuredInterfaceType(configured); configuredType != 0 {
+		return configuredType
+	}
+	switch {
+	case strings.HasPrefix(strings.ToLower(name), "vlan"):
+		return interfaceTypeL2VLAN
+	case strings.HasPrefix(strings.ToLower(name), "loopback"):
+		return interfaceTypeLoopback
+	case strings.HasPrefix(strings.ToLower(name), "tunnel"):
+		return interfaceTypeTunnel
+	default:
+		return interfaceTypeEthernet
+	}
 }
 
 func interfaceStatus(status string) int {
@@ -128,6 +186,12 @@ func (a *Agent) createInterfaceEntry(ifIdx int, interfaceName, mac string, speed
 
 	// Register ifTable basic properties
 	a.registerIfTableBasicOIDs(ifIdx, idxStr, interfaceName, macBytes, speedBps)
+	if interfaceTypeFor(interfaceName, "") == interfaceTypeEthernet {
+		a.mib.Set(
+			dot3StatsDuplexStatus+"."+idxStr,
+			&OIDValue{Type: gosnmp.Integer, Value: DuplexFull},
+		)
+	}
 
 	// Register ifTable counters (dynamic traffic simulation)
 	a.registerIfTableCounters(interfaceName, idxStr)
@@ -150,8 +214,8 @@ func (a *Agent) registerIfTableBasicOIDs(
 	// ifDescr
 	a.mib.Set(ifDescr+"."+idxStr, &OIDValue{Type: gosnmp.OctetString, Value: interfaceName})
 
-	// ifType (6 = ethernetCsmacd)
-	a.mib.Set(ifType+"."+idxStr, &OIDValue{Type: gosnmp.Integer, Value: EthernetCsmacdType})
+	interfaceType := interfaceTypeFor(interfaceName, "")
+	a.mib.Set(ifType+"."+idxStr, &OIDValue{Type: gosnmp.Integer, Value: interfaceType})
 
 	// ifMtu
 	a.mib.Set(ifMtu+"."+idxStr, &OIDValue{Type: gosnmp.Integer, Value: DefaultMTU})
@@ -165,6 +229,14 @@ func (a *Agent) registerIfTableBasicOIDs(
 
 	// ifPhysAddress (MAC)
 	a.mib.Set(ifPhysAddress+"."+idxStr, &OIDValue{Type: gosnmp.OctetString, Value: macBytes})
+	connector := TruthValueTrue
+	if interfaceType != interfaceTypeEthernet {
+		connector = TruthValueFalse
+	}
+	a.mib.Set(
+		ifConnectorPresent+"."+idxStr,
+		&OIDValue{Type: gosnmp.Integer, Value: connector},
+	)
 
 	// ifAdminStatus (1 = up)
 	a.mib.Set(ifAdminStatus+"."+idxStr, &OIDValue{Type: gosnmp.Integer, Value: 1})
@@ -202,7 +274,7 @@ func (a *Agent) registerIfTableCounters(interfaceName, idxStr string) {
 	for _, counter := range counters {
 		value := counter.value
 		a.mib.SetDynamic(counter.oid+"."+idxStr, func() *OIDValue {
-			snapshot := a.protocolStats.interfaceSnapshot(interfaceName)
+			snapshot := a.interfaceSnapshot(interfaceName)
 			return &OIDValue{
 				Type:  gosnmp.Counter32,
 				Value: wrapCounter32(value(snapshot)),
@@ -297,7 +369,7 @@ func (a *Agent) registerFaultCountersWithBaseline(interfaceName, index string) {
 		value := counter.value
 		snmpType := counter.snmpType
 		a.mib.SetDynamic(fullOID, func() *OIDValue {
-			result := baseline + value(a.protocolStats.interfaceSnapshot(interfaceName))
+			result := baseline + value(a.interfaceSnapshot(interfaceName))
 			if snmpType == gosnmp.Counter64 {
 				return &OIDValue{Type: snmpType, Value: result}
 			}
@@ -394,7 +466,7 @@ func (a *Agent) registerIfXTablePacketCounters(interfaceName, idxStr string) {
 	for _, counter := range counters {
 		value, snmpType := counter.value, counter.snmpType
 		a.mib.SetDynamic(counter.oid+"."+idxStr, func() *OIDValue {
-			result := value(a.protocolStats.interfaceSnapshot(interfaceName))
+			result := value(a.interfaceSnapshot(interfaceName))
 			if snmpType == gosnmp.Counter32 {
 				return &OIDValue{Type: snmpType, Value: wrapCounter32(result)}
 			}

--- a/internal/protocols/snmp/mib_if_authored_test.go
+++ b/internal/protocols/snmp/mib_if_authored_test.go
@@ -3,6 +3,7 @@ package snmp
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
@@ -30,18 +31,55 @@ func TestSynthesizedIFMIBMergesAuthoredAndTopologyInterfaces(t *testing.T) {
 func TestSynthesizedIFMIBAppliesAuthoredAttributes(t *testing.T) {
 	device := createTestDevice()
 	device.Interfaces = []config.Interface{{
-		Name: "Vlan200", Address: "10.0.0.2/24", Speed: 100_000,
-		AdminStatus: "up", OperStatus: "down", Duplex: "full", Description: "core SVI",
+		Name: "Vlan200", Type: "l2vlan", Address: "10.0.0.2/24", MTU: 9000, Speed: 100_000,
+		AdminStatus: "up", OperStatus: "down", Description: "core SVI",
+		InUtilization: 12.5, OutUtilization: 7.25,
 	}}
 
 	agent := NewAgent(device, 0)
+	agent.startTime = time.Now().Add(-time.Minute)
 	index, ok := agent.InterfaceIndex("Vlan200")
 	if !ok {
 		t.Fatal("missing Vlan200")
 	}
 	suffix := "." + strconv.Itoa(index)
 	assertMIBValue(t, agent, ifHighSpeed+suffix, uint32(100_000))
+	assertMIBValue(t, agent, ifType+suffix, interfaceTypeL2VLAN)
+	assertMIBValue(t, agent, ifMtu+suffix, 9000)
 	assertMIBValue(t, agent, ifOperStatus+suffix, interfaceStatusDown)
 	assertMIBValue(t, agent, ifAlias+suffix, "core SVI")
+	assertMIBValue(t, agent, ifConnectorPresent+suffix, TruthValueFalse)
+	if value := agent.mib.Get(dot3StatsDuplexStatus + suffix); value != nil {
+		t.Fatalf("logical interface has Ethernet duplex value: %#v", value)
+	}
+	assertPositiveCounter(t, agent, ifHCInOctets+suffix)
+	assertPositiveCounter(t, agent, ifHCOutOctets+suffix)
+	assertMIBValue(t, agent, ifInErrors+suffix, uint32(0))
+	assertMIBValue(t, agent, ifOutErrors+suffix, uint32(0))
+}
+
+func TestSynthesizedTopologyInterfaceDefaultsToFullDuplex(t *testing.T) {
+	device := createTestDevice()
+	device.TrunkPorts = []config.TrunkPort{{Interface: "GigabitEthernet1/0/1"}}
+
+	agent := NewAgent(device, 0)
+	index, ok := agent.InterfaceIndex("GigabitEthernet1/0/1")
+	if !ok {
+		t.Fatal("missing synthesized topology interface")
+	}
+	suffix := "." + strconv.Itoa(index)
 	assertMIBValue(t, agent, dot3StatsDuplexStatus+suffix, DuplexFull)
+	assertMIBValue(t, agent, ifMtu+suffix, DefaultMTU)
+}
+
+func assertPositiveCounter(t *testing.T, agent *Agent, oid string) {
+	t.Helper()
+	value, err := agent.HandleGet(oid)
+	if err != nil {
+		t.Fatalf("GET %s: %v", oid, err)
+	}
+	counter, ok := value.Value.(uint64)
+	if !ok || counter == 0 {
+		t.Fatalf("%s = %#v, want positive Counter64", oid, value.Value)
+	}
 }

--- a/internal/protocols/snmp/protocol_telemetry_interface.go
+++ b/internal/protocols/snmp/protocol_telemetry_interface.go
@@ -1,6 +1,9 @@
 package snmp
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+	"time"
+)
 
 type interfaceTelemetry struct {
 	inOctets, inUcast, inNUcast, outOctets, outUcast, outNUcast atomic.Uint64
@@ -110,4 +113,53 @@ func snapshotInterfaceTelemetry(entry *interfaceTelemetry) interfaceSnapshot {
 		inDiscards: entry.inDiscards.Load(), outDiscards: entry.outDiscards.Load(),
 		inErrors: entry.inErrors.Load(), outErrors: entry.outErrors.Load(), fcsErrors: entry.fcsErrors.Load(),
 	}
+}
+
+func (a *Agent) interfaceSnapshot(name string) interfaceSnapshot {
+	snapshot := a.protocolStats.interfaceSnapshot(name)
+	if a.device == nil {
+		return snapshot
+	}
+	for i := range a.device.Interfaces {
+		iface := &a.device.Interfaces[i]
+		if iface.Name != name || iface.Speed <= 0 {
+			continue
+		}
+		elapsed := max(time.Since(a.startTime).Seconds(), 0)
+		addSimulatedTraffic(
+			&snapshot,
+			trafficOctets(iface.Speed, iface.InUtilization, elapsed),
+			trafficOctets(iface.Speed, iface.OutUtilization, elapsed),
+		)
+		break
+	}
+	return snapshot
+}
+
+func trafficOctets(speedMbps int, utilization, elapsedSeconds float64) uint64 {
+	if utilization <= 0 || elapsedSeconds <= 0 {
+		return 0
+	}
+	bytesPerSecond := float64(speedMbps) * MicrosPerSec / bitsPerOctet
+	return uint64(bytesPerSecond * utilization / 100 * elapsedSeconds)
+}
+
+func addSimulatedTraffic(snapshot *interfaceSnapshot, inOctets, outOctets uint64) {
+	snapshot.inOctets += inOctets
+	snapshot.outOctets += outOctets
+	addSimulatedPackets(&snapshot.inUcast, &snapshot.inNUcast, &snapshot.inBroadcast, inOctets)
+	addSimulatedPackets(
+		&snapshot.outUcast,
+		&snapshot.outNUcast,
+		&snapshot.outBroadcast,
+		outOctets,
+	)
+}
+
+func addSimulatedPackets(unicast, nonUnicast, broadcast *uint64, octets uint64) {
+	total := octets / averageFrameOctets
+	simulatedNonUnicast := total / nonUnicastPacketRatio
+	*unicast += total - simulatedNonUnicast
+	*nonUnicast += simulatedNonUnicast
+	*broadcast += total / broadcastPacketRatio
 }


### PR DESCRIPTION
## Summary

- add authored interface type, MTU, and directional utilization fields
- expose correct IF-MIB type, connector, MTU, and Ethernet duplex semantics
- advance interface and bridge counters deterministically while preserving real telemetry and explicit faults
- reject invalid interface metadata and regenerate the committed schema

## Linked Issue

Closes #1133

## Testing Evidence

```text
make fmt-check: passed
make lint: passed (0 issues)
make test: passed (66.9% aggregate backend coverage; frontend and hooks passed)
make security: passed (govulncheck, npm audit, gitleaks)
make build: passed with Node 26.5.0 / npm 12.0.1
make test-e2e: 186 passed + 3 authenticated-browser tests passed; 6 scenario-dependent tests skipped
go test ./internal/config ./internal/converter ./internal/protocols/snmp: passed
enterprise scenario: niac validate passed
```

## Security and Release Checklist

- [x] No authentication or authorization boundary changed
- [x] No secrets or new dependencies added
- [x] Invalid authored bounds are rejected
- [x] Error/discard counters remain driven only by real or explicit fault telemetry
- [x] Full release build completed locally