### PR TITLE
feat: add revisioned scenario draft storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	go.etcd.io/bbolt v1.5.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -56,7 +57,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/exp v0.0.0-20260718201538-764159d718ef // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/internal/library/draft_lock_unix.go
+++ b/internal/library/draft_lock_unix.go
@@ -1,0 +1,20 @@
+//go:build darwin || linux
+
+package library
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockDraftFile(file *os.File, exclusive bool) (func(), error) {
+	mode := unix.LOCK_SH
+	if exclusive {
+		mode = unix.LOCK_EX
+	}
+	if err := unix.Flock(int(file.Fd()), mode); err != nil {
+		return nil, err
+	}
+	return func() { _ = unix.Flock(int(file.Fd()), unix.LOCK_UN) }, nil
+}

--- a/internal/library/draft_lock_windows.go
+++ b/internal/library/draft_lock_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package library
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockDraftFile(file *os.File, exclusive bool) (func(), error) {
+	overlapped := &windows.Overlapped{}
+	handle := windows.Handle(file.Fd())
+	var flags uint32
+	if exclusive {
+		flags = windows.LOCKFILE_EXCLUSIVE_LOCK
+	}
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, overlapped); err != nil {
+		return nil, err
+	}
+	return func() { _ = windows.UnlockFileEx(handle, 0, 1, 0, overlapped) }, nil
+}

--- a/internal/library/draft_sync_unix.go
+++ b/internal/library/draft_sync_unix.go
@@ -1,0 +1,17 @@
+//go:build darwin || linux
+
+package library
+
+import "fmt"
+
+func (l *Library) syncDraftDirectory() error {
+	dir, err := l.draftRoot.Open(".")
+	if err != nil {
+		return fmt.Errorf("open drafts directory for sync: %w", err)
+	}
+	defer func() { _ = dir.Close() }()
+	if syncErr := dir.Sync(); syncErr != nil {
+		return fmt.Errorf("sync drafts directory: %w", syncErr)
+	}
+	return nil
+}

--- a/internal/library/draft_sync_windows.go
+++ b/internal/library/draft_sync_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package library
+
+// Windows has no portable equivalent of fsync for a directory handle. Draft
+// contents are flushed before the atomic rename; returning success here avoids
+// reporting a failed mutation after Windows has already committed the rename.
+func (l *Library) syncDraftDirectory() error {
+	return nil
+}

--- a/internal/library/drafts.go
+++ b/internal/library/drafts.go
@@ -1,0 +1,283 @@
+package library
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	draftsDirName = "drafts"
+	draftDirMode  = 0o700
+	draftFileMode = 0o600
+)
+
+// ErrRevisionMismatch indicates that a draft changed after the caller read it.
+var ErrRevisionMismatch = errors.New("draft revision mismatch")
+
+// DraftEntry is the metadata returned when listing saved drafts.
+type DraftEntry struct {
+	Name       string    `json:"name"`
+	Revision   string    `json:"revision"`
+	ModifiedAt time.Time `json:"modifiedAt"`
+	SizeBytes  int64     `json:"sizeBytes"`
+}
+
+// Draft is a revisioned YAML configuration that is not attached to runtime.
+type Draft struct {
+	Name       string    `json:"name"`
+	Content    string    `json:"content"`
+	Format     string    `json:"format"`
+	Revision   string    `json:"revision"`
+	ModifiedAt time.Time `json:"modifiedAt"`
+	SizeBytes  int64     `json:"sizeBytes"`
+}
+
+func (l *Library) draftsDir() string {
+	return filepath.Join(l.root, draftsDirName)
+}
+
+func draftFilename(name string) (string, string, error) {
+	trimmed := trimYAMLExt(name)
+	if validationErr := validateName(trimmed); validationErr != nil {
+		return "", "", validationErr
+	}
+	return trimmed, trimmed + ".yaml", nil
+}
+
+func draftRevision(content []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(content))
+}
+
+// ListDrafts returns saved drafts in stable name order.
+func (l *Library) ListDrafts() ([]DraftEntry, error) {
+	l.draftMu.RLock()
+	defer l.draftMu.RUnlock()
+	release, lockErr := l.acquireDraftLock(false)
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	defer release()
+
+	entries, err := fs.ReadDir(l.draftRoot.FS(), ".")
+	if err != nil {
+		return nil, fmt.Errorf("read drafts: %w", err)
+	}
+
+	drafts := make([]DraftEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !isYAMLFilename(entry.Name()) {
+			continue
+		}
+		draft, readErr := l.readDraftUnlocked(trimYAMLExt(entry.Name()), entry.Name())
+		if readErr != nil {
+			return nil, readErr
+		}
+		drafts = append(drafts, DraftEntry{
+			Name:       draft.Name,
+			Revision:   draft.Revision,
+			ModifiedAt: draft.ModifiedAt,
+			SizeBytes:  draft.SizeBytes,
+		})
+	}
+	sort.Slice(drafts, func(i, j int) bool { return drafts[i].Name < drafts[j].Name })
+	return drafts, nil
+}
+
+// ReadDraft returns one saved draft and its current content revision.
+func (l *Library) ReadDraft(name string) (*Draft, error) {
+	trimmed, leaf, err := draftFilename(name)
+	if err != nil {
+		return nil, err
+	}
+
+	l.draftMu.RLock()
+	defer l.draftMu.RUnlock()
+	release, lockErr := l.acquireDraftLock(false)
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	defer release()
+	return l.readDraftUnlocked(trimmed, leaf)
+}
+
+func (l *Library) readDraftUnlocked(trimmed, leaf string) (*Draft, error) {
+	file, err := l.draftRoot.Open(leaf)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, trimmed)
+		}
+		return nil, fmt.Errorf("open draft %s: %w", trimmed, err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat draft %s: %w", trimmed, err)
+	}
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read draft %s: %w", trimmed, err)
+	}
+	return &Draft{
+		Name:       trimmed,
+		Content:    string(content),
+		Format:     "yaml",
+		Revision:   draftRevision(content),
+		ModifiedAt: info.ModTime().UTC(),
+		SizeBytes:  info.Size(),
+	}, nil
+}
+
+// CreateDraft saves a new draft without replacing an existing one.
+func (l *Library) CreateDraft(name, content string) (*Draft, error) {
+	trimmed, leaf, err := draftFilename(name)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(content) == "" {
+		return nil, ErrEmptyContent
+	}
+
+	l.draftMu.Lock()
+	defer l.draftMu.Unlock()
+	release, lockErr := l.acquireDraftLock(true)
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	defer release()
+
+	if _, statErr := l.draftRoot.Stat(leaf); statErr == nil {
+		return nil, fmt.Errorf("%w: %s", ErrAlreadyExists, trimmed)
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		return nil, fmt.Errorf("stat draft %s: %w", trimmed, statErr)
+	}
+	if writeErr := l.writeDraftAtomic(leaf, []byte(content)); writeErr != nil {
+		return nil, writeErr
+	}
+	return l.readDraftUnlocked(trimmed, leaf)
+}
+
+// ReplaceDraft atomically replaces a draft when expectedRevision is current.
+func (l *Library) ReplaceDraft(name, expectedRevision, content string) (*Draft, error) {
+	trimmed, leaf, err := draftFilename(name)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(content) == "" {
+		return nil, ErrEmptyContent
+	}
+
+	l.draftMu.Lock()
+	defer l.draftMu.Unlock()
+	release, lockErr := l.acquireDraftLock(true)
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	defer release()
+
+	current, err := l.readDraftUnlocked(trimmed, leaf)
+	if err != nil {
+		return nil, err
+	}
+	if current.Revision != expectedRevision {
+		return nil, fmt.Errorf("%w: %s", ErrRevisionMismatch, trimmed)
+	}
+	if writeErr := l.writeDraftAtomic(leaf, []byte(content)); writeErr != nil {
+		return nil, writeErr
+	}
+	return l.readDraftUnlocked(trimmed, leaf)
+}
+
+// DeleteDraft removes a draft when expectedRevision is current.
+func (l *Library) DeleteDraft(name, expectedRevision string) error {
+	trimmed, leaf, err := draftFilename(name)
+	if err != nil {
+		return err
+	}
+
+	l.draftMu.Lock()
+	defer l.draftMu.Unlock()
+	release, lockErr := l.acquireDraftLock(true)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer release()
+
+	current, err := l.readDraftUnlocked(trimmed, leaf)
+	if err != nil {
+		return err
+	}
+	if current.Revision != expectedRevision {
+		return fmt.Errorf("%w: %s", ErrRevisionMismatch, trimmed)
+	}
+	if removeErr := l.draftRoot.Remove(leaf); removeErr != nil {
+		return fmt.Errorf("delete draft %s: %w", trimmed, removeErr)
+	}
+	return l.syncDraftDirectory()
+}
+
+func (l *Library) writeDraftAtomic(leaf string, content []byte) error {
+	tmpLeaf, tmp, err := l.createDraftTemp()
+	if err != nil {
+		return fmt.Errorf("create draft temp file: %w", err)
+	}
+	defer func() { _ = l.draftRoot.Remove(tmpLeaf) }()
+
+	if _, writeErr := tmp.Write(content); writeErr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write draft temp file: %w", writeErr)
+	}
+	if syncErr := tmp.Sync(); syncErr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync draft temp file: %w", syncErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("close draft temp file: %w", closeErr)
+	}
+	if renameErr := l.draftRoot.Rename(tmpLeaf, leaf); renameErr != nil {
+		return fmt.Errorf("replace draft %s: %w", leaf, renameErr)
+	}
+	return l.syncDraftDirectory()
+}
+
+func (l *Library) createDraftTemp() (string, *os.File, error) {
+	for range 100 {
+		var suffix [16]byte
+		if _, err := rand.Read(suffix[:]); err != nil {
+			return "", nil, fmt.Errorf("generate draft temp name: %w", err)
+		}
+		leaf := fmt.Sprintf(".draft-%x", suffix)
+		file, err := l.draftRoot.OpenFile(leaf, os.O_RDWR|os.O_CREATE|os.O_EXCL, draftFileMode)
+		if err == nil {
+			return leaf, file, nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return "", nil, err
+		}
+	}
+	return "", nil, errors.New("allocate unique draft temp file")
+}
+
+func (l *Library) acquireDraftLock(exclusive bool) (func(), error) {
+	file, err := l.draftRoot.OpenFile(".lock", os.O_RDWR, draftFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("open draft lock: %w", err)
+	}
+	unlock, err := lockDraftFile(file, exclusive)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock drafts: %w", err)
+	}
+	return func() {
+		unlock()
+		_ = file.Close()
+	}, nil
+}

--- a/internal/library/drafts_test.go
+++ b/internal/library/drafts_test.go
@@ -1,0 +1,314 @@
+package library_test
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/library"
+)
+
+const updatedDraftYAML = `devices:
+  - name: r2
+    type: router
+`
+
+func TestDraftLifecycle(t *testing.T) {
+	lib := openTempLibrary(t)
+
+	created, err := lib.CreateDraft("branch-office", sampleYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft() error = %v", err)
+	}
+	if created.Name != "branch-office" || created.Content != sampleYAML {
+		t.Fatalf("CreateDraft() = %+v", created)
+	}
+	if len(created.Revision) != 64 {
+		t.Fatalf("revision length = %d, want 64", len(created.Revision))
+	}
+
+	read, err := lib.ReadDraft("branch-office")
+	if err != nil {
+		t.Fatalf("ReadDraft() error = %v", err)
+	}
+	if read.Revision != created.Revision || read.Content != created.Content {
+		t.Fatalf("ReadDraft() = %+v, want revision/content from create", read)
+	}
+
+	entries, err := lib.ListDrafts()
+	if err != nil {
+		t.Fatalf("ListDrafts() error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != created.Name || entries[0].Revision != created.Revision {
+		t.Fatalf("ListDrafts() = %+v", entries)
+	}
+
+	replaced, err := lib.ReplaceDraft("branch-office", created.Revision, updatedDraftYAML)
+	if err != nil {
+		t.Fatalf("ReplaceDraft() error = %v", err)
+	}
+	if replaced.Revision == created.Revision || replaced.Content != updatedDraftYAML {
+		t.Fatalf("ReplaceDraft() = %+v", replaced)
+	}
+
+	if deleteErr := lib.DeleteDraft("branch-office", replaced.Revision); deleteErr != nil {
+		t.Fatalf("DeleteDraft() error = %v", deleteErr)
+	}
+	if _, readErr := lib.ReadDraft("branch-office"); !errors.Is(readErr, library.ErrNotFound) {
+		t.Fatalf("ReadDraft() after delete error = %v, want ErrNotFound", readErr)
+	}
+}
+
+func TestCreateDraftRejectsDuplicateAndInvalidInput(t *testing.T) {
+	lib := openTempLibrary(t)
+	if _, err := lib.CreateDraft("valid", sampleYAML); err != nil {
+		t.Fatalf("CreateDraft() error = %v", err)
+	}
+	if _, err := lib.CreateDraft("valid", updatedDraftYAML); !errors.Is(err, library.ErrAlreadyExists) {
+		t.Fatalf("duplicate CreateDraft() error = %v, want ErrAlreadyExists", err)
+	}
+	if _, err := lib.CreateDraft("../escape", sampleYAML); !errors.Is(err, library.ErrInvalidName) {
+		t.Fatalf("traversal CreateDraft() error = %v, want ErrInvalidName", err)
+	}
+	if _, err := lib.CreateDraft("empty", ""); !errors.Is(err, library.ErrEmptyContent) {
+		t.Fatalf("empty CreateDraft() error = %v, want ErrEmptyContent", err)
+	}
+}
+
+func TestReplaceAndDeleteDraftRejectStaleRevision(t *testing.T) {
+	lib := openTempLibrary(t)
+	created, err := lib.CreateDraft("protected", sampleYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft() error = %v", err)
+	}
+
+	if _, replaceErr := lib.ReplaceDraft("protected", "stale", updatedDraftYAML); !errors.Is(
+		replaceErr,
+		library.ErrRevisionMismatch,
+	) {
+		t.Fatalf("ReplaceDraft() error = %v, want ErrRevisionMismatch", replaceErr)
+	}
+	if deleteErr := lib.DeleteDraft("protected", "stale"); !errors.Is(
+		deleteErr,
+		library.ErrRevisionMismatch,
+	) {
+		t.Fatalf("DeleteDraft() error = %v, want ErrRevisionMismatch", deleteErr)
+	}
+
+	read, err := lib.ReadDraft("protected")
+	if err != nil {
+		t.Fatalf("ReadDraft() error = %v", err)
+	}
+	if read.Revision != created.Revision || read.Content != sampleYAML {
+		t.Fatalf("stale operations changed draft: %+v", read)
+	}
+}
+
+func TestConcurrentDraftReplacementAllowsOneWriter(t *testing.T) {
+	lib := openTempLibrary(t)
+	created, err := lib.CreateDraft("shared", sampleYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft() error = %v", err)
+	}
+
+	contents := []string{updatedDraftYAML, `devices:
+  - name: r3
+    type: router
+`}
+	second, err := library.Open(lib.Root())
+	if err != nil {
+		t.Fatalf("open second library instance: %v", err)
+	}
+	libraries := []*library.Library{lib, second}
+	errs := make(chan error, len(contents))
+	var wg sync.WaitGroup
+	for index, content := range contents {
+		wg.Go(func() {
+			_, replaceErr := libraries[index].ReplaceDraft("shared", created.Revision, content)
+			errs <- replaceErr
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	successes := 0
+	mismatches := 0
+	for replaceErr := range errs {
+		switch {
+		case replaceErr == nil:
+			successes++
+		case errors.Is(replaceErr, library.ErrRevisionMismatch):
+			mismatches++
+		default:
+			t.Fatalf("ReplaceDraft() unexpected error = %v", replaceErr)
+		}
+	}
+	if successes != 1 || mismatches != 1 {
+		t.Fatalf("concurrent replacements: successes=%d mismatches=%d", successes, mismatches)
+	}
+}
+
+func TestConcurrentDraftCreateAcrossLibraryInstancesDoesNotOverwrite(t *testing.T) {
+	first := openTempLibrary(t)
+	second, err := library.Open(first.Root())
+	if err != nil {
+		t.Fatalf("open second library instance: %v", err)
+	}
+
+	libraries := []*library.Library{first, second}
+	contents := []string{sampleYAML, updatedDraftYAML}
+	errs := make(chan error, len(libraries))
+	var wg sync.WaitGroup
+	for index, lib := range libraries {
+		wg.Go(func() {
+			_, createErr := lib.CreateDraft("shared-create", contents[index])
+			errs <- createErr
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	successes := 0
+	conflicts := 0
+	for createErr := range errs {
+		switch {
+		case createErr == nil:
+			successes++
+		case errors.Is(createErr, library.ErrAlreadyExists):
+			conflicts++
+		default:
+			t.Fatalf("CreateDraft() unexpected error = %v", createErr)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent creates: successes=%d conflicts=%d", successes, conflicts)
+	}
+}
+
+func TestConcurrentDraftReadAndReplaceAcrossLibraryInstancesIsCoherent(t *testing.T) {
+	reader := openTempLibrary(t)
+	created, err := reader.CreateDraft("changing", sampleYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft() error = %v", err)
+	}
+	writer, err := library.Open(reader.Root())
+	if err != nil {
+		t.Fatalf("open writer library instance: %v", err)
+	}
+
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		revision := created.Revision
+		for index := range 100 {
+			content := sampleYAML
+			if index%2 == 0 {
+				content = updatedDraftYAML
+			}
+			replaced, replaceErr := writer.ReplaceDraft("changing", revision, content)
+			if replaceErr != nil {
+				errs <- replaceErr
+				return
+			}
+			revision = replaced.Revision
+		}
+	})
+	wg.Go(func() {
+		for range 200 {
+			draft, readErr := reader.ReadDraft("changing")
+			if readErr != nil {
+				errs <- readErr
+				return
+			}
+			wantRevision := fmt.Sprintf("%x", sha256.Sum256([]byte(draft.Content)))
+			if draft.SizeBytes != int64(len(draft.Content)) || draft.Revision != wantRevision {
+				errs <- fmt.Errorf("incoherent draft read: %+v", draft)
+				return
+			}
+		}
+	})
+	wg.Wait()
+	close(errs)
+	for operationErr := range errs {
+		t.Fatalf("concurrent draft operation: %v", operationErr)
+	}
+}
+
+func TestOpenRejectsDraftsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ordinary Windows users may not have symlink permission")
+	}
+	root := t.TempDir()
+	if err := os.Symlink(t.TempDir(), filepath.Join(root, "drafts")); err != nil {
+		t.Fatalf("create drafts symlink: %v", err)
+	}
+	if _, err := library.Open(root); err == nil || !strings.Contains(err.Error(), "real directory") {
+		t.Fatalf("library.Open() error = %v, want drafts symlink rejection", err)
+	}
+}
+
+func TestOpenRejectsDraftsFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "drafts"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("create drafts file: %v", err)
+	}
+	if _, err := library.Open(root); err == nil || !strings.Contains(err.Error(), "real directory") {
+		t.Fatalf("library.Open() error = %v, want drafts file rejection", err)
+	}
+}
+
+func TestOpenTightensExistingDraftsDirectoryPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix directory permission bits")
+	}
+	root := t.TempDir()
+	draftsDir := filepath.Join(root, "drafts")
+	if err := os.Mkdir(draftsDir, 0o755); err != nil {
+		t.Fatalf("create drafts directory: %v", err)
+	}
+	if _, err := library.Open(root); err != nil {
+		t.Fatalf("library.Open() error = %v", err)
+	}
+	info, err := os.Stat(draftsDir)
+	if err != nil {
+		t.Fatalf("stat drafts directory: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("drafts directory mode = %o, want 700", got)
+	}
+}
+
+func TestDraftPersistenceUsesPrivateFilesAndNoTemporaryResidue(t *testing.T) {
+	lib := openTempLibrary(t)
+	created, err := lib.CreateDraft("private", sampleYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft() error = %v", err)
+	}
+	if _, replaceErr := lib.ReplaceDraft("private", created.Revision, updatedDraftYAML); replaceErr != nil {
+		t.Fatalf("ReplaceDraft() error = %v", replaceErr)
+	}
+
+	draftsDir := filepath.Join(lib.Root(), "drafts")
+	entries, err := os.ReadDir(draftsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) error = %v", draftsDir, err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".draft-") {
+			t.Fatalf("temporary draft residue = %s", entry.Name())
+		}
+	}
+	info, err := os.Stat(filepath.Join(draftsDir, "private.yaml"))
+	if err != nil {
+		t.Fatalf("draft Info() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("draft mode = %o, want 600", got)
+	}
+}

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // Sentinel errors.
@@ -68,7 +69,9 @@ const (
 // every call to List or Read hits the filesystem so user-dropped files
 // appear immediately without an explicit watcher.
 type Library struct {
-	root string
+	root      string
+	draftRoot *os.Root
+	draftMu   sync.RWMutex
 }
 
 // DefaultRoot resolves the standard library root following:
@@ -116,10 +119,12 @@ func Open(root string) (*Library, error) {
 	}
 
 	if bootstrapErr := lib.bootstrapStarterPack(); bootstrapErr != nil {
+		_ = lib.draftRoot.Close()
 		return nil, fmt.Errorf("bootstrap starter pack: %w", bootstrapErr)
 	}
 
 	if bootstrapErr := lib.bootstrapWalks(); bootstrapErr != nil {
+		_ = lib.draftRoot.Close()
 		return nil, fmt.Errorf("bootstrap starter walks: %w", bootstrapErr)
 	}
 
@@ -141,12 +146,54 @@ func (l *Library) ensureLayout() error {
 	if err := os.MkdirAll(l.root, libraryDirMode); err != nil {
 		return fmt.Errorf("create library root %s: %w", l.root, err)
 	}
+	root, err := os.OpenRoot(l.root)
+	if err != nil {
+		return fmt.Errorf("open library root %s: %w", l.root, err)
+	}
+	defer func() { _ = root.Close() }()
+
 	for _, kind := range AllKinds() {
-		path := l.SubDir(kind)
-		if err := os.MkdirAll(path, libraryDirMode); err != nil {
-			return fmt.Errorf("create library subdir %s: %w", path, err)
+		if mkdirErr := root.MkdirAll(string(kind), libraryDirMode); mkdirErr != nil {
+			return fmt.Errorf("create library subdir %s: %w", l.SubDir(kind), mkdirErr)
 		}
 	}
+
+	info, statErr := root.Lstat(draftsDirName)
+	if errors.Is(statErr, os.ErrNotExist) {
+		if mkdirErr := root.Mkdir(draftsDirName, draftDirMode); mkdirErr != nil && !errors.Is(mkdirErr, os.ErrExist) {
+			return fmt.Errorf("create library drafts dir %s: %w", l.draftsDir(), mkdirErr)
+		}
+		info, statErr = root.Lstat(draftsDirName)
+	}
+	if statErr != nil {
+		return fmt.Errorf("inspect library drafts dir %s: %w", l.draftsDir(), statErr)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("library drafts path must be a real directory: %s", l.draftsDir())
+	}
+
+	draftRoot, openErr := root.OpenRoot(draftsDirName)
+	if openErr != nil {
+		return fmt.Errorf("open library drafts dir %s: %w", l.draftsDir(), openErr)
+	}
+	if chmodErr := draftRoot.Chmod(".", draftDirMode); chmodErr != nil {
+		_ = draftRoot.Close()
+		return fmt.Errorf("protect library drafts dir %s: %w", l.draftsDir(), chmodErr)
+	}
+	lockFile, lockErr := draftRoot.OpenFile(".lock", os.O_RDWR|os.O_CREATE, draftFileMode)
+	if lockErr != nil {
+		_ = draftRoot.Close()
+		return fmt.Errorf("create library draft lock: %w", lockErr)
+	}
+	if closeErr := lockFile.Close(); closeErr != nil {
+		_ = draftRoot.Close()
+		return fmt.Errorf("close library draft lock: %w", closeErr)
+	}
+	if chmodErr := draftRoot.Chmod(".lock", draftFileMode); chmodErr != nil {
+		_ = draftRoot.Close()
+		return fmt.Errorf("protect library draft lock: %w", chmodErr)
+	}
+	l.draftRoot = draftRoot
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- add a private, revisioned on-disk store for scenario drafts
- prevent lost updates across goroutines and NIAC processes with shared/exclusive OS file locks
- pin draft operations to an opened filesystem root and reject symlink/non-directory stores
- persist through synced temporary files and atomic rename, with directory sync on macOS/Linux
- exercise lifecycle, stale revisions, cross-instance reads/writes, containment, and permissions

## Linked Issue

Related to #1151

## Testing Evidence

```text
make verify
0 lint issues
45 backend packages passed; 69 frontend test files passed
67.2% repository coverage
No Go vulnerabilities; 0 npm vulnerabilities; no secrets found
Production frontend/backend build passed
Schema drift check passed

GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/library
passed

Independent staged-change review
No actionable findings.
```

## Security and Release Checklist

- [x] Draft directory is enforced as `0700`; draft and lock files are `0600`
- [x] User-controlled names remain inside an opened `os.Root`
- [x] Cross-process create/replace/delete operations are conditionally locked
- [x] Draft data does not touch the active configuration or runtime
- [x] No new module version was introduced; the existing `x/sys` dependency became direct
- [x] Release behavior and schema are unchanged
