### PR TITLE
fix(snmp): correlate routed clients in discovery

### DIFF
--- a/internal/protocols/snmp/agent_test.go
+++ b/internal/protocols/snmp/agent_test.go
@@ -156,7 +156,7 @@ func TestAgent_SystemIdentityMatchesDeviceRole(t *testing.T) {
 		},
 		{
 			name: "cisco access point", deviceType: "access-point", vendor: "cisco",
-			objectID: "1.3.6.1.4.1.9.1.2659", services: 6,
+			objectID: "1.3.6.1.4.1.9.1.2877", services: 6,
 		},
 		{
 			name: "generic server", deviceType: "server", vendor: "dell",

--- a/internal/protocols/snmp/arp_topology.go
+++ b/internal/protocols/snmp/arp_topology.go
@@ -1,0 +1,86 @@
+package snmp
+
+import (
+	"net"
+	"strings"
+)
+
+// ARPBinding is an authoritative IP-to-MAC association from the simulated fleet.
+type ARPBinding struct {
+	Address net.IP
+	MAC     net.HardwareAddr
+}
+
+type arpInterface struct {
+	index   int
+	network *net.IPNet
+	prefix  int
+}
+
+// SynthesizeARPTable publishes directly connected fleet devices in a router's
+// standard IP-MIB tables so managers can correlate routed IPs with bridge FDBs.
+func (a *Agent) SynthesizeARPTable(bindings []ARPBinding) {
+	if a == nil || a.device == nil || !isForwardingDevice(a.device.Type) {
+		return
+	}
+	interfaces := a.connectedARPInterfaces()
+	changed := false
+	for _, binding := range bindings {
+		iface, ok := bestARPInterface(interfaces, binding.Address)
+		if !ok || a.isLocalAddress(binding.Address) || len(binding.MAC) == 0 {
+			continue
+		}
+		a.registerARPEntry(iface.index, binding.Address, binding.MAC)
+		changed = true
+	}
+	if changed {
+		a.mib.Reindex()
+	}
+}
+
+func isForwardingDevice(deviceType string) bool {
+	switch strings.ToLower(strings.TrimSpace(deviceType)) {
+	case "router", "firewall":
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *Agent) connectedARPInterfaces() []arpInterface {
+	result := make([]arpInterface, 0, len(a.device.Interfaces))
+	for _, iface := range a.device.Interfaces {
+		ip, network, err := net.ParseCIDR(iface.Address)
+		if err != nil || ip.To4() == nil {
+			continue
+		}
+		index, ok := a.InterfaceIndex(iface.Name)
+		if !ok {
+			continue
+		}
+		prefix, _ := network.Mask.Size()
+		result = append(result, arpInterface{index: index, network: network, prefix: prefix})
+	}
+	return result
+}
+
+func bestARPInterface(interfaces []arpInterface, address net.IP) (arpInterface, bool) {
+	var best arpInterface
+	found := false
+	for _, iface := range interfaces {
+		if iface.network.Contains(address) && (!found || iface.prefix > best.prefix) {
+			best, found = iface, true
+		}
+	}
+	return best, found
+}
+
+func (a *Agent) isLocalAddress(address net.IP) bool {
+	for _, iface := range a.device.Interfaces {
+		local, _, err := net.ParseCIDR(iface.Address)
+		if err == nil && local.Equal(address) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/protocols/snmp/synth/profiles.go
+++ b/internal/protocols/snmp/synth/profiles.go
@@ -199,7 +199,7 @@ var profileTable = func() map[profileKey]Profile {
 	add(
 		VendorCiscoIOS,
 		TypeAccessPoint,
-		withFlags(cisco("Aironet 2802i", "2659", "Dot11Radio%d", defaultIfAP), false, false, true, false),
+		withFlags(cisco("Catalyst 9130AXI", "2877", "Dot11Radio%d", defaultIfAP), false, false, true, false),
 	)
 	add(
 		VendorCiscoIOS,

--- a/internal/protocols/snmp_agents.go
+++ b/internal/protocols/snmp_agents.go
@@ -115,6 +115,16 @@ func (g *snmpAgentGroup) SynthesizePeerTopologyAll(resolve snmp.PeerResolver) {
 	}
 }
 
+func (g *snmpAgentGroup) SynthesizeARPTableAll(bindings []snmp.ARPBinding) {
+	if g == nil {
+		return
+	}
+
+	for _, agent := range g.agents {
+		agent.SynthesizeARPTable(bindings)
+	}
+}
+
 func (g *snmpAgentGroup) Communities() []string {
 	if g == nil {
 		return nil

--- a/internal/protocols/stack_snmp.go
+++ b/internal/protocols/stack_snmp.go
@@ -84,10 +84,13 @@ func (s *Stack) initSNMPAgent(device *config.Device) {
 	// Now that the MIB is loaded, fill downstream bridge FDB entries from the
 	// fleet roster (a host MAC on the access port it hangs off) so a scanner can
 	// answer "nearest switch/port" for discovered hosts.
+	arpBindings := s.arpBindings()
 	if !v2Enabled {
 		baseAgent.SynthesizePeerTopology(s.peerResolver())
+		baseAgent.SynthesizeARPTable(arpBindings)
 	}
 	group.SynthesizePeerTopologyAll(s.peerResolver())
+	group.SynthesizeARPTableAll(arpBindings)
 
 	// Every MIB is now fully loaded (walk files, AddMib, topology, peer FDB).
 	// Build the sorted OID indexes eagerly so the first GetNext of a discovery

--- a/internal/protocols/stack_snmp_arp.go
+++ b/internal/protocols/stack_snmp_arp.go
@@ -1,0 +1,26 @@
+package protocols
+
+import (
+	"net"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp"
+)
+
+func (s *Stack) arpBindings() []snmp.ARPBinding {
+	bindings := make([]snmp.ARPBinding, 0, len(s.config.Devices))
+	for i := range s.config.Devices {
+		device := &s.config.Devices[i]
+		if len(device.MACAddress) == 0 {
+			continue
+		}
+		for _, iface := range device.Interfaces {
+			address, _, err := net.ParseCIDR(iface.Address)
+			if err == nil && address.To4() != nil {
+				bindings = append(bindings, snmp.ARPBinding{
+					Address: address.To4(), MAC: device.MACAddress,
+				})
+			}
+		}
+	}
+	return bindings
+}

--- a/internal/protocols/stack_snmp_topology_test.go
+++ b/internal/protocols/stack_snmp_topology_test.go
@@ -53,6 +53,49 @@ func TestSNMPTopologyUsesAuthoredCDPPeerAddress(t *testing.T) {
 	}
 }
 
+func TestSNMPTopologyPublishesRouterARPForConnectedHost(t *testing.T) {
+	hostMAC := mustTestMAC(t, "00:1a:2b:00:00:21")
+	cfg := &config.Config{Devices: []config.Device{
+		{
+			Name: "COS-CORE-SW01", Type: "router",
+			MACAddress: mustTestMAC(t, "00:00:0c:00:01:01"),
+			Interfaces: []config.Interface{{
+				Name: "Vlan210", Address: "10.240.210.2/24",
+			}},
+			SNMPConfig: config.SNMPConfig{Community: "NetAllyDemo"},
+		},
+		{
+			Name: "COS-WS-B01-F01-01", Type: "host", MACAddress: hostMAC,
+			Interfaces: []config.Interface{{
+				Name: "eth0", Address: "10.240.210.21/24",
+			}},
+		},
+		{
+			Name: "REMOTE-WS01", Type: "host",
+			MACAddress: mustTestMAC(t, "00:1a:2b:00:01:21"),
+			Interfaces: []config.Interface{{
+				Name: "eth0", Address: "10.241.210.21/24",
+			}},
+		},
+	}}
+
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	agent := stack.snmpAgents[&cfg.Devices[0]].baseAgent
+	const arpMAC = "1.3.6.1.2.1.4.22.1.2.1.10.240.210.21"
+	value, err := agent.HandleGet(arpMAC)
+	if err != nil {
+		t.Fatalf("get connected host ARP entry: %v", err)
+	}
+	got, ok := value.Value.([]byte)
+	if !ok || !bytes.Equal(got, hostMAC) {
+		t.Fatalf("connected host ARP MAC = %v, want %v", value.Value, hostMAC)
+	}
+	const remoteARP = "1.3.6.1.2.1.4.22.1.2.1.10.241.210.21"
+	if _, remoteErr := agent.HandleGet(remoteARP); remoteErr == nil {
+		t.Fatal("router published ARP entry for a host outside its connected subnet")
+	}
+}
+
 func mustTestMAC(t *testing.T, raw string) net.HardwareAddr {
 	t.Helper()
 	mac, err := net.ParseMAC(raw)


### PR DESCRIPTION
## Summary
- publish directly connected fleet IP-to-MAC bindings through router IP-MIB ARP tables
- preserve Layer-2 client MAC-to-port placement through the existing bridge/Q-BRIDGE tables
- advertise Cisco access points with a recognized Catalyst AP sysObjectID

## Linked Issue

Related to #1143

## Testing Evidence

```text
make fmt-check: passed
make lint: 0 issues
make test: passed, 66.9% aggregate Go coverage
make security: no vulnerabilities or secrets
make build: frontend and backend passed
make test-e2e: 186 passed, 6 intentionally skipped; auth 3 passed
staged Codex review: no actionable correctness issues
```

## Security and Release Checklist

- [x] No authentication, authorization, or secret-handling changes
- [x] govulncheck, npm audit, and gitleaks passed
- [x] Full backend and frontend build passed
- [x] Cross-browser E2E passed
- [x] Requires fresh CyberScope and Link-Live acceptance after release
