### PR TITLE
fix: improve discovery topology fidelity

### DIFF
--- a/internal/protocols/snmp/addmib.go
+++ b/internal/protocols/snmp/addmib.go
@@ -341,8 +341,5 @@ func castIntegral(asnType gosnmp.Asn1BER, value int64) any {
 }
 
 func (a *Agent) sysUpTimeTicks() uint32 {
-	uptime := time.Since(a.startTime)
-	ms := uptime.Milliseconds() / MillisecsPerCentisec
-
-	return safeUint32(ms)
+	return uptimeTicks(a.uptimeBase + time.Since(a.startTime))
 }

--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -3,9 +3,11 @@ package snmp
 
 import (
 	"fmt"
+	"hash/crc32"
 	"log/slog"
 	"net"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,24 +17,22 @@ import (
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/devicestate"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp/synth"
 )
 
-// Default OID constants.
 const (
-	// DefaultCiscoSysObjectID is the default sysObjectID for Cisco devices.
-	DefaultCiscoSysObjectID = "1.3.6.1.4.1.9.1.1"
-
 	// unknownPlaceholder is used as a fallback value when actual data is unavailable.
 	unknownPlaceholder = "Unknown"
+
+	minimumDefaultUptime = 30 * 24 * time.Hour
+	defaultUptimeSpread  = 330 * 24 * time.Hour
 )
 
 // Package-local aliases for exported constants.
 const (
-	millisecsPerCentisec = MillisecsPerCentisec
-	maxUint32            = MaxUint32Value
-	debugLevelVerbose    = DebugLevelVerbose
-	debugLevelDebug      = DebugLevelDebug
-	minRedactLen         = MinRedactLen
+	debugLevelVerbose = DebugLevelVerbose
+	debugLevelDebug   = DebugLevelDebug
+	minRedactLen      = MinRedactLen
 )
 
 // Agent represents an SNMP agent instance for a device.
@@ -41,6 +41,7 @@ type Agent struct {
 	mib             *MIB
 	community       string
 	startTime       time.Time
+	uptimeBase      time.Duration
 	debugLevel      int
 	logger          *slog.Logger
 	mu              sync.RWMutex
@@ -80,6 +81,7 @@ func NewAgentWithCommunityAndTelemetry(
 		mib:           NewMIB(),
 		community:     community,
 		startTime:     time.Now(),
+		uptimeBase:    simulatedUptimeBase(device),
 		debugLevel:    debugLevel,
 		logger:        slog.Default(),
 		protocolStats: telemetry,
@@ -101,6 +103,8 @@ func NewAgentWithCommunityAndTelemetry(
 
 // initializeSystemMIB initializes standard MIB-II system group OIDs.
 func (a *Agent) initializeSystemMIB() {
+	profile := systemProfile(a.device)
+
 	// sysDescr (1.3.6.1.2.1.1.1.0)
 	sysDescr := a.device.SNMPConfig.SysDescr
 	if sysDescr == "" {
@@ -118,7 +122,7 @@ func (a *Agent) initializeSystemMIB() {
 	// sysObjectID (1.3.6.1.2.1.1.2.0)
 	sysObjectID := a.device.Properties["sysObjectID"]
 	if sysObjectID == "" {
-		sysObjectID = DefaultCiscoSysObjectID // Default to generic Cisco
+		sysObjectID = profile.SysObjectID
 	}
 
 	a.mib.Set("1.3.6.1.2.1.1.2.0", &OIDValue{
@@ -128,17 +132,9 @@ func (a *Agent) initializeSystemMIB() {
 
 	// sysUpTime (1.3.6.1.2.1.1.3.0) - TimeTicks (hundredths of second)
 	a.mib.SetDynamic("1.3.6.1.2.1.1.3.0", func() *OIDValue {
-		uptime := time.Since(a.startTime)
-
-		ms := min(
-			// Convert to hundredths of second
-			uptime.Milliseconds()/millisecsPerCentisec, maxUint32)
-
-		timeticks := safeUint32(ms)
-
 		return &OIDValue{
 			Type:  gosnmp.TimeTicks,
-			Value: timeticks,
+			Value: a.sysUpTimeTicks(),
 		}
 	})
 
@@ -189,15 +185,81 @@ func (a *Agent) initializeSystemMIB() {
 	// Bit 2: internet (e.g., IP gateways)
 	// Bit 3: end-to-end  (e.g., IP hosts)
 	// Bit 6: application (e.g., mail relays)
-	sysServices := 72 // Typical for L3 device (bits 3 and 6)
 	a.mib.Set("1.3.6.1.2.1.1.7.0", &OIDValue{
 		Type:  gosnmp.Integer,
-		Value: sysServices,
+		Value: synth.SystemServices(profile.Type),
 	})
 
 	if a.debugLevel >= debugLevelVerbose {
 		a.logger.Debug("Initialized system MIB", "device", a.device.Name)
 	}
+}
+
+func systemProfile(device *config.Device) synth.Profile {
+	deviceType := synthDeviceType(device.Type)
+	profile, err := synth.Pick(synthVendor(device.MACVendor), deviceType)
+	if err == nil {
+		return profile
+	}
+
+	profile, _ = synth.Pick(synth.VendorGeneric, deviceType)
+	return profile
+}
+
+func synthVendor(vendor string) synth.Vendor {
+	switch strings.ToLower(strings.TrimSpace(vendor)) {
+	case "cisco", "cisco-ios":
+		return synth.VendorCiscoIOS
+	case "juniper", "junos":
+		return synth.VendorJunos
+	case "arista", "arista-eos":
+		return synth.VendorAristaEOS
+	case "aruba":
+		return synth.VendorAruba
+	case "extreme":
+		return synth.VendorExtreme
+	case "hp", "hpe":
+		return synth.VendorHP
+	default:
+		return synth.VendorGeneric
+	}
+}
+
+func synthDeviceType(deviceType string) synth.DeviceType {
+	switch strings.ToLower(strings.TrimSpace(deviceType)) {
+	case "switch":
+		return synth.TypeSwitch
+	case "router":
+		return synth.TypeRouter
+	case "firewall":
+		return synth.TypeFirewall
+	case "ap", "access-point", "access_point":
+		return synth.TypeAccessPoint
+	case "server":
+		return synth.TypeServer
+	case "printer":
+		return synth.TypePrinter
+	case "phone", "voip-phone", "voip_phone":
+		return synth.TypeVoIPPhone
+	default:
+		return synth.TypeHost
+	}
+}
+
+func simulatedUptimeBase(device *config.Device) time.Duration {
+	if device == nil {
+		return minimumDefaultUptime
+	}
+	if raw := strings.TrimSpace(device.Properties["uptimeSeconds"]); raw != "" {
+		seconds, err := strconv.ParseUint(raw, 10, 32)
+		if err == nil {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+
+	spreadSeconds := uint32(defaultUptimeSpread / time.Second)
+	offset := time.Duration(crc32.ChecksumIEEE([]byte(device.Name))%spreadSeconds) * time.Second
+	return minimumDefaultUptime + offset
 }
 
 // Reindex eagerly builds the agent's sorted OID index. Call after all MIB
@@ -325,13 +387,15 @@ func (a *Agent) ownsSynthesizedTopology() bool {
 
 // isSynthesizedTopologyOID reports whether oid falls under a MIB subtree that
 // trunk_ports synthesis owns — LLDP remote systems, CDP cache, and the bridge
-// forwarding DB — and so must not be loaded from a capture walk. Handles the
+// forwarding DBs — and so must not be loaded from a capture walk. Handles the
 // optional leading dot in walk OIDs.
 func isSynthesizedTopologyOID(oid string) bool {
 	prefixes := []string{
 		lldpRemoteSystemsData, // 1.0.8802.1.1.2.1.4 — LLDP-MIB neighbours
 		cdpCache,              // 1.3.6.1.4.1.9.9.23.1.2 — CDP cache neighbours
 		dot1dTpFdbTable,       // 1.3.6.1.2.1.17.4.3 — bridge MAC→port
+		dot1qFDBTable,         // 1.3.6.1.2.1.17.7.1.2.1 — VLAN FDB counters
+		dot1qTpFDBTable,       // 1.3.6.1.2.1.17.7.1.2.2 — VLAN MAC→port
 	}
 
 	trimmed := strings.TrimPrefix(oid, ".")

--- a/internal/protocols/snmp/agent_test.go
+++ b/internal/protocols/snmp/agent_test.go
@@ -142,6 +142,79 @@ func TestAgent_SystemMIB_DefaultValues(t *testing.T) {
 	}
 }
 
+func TestAgent_SystemIdentityMatchesDeviceRole(t *testing.T) {
+	tests := []struct {
+		name       string
+		deviceType string
+		vendor     string
+		objectID   string
+		services   int
+	}{
+		{
+			name: "cisco switch", deviceType: "switch", vendor: "cisco",
+			objectID: "1.3.6.1.4.1.9.1.1641", services: 2,
+		},
+		{
+			name: "cisco access point", deviceType: "access-point", vendor: "cisco",
+			objectID: "1.3.6.1.4.1.9.1.2659", services: 6,
+		},
+		{
+			name: "generic server", deviceType: "server", vendor: "dell",
+			objectID: "1.3.6.1.4.1.8072.3.2.10", services: 78,
+		},
+		{
+			name: "cisco voip phone", deviceType: "voip_phone", vendor: "cisco",
+			objectID: "1.3.6.1.4.1.9.1.404", services: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			device := createTestDevice()
+			device.Type = tt.deviceType
+			device.MACVendor = tt.vendor
+			agent := NewAgent(device, 0)
+
+			assertMIBValue(t, agent, "1.3.6.1.2.1.1.2.0", tt.objectID)
+			assertMIBValue(t, agent, "1.3.6.1.2.1.1.7.0", tt.services)
+		})
+	}
+}
+
+func TestAgent_DefaultUptimePredatesRecentRebootWindow(t *testing.T) {
+	device := createTestDevice()
+	agent := NewAgent(device, 0)
+
+	uptime := agent.mib.Get("1.3.6.1.2.1.1.3.0")
+	if uptime == nil {
+		t.Fatal("sysUpTime not initialized")
+	}
+	minimumTicks := uint32(minimumDefaultUptime / (10 * time.Millisecond))
+	if got := uptime.Value.(uint32); got < minimumTicks {
+		t.Fatalf("sysUpTime = %d, want at least %d", got, minimumTicks)
+	}
+}
+
+func TestAgent_AuthoredUptimeOverridesDefault(t *testing.T) {
+	device := createTestDevice()
+	device.Properties["uptimeSeconds"] = "86400"
+	agent := NewAgent(device, 0)
+
+	uptime := agent.mib.Get("1.3.6.1.2.1.1.3.0")
+	got := uptime.Value.(uint32)
+	const dayTicks = uint32(8_640_000)
+	if got < dayTicks || got > dayTicks+100 {
+		t.Fatalf("sysUpTime = %d, want approximately %d", got, dayTicks)
+	}
+}
+
+func TestUptimeTicksWrapsAtUint32(t *testing.T) {
+	overflow := time.Duration(Uint32Overflow) * 10 * time.Millisecond
+	if got := uptimeTicks(overflow + time.Second); got != 100 {
+		t.Fatalf("uptimeTicks after wrap = %d, want 100", got)
+	}
+}
+
 // TestAgent_SystemMIB_CustomProperties tests system MIB with custom properties.
 func TestAgent_SystemMIB_CustomProperties(t *testing.T) {
 	device := createTestDevice()

--- a/internal/protocols/snmp/constants.go
+++ b/internal/protocols/snmp/constants.go
@@ -82,6 +82,8 @@ const (
 	CapabilityWLANAP = 0x08
 	// CapabilityStationOnly is the Station Only capability bitmask.
 	CapabilityStationOnly = 0x80
+	// CapabilityTelephoneStation is the Telephone + Station Only capability bitmask.
+	CapabilityTelephoneStation = 0xA0
 
 	// BERLenByteMask is the mask for length bytes count in BER.
 	BERLenByteMask = 7
@@ -112,6 +114,8 @@ const (
 
 	// ChassisIDSubtypeMAC is the LLDP chassis ID subtype for MAC address.
 	ChassisIDSubtypeMAC = 4
+	// ChassisIDSubtypeLocal is the LLDP chassis ID subtype for a locally assigned value.
+	ChassisIDSubtypeLocal = 7
 
 	// PortIDSubtypeInterfaceName is the LLDP port ID subtype for interface name.
 	PortIDSubtypeInterfaceName = 5

--- a/internal/protocols/snmp/mib_discovery.go
+++ b/internal/protocols/snmp/mib_discovery.go
@@ -143,14 +143,13 @@ func (a *Agent) createLLDPRemoteEntry(timeMark, portNum, remIndex int, trunk con
 	indexStr := fmt.Sprintf("%d.%d.%d", timeMark, portNum, remIndex)
 	entryBase := lldpRemTable + ".1"
 
-	// lldpRemChassisIdSubtype (4 = macAddress)
+	// The fleet resolver replaces this temporary local identity with the
+	// remote MAC after every device has been loaded.
 	a.mib.Set(entryBase+".4."+indexStr, &OIDValue{
 		Type:  gosnmp.Integer,
-		Value: ChassisIDSubtypeMAC,
+		Value: ChassisIDSubtypeLocal,
 	})
 
-	// lldpRemChassisId - Use remote device name as chassis ID for now
-	// In a real implementation, we'd look up the remote device's MAC
 	a.mib.Set(entryBase+".5."+indexStr, &OIDValue{
 		Type:  gosnmp.OctetString,
 		Value: trunk.RemoteDevice,

--- a/internal/protocols/snmp/mib_helpers.go
+++ b/internal/protocols/snmp/mib_helpers.go
@@ -61,12 +61,14 @@ func getCapabilitiesBitfield(deviceType string) int {
 	deviceTypeLower := strings.ToLower(deviceType)
 
 	switch deviceTypeLower {
-	case "router":
+	case "router", "firewall":
 		return CapabilityRouterBridge // Router + Bridge
 	case "switch":
 		return CapabilityBridge // Bridge
-	case "ap", "access-point":
+	case "ap", "access-point", "access_point":
 		return CapabilityWLANAP // WLAN AP
+	case "phone", "voip-phone", "voip_phone":
+		return CapabilityTelephoneStation // Telephone + Station Only
 	case "server", "host":
 		return CapabilityStationOnly // Station Only
 	default:

--- a/internal/protocols/snmp/mib_qbridge.go
+++ b/internal/protocols/snmp/mib_qbridge.go
@@ -1,0 +1,135 @@
+package snmp
+
+import (
+	"strconv"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
+)
+
+const (
+	qBridgeMIBObjects          = "1.3.6.1.2.1.17.7.1"
+	dot1qVlanVersionNumber     = qBridgeMIBObjects + ".1.1.0"
+	dot1qMaxVlanID             = qBridgeMIBObjects + ".1.2.0"
+	dot1qMaxSupportedVLANs     = qBridgeMIBObjects + ".1.3.0"
+	dot1qNumVLANs              = qBridgeMIBObjects + ".1.4.0"
+	dot1qGVRPStatus            = qBridgeMIBObjects + ".1.5.0"
+	dot1qFDBTable              = qBridgeMIBObjects + ".2.1"
+	dot1qFDBDynamicCount       = qBridgeMIBObjects + ".2.1.1.2"
+	dot1qTpFDBTable            = qBridgeMIBObjects + ".2.2"
+	dot1qTpFDBAddress          = qBridgeMIBObjects + ".2.2.1.1"
+	dot1qTpFDBPort             = qBridgeMIBObjects + ".2.2.1.2"
+	dot1qTpFDBStatus           = qBridgeMIBObjects + ".2.2.1.3"
+	dot1qVlanFDBID             = qBridgeMIBObjects + ".4.2.1.3"
+	dot1qVlanStatus            = qBridgeMIBObjects + ".4.2.1.6"
+	dot1qVlanCreationTime      = qBridgeMIBObjects + ".4.2.1.7"
+	dot1qPVID                  = qBridgeMIBObjects + ".4.5.1.1"
+	maxVLANID                  = 4094
+	qBridgeVLANVersion         = 1
+	qBridgeGVRPDisabled        = 2
+	qBridgeVLANStatusPermanent = 2
+)
+
+func (a *Agent) initializeQBridgeMIB() {
+	vlans := configuredVLANs(a.device)
+	if len(vlans) == 0 {
+		return
+	}
+
+	a.mib.Set(dot1qVlanVersionNumber, &OIDValue{
+		Type: gosnmp.Integer, Value: qBridgeVLANVersion,
+	})
+	a.mib.Set(dot1qMaxVlanID, &OIDValue{Type: gosnmp.Integer, Value: maxVLANID})
+	a.mib.Set(dot1qMaxSupportedVLANs, &OIDValue{
+		Type: gosnmp.Gauge32, Value: uint32(maxVLANID),
+	})
+	a.mib.Set(dot1qNumVLANs, &OIDValue{
+		Type: gosnmp.Gauge32, Value: safeconv.Uint32(len(vlans)),
+	})
+	a.mib.Set(dot1qGVRPStatus, &OIDValue{
+		Type: gosnmp.Integer, Value: qBridgeGVRPDisabled,
+	})
+
+	for _, vlan := range vlans {
+		index := "0." + strconv.Itoa(vlan)
+		a.mib.Set(dot1qFDBDynamicCount+"."+strconv.Itoa(vlan), &OIDValue{
+			Type: gosnmp.Counter32, Value: uint32(0),
+		})
+		a.mib.Set(dot1qVlanFDBID+"."+index, &OIDValue{
+			Type: gosnmp.Gauge32, Value: safeconv.Uint32(vlan),
+		})
+		a.mib.Set(dot1qVlanStatus+"."+index, &OIDValue{
+			Type: gosnmp.Integer, Value: qBridgeVLANStatusPermanent,
+		})
+		a.mib.Set(dot1qVlanCreationTime+"."+index, &OIDValue{
+			Type: gosnmp.TimeTicks, Value: a.sysUpTimeTicks(),
+		})
+	}
+
+	a.initializeQBridgePVIDs()
+}
+
+func (a *Agent) initializeQBridgePVIDs() {
+	offset, hasOffset := a.basePortOffset()
+	maxPort := 0
+	for _, trunk := range a.device.TrunkPorts {
+		vlan := forwardingVLAN(trunk)
+		if vlan == 0 {
+			continue
+		}
+		port, ok := a.bridgePortForInterface(trunk.Interface, offset, hasOffset)
+		if !ok {
+			continue
+		}
+		a.mib.Set(dot1qPVID+"."+strconv.Itoa(port), &OIDValue{
+			Type: gosnmp.Gauge32, Value: safeconv.Uint32(vlan),
+		})
+		maxPort = max(maxPort, port)
+	}
+	a.raiseBaseNumPorts(maxPort)
+}
+
+func configuredVLANs(device *config.Device) []int {
+	if device == nil {
+		return nil
+	}
+
+	seen := make(map[int]struct{})
+	vlans := make([]int, 0)
+	for _, trunk := range device.TrunkPorts {
+		candidates := append([]int(nil), trunk.VLANs...)
+		candidates = append(candidates, forwardingVLAN(trunk))
+		for _, vlan := range candidates {
+			if vlan <= 0 || vlan > maxVLANID {
+				continue
+			}
+			if _, exists := seen[vlan]; exists {
+				continue
+			}
+			seen[vlan] = struct{}{}
+			vlans = append(vlans, vlan)
+		}
+	}
+	return vlans
+}
+
+func (a *Agent) addLearnedQBridgeFDBEntry(vlan int, mac []byte, bridgePort int) {
+	index := strconv.Itoa(vlan) + "." + macBytesToOIDIndex(mac)
+	portOID := dot1qTpFDBPort + "." + index
+	if a.mib.Get(portOID) == nil {
+		countOID := dot1qFDBDynamicCount + "." + strconv.Itoa(vlan)
+		count := oidCounterValue(a.mib.Get(countOID))
+		a.mib.Set(countOID, &OIDValue{
+			Type: gosnmp.Counter32, Value: safeconv.Uint32FromUint64(count + 1),
+		})
+	}
+	a.mib.Set(dot1qTpFDBAddress+"."+index, &OIDValue{
+		Type: gosnmp.OctetString, Value: mac,
+	})
+	a.mib.Set(portOID, &OIDValue{Type: gosnmp.Integer, Value: bridgePort})
+	a.mib.Set(dot1qTpFDBStatus+"."+index, &OIDValue{
+		Type: gosnmp.Integer, Value: FDBStatusLearned,
+	})
+}

--- a/internal/protocols/snmp/neighbor_mib.go
+++ b/internal/protocols/snmp/neighbor_mib.go
@@ -240,6 +240,7 @@ func (a *Agent) initializeNeighborMIBs() {
 
 	// Initialize BRIDGE-MIB (dot1dBridge - STP and FDB)
 	a.initializeBridgeMIB()
+	a.initializeQBridgeMIB()
 
 	// Initialize LLDP local system data
 	if device.LLDPConfig != nil && device.LLDPConfig.Enabled {
@@ -271,4 +272,5 @@ func (a *Agent) refreshAuthoredDiscoveryMIBs() {
 	if a.device.CDPConfig != nil && a.device.CDPConfig.Enabled {
 		a.initializeCDPMIB()
 	}
+	a.initializeQBridgePVIDs()
 }

--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -8,13 +8,16 @@ import (
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
 )
 
 // PeerIdentity contains the fleet-wide identity needed to synthesize discovery
 // and forwarding topology for a remote device.
 type PeerIdentity struct {
-	MAC     []byte
-	Address net.IP
+	MAC               []byte
+	Address           net.IP
+	Type              string
+	SystemDescription string
 }
 
 // PeerResolver returns the identity for a remote device and interface. The
@@ -54,21 +57,26 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerResolver) {
 	// table. Sampling per-port would drift as we add rows below.
 	offset, hasOffset := a.basePortOffset()
 
-	cdpIndex := 0
-	for _, trunk := range a.device.TrunkPorts {
+	remoteIndex := 0
+	for portIndex, trunk := range a.device.TrunkPorts {
 		if trunk.RemoteDevice == "" {
 			continue
 		}
 
 		if !trunk.FDBOnly {
-			cdpIndex++
+			remoteIndex++
 		}
 		peer, ok := resolve(trunk.RemoteDevice, trunk.RemoteInterface)
 		if !ok {
 			continue
 		}
 
-		changed = a.setCDPPeerAddress(trunk, peer.Address, cdpIndex) || changed
+		changed = a.setPeerDiscoveryIdentity(
+			trunk,
+			peer,
+			portIndex+1,
+			remoteIndex,
+		) || changed
 
 		if trunk.Interface == "" || len(peer.MAC) == 0 {
 			continue
@@ -79,6 +87,9 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerResolver) {
 		}
 
 		a.addLearnedFDBEntry(peer.MAC, bridgePort)
+		if vlan := forwardingVLAN(trunk); vlan > 0 {
+			a.addLearnedQBridgeFDBEntry(vlan, peer.MAC, bridgePort)
+		}
 
 		maxPort = max(maxPort, bridgePort)
 
@@ -94,7 +105,25 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerResolver) {
 	}
 }
 
-func (a *Agent) setCDPPeerAddress(trunk config.TrunkPort, address net.IP, index int) bool {
+func (a *Agent) setPeerDiscoveryIdentity(
+	trunk config.TrunkPort,
+	peer PeerIdentity,
+	fallbackIfIndex, remoteIndex int,
+) bool {
+	if trunk.FDBOnly {
+		return false
+	}
+	ifIndex := a.discoveryIfIndex(trunk.Interface, fallbackIfIndex)
+	cdpChanged := a.setCDPPeerAddress(trunk, peer.Address, ifIndex, remoteIndex)
+	lldpChanged := a.setLLDPPeerIdentity(trunk, peer, ifIndex, remoteIndex)
+	return cdpChanged || lldpChanged
+}
+
+func (a *Agent) setCDPPeerAddress(
+	trunk config.TrunkPort,
+	address net.IP,
+	ifIndex, deviceIndex int,
+) bool {
 	if trunk.FDBOnly || a.device.CDPConfig == nil || !a.device.CDPConfig.Enabled {
 		return false
 	}
@@ -103,13 +132,48 @@ func (a *Agent) setCDPPeerAddress(trunk config.TrunkPort, address net.IP, index 
 		return false
 	}
 
-	ifIndex := a.discoveryIfIndex(trunk.Interface, index)
-	row := strconv.Itoa(ifIndex) + "." + strconv.Itoa(index)
+	row := strconv.Itoa(ifIndex) + "." + strconv.Itoa(deviceIndex)
 	a.mib.Set(cdpCacheTable+".1.4."+row, &OIDValue{
 		Type:  gosnmp.OctetString,
 		Value: []byte(ipv4),
 	})
 	return true
+}
+
+func (a *Agent) setLLDPPeerIdentity(
+	trunk config.TrunkPort,
+	peer PeerIdentity,
+	ifIndex, remoteIndex int,
+) bool {
+	if trunk.FDBOnly || a.device.LLDPConfig == nil || !a.device.LLDPConfig.Enabled ||
+		len(peer.MAC) == 0 {
+		return false
+	}
+
+	row := "0." + strconv.Itoa(ifIndex) + "." + strconv.Itoa(remoteIndex)
+	entry := lldpRemTable + ".1"
+	a.mib.Set(entry+".4."+row, &OIDValue{Type: gosnmp.Integer, Value: ChassisIDSubtypeMAC})
+	a.mib.Set(entry+".5."+row, &OIDValue{Type: gosnmp.OctetString, Value: peer.MAC})
+	if peer.SystemDescription != "" {
+		a.mib.Set(entry+".10."+row, &OIDValue{
+			Type: gosnmp.OctetString, Value: peer.SystemDescription,
+		})
+	}
+	capabilities := safeconv.Uint32(getCapabilitiesBitfield(peer.Type))
+	bits := []byte{
+		safeconv.ByteFromUint32(capabilities >> BitShiftByte),
+		safeconv.ByteFromUint32(capabilities),
+	}
+	a.mib.Set(entry+".11."+row, &OIDValue{Type: gosnmp.OctetString, Value: bits})
+	a.mib.Set(entry+".12."+row, &OIDValue{Type: gosnmp.OctetString, Value: bits})
+	return true
+}
+
+func forwardingVLAN(trunk config.TrunkPort) int {
+	if trunk.NativeVLAN > 0 {
+		return trunk.NativeVLAN
+	}
+	return 1
 }
 
 // bridgePortForInterface resolves an interface name (e.g. "FastEthernet0/5") to

--- a/internal/protocols/snmp/peer_topology_test.go
+++ b/internal/protocols/snmp/peer_topology_test.go
@@ -76,6 +76,7 @@ func TestAuthoredDiscoveryUsesWalkInterfaceIdentityEndToEnd(t *testing.T) {
 	dev.CDPConfig = &config.CDPConfig{Enabled: true}
 	dev.TrunkPorts = []config.TrunkPort{{
 		Interface: "FastEthernet0/5", RemoteDevice: "PC01", RemoteInterface: "eth0",
+		VLANs: []int{200}, NativeVLAN: 200,
 	}}
 	dev.Interfaces = []config.Interface{{
 		Name: "FastEthernet0/5", Speed: 100, Duplex: "half", AdminStatus: "down",
@@ -103,6 +104,7 @@ func TestAuthoredDiscoveryUsesWalkInterfaceIdentityEndToEnd(t *testing.T) {
 	assertMIBValue(t, agent, cdpCacheTable+".1.6.10005.1", "PC01")
 	assertMIBValue(t, agent, dot1dBasePortIfIndex+".5", 10005)
 	assertMIBValue(t, agent, dot1dTpFdbPort+"."+macBytesToOIDIndex(pcMAC), 5)
+	assertMIBValue(t, agent, dot1qPVID+".5", 200)
 	assertMIBValue(t, agent, ifSpeed+".10005", 100000000)
 	assertMIBValue(t, agent, ifHighSpeed+".10005", 100)
 	assertMIBValue(t, agent, ifAdminStatus+".10005", 2)
@@ -122,7 +124,8 @@ func TestFDBOnlyAttachmentLearnsMACWithoutInventingNeighbor(t *testing.T) {
 	dev.CDPConfig = &config.CDPConfig{Enabled: true}
 	dev.Interfaces = []config.Interface{{Name: "FastEthernet0/5"}}
 	dev.TrunkPorts = []config.TrunkPort{{
-		Interface: "FastEthernet0/5", RemoteDevice: "PC01", RemoteInterface: "eth0", FDBOnly: true,
+		Interface: "FastEthernet0/5", RemoteDevice: "PC01", RemoteInterface: "eth0",
+		VLANs: []int{210}, NativeVLAN: 210, FDBOnly: true,
 	}}
 	agent := NewAgent(dev, 0)
 	pcMAC, _ := net.ParseMAC("aa:bb:cc:00:00:21")
@@ -132,12 +135,106 @@ func TestFDBOnlyAttachmentLearnsMACWithoutInventingNeighbor(t *testing.T) {
 
 	assertMIBValue(t, agent, lldpLocPortTable+".1.3.1", "FastEthernet0/5")
 	assertMIBValue(t, agent, dot1dTpFdbPort+"."+macBytesToOIDIndex(pcMAC), 1)
+	qBridgeIndex := "210." + macBytesToOIDIndex(pcMAC)
+	assertMIBValue(t, agent, dot1qTpFDBAddress+"."+qBridgeIndex, []byte(pcMAC))
+	assertMIBValue(t, agent, dot1qTpFDBPort+"."+qBridgeIndex, 1)
+	assertMIBValue(t, agent, dot1qTpFDBStatus+"."+qBridgeIndex, FDBStatusLearned)
+	assertMIBValue(t, agent, dot1qFDBDynamicCount+".210", uint32(1))
+	if got := agent.mib.Get(dot1qFDBDynamicCount + ".210").Type; got != gosnmp.Counter32 {
+		t.Fatalf("dot1qFdbDynamicCount type = %v, want Counter32", got)
+	}
+	assertMIBValue(t, agent, dot1qVlanFDBID+".0.210", uint32(210))
+	assertMIBValue(t, agent, dot1qPVID+".1", 210)
 	for _, prefix := range []string{lldpRemTable, cdpCacheTable} {
 		for _, oid := range agent.mib.AllOIDs() {
 			if strings.HasPrefix(oid, prefix+".") {
 				t.Fatalf("FDB-only host produced discovery neighbor %s", oid)
 			}
 		}
+	}
+}
+
+func TestQBridgeUsesDefaultNativeVLAN(t *testing.T) {
+	dev := createTestDevice()
+	dev.Type = "switch"
+	dev.Interfaces = []config.Interface{{Name: "FastEthernet0/5"}}
+	dev.TrunkPorts = []config.TrunkPort{{
+		Interface: "FastEthernet0/5", RemoteDevice: "PC01",
+		VLANs: []int{200, 220}, FDBOnly: true,
+	}}
+	agent := NewAgent(dev, 0)
+	pcMAC, _ := net.ParseMAC("aa:bb:cc:00:00:21")
+	agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+		return PeerIdentity{MAC: pcMAC}, true
+	})
+
+	qBridgeIndex := "1." + macBytesToOIDIndex(pcMAC)
+	assertMIBValue(t, agent, dot1qTpFDBPort+"."+qBridgeIndex, 1)
+	assertMIBValue(t, agent, dot1qVlanFDBID+".0.1", uint32(1))
+	assertMIBValue(t, agent, dot1qPVID+".1", 1)
+	if got := agent.mib.Get(dot1qMaxVlanID).Type; got != gosnmp.Integer {
+		t.Fatalf("dot1qMaxVlanId type = %v, want Integer", got)
+	}
+	if got := agent.mib.Get(dot1qPVID + ".1").Type; got != gosnmp.Gauge32 {
+		t.Fatalf("dot1qPVID type = %v, want Gauge32", got)
+	}
+}
+
+func TestSynthesizePeerTopologyPublishesResolvedLLDPIdentity(t *testing.T) {
+	dev := createTestDevice()
+	dev.Type = "switch"
+	dev.LLDPConfig = &config.LLDPConfig{Enabled: true}
+	dev.Interfaces = []config.Interface{{Name: "TenGigabitEthernet1/0/1"}}
+	dev.TrunkPorts = []config.TrunkPort{{
+		Interface: "TenGigabitEthernet1/0/1", RemoteDevice: "AP01",
+		RemoteInterface: "mGigabitEthernet0", VLANs: []int{200, 220}, NativeVLAN: 200,
+	}}
+	agent := NewAgent(dev, 0)
+	apMAC, _ := net.ParseMAC("aa:bb:cc:00:00:31")
+	agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+		return PeerIdentity{
+			MAC: apMAC, Type: "access_point",
+			SystemDescription: "Cisco Wireless CW9178I Wi-Fi 7 access point",
+		}, true
+	})
+
+	row := "0.1.1"
+	assertMIBValue(t, agent, lldpRemTable+".1.4."+row, ChassisIDSubtypeMAC)
+	assertMIBValue(t, agent, lldpRemTable+".1.5."+row, []byte(apMAC))
+	assertMIBValue(
+		t,
+		agent,
+		lldpRemTable+".1.10."+row,
+		"Cisco Wireless CW9178I Wi-Fi 7 access point",
+	)
+	assertMIBValue(t, agent, lldpRemTable+".1.11."+row, []byte{0, CapabilityWLANAP})
+	assertMIBValue(t, agent, lldpRemTable+".1.12."+row, []byte{0, CapabilityWLANAP})
+}
+
+func TestLLDPPeerCapabilitiesCoverSupportedRoles(t *testing.T) {
+	tests := []struct {
+		deviceType string
+		want       byte
+	}{
+		{deviceType: "firewall", want: CapabilityRouterBridge},
+		{deviceType: "voip_phone", want: CapabilityTelephoneStation},
+	}
+	for _, tt := range tests {
+		t.Run(tt.deviceType, func(t *testing.T) {
+			dev := createTestDevice()
+			dev.Type = "switch"
+			dev.LLDPConfig = &config.LLDPConfig{Enabled: true}
+			dev.Interfaces = []config.Interface{{Name: "GigabitEthernet0/1"}}
+			dev.TrunkPorts = []config.TrunkPort{{
+				Interface: "GigabitEthernet0/1", RemoteDevice: "PEER",
+			}}
+			agent := NewAgent(dev, 0)
+			mac, _ := net.ParseMAC("aa:bb:cc:00:00:31")
+			agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+				return PeerIdentity{MAC: mac, Type: tt.deviceType}, true
+			})
+			assertMIBValue(t, agent, lldpRemTable+".1.11.0.1.1", []byte{0, tt.want})
+		})
 	}
 }
 

--- a/internal/protocols/snmp/safeconv.go
+++ b/internal/protocols/snmp/safeconv.go
@@ -61,9 +61,11 @@ func safeUint32FromInt(v int) uint32 {
 // uptimeTicks converts a duration to SNMP timeticks (centiseconds).
 // SNMP timeticks are 32-bit values that wrap around by design.
 func uptimeTicks(d time.Duration) uint32 {
-	ms := d.Milliseconds() / CentisecsPerSec // centiseconds
-
-	return safeUint32(ms)
+	if d <= 0 {
+		return 0
+	}
+	tick := time.Duration(MillisecsPerCentisec) * time.Millisecond
+	return wrapCounter32(uint64(d / tick))
 }
 
 // safeUint32FromUint64 converts a uint64 to uint32 with bounds checking.

--- a/internal/protocols/snmp/synth/build.go
+++ b/internal/protocols/snmp/synth/build.go
@@ -96,14 +96,14 @@ func emitSystemGroup(buf *bytes.Buffer, p Profile, dev DeviceInput) {
 	emitString(buf, "1.3.6.1.2.1.1.4.0", "niac-baseline-synth")   // sysContact
 	emitString(buf, "1.3.6.1.2.1.1.5.0", dev.Hostname)            // sysName
 	emitString(buf, "1.3.6.1.2.1.1.6.0", "synthesised by niac")   // sysLocation
-	emitInteger(buf, "1.3.6.1.2.1.1.7.0", sysServicesFor(p.Type)) // sysServices
+	emitInteger(buf, "1.3.6.1.2.1.1.7.0", SystemServices(p.Type)) // sysServices
 }
 
-// sysServices is the bitmask of layers this device operates at.
+// SystemServices returns the sysServices bitmask for a simulated device type.
 // Bit 1=physical, 2=datalink, 4=internet, 8=end-to-end, 64=apps.
 // Switches operate at L2 (2). Routers + firewalls at L3 (4+2=6).
 // Hosts/servers/printers at L7 (64+8+4+2=78).
-func sysServicesFor(t DeviceType) int {
+func SystemServices(t DeviceType) int {
 	switch t {
 	case TypeSwitch:
 		return servicesL2

--- a/internal/protocols/snmp/walk_topology_test.go
+++ b/internal/protocols/snmp/walk_topology_test.go
@@ -19,14 +19,19 @@ const topoWalk = `.1.3.6.1.2.1.1.1.0 = STRING: "captured description"
 .1.0.8802.1.1.2.1.4.1.1.9.1.1 = STRING: "foreign-lldp-neighbor"
 .1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1 = STRING: "foreign-cdp-device"
 .1.3.6.1.2.1.17.4.3.1.2.1.2.3.4.5.6 = INTEGER: 5
+.1.3.6.1.2.1.17.7.1.2.1.1.2.210 = Gauge32: 1
+.1.3.6.1.2.1.17.7.1.2.2.1.2.210.1.2.3.4.5.6 = INTEGER: 5
+.1.3.6.1.2.1.17.7.1.4.5.1.1.9 = INTEGER: 220
 `
 
 func TestIsSynthesizedTopologyOID(t *testing.T) {
 	strip := []string{
-		"1.0.8802.1.1.2.1.4",                  // lldpRemoteSystemsData root
-		".1.0.8802.1.1.2.1.4.1.1.9.1.1",       // lldpRemTable entry (leading dot)
-		".1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1",   // cdpCacheTable entry
-		".1.3.6.1.2.1.17.4.3.1.2.1.2.3.4.5.6", // dot1dTpFdbTable entry
+		"1.0.8802.1.1.2.1.4",                          // lldpRemoteSystemsData root
+		".1.0.8802.1.1.2.1.4.1.1.9.1.1",               // lldpRemTable entry (leading dot)
+		".1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1",           // cdpCacheTable entry
+		".1.3.6.1.2.1.17.4.3.1.2.1.2.3.4.5.6",         // dot1dTpFdbTable entry
+		".1.3.6.1.2.1.17.7.1.2.1.1.2.210",             // dot1qFdbTable entry
+		".1.3.6.1.2.1.17.7.1.2.2.1.2.210.1.2.3.4.5.6", // dot1qTpFdbTable entry
 	}
 	keep := []string{
 		".1.3.6.1.2.1.2.2.1.2.1",      // ifDescr (device content)
@@ -71,6 +76,7 @@ func TestLoadWalkFileStripsTopologyWhenTrunkPortsDeclared(t *testing.T) {
 	const (
 		lldpRem = ".1.0.8802.1.1.2.1.4.1.1.9.1.1"
 		cdpCch  = ".1.3.6.1.4.1.9.9.23.1.2.1.1.6.1.1"
+		qFdb    = ".1.3.6.1.2.1.17.7.1.2.2.1.2.210.1.2.3.4.5.6"
 		ifDescr = ".1.3.6.1.2.1.2.2.1.2.1"
 	)
 
@@ -87,6 +93,12 @@ func TestLoadWalkFileStripsTopologyWhenTrunkPortsDeclared(t *testing.T) {
 	}
 	if v, _ := trunks.HandleGet(cdpCch); v != nil {
 		t.Errorf("with trunk_ports, walk CDP cache must be skipped, got %v", v.Value)
+	}
+	if v, _ := trunks.HandleGet(qFdb); v != nil {
+		t.Errorf("with trunk_ports, walk Q-BRIDGE FDB must be skipped, got %v", v.Value)
+	}
+	if v, _ := trunks.HandleGet(".1.3.6.1.2.1.17.7.1.4.5.1.1.9"); v == nil || v.Value != 220 {
+		t.Errorf("captured PVID outside authored ports must survive, got %v", v)
 	}
 	// Device content survives the strip.
 	if v, _ := trunks.HandleGet(ifDescr); v == nil {

--- a/internal/protocols/stack_snmp.go
+++ b/internal/protocols/stack_snmp.go
@@ -138,10 +138,22 @@ func (s *Stack) peerResolver() snmp.PeerResolver {
 		}
 
 		return snmp.PeerIdentity{
-			MAC:     device.MACAddress,
-			Address: peerInterfaceAddress(device, interfaceName),
+			MAC:               device.MACAddress,
+			Address:           peerInterfaceAddress(device, interfaceName),
+			Type:              device.Type,
+			SystemDescription: peerSystemDescription(device),
 		}, true
 	}
+}
+
+func peerSystemDescription(device *config.Device) string {
+	if device.LLDPConfig != nil && device.LLDPConfig.SystemDescription != "" {
+		return device.LLDPConfig.SystemDescription
+	}
+	if device.SNMPConfig.SysDescr != "" {
+		return device.SNMPConfig.SysDescr
+	}
+	return device.Type + " " + device.Name
 }
 
 func peerInterfaceAddress(device *config.Device, interfaceName string) net.IP {


### PR DESCRIPTION
## Summary
- derive SNMP system identity and services from each simulated device role and vendor
- publish resolved LLDP peer identity and standards-correct Q-BRIDGE forwarding data
- make simulated uptime realistic while preserving TimeTicks wrap behavior
- keep authored topology authoritative over captured neighbor and forwarding rows

## Linked Issue
Closes #1140

## Testing Evidence
```
make lint: 0 issues; Biome checked 329 files
make fmt-check: all formatting checks passed
make test: 43 Go packages and 69 frontend test files passed; coverage 67.0%
make security: govulncheck clean; npm audit 0 vulnerabilities; gitleaks no leaks
make test-e2e: 186 passed, 6 skipped; authenticated Chrome/Safari/Firefox 3 passed
make build: complete with Node 26.5.0 and npm 12.0.1
focused SNMP topology tests: passed
```

## Security and Release Checklist
- [x] No secrets or credentials added
- [x] No authentication, authorization, CSRF, or CORS behavior changed
- [x] Dependency vulnerability scans are clean
- [x] Independent code review completed; all substantiated findings addressed
- [x] Release requires GitHub Actions artifacts, checksums, provenance, and signatures
- [ ] Deploy the released package to CT 304
- [ ] Repeat CyberScope VLAN 200 Discovery and Link-Live topology-map acceptance
