### PR TITLE
fix: harden Npcap SDK release dependency

### DIFF
--- a/.github/workflows/cache-npcap-sdk.yml
+++ b/.github/workflows/cache-npcap-sdk.yml
@@ -1,0 +1,58 @@
+name: Cache Npcap SDK
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/cache-npcap-sdk.yml"
+      - ".github/workflows/release.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NPCAP_SDK_VERSION: "1.16"
+  NPCAP_SDK_SHA256: "f0a8be7778ee3ae1b99bbbecb27a3ff0f6c111a4093f1c78c5c5a099607184db"
+
+jobs:
+  seed-cache:
+    name: Seed checksum-keyed cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore Npcap SDK cache
+        id: npcap-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: npcap-cache/npcap-sdk-${{ env.NPCAP_SDK_VERSION }}.zip
+          key: npcap-sdk-${{ env.NPCAP_SDK_VERSION }}-${{ env.NPCAP_SDK_SHA256 }}
+          enableCrossOsArchive: true
+
+      - name: Download Npcap SDK on cache miss
+        if: steps.npcap-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p npcap-cache
+          archive="npcap-cache/npcap-sdk-${NPCAP_SDK_VERSION}.zip"
+          if ! curl --fail --location --show-error \
+            --connect-timeout 30 --max-time 120 \
+            --output "$archive" \
+            "https://npcap.com/dist/npcap-sdk-${NPCAP_SDK_VERSION}.zip"; then
+            echo "::error::Npcap SDK cache miss and the official origin could not be reached"
+            exit 1
+          fi
+
+      - name: Verify Npcap SDK
+        run: |
+          set -euo pipefail
+          archive="npcap-cache/npcap-sdk-${NPCAP_SDK_VERSION}.zip"
+          echo "${NPCAP_SDK_SHA256}  ${archive}" | sha256sum -c -
+
+      - name: Save verified Npcap SDK cache
+        if: steps.npcap-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: npcap-cache/npcap-sdk-${{ env.NPCAP_SDK_VERSION }}.zip
+          key: npcap-sdk-${{ env.NPCAP_SDK_VERSION }}-${{ env.NPCAP_SDK_SHA256 }}
+          enableCrossOsArchive: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,12 @@ permissions:
   id-token: write # cosign keyless OIDC
   attestations: write
 
+env:
+  NPCAP_SDK_VERSION: "1.16"
+  # SHA-256 of npcap-sdk-1.16.zip. Upstream publishes no checksum file;
+  # rotate this together with the pinned version.
+  NPCAP_SDK_SHA256: "f0a8be7778ee3ae1b99bbbecb27a3ff0f6c111a4093f1c78c5c5a099607184db"
+
 jobs:
   # =========================================================================
   # UI build — done outside the goreleaser-cross container because that
@@ -108,6 +114,52 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
+  # Restore the default-branch cache seeded by cache-npcap-sdk.yml, or fetch
+  # and verify the pinned SDK once if that cache was evicted. The same-run
+  # cache then feeds both Windows builders. This keeps Windows ARM64 off
+  # npcap.com's unreliable TLS path without publishing the SDK as a
+  # downloadable workflow artifact.
+  prepare-npcap-sdk:
+    name: Prepare Npcap SDK
+    if: ${{ !inputs.provenance_only }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore checksum-keyed Npcap SDK cache
+        id: npcap-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: npcap-cache/npcap-sdk-${{ env.NPCAP_SDK_VERSION }}.zip
+          key: npcap-sdk-${{ env.NPCAP_SDK_VERSION }}-${{ env.NPCAP_SDK_SHA256 }}
+          enableCrossOsArchive: true
+
+      - name: Download Npcap SDK on cache miss
+        if: steps.npcap-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p npcap-cache
+          archive="npcap-cache/npcap-sdk-${NPCAP_SDK_VERSION}.zip"
+          if ! curl --fail --location --show-error \
+            --connect-timeout 30 --max-time 120 \
+            --output "$archive" \
+            "https://npcap.com/dist/npcap-sdk-${NPCAP_SDK_VERSION}.zip"; then
+            echo "::error::Npcap SDK cache miss and the official origin could not be reached"
+            exit 1
+          fi
+
+      - name: Verify Npcap SDK
+        run: |
+          set -euo pipefail
+          archive="npcap-cache/npcap-sdk-${NPCAP_SDK_VERSION}.zip"
+          echo "${NPCAP_SDK_SHA256}  ${archive}" | sha256sum -c -
+
+      - name: Save verified Npcap SDK cache
+        if: steps.npcap-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: npcap-cache/npcap-sdk-${{ env.NPCAP_SDK_VERSION }}.zip
+          key: npcap-sdk-${{ env.NPCAP_SDK_VERSION }}-${{ env.NPCAP_SDK_SHA256 }}
+          enableCrossOsArchive: true
+
   # =========================================================================
   # Windows build — native GitHub Windows runners, CGO_ENABLED=1 linked
   # against the Npcap SDK, so gopacket/pcap gets real packet-capture cgo on
@@ -134,7 +186,7 @@ jobs:
   build-windows:
     name: build windows/${{ matrix.goarch }}
     if: ${{ !inputs.provenance_only }}
-    needs: [build-ui]
+    needs: [build-ui, prepare-npcap-sdk]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -176,22 +228,28 @@ jobs:
           # /clangarm64 bin dir, or `go build` below can't find `go`.
           path-type: inherit
 
-      - name: Download + verify Npcap SDK
+      - name: Restore verified Npcap SDK cache
+        id: npcap-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: npcap-cache/npcap-sdk-${{ env.NPCAP_SDK_VERSION }}.zip
+          key: npcap-sdk-${{ env.NPCAP_SDK_VERSION }}-${{ env.NPCAP_SDK_SHA256 }}
+          enableCrossOsArchive: true
+
+      - name: Verify + unpack Npcap SDK
         shell: bash
         env:
-          NPCAP_SDK_VERSION: "1.16"
-          # SHA-256 of npcap-sdk-1.16.zip, computed locally from
-          # https://npcap.com/dist/npcap-sdk-1.16.zip (upstream publishes
-          # no checksum file). Rotate this together with the version.
-          NPCAP_SDK_SHA256: "f0a8be7778ee3ae1b99bbbecb27a3ff0f6c111a4093f1c78c5c5a099607184db"
+          NPCAP_CACHE_HIT: ${{ steps.npcap-cache.outputs.cache-hit }}
         run: |
           set -euo pipefail
-          curl -sSfL -o npcap-sdk.zip \
-            "https://npcap.com/dist/npcap-sdk-${NPCAP_SDK_VERSION}.zip"
-          echo "${NPCAP_SDK_SHA256}  npcap-sdk.zip" | sha256sum -c -
+          if [ "$NPCAP_CACHE_HIT" != "true" ]; then
+            echo "::error::Verified Npcap SDK cache was not available to the Windows builder"
+            exit 1
+          fi
+          archive="npcap-cache/npcap-sdk-${NPCAP_SDK_VERSION}.zip"
+          echo "${NPCAP_SDK_SHA256}  ${archive}" | sha256sum -c -
           mkdir -p "${RUNNER_TEMP}/npcap-sdk"
-          unzip -q npcap-sdk.zip -d "${RUNNER_TEMP}/npcap-sdk"
-          rm -f npcap-sdk.zip
+          unzip -q "$archive" -d "${RUNNER_TEMP}/npcap-sdk"
 
       - name: Build niac.exe (CGO + Npcap SDK)
         shell: msys2 {0}

--- a/scripts/tests/release-content-integrity-test.sh
+++ b/scripts/tests/release-content-integrity-test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+NPCAP_CACHE_WORKFLOW="$REPO_ROOT/.github/workflows/cache-npcap-sdk.yml"
 CONTENT_CONFIG="$REPO_ROOT/.goreleaser.content.yml"
 
 job_block() {
@@ -27,6 +28,81 @@ require_text() {
 
 CONTENT_JOB=$(job_block "niac-content")
 GORELEASER_JOB=$(job_block "goreleaser")
+NPCAP_JOB=$(job_block "prepare-npcap-sdk")
+WINDOWS_JOB=$(job_block "build-windows")
+NPCAP_CACHE_WORKFLOW_CONTENT=$(<"$NPCAP_CACHE_WORKFLOW")
+
+require_text "$NPCAP_JOB" \
+  'key: npcap-sdk-${{ env.NPCAP_SDK_VERSION }}-${{ env.NPCAP_SDK_SHA256 }}' \
+  "the Npcap SDK cache key must include both the pinned version and checksum"
+require_text "$NPCAP_JOB" \
+  "if: steps.npcap-cache.outputs.cache-hit != 'true'" \
+  "the official Npcap origin must only be contacted on a cache miss"
+require_text "$NPCAP_JOB" \
+  "Npcap SDK cache miss and the official origin could not be reached" \
+  "an Npcap SDK cache miss must fail with a clear origin diagnostic"
+require_text "$NPCAP_JOB" \
+  'echo "${NPCAP_SDK_SHA256}  ${archive}" | sha256sum -c -' \
+  "the prepared Npcap SDK must be verified before caching"
+require_text "$NPCAP_JOB" \
+  "uses: actions/cache/save@" \
+  "the verified Npcap SDK must be saved to the internal build cache"
+require_text "$NPCAP_JOB" \
+  "enableCrossOsArchive: true" \
+  "the verified Npcap SDK cache must be readable by Windows builders"
+require_text "$NPCAP_JOB" \
+  'path: npcap-cache/npcap-sdk-${{ env.NPCAP_SDK_VERSION }}.zip' \
+  "the Npcap SDK cache must use an OS-neutral relative path"
+require_text "$WINDOWS_JOB" \
+  "needs: [build-ui, prepare-npcap-sdk]" \
+  "both Windows builders must wait for the verified Npcap SDK cache"
+require_text "$WINDOWS_JOB" \
+  "uses: actions/cache/restore@" \
+  "Windows builders must restore the verified Npcap SDK cache"
+require_text "$WINDOWS_JOB" \
+  "Verified Npcap SDK cache was not available to the Windows builder" \
+  "Windows builders must fail clearly when the verified cache is unavailable"
+require_text "$WINDOWS_JOB" \
+  'echo "${NPCAP_SDK_SHA256}  ${archive}" | sha256sum -c -' \
+  "Windows builders must independently verify the Npcap SDK cache"
+if grep -Fq "curl " <<<"$WINDOWS_JOB"; then
+  echo "Windows builders must not contact the Npcap SDK origin directly"
+  exit 1
+fi
+if grep -Fq 'runner.temp }}/npcap-sdk' <<<"$NPCAP_JOB$WINDOWS_JOB"; then
+  echo "cross-OS cache paths must not depend on the runner-specific temporary directory"
+  exit 1
+fi
+if grep -Fq "actions/upload-artifact@" <<<"$NPCAP_JOB"; then
+  echo "the Npcap SDK must not be published as a downloadable workflow artifact"
+  exit 1
+fi
+require_text "$NPCAP_CACHE_WORKFLOW_CONTENT" \
+  'branches:' \
+  "the persistent Npcap SDK cache must be seeded from the default branch"
+require_text "$NPCAP_CACHE_WORKFLOW_CONTENT" \
+  '      - main' \
+  "the persistent Npcap SDK cache must be accessible to tagged releases"
+require_text "$NPCAP_CACHE_WORKFLOW_CONTENT" \
+  '      - ".github/workflows/release.yml"' \
+  "changing the release workflow must refresh the default-branch Npcap SDK cache"
+require_text "$NPCAP_CACHE_WORKFLOW_CONTENT" \
+  'echo "${NPCAP_SDK_SHA256}  ${archive}" | sha256sum -c -' \
+  "the default-branch Npcap SDK cache must be checksum verified"
+if grep -Fq "actions/upload-artifact@" <<<"$NPCAP_CACHE_WORKFLOW_CONTENT"; then
+  echo "the default-branch cache workflow must not publish the Npcap SDK as an artifact"
+  exit 1
+fi
+
+RELEASE_NPCAP_VERSION=$(sed -n 's/^  NPCAP_SDK_VERSION: "\(.*\)"/\1/p' "$WORKFLOW")
+CACHE_NPCAP_VERSION=$(sed -n 's/^  NPCAP_SDK_VERSION: "\(.*\)"/\1/p' "$NPCAP_CACHE_WORKFLOW")
+RELEASE_NPCAP_SHA=$(sed -n 's/^  NPCAP_SDK_SHA256: "\(.*\)"/\1/p' "$WORKFLOW")
+CACHE_NPCAP_SHA=$(sed -n 's/^  NPCAP_SDK_SHA256: "\(.*\)"/\1/p' "$NPCAP_CACHE_WORKFLOW")
+if [ "$RELEASE_NPCAP_VERSION" != "$CACHE_NPCAP_VERSION" ] ||
+  [ "$RELEASE_NPCAP_SHA" != "$CACHE_NPCAP_SHA" ]; then
+  echo "release and default-branch cache workflows must use the same Npcap SDK pin"
+  exit 1
+fi
 
 if grep -Fq "needs: [goreleaser]" <<<"$CONTENT_JOB"; then
   echo "content packages must be built before the core release finalizes integrity metadata"


### PR DESCRIPTION
## Summary
- Seed a checksum-keyed Npcap SDK cache from trusted pushes to the default branch.
- Restore the same verified cross-OS cache for both Windows release architectures.
- Retain a fail-closed Linux origin fallback and re-verify before every Windows build.
- Prevent publishing the SDK as a workflow artifact.
- Extend the release integrity contract to guard cache scope, path, pin, and checksum behavior.

## Linked Issue
Closes #1136

## Testing Evidence
```
make fmt-check: passed
make lint: passed, 0 issues
make test: passed, backend 66.9%, 69 frontend test files, repository hooks passed
make security: govulncheck clean, npm audit 0 vulnerabilities, gitleaks clean
scripts/tests/release-content-integrity-test.sh: passed
actionlint .github/workflows/cache-npcap-sdk.yml: passed
independent code review: no remaining findings
```

## Security and Release Checklist
- [x] Npcap SDK remains pinned by version and SHA-256.
- [x] Cache misses and checksum failures fail closed with explicit diagnostics.
- [x] The SDK is not uploaded as a workflow or release artifact.
- [x] Both Windows architectures independently verify the cached archive.
- [x] No secrets or new dependencies were added.
