### PR TITLE
fix(snmp): preserve discovery device roles

### DIFF
--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -311,7 +311,7 @@ func (a *Agent) LoadWalkFile(filename string) error {
 		})
 		loaded++
 	}
-	if a.mib.Get(dot1dBaseNumPorts) == nil {
+	if a.supportsSynthesizedBridgeMIB() && a.mib.Get(dot1dBaseNumPorts) == nil {
 		a.initializeBridgeMIB()
 	}
 	a.registerLiveMIBIIProtocolCounters()

--- a/internal/protocols/snmp/neighbor_mib.go
+++ b/internal/protocols/snmp/neighbor_mib.go
@@ -238,9 +238,12 @@ func (a *Agent) initializeNeighborMIBs() {
 	// Initialize IP-MIB (IP address table, routing table)
 	a.initializeIPMIB()
 
-	// Initialize BRIDGE-MIB (dot1dBridge - STP and FDB)
-	a.initializeBridgeMIB()
-	a.initializeQBridgeMIB()
+	// Discovery managers use bridge tables as device-role evidence. Only bridge
+	// profiles synthesize them; authoritative walk data remains untouched.
+	if a.supportsSynthesizedBridgeMIB() {
+		a.initializeBridgeMIB()
+		a.initializeQBridgeMIB()
+	}
 
 	// Initialize LLDP local system data
 	if device.LLDPConfig != nil && device.LLDPConfig.Enabled {
@@ -272,5 +275,7 @@ func (a *Agent) refreshAuthoredDiscoveryMIBs() {
 	if a.device.CDPConfig != nil && a.device.CDPConfig.Enabled {
 		a.initializeCDPMIB()
 	}
-	a.initializeQBridgePVIDs()
+	if a.supportsBridgeTopology() {
+		a.initializeQBridgePVIDs()
+	}
 }

--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -78,6 +78,9 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerResolver) {
 			remoteIndex,
 		) || changed
 
+		if !a.supportsBridgeTopology() {
+			continue
+		}
 		if trunk.Interface == "" || len(peer.MAC) == 0 {
 			continue
 		}
@@ -103,6 +106,15 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerResolver) {
 		a.raiseBaseNumPorts(maxPort)
 		a.mib.Reindex()
 	}
+}
+
+func (a *Agent) supportsSynthesizedBridgeMIB() bool {
+	return a != nil && a.device != nil && systemProfile(a.device).IncludeBridge
+}
+
+func (a *Agent) supportsBridgeTopology() bool {
+	return a.supportsSynthesizedBridgeMIB() ||
+		(a.hasWalkContent() && a.mib.Get(dot1dBaseNumPorts) != nil)
 }
 
 func (a *Agent) setPeerDiscoveryIdentity(

--- a/internal/protocols/snmp/peer_topology_test.go
+++ b/internal/protocols/snmp/peer_topology_test.go
@@ -211,6 +211,29 @@ func TestSynthesizePeerTopologyPublishesResolvedLLDPIdentity(t *testing.T) {
 	assertMIBValue(t, agent, lldpRemTable+".1.12."+row, []byte{0, CapabilityWLANAP})
 }
 
+func TestSynthesizePeerTopologyDoesNotTurnAccessPointIntoBridge(t *testing.T) {
+	dev := createTestDevice()
+	dev.Type = "access-point"
+	dev.LLDPConfig = &config.LLDPConfig{Enabled: true}
+	dev.Interfaces = []config.Interface{{Name: "mGigabitEthernet0"}}
+	dev.TrunkPorts = []config.TrunkPort{{
+		Interface: "mGigabitEthernet0", RemoteDevice: "ACCESS-SW01",
+		RemoteInterface: "TenGigabitEthernet1/0/1", NativeVLAN: 200,
+	}}
+	agent := NewAgent(dev, 0)
+	switchMAC, _ := net.ParseMAC("aa:bb:cc:00:00:41")
+	agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+		return PeerIdentity{MAC: switchMAC, Type: "switch"}, true
+	})
+
+	assertMIBValue(t, agent, lldpRemTable+".1.9.0.1.1", "ACCESS-SW01")
+	for _, oid := range agent.mib.AllOIDs() {
+		if oid == dot1dBridge || strings.HasPrefix(oid, dot1dBridge+".") {
+			t.Fatalf("access point published bridge OID %s", oid)
+		}
+	}
+}
+
 func TestLLDPPeerCapabilitiesCoverSupportedRoles(t *testing.T) {
 	tests := []struct {
 		deviceType string


### PR DESCRIPTION
## Summary
- synthesize BRIDGE-MIB and Q-BRIDGE-MIB data only for actual bridge-capable switch profiles
- preserve authoritative bridge data supplied by real SNMP walk captures
- retain LLDP/CDP topology relationships for APs, servers, routers, and firewalls without misclassifying them as switches

## Linked Issue

Fixes #1145

## Testing Evidence

```text
make fmt-check: passed
make lint: 0 issues
make test: passed, 66.9% aggregate Go coverage
make security: no vulnerabilities or secrets
make build: frontend and backend passed
make test-e2e: 186 passed, 6 intentionally skipped; auth 3 passed
Codex review: no actionable regressions identified
```

## Security and Release Checklist

- [x] No authentication, authorization, or secret-handling changes
- [x] govulncheck, npm audit, and gitleaks passed
- [x] Full backend and frontend build passed
- [x] Cross-browser E2E passed
- [x] Requires fresh CyberScope and Link-Live acceptance after release
