### PR TITLE
feat: make simulation wizard draft-first

### DIFF
--- a/cmd/niac/templates/ap.yaml
+++ b/cmd/niac/templates/ap.yaml
@@ -11,46 +11,44 @@ devices:
       - "10.0.2.50"
 
     # Basic protocols
-    arp:
-      enabled: true
     icmp:
       enabled: true
 
     # Discovery
+    interfaces:
+      - name: "GigabitEthernet0"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "WiFi AP 01"
       system_description: "Cisco Aironet 9120AX"
-      chassis_id: "00:1C:2D:3E:4F:01"
-      port_id: "GigabitEthernet0"
+      port_description: "GigabitEthernet0"
       ttl: 120
-      capabilities: ["wlan-access-point"]
-      management_addresses:
-        - "10.0.2.50"
-
     cdp:
       enabled: true
-      device_id: "wifi-ap-01"
       platform: "Cisco Aironet 9120AXI"
       software_version: "17.9.4"
-      capabilities: ["Host"]
       port_id: "GigabitEthernet0"
-      power_draw: 15.4
-      ttl: 180
+      holdtime: 180
 
     # SNMP
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_name: "wifi-ap-01"
-      sys_descr: "Cisco Aironet Access Point"
-      sys_location: "Building A - Floor 2 - Room 201"
-      sys_contact: "wireless@example.com"
+      sysname: "wifi-ap-01"
+      sysdescr: "Cisco Aironet Access Point"
+      syslocation: "Building A - Floor 2 - Room 201"
+      syscontact: "wireless@example.com"
 
     # HTTP - Web interface
     http:
       enabled: true
-      server_header: "Cisco-IOS"
+      server_name: "Cisco-IOS"
       endpoints:
         - path: "/"
-          content: "<html><body><h1>Cisco Aironet AP</h1></body></html>"
+          body: "<html><body><h1>Cisco Aironet AP</h1></body></html>"

--- a/cmd/niac/templates/complete.yaml
+++ b/cmd/niac/templates/complete.yaml
@@ -8,60 +8,61 @@ devices:
     type: router
     mac: "00:0A:0B:0C:0D:01"
     ips: ["10.0.0.1"]
-    arp: {enabled: true}
     icmp: {enabled: true}
+    interfaces:
+      - name: "GigabitEthernet0/1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
     lldp:
       enabled: true
-      system_name: "Core Router"
-      chassis_id: "00:0A:0B:0C:0D:01"
-      port_id: "GigabitEthernet0/1"
+      port_description: "GigabitEthernet0/1"
       ttl: 120
-      capabilities: ["router"]
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_name: "core-router"
-      sys_descr: "Cisco IOS Router"
+      sysname: "core-router"
+      sysdescr: "Cisco IOS Router"
 
   - name: access-switch
     type: switch
     mac: "00:0A:0B:0C:0D:02"
     ips: ["10.0.0.2"]
-    arp: {enabled: true}
     icmp: {enabled: true}
+    interfaces:
+      - name: "GigabitEthernet1/0/1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
     lldp:
       enabled: true
-      system_name: "Access Switch"
-      chassis_id: "00:0A:0B:0C:0D:02"
-      port_id: "GigabitEthernet1/0/1"
-      capabilities: ["bridge"]
+      port_description: "GigabitEthernet1/0/1"
     stp:
       enabled: true
       bridge_priority: 32768
-      bridge_id: "00:0A:0B:0C:0D:02"
 
   - name: wifi-ap
     type: ap
     mac: "00:0A:0B:0C:0D:03"
     ips: ["10.0.0.3"]
-    arp: {enabled: true}
     icmp: {enabled: true}
     lldp:
       enabled: true
-      system_name: "WiFi AP"
-      chassis_id: "00:0A:0B:0C:0D:03"
-      capabilities: ["wlan-access-point"]
 
   - name: dhcp-server
     type: server
     mac: "00:0A:0B:0C:0D:04"
     ips: ["10.0.0.10"]
-    arp: {enabled: true}
     icmp: {enabled: true}
     dhcp:
       router: "10.0.0.1"
       domain_name_server: "10.0.0.10"
-      domain_name: "lab.local"
     dns:
       forward_records:
         - {name: "router.lab.local", ip: "10.0.0.1"}

--- a/cmd/niac/templates/iot.yaml
+++ b/cmd/niac/templates/iot.yaml
@@ -11,27 +11,31 @@ devices:
       - "10.0.3.100"
 
     # Basic protocols only
-    arp:
-      enabled: true
     icmp:
       enabled: true
 
     # Minimal LLDP
+    interfaces:
+      - name: "eth0"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "IoT Sensor 01"
       system_description: "Temperature/Humidity Sensor"
-      chassis_id: "00:1E:2F:3A:4B:01"
-      port_id: "eth0"
+      port_description: "eth0"
       ttl: 300
-      capabilities: ["station-only"]
 
     # Simple HTTP API
     http:
       enabled: true
-      server_header: "IoTDevice/1.0"
+      server_name: "IoTDevice/1.0"
       endpoints:
         - path: "/"
-          content: '{"device": "sensor-01", "type": "temp-humidity"}'
+          body: '{"device": "sensor-01", "type": "temp-humidity"}'
         - path: "/data"
-          content: '{"temp": 22.5, "humidity": 45}'
+          body: '{"temp": 22.5, "humidity": 45}'

--- a/cmd/niac/templates/minimal.yaml
+++ b/cmd/niac/templates/minimal.yaml
@@ -11,9 +11,5 @@ devices:
       - "192.168.1.1"
 
     # ARP - Address Resolution Protocol
-    arp:
-      enabled: true
-
-    # ICMP - Ping responses
     icmp:
       enabled: true

--- a/cmd/niac/templates/router.yaml
+++ b/cmd/niac/templates/router.yaml
@@ -12,38 +12,40 @@ devices:
       - "192.168.1.1"
 
     # Basic protocols
-    arp:
-      enabled: true
     icmp:
       enabled: true
 
     # Discovery protocols
+    interfaces:
+      - name: "GigabitEthernet0/1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "Core Router 01"
       system_description: "Cisco IOS XE 17.3"
-      chassis_id: "00:1A:2B:3C:4D:01"
-      port_id: "GigabitEthernet0/1"
+      port_description: "GigabitEthernet0/1"
       ttl: 120
-      capabilities: ["bridge", "router"]
 
     cdp:
       enabled: true
-      device_id: "core-router-01"
       platform: "Cisco ISR4331"
       software_version: "IOS XE 17.3.5"
-      capabilities: ["Router", "Switch", "IGMP"]
       port_id: "GigabitEthernet0/1"
-      ttl: 180
+      holdtime: 180
 
     # SNMP
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_name: "core-router-01"
-      sys_descr: "Cisco IOS XE Router"
-      sys_location: "Data Center A - Rack 12"
-      sys_contact: "netops@example.com"
+      sysname: "core-router-01"
+      sysdescr: "Cisco IOS XE Router"
+      syslocation: "Data Center A - Rack 12"
+      syscontact: "netops@example.com"
 
       traps:
         enabled: true

--- a/cmd/niac/templates/server.yaml
+++ b/cmd/niac/templates/server.yaml
@@ -11,29 +11,33 @@ devices:
       - "10.0.0.10"
 
     # Basic protocols
-    arp:
-      enabled: true
     icmp:
       enabled: true
 
     # LLDP
+    interfaces:
+      - name: "eth0"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "Server 01"
       system_description: "Ubuntu 22.04 LTS"
-      chassis_id: "00:1D:2E:3F:4A:01"
-      port_id: "eth0"
+      port_description: "eth0"
       ttl: 120
-      capabilities: ["station-only"]
 
     # SNMP
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_name: "server-01"
-      sys_descr: "Ubuntu 22.04.3 LTS"
-      sys_location: "Data Center A - Rack 5"
-      sys_contact: "sysadmin@example.com"
+      sysname: "server-01"
+      sysdescr: "Ubuntu 22.04.3 LTS"
+      syslocation: "Data Center A - Rack 5"
+      syscontact: "sysadmin@example.com"
 
       traps:
         enabled: true
@@ -51,8 +55,6 @@ devices:
     dhcp:
       router: "10.0.0.1"
       domain_name_server: "10.0.0.10"
-      domain_name: "example.local"
-      lease_time: 86400
 
     # DNS Server
     dns:
@@ -68,9 +70,9 @@ devices:
     # HTTP Server
     http:
       enabled: true
-      server_header: "nginx/1.24.0"
+      server_name: "nginx/1.24.0"
       endpoints:
         - path: "/"
-          content: "<html><body><h1>Server 01</h1><p>Services: DHCP, DNS, HTTP</p></body></html>"
+          body: "<html><body><h1>Server 01</h1><p>Services: DHCP, DNS, HTTP</p></body></html>"
         - path: "/status"
-          content: '{"status": "ok", "services": ["dhcp", "dns", "http"]}'
+          body: '{"status": "ok", "services": ["dhcp", "dns", "http"]}'

--- a/cmd/niac/templates/switch.yaml
+++ b/cmd/niac/templates/switch.yaml
@@ -11,47 +11,42 @@ devices:
       - "10.0.1.10"
 
     # Basic protocols
-    arp:
-      enabled: true
     icmp:
       enabled: true
 
     # Discovery
+    interfaces:
+      - name: "GigabitEthernet1/0/1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "Access Switch 01"
       system_description: "Cisco Catalyst 9300"
-      chassis_id: "00:1B:2C:3D:4E:01"
-      port_id: "GigabitEthernet1/0/1"
+      port_description: "GigabitEthernet1/0/1"
       ttl: 120
-      capabilities: ["bridge"]
-      vlan_id: 100
 
     cdp:
       enabled: true
-      device_id: "access-switch-01"
       platform: "Cisco Catalyst 9300-48P"
       software_version: "IOS XE 17.6.3"
-      capabilities: ["Switch", "IGMP"]
       port_id: "GigabitEthernet1/0/1"
-      vlan_id: 100
-      native_vlan: 1
-      duplex: "full"
-      ttl: 180
+      holdtime: 180
 
     # Spanning Tree Protocol
     stp:
       enabled: true
       bridge_priority: 32768
-      bridge_id: "00:1B:2C:3D:4E:01"
-      root_priority: 4096
-      root_id: "00:1A:2B:3C:4D:01"
 
     # SNMP
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_name: "access-switch-01"
-      sys_descr: "Cisco Catalyst 9300 Switch"
-      sys_location: "Building A - Floor 2 - IDF"
-      sys_contact: "netops@example.com"
+      sysname: "access-switch-01"
+      sysdescr: "Cisco Catalyst 9300 Switch"
+      syslocation: "Building A - Floor 2 - IDF"
+      syscontact: "netops@example.com"

--- a/cmd/niac/templates/vendor-templates/aruba/cx-6300m-48g.yaml
+++ b/cmd/niac/templates/vendor-templates/aruba/cx-6300m-48g.yaml
@@ -11,33 +11,38 @@ devices:
     ips:
       - "10.0.12.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "1/1/1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "cx6300m-48g-01"
       system_description: "Aruba JL663A 6300M 48G CL4 PoE 4SFP56 Swch, AOS-CX 10.13.1000"
-      port_id: "1/1/1"
-      capabilities: ["bridge"]
+      port_description: "1/1/1"
       ttl: 120
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.47196.4.1.1.3.123"  # arubaCX6300M48G
-      sys_descr: "Aruba 6300M 48G PoE 4SFP56 Switch, AOS-CX 10.13.1000"
-      sys_contact: "noc@example.com"
-      sys_location: "Campus Building C"
+      sysdescr: "Aruba 6300M 48G PoE 4SFP56 Switch, AOS-CX 10.13.1000"
+      syscontact: "noc@example.com"
+      syslocation: "Campus Building C"
 
     stp:
       enabled: true
       bridge_priority: 32768
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.47196.4.1.1.3.123"
       vendor: "aruba"
       model: "JL663A 6300M-48G"
       os: "AOS-CX"

--- a/cmd/niac/templates/vendor-templates/aruba/iap-505.yaml
+++ b/cmd/niac/templates/vendor-templates/aruba/iap-505.yaml
@@ -11,29 +11,34 @@ devices:
     ips:
       - "10.0.52.10"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "eth0"
+        type: ethernet
+        mtu: 1500
+        speed: 2500
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "iap-505-01"
       system_description: "Aruba AP-505 (RW), ArubaOS 8.11.1.0"
-      port_id: "eth0"
-      capabilities: ["wlan_ap"]
+      port_description: "eth0"
       ttl: 120
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.14823.1.2.96"  # ArubaAP505
-      sys_descr: "Aruba AP-505, ArubaOS 8.11.1.0"
-      sys_contact: "wifi@example.com"
-      sys_location: "Floor 2 SE"
+      sysdescr: "Aruba AP-505, ArubaOS 8.11.1.0"
+      syscontact: "wifi@example.com"
+      syslocation: "Floor 2 SE"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.14823.1.2.96"
       vendor: "aruba"
       model: "AP-505"
       os: "ArubaOS"

--- a/cmd/niac/templates/vendor-templates/cisco/aironet-iw9165e.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/aironet-iw9165e.yaml
@@ -11,39 +11,41 @@ devices:
     ips:
       - "10.0.50.10"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "GigabitEthernet0"
+        type: ethernet
+        mtu: 1500
+        speed: 5000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "iw9165e-ap-01"
       system_description: "Cisco Catalyst IW-9165E Wi-Fi 6E Access Point, IOS XE 17.13.1"
-      port_id: "GigabitEthernet0"
-      capabilities: ["wlan_ap"]
+      port_description: "GigabitEthernet0"
       ttl: 120
 
     cdp:
       enabled: true
-      device_id: "iw9165e-ap-01.local"
       platform: "cisco IW-9165E-B-K9"
       software_version: "Cisco IOS XE Software, Version 17.13.01"
-      capabilities: ["Trans-Bridge", "Source-Route-Bridge"]
       port_id: "GigabitEthernet0"
-      duplex: "full"
-      ttl: 180
+      holdtime: 180
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.9.1.3120"  # IW-9165E
-      sys_descr: "Cisco AP Software, ap1g8, Version 17.13.1"
-      sys_contact: "wifi@example.com"
-      sys_location: "Outdoor Yard A"
+      sysdescr: "Cisco AP Software, ap1g8, Version 17.13.1"
+      syscontact: "wifi@example.com"
+      syslocation: "Outdoor Yard A"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.9.1.3120"
       vendor: "cisco"
       model: "IW-9165E-B-K9"
       os: "IOS-XE-AP"

--- a/cmd/niac/templates/vendor-templates/cisco/asa-5525-x.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/asa-5525-x.yaml
@@ -11,39 +11,41 @@ devices:
     ips:
       - "10.0.40.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 255
 
+    interfaces:
+      - name: "GigabitEthernet0/0"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "asa5525-fw-01"
       system_description: "Cisco Adaptive Security Appliance Software Version 9.18(3)"
-      port_id: "GigabitEthernet0/0"
-      capabilities: ["router"]
+      port_description: "GigabitEthernet0/0"
       ttl: 120
 
     cdp:
       enabled: true
-      device_id: "asa5525-fw-01.local"
       platform: "cisco ASA5525-X"
       software_version: "Cisco Adaptive Security Appliance Software Version 9.18(3)"
-      capabilities: ["Router"]
       port_id: "GigabitEthernet0/0"
-      duplex: "full"
-      ttl: 180
+      holdtime: 180
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.9.1.1408"  # ciscoASA5525
-      sys_descr: "Cisco Adaptive Security Appliance Version 9.18(3)"
-      sys_contact: "secops@example.com"
-      sys_location: "DMZ"
+      sysdescr: "Cisco Adaptive Security Appliance Version 9.18(3)"
+      syscontact: "secops@example.com"
+      syslocation: "DMZ"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.9.1.1408"
       vendor: "cisco"
       model: "ASA5525-X"
       os: "ASA"

--- a/cmd/niac/templates/vendor-templates/cisco/catalyst-9300-48p.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/catalyst-9300-48p.yaml
@@ -11,43 +11,45 @@ devices:
     ips:
       - "10.0.10.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 255
 
+    interfaces:
+      - name: "GigabitEthernet1/0/1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "cat9300-48p-01"
       system_description: "Cisco IOS XE Software, C9300-48P, Version 17.9.3"
-      port_id: "GigabitEthernet1/0/1"
-      capabilities: ["bridge"]
+      port_description: "GigabitEthernet1/0/1"
       ttl: 120
 
     cdp:
       enabled: true
-      device_id: "cat9300-48p-01.local"
       platform: "cisco WS-C9300-48P"
       software_version: "Cisco IOS XE Software, Version 17.09.03"
-      capabilities: ["Switch", "IGMP"]
       port_id: "GigabitEthernet1/0/1"
-      duplex: "full"
-      ttl: 180
+      holdtime: 180
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.9.1.2697"  # cevChassisCat9300L48P
-      sys_descr: "Cisco IOS Software, Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.9.3"
-      sys_contact: "noc@example.com"
-      sys_location: "Campus Building A"
+      sysdescr: "Cisco IOS Software, Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.9.3"
+      syscontact: "noc@example.com"
+      syslocation: "Campus Building A"
 
     stp:
       enabled: true
       bridge_priority: 32768
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.9.1.2697"
       vendor: "cisco"
       model: "C9300-48P"
       os: "IOS-XE"

--- a/cmd/niac/templates/vendor-templates/cisco/isr-4451-x.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/isr-4451-x.yaml
@@ -12,39 +12,41 @@ devices:
       - "10.0.30.1"
       - "203.0.113.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 255
 
+    interfaces:
+      - name: "GigabitEthernet0/0/0"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "isr4451-edge-01"
       system_description: "Cisco IOS XE Software, ISR4451-X/K9, Version 17.9.4"
-      port_id: "GigabitEthernet0/0/0"
-      capabilities: ["router"]
+      port_description: "GigabitEthernet0/0/0"
       ttl: 120
 
     cdp:
       enabled: true
-      device_id: "isr4451-edge-01.local"
       platform: "cisco ISR4451-X/K9"
       software_version: "Cisco IOS XE Software, Version 17.09.04"
-      capabilities: ["Router", "IGMP"]
       port_id: "GigabitEthernet0/0/0"
-      duplex: "full"
-      ttl: 180
+      holdtime: 180
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.9.1.1903"  # ISR4451
-      sys_descr: "Cisco IOS Software [Cupertino], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.9.4"
-      sys_contact: "noc@example.com"
-      sys_location: "Branch Office 12"
+      sysdescr: "Cisco IOS Software [Cupertino], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.9.4"
+      syscontact: "noc@example.com"
+      syslocation: "Branch Office 12"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.9.1.1903"
       vendor: "cisco"
       model: "ISR4451-X/K9"
       os: "IOS-XE"

--- a/cmd/niac/templates/vendor-templates/cisco/nexus-9336c-fx2.yaml
+++ b/cmd/niac/templates/vendor-templates/cisco/nexus-9336c-fx2.yaml
@@ -11,39 +11,41 @@ devices:
     ips:
       - "10.0.20.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 255
 
+    interfaces:
+      - name: "Ethernet1/1"
+        type: ethernet
+        mtu: 1500
+        speed: 100000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "n9k-9336c-01"
       system_description: "Cisco Nexus Operating System (NX-OS) Software, Version 10.2(5)"
-      port_id: "Ethernet1/1"
-      capabilities: ["bridge", "router"]
+      port_description: "Ethernet1/1"
       ttl: 120
 
     cdp:
       enabled: true
-      device_id: "n9k-9336c-01.local"
       platform: "N9K-C9336C-FX2"
       software_version: "Cisco Nexus OS, Version 10.2(5)"
-      capabilities: ["Switch", "Router", "IGMP"]
       port_id: "Ethernet1/1"
-      duplex: "full"
-      ttl: 180
+      holdtime: 180
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.9.12.3.1.3.1411"  # nexus9336C-FX2
-      sys_descr: "Cisco NX-OS(tm) n9000, Software (n9000-dk9), Version 10.2(5)"
-      sys_contact: "noc@example.com"
-      sys_location: "DC1 Spine"
+      sysdescr: "Cisco NX-OS(tm) n9000, Software (n9000-dk9), Version 10.2(5)"
+      syscontact: "noc@example.com"
+      syslocation: "DC1 Spine"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.9.12.3.1.3.1411"
       vendor: "cisco"
       model: "N9K-C9336C-FX2"
       os: "NX-OS"

--- a/cmd/niac/templates/vendor-templates/extreme/x440-g2-48t.yaml
+++ b/cmd/niac/templates/vendor-templates/extreme/x440-g2-48t.yaml
@@ -11,18 +11,23 @@ devices:
     ips:
       - "10.0.13.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "x440-g2-48t-01"
       system_description: "ExtremeXOS (X440G2-48t) version 31.7.1.4"
-      port_id: "1"
-      capabilities: ["bridge"]
+      port_description: "1"
       ttl: 120
 
     # Extreme's proprietary discovery protocol — disabled by default
@@ -32,19 +37,19 @@ devices:
       display_string: "x440-g2-48t-01"
       version_string: "ExtremeXOS 31.7.1.4"
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.1916.2.140"  # extremeSummitX440G2-48t
-      sys_descr: "ExtremeXOS (X440G2-48t) version 31.7.1.4"
-      sys_contact: "noc@example.com"
-      sys_location: "Campus Edge"
+      sysdescr: "ExtremeXOS (X440G2-48t) version 31.7.1.4"
+      syscontact: "noc@example.com"
+      syslocation: "Campus Edge"
 
     stp:
       enabled: true
       bridge_priority: 32768
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.1916.2.140"
       vendor: "extreme"
       model: "X440-G2-48t"
       os: "EXOS"

--- a/cmd/niac/templates/vendor-templates/extreme/x670-g2-48x.yaml
+++ b/cmd/niac/templates/vendor-templates/extreme/x670-g2-48x.yaml
@@ -11,18 +11,23 @@ devices:
     ips:
       - "10.0.23.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "1"
+        type: ethernet
+        mtu: 1500
+        speed: 10000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "x670-g2-48x-01"
       system_description: "ExtremeXOS (X670G2-48x) version 31.7.1.4"
-      port_id: "1"
-      capabilities: ["bridge", "router"]
+      port_description: "1"
       ttl: 120
 
     edp:
@@ -30,15 +35,15 @@ devices:
       display_string: "x670-g2-48x-01"
       version_string: "ExtremeXOS 31.7.1.4"
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.1916.2.139"  # extremeSummitX670G2-48x
-      sys_descr: "ExtremeXOS (X670G2-48x) version 31.7.1.4"
-      sys_contact: "noc@example.com"
-      sys_location: "DC1 Aggregation"
+      sysdescr: "ExtremeXOS (X670G2-48x) version 31.7.1.4"
+      syscontact: "noc@example.com"
+      syslocation: "DC1 Aggregation"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.1916.2.139"
       vendor: "extreme"
       model: "X670-G2-48x"
       os: "EXOS"

--- a/cmd/niac/templates/vendor-templates/hp/procurve-2530-48.yaml
+++ b/cmd/niac/templates/vendor-templates/hp/procurve-2530-48.yaml
@@ -11,33 +11,38 @@ devices:
     ips:
       - "10.0.14.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "1"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "procurve-2530-48-01"
       system_description: "HP ProCurve J9853A 2530-48, revision YA.16.10.0019"
-      port_id: "1"
-      capabilities: ["bridge"]
+      port_description: "1"
       ttl: 120
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.11.2.3.7.11.150"  # hpProcurve2530-48
-      sys_descr: "HP ProCurve J9853A 2530-48 Switch, revision YA.16.10.0019"
-      sys_contact: "noc@example.com"
-      sys_location: "SMB Wiring Closet"
+      sysdescr: "HP ProCurve J9853A 2530-48 Switch, revision YA.16.10.0019"
+      syscontact: "noc@example.com"
+      syslocation: "SMB Wiring Closet"
 
     stp:
       enabled: true
       bridge_priority: 32768
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.11.2.3.7.11.150"
       vendor: "hp"
       model: "J9853A 2530-48"
       os: "ProCurve"

--- a/cmd/niac/templates/vendor-templates/juniper/ex4300-48t.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/ex4300-48t.yaml
@@ -11,33 +11,38 @@ devices:
     ips:
       - "10.0.11.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "ge-0/0/0"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "ex4300-48t-01"
       system_description: "Juniper Networks, Inc. ex4300-48t, version 21.4R3, kernel JUNOS 21.4R3"
-      port_id: "ge-0/0/0"
-      capabilities: ["bridge"]
+      port_description: "ge-0/0/0"
       ttl: 120
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.2636.1.1.1.2.71"  # jnxProductLineEx4300
-      sys_descr: "Juniper Networks, Inc. ex4300-48t, version 21.4R3"
-      sys_contact: "noc@example.com"
-      sys_location: "Campus Building B"
+      sysdescr: "Juniper Networks, Inc. ex4300-48t, version 21.4R3"
+      syscontact: "noc@example.com"
+      syslocation: "Campus Building B"
 
     stp:
       enabled: true
       bridge_priority: 32768
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.2636.1.1.1.2.71"
       vendor: "juniper"
       model: "EX4300-48T"
       os: "Junos"

--- a/cmd/niac/templates/vendor-templates/juniper/mist-ap43.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/mist-ap43.yaml
@@ -11,31 +11,36 @@ devices:
     ips:
       - "10.0.51.10"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "eth0"
+        type: ethernet
+        mtu: 1500
+        speed: 2500
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "mist-ap43-01"
       system_description: "Juniper Mist AP43, firmware 0.14.29528"
-      port_id: "eth0"
-      capabilities: ["wlan_ap"]
+      port_description: "eth0"
       ttl: 120
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
       # Mist APs expose minimal SNMP — management lives in the Mist cloud API.
       # sysObjectID below is the Mist enterprise OID; real-world MIB tables are sparse.
-      sys_object_id: "1.3.6.1.4.1.55538"  # Mist Systems
-      sys_descr: "Juniper Mist AP43"
-      sys_contact: "wifi@example.com"
-      sys_location: "Floor 3 NW"
+      sysdescr: "Juniper Mist AP43"
+      syscontact: "wifi@example.com"
+      syslocation: "Floor 3 NW"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.55538"
       vendor: "juniper"
       model: "AP43"
       os: "Mist"

--- a/cmd/niac/templates/vendor-templates/juniper/mx204.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/mx204.yaml
@@ -12,29 +12,34 @@ devices:
       - "10.0.31.1"
       - "203.0.113.10"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "et-0/0/0"
+        type: ethernet
+        mtu: 1500
+        speed: 100000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "mx204-pe-01"
       system_description: "Juniper Networks, Inc. mx204, version 22.4R2, kernel JUNOS 22.4R2"
-      port_id: "et-0/0/0"
-      capabilities: ["router"]
+      port_description: "et-0/0/0"
       ttl: 120
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.2636.1.1.1.2.57"  # jnxProductLineMX204
-      sys_descr: "Juniper Networks, Inc. mx204, version 22.4R2"
-      sys_contact: "noc@example.com"
-      sys_location: "Metro POP 03"
+      sysdescr: "Juniper Networks, Inc. mx204, version 22.4R2"
+      syscontact: "noc@example.com"
+      syslocation: "Metro POP 03"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.2636.1.1.1.2.57"
       vendor: "juniper"
       model: "MX204"
       os: "Junos"

--- a/cmd/niac/templates/vendor-templates/juniper/srx340.yaml
+++ b/cmd/niac/templates/vendor-templates/juniper/srx340.yaml
@@ -11,29 +11,34 @@ devices:
     ips:
       - "10.0.41.1"
 
-    arp:
-      enabled: true
     icmp:
       enabled: true
       ttl: 64
 
+    interfaces:
+      - name: "ge-0/0/0"
+        type: ethernet
+        mtu: 1500
+        speed: 1000
+        duplex: full
+        admin_status: up
+        oper_status: up
+
     lldp:
       enabled: true
-      system_name: "srx340-fw-01"
       system_description: "Juniper Networks, Inc. srx340, version 21.4R3, kernel JUNOS 21.4R3"
-      port_id: "ge-0/0/0"
-      capabilities: ["router"]
+      port_description: "ge-0/0/0"
       ttl: 120
 
-    snmp:
+    snmp_agent:
       enabled: true
       community: "public"
-      sys_object_id: "1.3.6.1.4.1.2636.1.1.1.2.92"  # jnxProductLineSRX340
-      sys_descr: "Juniper Networks, Inc. srx340, version 21.4R3"
-      sys_contact: "secops@example.com"
-      sys_location: "Branch Office 12 DMZ"
+      sysdescr: "Juniper Networks, Inc. srx340, version 21.4R3"
+      syscontact: "secops@example.com"
+      syslocation: "Branch Office 12 DMZ"
 
     properties:
+      sysObjectID: "1.3.6.1.4.1.2636.1.1.1.2.92"
       vendor: "juniper"
       model: "SRX340"
       os: "Junos"

--- a/internal/api/handlers_drafts.go
+++ b/internal/api/handlers_drafts.go
@@ -4,14 +4,18 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"path/filepath"
 	"strings"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/api/templates"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/library"
 )
 
 type draftCreateRequest struct {
-	Name    string `json:"name"`
-	Content string `json:"content"`
+	Name         string `json:"name"`
+	Content      string `json:"content"`
+	TemplateName string `json:"template_name"`
 }
 
 type draftReplaceRequest struct {
@@ -76,17 +80,63 @@ func (s *Server) handleLibraryDraftCreate(w http.ResponseWriter, r *http.Request
 	if !decodeJSONStrict(w, r, &req, MaxRequestBodySize) {
 		return
 	}
-	if !s.validateDraftContent(w, r, req.Content) {
+	content, ok := s.prepareDraftContent(w, r, req)
+	if !ok {
 		return
 	}
 
-	draft, err := s.library.CreateDraft(req.Name, req.Content)
+	draft, err := s.library.CreateDraft(req.Name, content)
 	if err != nil {
 		s.writeDraftStoreError(w, r, "create", req.Name, err)
 		return
 	}
 	w.Header().Set("Location", "/api/v1/library/drafts/"+draft.Name)
 	s.writeDraft(w, http.StatusCreated, draft)
+}
+
+func (s *Server) prepareDraftContent(
+	w http.ResponseWriter, r *http.Request, req draftCreateRequest,
+) (string, bool) {
+	hasContent := strings.TrimSpace(req.Content) != ""
+	hasTemplate := strings.TrimSpace(req.TemplateName) != ""
+	if hasContent == hasTemplate {
+		writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"Exactly one of content or templateName is required", nil)
+		return "", false
+	}
+	if hasContent {
+		return req.Content, s.validateDraftContent(w, r, req.Content)
+	}
+
+	_, templatePath, err := templates.Load(req.TemplateName)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "not_found", "Template not found", nil)
+		return "", false
+	}
+	cfg, _, err := config.LoadYAMLManaged(templatePath, templates.Dirs())
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "[API] Draft template validation failed", "error", err)
+		writeError(w, r, http.StatusBadRequest, "config_invalid", "Template configuration is invalid", nil)
+		return "", false
+	}
+	if !s.authorizeConfigEntitlements(w, r, cfg) {
+		return "", false
+	}
+
+	// Loading resolves include_path and every SNMP resource to absolute paths.
+	// Preserve that resolved base when moving the YAML into draft storage so
+	// inline preflight can enforce that each resource remains inside it.
+	if cfg.CapturePlayback != nil && !filepath.IsAbs(cfg.CapturePlayback.FileName) {
+		cfg.CapturePlayback.FileName = filepath.Join(filepath.Dir(templatePath), cfg.CapturePlayback.FileName)
+	}
+	materialized, err := config.MarshalConfigYAML(cfg)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "[API] Draft template materialization failed", "error", err)
+		writeError(w, r, http.StatusInternalServerError, "draft_materialization_failed",
+			"Failed to prepare template draft", nil)
+		return "", false
+	}
+	return string(materialized), true
 }
 
 func (s *Server) handleLibraryDraftRead(w http.ResponseWriter, r *http.Request, name string) {

--- a/internal/api/handlers_drafts.go
+++ b/internal/api/handlers_drafts.go
@@ -15,7 +15,7 @@ import (
 type draftCreateRequest struct {
 	Name         string `json:"name"`
 	Content      string `json:"content"`
-	TemplateName string `json:"template_name"`
+	TemplateName string `json:"templateName"`
 }
 
 type draftReplaceRequest struct {

--- a/internal/api/handlers_drafts_test.go
+++ b/internal/api/handlers_drafts_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -183,6 +184,71 @@ func TestDraftCreateValidatesConfigAndEntitlementsBeforePersistence(t *testing.T
 	}
 	if _, err := lib.ReadDraft("too-large"); !errors.Is(err, library.ErrNotFound) {
 		t.Fatalf("unlicensed config persisted, ReadDraft() error = %v", err)
+	}
+}
+
+func TestDraftCreateFromTemplateMaterializesRelativeResources(t *testing.T) {
+	server, _ := newTestServer(t)
+	lib := attachDraftLibrary(t, server)
+	templateDir := t.TempDir()
+	t.Setenv("NIAC_TEMPLATES_DIR", templateDir)
+	walkPath := filepath.Join(templateDir, "switch.walk")
+	if err := os.WriteFile(walkPath, []byte("SNMPv2-MIB::sysName.0 = STRING: access-1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	templateYAML := `include_path: "."
+devices:
+  - name: access-1
+    type: switch
+    mac: "02:00:00:00:00:01"
+    snmp_agent:
+      community: "public"
+      walk_file: "switch.walk"
+`
+	if err := os.WriteFile(filepath.Join(templateDir, "relative.yaml"), []byte(templateYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.handleLibraryDrafts(rec, draftRequest(
+		http.MethodPost,
+		"/api/v1/library/drafts",
+		`{"name":"from-template","template_name":"relative"}`,
+		"",
+	))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	draft, err := lib.ReadDraft("from-template")
+	if err != nil {
+		t.Fatalf("ReadDraft() error = %v", err)
+	}
+	resolvedTemplateDir, err := filepath.EvalSymlinks(templateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(draft.Content, "include_path: "+resolvedTemplateDir) {
+		t.Fatalf(
+			"materialized draft does not contain resolved include path %q:\n%s",
+			resolvedTemplateDir,
+			draft.Content,
+		)
+	}
+	resolvedWalkPath := filepath.Join(resolvedTemplateDir, filepath.Base(walkPath))
+	if !strings.Contains(draft.Content, resolvedWalkPath) {
+		t.Fatalf(
+			"materialized draft does not contain resolved walk path %q:\n%s",
+			resolvedWalkPath,
+			draft.Content,
+		)
+	}
+	if _, loadErr := config.LoadYAMLBytes([]byte(draft.Content)); loadErr != nil {
+		t.Fatalf("materialized draft is not independently loadable: %v", loadErr)
+	}
+	if _, loadErr := config.LoadYAMLBytesManaged(
+		[]byte(draft.Content), t.TempDir(), []string{templateDir},
+	); loadErr != nil {
+		t.Fatalf("materialized draft does not survive managed inline loading: %v", loadErr)
 	}
 }
 

--- a/internal/api/handlers_drafts_test.go
+++ b/internal/api/handlers_drafts_test.go
@@ -213,7 +213,7 @@ devices:
 	server.handleLibraryDrafts(rec, draftRequest(
 		http.MethodPost,
 		"/api/v1/library/drafts",
-		`{"name":"from-template","template_name":"relative"}`,
+		`{"name":"from-template","templateName":"relative"}`,
 		"",
 	))
 	if rec.Code != http.StatusCreated {

--- a/internal/api/templates/templates_test.go
+++ b/internal/api/templates/templates_test.go
@@ -1,11 +1,14 @@
 package templates
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
 
 func TestSplitTags(t *testing.T) {
@@ -299,6 +302,106 @@ func TestScan(t *testing.T) {
 			t.Errorf("Scan missing %q in %v", want, names)
 		}
 	}
+}
+
+func TestShippedTemplatesAreValid(t *testing.T) {
+	templateRoot, err := filepath.Abs(filepath.Join("..", "..", "..", "cmd", "niac", "templates"))
+	if err != nil {
+		t.Fatalf("resolve shipped template path: %v", err)
+	}
+	templateList, err := Scan(templateRoot)
+	if err != nil {
+		t.Fatalf("scan shipped templates: %v", err)
+	}
+	if len(templateList) == 0 {
+		t.Fatal("no shipped templates found")
+	}
+	t.Setenv("NIAC_TEMPLATES_DIR", templateRoot)
+
+	validated, err := validateShippedTemplates(t, templateRoot)
+	if err != nil {
+		t.Fatalf("walk shipped templates: %v", err)
+	}
+	if validated != len(templateList) {
+		t.Fatalf("validated %d shipped templates, scan found %d", validated, len(templateList))
+	}
+}
+
+func validateShippedTemplates(t *testing.T, templateRoot string) (int, error) {
+	t.Helper()
+	validated := 0
+	err := filepath.WalkDir(templateRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		extension := strings.ToLower(filepath.Ext(path))
+		if entry.IsDir() || (extension != ".yaml" && extension != ".yml") {
+			return nil
+		}
+		validated++
+		name := strings.TrimSuffix(filepath.Base(path), extension)
+		t.Run(name, func(t *testing.T) { validateShippedTemplate(t, name, path) })
+		return nil
+	})
+	return validated, err
+}
+
+func validateShippedTemplate(t *testing.T, name, templatePath string) {
+	t.Helper()
+	content, loadedPath, err := Load(name)
+	if err != nil {
+		t.Fatalf("select shipped template: %v", err)
+	}
+	if loadedPath != templatePath {
+		t.Fatalf("selected %q, want %q", loadedPath, templatePath)
+	}
+	cfg, err := config.LoadYAMLBytes(content)
+	if err != nil {
+		t.Fatalf("parse selected template: %v", err)
+	}
+	result := config.NewValidator(templatePath).Validate(cfg)
+	if result.HasErrors() {
+		t.Fatal(result.Format())
+	}
+	assertShippedTemplateBehavior(t, templatePath, cfg)
+}
+
+func assertShippedTemplateBehavior(t *testing.T, templatePath string, cfg *config.Config) {
+	t.Helper()
+	expectedOID := expectedVendorObjectID(filepath.Base(templatePath))
+	if strings.Contains(templatePath, "vendor-templates") && expectedOID == "" {
+		t.Fatalf("vendor template %q has no expected sysObjectID", templatePath)
+	}
+	for _, device := range cfg.Devices {
+		if device.LLDPConfig != nil && device.LLDPConfig.PortDescription != "" {
+			if len(device.Interfaces) == 0 || device.Interfaces[0].Name != device.LLDPConfig.PortDescription {
+				t.Errorf("device %q does not preserve its LLDP interface identity", device.Name)
+			}
+		}
+		if expectedOID != "" && device.Properties["sysObjectID"] != expectedOID {
+			t.Errorf("vendor device %q sysObjectID = %q, want %q",
+				device.Name, device.Properties["sysObjectID"], expectedOID)
+		}
+	}
+}
+
+func expectedVendorObjectID(name string) string {
+	return map[string]string{
+		"cx-6300m-48g.yaml":      "1.3.6.1.4.1.47196.4.1.1.3.123",
+		"iap-505.yaml":           "1.3.6.1.4.1.14823.1.2.96",
+		"aironet-iw9165e.yaml":   "1.3.6.1.4.1.9.1.3120",
+		"asa-5525-x.yaml":        "1.3.6.1.4.1.9.1.1408",
+		"catalyst-9300-48p.yaml": "1.3.6.1.4.1.9.1.2697",
+		"isr-4451-x.yaml":        "1.3.6.1.4.1.9.1.1903",
+		"nexus-9336c-fx2.yaml":   "1.3.6.1.4.1.9.12.3.1.3.1411",
+		"x440-g2-48t.yaml":       "1.3.6.1.4.1.1916.2.140",
+		"x670-g2-48x.yaml":       "1.3.6.1.4.1.1916.2.139",
+		"procurve-2530-48.yaml":  "1.3.6.1.4.1.11.2.3.7.11.150",
+		"ex4300-48t.yaml":        "1.3.6.1.4.1.2636.1.1.1.2.71",
+		"mist-ap43.yaml":         "1.3.6.1.4.1.55538",
+		"mx204.yaml":             "1.3.6.1.4.1.2636.1.1.1.2.57",
+		"srx340.yaml":            "1.3.6.1.4.1.2636.1.1.1.2.92",
+	}[name]
 }
 
 func TestScan_MissingDirIsNotFatal(t *testing.T) {

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -434,16 +434,15 @@
   },
   "newSimWizard": {
     "backLabel": "Back",
-    "description": "Guided path to build a config, add devices, and start a simulation.",
+    "description": "Build and validate a saved draft before starting a simulation.",
     "devices": {
-      "help": "Add or edit devices for this simulation using the Device Library below."
+      "help": "Edit the saved draft. Changes here do not affect the running simulation.",
+      "saveLabel": "Save draft",
+      "savingLabel": "Saving…"
     },
     "finish": {
       "gotoRuntime": "Go to Simulation",
-      "help": "The simulation is already running on the config you built. Save it, then head to Simulation to monitor or stop it.",
-      "saved": "Configuration saved.",
-      "saveLabel": "Save configuration",
-      "savingLabel": "Saving…",
+      "help": "The simulation started from the validated draft. The saved draft remains available for future editing.",
       "title": "All set"
     },
     "label": "New Simulation",
@@ -482,7 +481,7 @@
       "help": "Pick a starting config below, or start empty and add devices in the next step.",
       "interfaceLabel": "Network interface",
       "startEmpty": "Start empty",
-      "startingLabel": "Starting…"
+      "startingLabel": "Preparing draft…"
     },
     "title": "New Simulation"
   },

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -133,7 +133,7 @@
   "newSimWizard": {
     "label": "Nueva simulación",
     "title": "Nueva simulación",
-    "description": "Ruta guiada para construir una configuración, agregar dispositivos e iniciar una simulación.",
+    "description": "Construye y valida un borrador guardado antes de iniciar una simulación.",
     "steps": {
       "template": "Plantilla",
       "preflight": "Conexión",
@@ -149,7 +149,7 @@
       "startEmpty": "Empezar vacío",
       "help": "Elige una configuración inicial abajo, o empieza vacío y agrega dispositivos en el siguiente paso.",
       "errorNoSource": "Elige una plantilla, configuración guardada, archivo subido, o Empezar vacío primero",
-      "startingLabel": "Iniciando…"
+      "startingLabel": "Preparando borrador…"
     },
     "preflight": {
       "title": "Revisar conexión física",
@@ -169,7 +169,9 @@
       "startLabel": "Iniciar simulación"
     },
     "devices": {
-      "help": "Agrega o edita dispositivos para esta simulación usando la Biblioteca de dispositivos abajo."
+      "help": "Edita el borrador guardado. Los cambios aquí no afectan la simulación en ejecución.",
+      "saveLabel": "Guardar borrador",
+      "savingLabel": "Guardando…"
     },
     "protocols": {
       "title": "Protocolos",
@@ -177,10 +179,7 @@
     },
     "finish": {
       "title": "Todo listo",
-      "help": "La simulación ya está corriendo con la configuración que construiste. Guárdala y luego ve a Simulación para monitorearla o detenerla.",
-      "saveLabel": "Guardar configuración",
-      "savingLabel": "Guardando…",
-      "saved": "Configuración guardada.",
+      "help": "La simulación se inició desde el borrador validado. El borrador guardado permanece disponible para futuras ediciones.",
       "gotoRuntime": "Ir a Simulación"
     }
   },

--- a/ui/src/api/library-client.test.ts
+++ b/ui/src/api/library-client.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('scenario draft client', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+  });
+
+  it('creates and reads drafts through the protected library boundary', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ token: 'csrf-token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: () =>
+          Promise.resolve({
+            name: 'campus-draft',
+            content: 'devices: []\n',
+            format: 'yaml',
+            revision: 'revision-1',
+            modifiedAt: '2026-07-28T12:00:00Z',
+            sizeBytes: 12,
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            name: 'campus-draft',
+            content: 'devices: []\n',
+            format: 'yaml',
+            revision: 'revision-1',
+            modifiedAt: '2026-07-28T12:00:00Z',
+            sizeBytes: 12,
+          }),
+      });
+
+    const { createScenarioDraft, fetchScenarioDraft } = await import('./library-client');
+    await createScenarioDraft('campus-draft', 'devices: []\n');
+    await fetchScenarioDraft('campus-draft');
+
+    expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/library/drafts');
+    expect(mockFetch.mock.calls[1][1]).toMatchObject({
+      method: 'POST',
+      body: JSON.stringify({ name: 'campus-draft', content: 'devices: []\n' }),
+    });
+    expect(mockFetch.mock.calls[2][0]).toContain('/api/v1/library/drafts/campus-draft');
+    expect(mockFetch.mock.calls[2][1]).toMatchObject({ credentials: 'same-origin' });
+  });
+
+  it('sends the current revision when replacing and deleting a draft', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ token: 'csrf-token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            name: 'campus-draft',
+            content: 'devices:\n  - name: router-1\n',
+            format: 'yaml',
+            revision: 'revision-2',
+            modifiedAt: '2026-07-28T12:01:00Z',
+            sizeBytes: 28,
+          }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 204 });
+
+    const { deleteScenarioDraft, replaceScenarioDraft } = await import('./library-client');
+    await replaceScenarioDraft('campus-draft', 'revision-1', 'devices:\n  - name: router-1\n');
+    await deleteScenarioDraft('campus-draft', 'revision-2');
+
+    const replaceHeaders = mockFetch.mock.calls[1][1]?.headers as Headers;
+    expect(mockFetch.mock.calls[1][1]).toMatchObject({ method: 'PUT' });
+    expect(replaceHeaders.get('If-Match')).toBe('"revision-1"');
+
+    const deleteHeaders = mockFetch.mock.calls[2][1]?.headers as Headers;
+    expect(mockFetch.mock.calls[2][1]).toMatchObject({ method: 'DELETE' });
+    expect(deleteHeaders.get('If-Match')).toBe('"revision-2"');
+  });
+
+  it('creates template drafts without flattening resources in the browser', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ token: 'csrf-token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: () =>
+          Promise.resolve({
+            name: 'switch-draft',
+            content: 'devices:\n  - name: switch-1\n',
+            format: 'yaml',
+            revision: 'revision-1',
+            modifiedAt: '2026-07-28T12:00:00Z',
+            sizeBytes: 29,
+          }),
+      });
+
+    const { createScenarioDraftFromTemplate } = await import('./library-client');
+    await createScenarioDraftFromTemplate('switch-draft', 'catalyst-9300-48p');
+
+    expect(mockFetch.mock.calls[1][1]).toMatchObject({
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'switch-draft',
+        template_name: 'catalyst-9300-48p',
+      }),
+    });
+  });
+});

--- a/ui/src/api/library-client.test.ts
+++ b/ui/src/api/library-client.test.ts
@@ -116,7 +116,7 @@ describe('scenario draft client', () => {
       method: 'POST',
       body: JSON.stringify({
         name: 'switch-draft',
-        template_name: 'catalyst-9300-48p',
+        templateName: 'catalyst-9300-48p',
       }),
     });
   });

--- a/ui/src/api/library-client.ts
+++ b/ui/src/api/library-client.ts
@@ -53,6 +53,43 @@ export const uploadLibraryNetwork = (payload: UploadLibraryNetworkRequest) =>
 export const deleteLibraryNetwork = (name: string) =>
   request<void>(`/api/v1/library/networks/${encodeURIComponent(name)}`, { method: 'DELETE' });
 
+export interface ScenarioDraftEntry {
+  name: string;
+  revision: string;
+  modifiedAt: string;
+  sizeBytes: number;
+}
+
+export interface ScenarioDraft extends ScenarioDraftEntry {
+  content: string;
+  format: 'yaml';
+}
+
+export const fetchScenarioDrafts = () =>
+  deduplicatedGet<ScenarioDraftEntry[]>('/api/v1/library/drafts');
+
+export const fetchScenarioDraft = (name: string) =>
+  request<ScenarioDraft>(`/api/v1/library/drafts/${encodeURIComponent(name)}`);
+
+export const createScenarioDraft = (name: string, content: string) =>
+  requestJson<ScenarioDraft>('/api/v1/library/drafts', { name, content }, { method: 'POST' });
+
+export const createScenarioDraftFromTemplate = (name: string, templateName: string) =>
+  requestJson<ScenarioDraft>('/api/v1/library/drafts', { name, templateName }, { method: 'POST' });
+
+export const replaceScenarioDraft = (name: string, revision: string, content: string) =>
+  requestJson<ScenarioDraft>(
+    `/api/v1/library/drafts/${encodeURIComponent(name)}`,
+    { content },
+    { method: 'PUT', headers: { 'If-Match': `"${revision}"` } },
+  );
+
+export const deleteScenarioDraft = (name: string, revision: string) =>
+  request<void>(`/api/v1/library/drafts/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+    headers: { 'If-Match': `"${revision}"` },
+  });
+
 /**
  * Revert a library walk to its preserved pristine original, discarding
  * any edits made since the walk was first written. Backed by POST

--- a/ui/src/api/library-client.ts
+++ b/ui/src/api/library-client.ts
@@ -75,7 +75,11 @@ export const createScenarioDraft = (name: string, content: string) =>
   requestJson<ScenarioDraft>('/api/v1/library/drafts', { name, content }, { method: 'POST' });
 
 export const createScenarioDraftFromTemplate = (name: string, templateName: string) =>
-  requestJson<ScenarioDraft>('/api/v1/library/drafts', { name, templateName }, { method: 'POST' });
+  request<ScenarioDraft>('/api/v1/library/drafts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, templateName }),
+  });
 
 export const replaceScenarioDraft = (name: string, revision: string, content: string) =>
   requestJson<ScenarioDraft>(

--- a/ui/src/components/wizard/DevicesStep.tsx
+++ b/ui/src/components/wizard/DevicesStep.tsx
@@ -1,23 +1,64 @@
+import { FileCog, Save } from 'lucide-react';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { DeviceListPage } from '../../pages/DeviceListPage';
+import { iconSizes } from '../../constants/sizes';
+import { Button } from '../../ui/Button';
+import { Card, CardContent } from '../../ui/Card';
 import { SmallText } from '../../ui/Typography';
+import { YamlEditor } from '../config/YamlEditor';
+
+interface DevicesStepProps {
+  draftName: string;
+  content: string;
+  dirty: boolean;
+  saving: boolean;
+  onChange: (content: string) => void;
+  onSave: () => void;
+}
 
 /**
- * Step 2 — add/edit devices. Embeds the existing Device Library page
- * (`DeviceListPage`) unmodified: it already reads/writes the daemon's
- * currently-active config (which the wizard just started the simulation
- * against in step 1), so device CRUD here is the same code path the
- * standalone "Devices" nav item uses. Clicking a device to edit it
- * navigates to the existing `/device-config/:hostname` route — the same
- * app-wide behavior every other device list uses.
+ * Step 2 edits the saved draft directly. The visual device composer replaces
+ * this YAML surface in Phase 3; until then, server validation and revision
+ * matching keep this editor safe without touching the active runtime.
  */
-export const DevicesStep: FC = () => {
+export const DevicesStep: FC<DevicesStepProps> = ({
+  draftName,
+  content,
+  dirty,
+  saving,
+  onChange,
+  onSave,
+}) => {
   const { t } = useTranslation('pages');
   return (
-    <div className="stack" data-testid="wizard-step-devices-content">
-      <SmallText className="text-text-muted">{t('newSimWizard.devices.help')}</SmallText>
-      <DeviceListPage />
-    </div>
+    <Card className="border-surface-border bg-bg-surface/70">
+      <CardContent className="stack">
+        <div className="flex items-center gap-default">
+          <FileCog className={`${iconSizes.lg} text-brand-accent`} />
+          <div>
+            <p className="font-medium text-text-primary">{draftName}</p>
+            <SmallText className="text-text-muted">{t('newSimWizard.devices.help')}</SmallText>
+          </div>
+        </div>
+        <YamlEditor
+          value={content}
+          onChange={onChange}
+          readOnly={saving}
+          height="24rem"
+          className="mt-heading"
+        />
+        <div>
+          <Button
+            tone="violet"
+            leftIcon={<Save className={iconSizes.md} />}
+            disabled={!dirty || saving}
+            loading={saving}
+            onClick={onSave}
+          >
+            {saving ? t('newSimWizard.devices.savingLabel') : t('newSimWizard.devices.saveLabel')}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 };

--- a/ui/src/components/wizard/FinishStep.test.tsx
+++ b/ui/src/components/wizard/FinishStep.test.tsx
@@ -1,59 +1,27 @@
 /**
  * FinishStep.test.tsx
  *
- * The wizard's Save action must go through the existing config-save
- * endpoint (`PUT /api/v1/config`, wrapped by `updateConfig`) — same one
- * the Devices page's YAML editor uses. No new save endpoint.
+ * The finish step confirms the saved draft used for the running simulation
+ * and hands the operator to runtime monitoring.
  */
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ConfigDocument } from '../../api/types';
+import { describe, expect, it } from 'vitest';
 import '../../i18n';
 import { FinishStep } from './FinishStep';
-
-const fetchConfig = vi.fn<() => Promise<ConfigDocument>>();
-const updateConfig = vi.fn<(payload: { content: string }) => Promise<ConfigDocument>>();
-
-vi.mock('../../api/client', () => ({
-  fetchConfig: () => fetchConfig(),
-  updateConfig: (payload: { content: string }) => updateConfig(payload),
-}));
-
-const doc: ConfigDocument = {
-  path: '/tmp/config.yaml',
-  filename: 'config.yaml',
-  modifiedAt: new Date().toISOString(),
-  sizeBytes: 42,
-  deviceCount: 0,
-  content: 'devices: []\n',
-};
 
 function renderStep() {
   return render(
     <MemoryRouter>
-      <FinishStep />
+      <FinishStep draftName="campus-draft" />
     </MemoryRouter>,
   );
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  fetchConfig.mockResolvedValue(doc);
-  updateConfig.mockResolvedValue(doc);
-});
-
 describe('FinishStep', () => {
-  it('calls the existing config-save endpoint on Save', async () => {
-    const user = userEvent.setup();
+  it('shows the saved draft used to start the simulation', () => {
     renderStep();
-
-    await user.click(screen.getByTestId('wizard-save-button'));
-
-    await waitFor(() => expect(updateConfig).toHaveBeenCalledTimes(1));
-    expect(updateConfig).toHaveBeenCalledWith({ content: doc.content });
-    expect(await screen.findByRole('status')).toHaveTextContent(/saved/i);
+    expect(screen.getByTestId('wizard-finish-draft-name')).toHaveTextContent('campus-draft');
   });
 
   it('links to the existing Simulation page', () => {

--- a/ui/src/components/wizard/FinishStep.tsx
+++ b/ui/src/components/wizard/FinishStep.tsx
@@ -1,41 +1,14 @@
-import { PartyPopper, Save } from 'lucide-react';
-import { type FC, useState } from 'react';
+import { PartyPopper } from 'lucide-react';
+import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
-import { fetchConfig, updateConfig } from '../../api/client';
 import { iconSizes } from '../../constants/sizes';
-import { useErrorToast } from '../../hooks/useErrorToast';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { H2, SmallText } from '../../ui/Typography';
 
-/**
- * Step 5 — Save / Start. The simulation is already running by this point
- * (step 1 had to start it against the picked config so the existing
- * device-editing surface in steps 2-3 had something live to operate on —
- * there's no separate "load config without starting" endpoint). This step
- * re-saves the final config via the same `PUT /api/v1/config` the Devices
- * page's YAML editor uses, then hands off to the existing Simulation page,
- * which already shows the running status.
- */
-export const FinishStep: FC = () => {
+export const FinishStep: FC<{ draftName: string }> = ({ draftName }) => {
   const { t } = useTranslation('pages');
-  const showError = useErrorToast();
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      const current = await fetchConfig();
-      await updateConfig({ content: current.content });
-      setSaved(true);
-    } catch (err) {
-      showError(err);
-    } finally {
-      setSaving(false);
-    }
-  };
 
   return (
     <Card className="border-surface-border bg-bg-surface/70">
@@ -45,29 +18,17 @@ export const FinishStep: FC = () => {
           <H2>{t('newSimWizard.finish.title')}</H2>
         </div>
         <SmallText className="text-text-muted">{t('newSimWizard.finish.help')}</SmallText>
+        <SmallText data-testid="wizard-finish-draft-name" className="font-mono text-text-secondary">
+          {draftName}
+        </SmallText>
 
-        <div className="flex flex-wrap gap-default">
-          <Button
-            tone="violet"
-            data-testid="wizard-save-button"
-            leftIcon={<Save className={iconSizes.md} />}
-            disabled={saving}
-            onClick={handleSave}
-          >
-            {saving ? t('newSimWizard.finish.savingLabel') : t('newSimWizard.finish.saveLabel')}
-          </Button>
+        <div>
           <Link to="/runtime">
-            <Button variant="outline" data-testid="wizard-goto-runtime">
+            <Button tone="violet" data-testid="wizard-goto-runtime">
               {t('newSimWizard.finish.gotoRuntime')}
             </Button>
           </Link>
         </div>
-
-        {saved && (
-          <SmallText className="text-status-success" role="status" aria-live="polite">
-            {t('newSimWizard.finish.saved')}
-          </SmallText>
-        )}
       </CardContent>
     </Card>
   );

--- a/ui/src/components/wizard/ProtocolsStep.tsx
+++ b/ui/src/components/wizard/ProtocolsStep.tsx
@@ -1,35 +1,15 @@
-import { ShieldCheck } from 'lucide-react';
 import type { FC } from 'react';
-import { useTranslation } from 'react-i18next';
-import { fetchDevices } from '../../api/client';
-import type { DeviceSummary } from '../../api/types';
-import { DeviceTable } from '../../components/DeviceTable';
-import { iconSizes } from '../../constants/sizes';
-import { useApiResource } from '../../hooks/useApiResource';
-import { BaseCard } from '../../ui/BaseCard';
+import { SelectedNetworkPreview } from '../../pages/runtime/SelectedNetworkPreview';
+
+interface ProtocolsStepProps {
+  name: string;
+  content: string;
+}
 
 /**
- * Step 3 — a focused, read-only view of per-device protocol config. Reuses
- * `DeviceTable`, which already renders a Protocols column (see
- * `DevicesPage`'s "Running Devices" card) — no new controls, just this
- * step's own fetch of the config the wizard just built in step 2.
+ * Step 3 summarizes identities and configured services from draft content.
+ * It cannot accidentally report devices from a different running scenario.
  */
-export const ProtocolsStep: FC = () => {
-  const { t } = useTranslation('pages');
-  const { data: devices, loading, error } = useApiResource(fetchDevices, []);
-
-  return (
-    <BaseCard<DeviceSummary[]>
-      title={t('newSimWizard.protocols.title')}
-      subtitle={t('newSimWizard.protocols.subtitle')}
-      icon={<ShieldCheck className={`${iconSizes.lg} text-status-info`} />}
-      data={devices}
-      loading={loading && !devices}
-      error={error?.message}
-      getStatus={(d) => (d.length > 0 ? 'success' : 'unknown')}
-      emptyMessage={t('devices.emptyMessage')}
-    >
-      {(data) => <DeviceTable devices={data} />}
-    </BaseCard>
-  );
-};
+export const ProtocolsStep: FC<ProtocolsStepProps> = ({ name, content }) => (
+  <SelectedNetworkPreview source="upload" name={name} content={content} view="protocols" />
+);

--- a/ui/src/components/wizard/ReviewStep.tsx
+++ b/ui/src/components/wizard/ReviewStep.tsx
@@ -1,32 +1,14 @@
 import type { FC } from 'react';
-import { useTranslation } from 'react-i18next';
-import { fetchConfig } from '../../api/client';
-import { useApiResource } from '../../hooks/useApiResource';
 import { SelectedNetworkPreview } from '../../pages/runtime/SelectedNetworkPreview';
-import { SmallText } from '../../ui/Typography';
+
+interface ReviewStepProps {
+  name: string;
+  content: string;
+}
 
 /**
- * Step 4 — review the config the wizard built. Reuses
- * `SelectedNetworkPreview` (Simulation page's "what's about to launch"
- * card) fed with the live daemon config content via its `content` prop,
- * instead of the usual template/userConfig/upload source fetch — the
- * wizard's config is already the daemon's active config by this point.
+ * Step 4 reviews the exact revisioned draft that will be sent to preflight.
  */
-export const ReviewStep: FC = () => {
-  const { t } = useTranslation('pages');
-  const { data, loading, error } = useApiResource(fetchConfig, []);
-
-  if (loading && !data) {
-    return <SmallText className="text-text-muted">{t('runtime.preview.loading')}</SmallText>;
-  }
-
-  if (error || !data) {
-    return (
-      <SmallText className="text-status-error" role="alert">
-        {t('runtime.preview.loadError', { error: error?.message ?? '' })}
-      </SmallText>
-    );
-  }
-
-  return <SelectedNetworkPreview source="upload" name={data.filename} content={data.content} />;
-};
+export const ReviewStep: FC<ReviewStepProps> = ({ name, content }) => (
+  <SelectedNetworkPreview source="upload" name={name} content={content} />
+);

--- a/ui/src/components/wizard/TemplateStep.tsx
+++ b/ui/src/components/wizard/TemplateStep.tsx
@@ -20,11 +20,9 @@ interface TemplateStepProps {
 
 /**
  * Step 1 — pick a starting config (built-in template, saved config, local
- * upload, or blank) and the network interface the simulation will run on.
- * Composes the same `ConfigPicker` used on the Simulation page; the
- * interface picker mirrors `RuntimeControlPage`'s inline `<select>` since
- * the daemon requires an interface up front (there's no "load config
- * without starting" endpoint to defer it to a later step).
+ * upload, or blank) and the network interface the simulation will use after
+ * authoring and preflight. The selected content is copied into a revisioned
+ * draft; this step never changes the daemon's active configuration.
  */
 export const TemplateStep: FC<TemplateStepProps> = ({
   state,

--- a/ui/src/components/wizard/wizard-types.ts
+++ b/ui/src/components/wizard/wizard-types.ts
@@ -7,10 +7,10 @@ import type { LibraryNetwork, Template } from '../../api/types';
  */
 export const WIZARD_STEPS = [
   'template',
-  'preflight',
   'devices',
   'protocols',
   'review',
+  'preflight',
   'finish',
 ] as const;
 export type WizardStepId = (typeof WIZARD_STEPS)[number];
@@ -23,11 +23,9 @@ export type WizardStepId = (typeof WIZARD_STEPS)[number];
 export type WizardSource = 'template' | 'userConfig' | 'upload' | 'empty';
 
 /**
- * WizardState is held locally (useState) in the container — it never
- * touches the global ui-store. Once `configPath` is set the picked
- * config has been materialised as a real, safe (non-built-in) file. The
- * preflight step starts it only after the server accepts the physical
- * binding, which unlocks the existing device-editing surface.
+ * WizardState is held locally in the container. Draft content and its
+ * revision live beside this navigation/source state so authoring never
+ * changes the daemon's active configuration.
  */
 export interface WizardState {
   step: number;
@@ -36,7 +34,6 @@ export interface WizardState {
   userConfig: LibraryNetwork | null;
   uploadFile: File | null;
   selectedInterface: string;
-  configPath: string | null;
   starting: boolean;
   saving: boolean;
 }
@@ -48,7 +45,6 @@ export const initialWizardState: WizardState = {
   userConfig: null,
   uploadFile: null,
   selectedInterface: '',
-  configPath: null,
   starting: false,
   saving: false,
 };

--- a/ui/src/pages/NewSimulationWizardPage.test.tsx
+++ b/ui/src/pages/NewSimulationWizardPage.test.tsx
@@ -1,18 +1,17 @@
 /**
  * NewSimulationWizardPage.test.tsx
  *
- * Covers the two behaviors called out in issue #958: step
- * navigation (Next/Back, Next disabled until step 1 is complete) and
- * that finishing the wizard's step 1 ("start empty" + interface) drives
- * the existing `startSimulation` endpoint — the materialise-then-start
- * seam that unlocks the embedded Devices step.
+ * Covers draft-first authoring: the picked source is saved as a revisioned
+ * draft, edits update that draft, and runtime does not start until the final
+ * preflight succeeds.
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DeviceListResponse, LibraryNetwork, SimulationStatus, Template } from '../api/types';
+import type { ScenarioDraft } from '../api/library-client';
+import type { LibraryNetwork, SimulationStatus, Template } from '../api/types';
 import { AppProvider } from '../contexts/AppContext';
 import '../i18n';
 import { NewSimulationWizardPage } from './NewSimulationWizardPage';
@@ -43,7 +42,16 @@ const preflightSimulation = vi.fn();
 const fetchUsableInterfaces = vi.fn();
 const fetchTemplates = vi.fn<() => Promise<Template[]>>();
 const fetchLibraryNetworks = vi.fn<() => Promise<LibraryNetwork[]>>();
-const fetchConfigDevices = vi.fn<() => Promise<DeviceListResponse>>();
+const createScenarioDraft = vi.fn<(name: string, content: string) => Promise<ScenarioDraft>>();
+const createScenarioDraftFromTemplate =
+  vi.fn<(name: string, templateName: string) => Promise<ScenarioDraft>>();
+const replaceScenarioDraft =
+  vi.fn<(name: string, revision: string, content: string) => Promise<ScenarioDraft>>();
+const emptyDraftContent = `devices:
+  - name: new-device
+    type: host
+    mac: 02:00:00:00:00:01
+`;
 
 vi.mock('../api/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/client')>();
@@ -63,7 +71,6 @@ vi.mock('../api/client', async (importOriginal) => {
     // Wizard-specific
     fetchUsableInterfaces: () => fetchUsableInterfaces(),
     fetchTemplates: () => fetchTemplates(),
-    fetchConfigDevices: () => fetchConfigDevices(),
     startSimulation: (payload: unknown) => startSimulation(payload),
     preflightSimulation: (payload: unknown) => preflightSimulation(payload),
   };
@@ -71,6 +78,21 @@ vi.mock('../api/client', async (importOriginal) => {
 
 vi.mock('../api/library-client', () => ({
   fetchLibraryNetworks: () => fetchLibraryNetworks(),
+  createScenarioDraft: (name: string, content: string) => createScenarioDraft(name, content),
+  createScenarioDraftFromTemplate: (name: string, templateName: string) =>
+    createScenarioDraftFromTemplate(name, templateName),
+  replaceScenarioDraft: (name: string, revision: string, content: string) =>
+    replaceScenarioDraft(name, revision, content),
+}));
+
+vi.mock('../components/config/YamlEditor', () => ({
+  YamlEditor: ({ value, onChange }: { value: string; onChange?: (value: string) => void }) => (
+    <textarea
+      data-testid="wizard-draft-editor"
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
 }));
 
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -90,7 +112,30 @@ beforeEach(() => {
   });
   fetchTemplates.mockResolvedValue([]);
   fetchLibraryNetworks.mockResolvedValue([]);
-  fetchConfigDevices.mockResolvedValue({ devices: [], total: 0 });
+  createScenarioDraft.mockResolvedValue({
+    name: 'scenario-20260728-120000',
+    content: emptyDraftContent,
+    format: 'yaml',
+    revision: 'revision-1',
+    modifiedAt: '2026-07-28T12:00:00Z',
+    sizeBytes: emptyDraftContent.length,
+  });
+  createScenarioDraftFromTemplate.mockResolvedValue({
+    name: 'scenario-20260728-120000',
+    content: emptyDraftContent,
+    format: 'yaml',
+    revision: 'revision-1',
+    modifiedAt: '2026-07-28T12:00:00Z',
+    sizeBytes: emptyDraftContent.length,
+  });
+  replaceScenarioDraft.mockResolvedValue({
+    name: 'scenario-20260728-120000',
+    content: 'devices:\n  - name: edge-1\n    type: router\n    mac: 02:00:00:00:00:01\n',
+    format: 'yaml',
+    revision: 'revision-2',
+    modifiedAt: '2026-07-28T12:01:00Z',
+    sizeBytes: 76,
+  });
   startSimulation.mockResolvedValue({
     running: true,
     interface: 'lo0',
@@ -133,7 +178,7 @@ describe('NewSimulationWizardPage — step navigation', () => {
     expect(screen.getByTestId('wizard-next-button')).not.toBeDisabled();
   });
 
-  it('starts the simulation and advances to Devices, then Back returns to Connection', async () => {
+  it('creates and edits a draft without starting or changing the active runtime', async () => {
     const user = userEvent.setup();
     renderWizard();
 
@@ -142,8 +187,76 @@ describe('NewSimulationWizardPage — step navigation', () => {
     await user.click(screen.getByTestId('wizard-start-empty'));
     await user.click(screen.getByTestId('wizard-next-button'));
 
+    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    expect(createScenarioDraft).toHaveBeenCalledWith(
+      expect.stringMatching(/^scenario-/),
+      emptyDraftContent,
+    );
+    expect(startSimulation).not.toHaveBeenCalled();
+    expect(screen.getByTestId('wizard-draft-editor')).toHaveTextContent('new-device');
+
+    fireEvent.change(screen.getByTestId('wizard-draft-editor'), {
+      target: {
+        value: 'devices:\n  - name: edge-1\n    type: router\n    mac: 02:00:00:00:00:01\n',
+      },
+    });
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await waitFor(() => expect(replaceScenarioDraft).toHaveBeenCalledTimes(1));
+    expect(replaceScenarioDraft).toHaveBeenCalledWith(
+      'scenario-20260728-120000',
+      'revision-1',
+      expect.stringContaining('edge-1'),
+    );
+    expect(startSimulation).not.toHaveBeenCalled();
+
+    expect(screen.getByTestId('wizard-step-template')).toHaveAttribute('data-status', 'done');
+    expect(screen.getByTestId('wizard-step-protocols')).toHaveAttribute('data-status', 'active');
+
+    await user.click(screen.getByTestId('wizard-back-button'));
+    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+  });
+
+  it('saves dirty edits before Back and resumes the same draft for an unchanged source', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByTestId('wizard-interface-select')).not.toBeDisabled());
+    await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
+    await user.click(screen.getByTestId('wizard-start-empty'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('wizard-draft-editor'), {
+      target: {
+        value: 'devices:\n  - name: edge-1\n    type: router\n    mac: 02:00:00:00:00:01\n',
+      },
+    });
+    await user.click(screen.getByTestId('wizard-back-button'));
+
+    await waitFor(() => expect(replaceScenarioDraft).toHaveBeenCalledTimes(1));
+    expect(await screen.findByTestId('wizard-interface-select')).toHaveValue('lo0');
+    await user.click(screen.getByTestId('wizard-next-button'));
+
+    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    expect(createScenarioDraft).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('wizard-draft-editor')).toHaveTextContent('edge-1');
+  });
+
+  it('starts only after draft review and a successful preflight', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByTestId('wizard-interface-select')).not.toBeDisabled());
+    await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
+    await user.click(screen.getByTestId('wizard-start-empty'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(screen.getByTestId('wizard-next-button'));
     await waitFor(() => expect(screen.getByTestId('wizard-preflight-check')).toBeInTheDocument());
     expect(startSimulation).not.toHaveBeenCalled();
+
     await user.click(screen.getByTestId('wizard-preflight-check'));
     await waitFor(() => expect(screen.getByTestId('wizard-preflight-start')).not.toBeDisabled());
     await user.click(screen.getByTestId('wizard-preflight-start'));
@@ -152,40 +265,54 @@ describe('NewSimulationWizardPage — step navigation', () => {
     expect(startSimulation).toHaveBeenCalledWith(
       expect.objectContaining({
         interface: 'lo0',
+        configData: emptyDraftContent,
         attachmentMode: 'access',
         accessVlan: 200,
       }),
     );
-
-    await waitFor(() =>
-      expect(screen.getByTestId('wizard-step-devices-content')).toBeInTheDocument(),
+    expect(await screen.findByTestId('wizard-finish-draft-name')).toHaveTextContent(
+      'scenario-20260728-120000',
     );
-    expect(screen.getByTestId('wizard-step-template')).toHaveAttribute('data-status', 'done');
-    expect(screen.getByTestId('wizard-step-devices')).toHaveAttribute('data-status', 'active');
-
-    await user.click(screen.getByTestId('wizard-back-button'));
-    await waitFor(() => expect(screen.getByTestId('wizard-preflight-check')).toBeInTheDocument());
   });
 
-  it('returns from a failed preflight without losing the selected source or interface', async () => {
+  it('keeps the selected source and interface after a failed preflight and allows retry', async () => {
     const user = userEvent.setup();
-    preflightSimulation.mockRejectedValueOnce(new Error('connection rejected'));
+    preflightSimulation.mockRejectedValueOnce(new Error('preflight unavailable'));
     renderWizard();
 
     await waitFor(() => expect(screen.getByTestId('wizard-interface-select')).not.toBeDisabled());
     await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
     await user.click(screen.getByTestId('wizard-start-empty'));
     await user.click(screen.getByTestId('wizard-next-button'));
-    await waitFor(() => expect(screen.getByTestId('wizard-preflight-check')).toBeInTheDocument());
-
+    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(screen.getByTestId('wizard-next-button'));
     await user.click(screen.getByTestId('wizard-preflight-check'));
-    expect(await screen.findByRole('alert')).toHaveTextContent('connection rejected');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('preflight unavailable');
+    expect(screen.getByTestId('wizard-preflight-start')).toBeDisabled();
+
+    await user.click(screen.getByTestId('wizard-back-button'));
+    await user.click(screen.getByTestId('wizard-back-button'));
+    await user.click(screen.getByTestId('wizard-back-button'));
     await user.click(screen.getByTestId('wizard-back-button'));
 
     expect(await screen.findByTestId('wizard-interface-select')).toHaveValue('lo0');
+    expect(screen.getByTestId('wizard-start-empty')).toHaveClass('border-brand-accent');
     expect(screen.getByTestId('wizard-next-button')).not.toBeDisabled();
-    await user.click(screen.getByTestId('wizard-next-button'));
 
-    await waitFor(() => expect(screen.getByTestId('wizard-preflight-check')).toBeInTheDocument());
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    expect(createScenarioDraft).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(screen.getByTestId('wizard-preflight-check'));
+
+    await waitFor(() => expect(screen.getByTestId('wizard-preflight-start')).not.toBeDisabled());
+    expect(preflightSimulation).toHaveBeenLastCalledWith(
+      expect.objectContaining({ interface: 'lo0', configData: emptyDraftContent }),
+    );
   });
 });

--- a/ui/src/pages/NewSimulationWizardPage.tsx
+++ b/ui/src/pages/NewSimulationWizardPage.tsx
@@ -1,7 +1,13 @@
 import { type FC, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { applyTemplate, startSimulation } from '../api/client';
-import { fetchLibraryNetworkContent } from '../api/library-client';
+import { startSimulation } from '../api/client';
+import {
+  createScenarioDraft,
+  createScenarioDraftFromTemplate,
+  fetchLibraryNetworkContent,
+  replaceScenarioDraft,
+  type ScenarioDraft,
+} from '../api/library-client';
 import type { LibraryNetwork, SimulationRequest, Template } from '../api/types';
 import { DevicesStep } from '../components/wizard/DevicesStep';
 import { FinishStep } from '../components/wizard/FinishStep';
@@ -23,102 +29,116 @@ import { Card, CardContent } from '../ui/Card';
 import { SmallText } from '../ui/Typography';
 import { fileToText } from '../utils/file';
 
-// Placeholder skeleton for the "start empty" source — the smallest valid
-// config the daemon will load. Not a reimplementation of `niac config
-// generate`; it's just the seed content for a config the wizard's
-// existing-component steps then build up.
 const EMPTY_CONFIG_YAML = `devices:
   - name: new-device
     type: host
     mac: 02:00:00:00:00:01
 `;
 
+function newDraftName(now = new Date()) {
+  return `scenario-${now.toISOString().replaceAll(/[-:.TZ]/g, '')}`;
+}
+
+function selectedSourceKey(state: WizardState) {
+  if (state.source === 'template' && state.template) return `template:${state.template.name}`;
+  if (state.source === 'userConfig' && state.userConfig) return `network:${state.userConfig.name}`;
+  if (state.source === 'upload' && state.uploadFile) {
+    return `upload:${state.uploadFile.name}:${state.uploadFile.size}:${state.uploadFile.lastModified}`;
+  }
+  return state.source === 'empty' ? 'empty' : null;
+}
+
 /**
- * NewSimulationWizard — a thin orchestration layer over existing pages
- * and endpoints (issue #958). It does not introduce any new backend route
- * or reimplement device/config editing; it sequences:
+ * NewSimulationWizard sequences draft authoring and runtime activation:
  *
  *   1. Template  — ConfigPicker (pick a template / saved config / upload / empty)
- *   2. Connection — server preflight of the logical and physical binding
- *   3. Devices   — the existing Device Library page (device CRUD)
- *   4. Protocols — the existing DeviceTable's Protocols column, read-only
- *   5. Review    — the existing SelectedNetworkPreview
- *   6. Finish    — the existing config-save endpoint, then hand off to
- *                  the existing Simulation page
- *
- * Device CRUD in this app only operates on the daemon's single active
- * config (`s.configPath()` server-side) — there's no "stage a draft
- * config" endpoint. Step 1 therefore materialises the picked source as
- * a real (non-built-in) config. Step 2 preflights and starts that config,
- * which unlocks the existing editing surfaces.
+ *   2. Devices   — edit and revision-save the isolated draft
+ *   3. Protocols — inspect identities and configured services
+ *   4. Review    — review the exact saved draft revision
+ *   5. Connection — preflight and start only after authoring is complete
+ *   6. Finish    — hand off to runtime monitoring
  */
 export const NewSimulationWizardPage: FC = () => {
   const { t } = useTranslation('pages');
   const { data: simStatus } = useSimulationStatus();
   const showError = useErrorToast();
   const [state, setState] = useState<WizardState>(initialWizardState);
-  const [preparedRequest, setPreparedRequest] = useState<SimulationRequest | null>(null);
+  const [draft, setDraft] = useState<ScenarioDraft | null>(null);
+  const [draftContent, setDraftContent] = useState('');
+  const [draftDirty, setDraftDirty] = useState(false);
+  const [draftSourceKey, setDraftSourceKey] = useState<string | null>(null);
 
   const steps = WIZARD_STEPS.map((id) => ({
     id,
     label: t(`newSimWizard.steps.${id}`),
   }));
 
-  const goBack = useCallback(() => {
-    setState((s) => ({ ...s, step: Math.max(0, s.step - 1) }));
-  }, []);
-
   const prepareConfig = useCallback(async () => {
     setState((s) => ({ ...s, starting: true }));
     try {
-      let configPath: string | undefined;
-      let configData: string | undefined;
+      const sourceKey = selectedSourceKey(state);
+      if (draft && sourceKey === draftSourceKey) {
+        setDraftContent(draft.content);
+        setDraftDirty(false);
+        setState((s) => ({ ...s, step: 1, starting: false }));
+        return;
+      }
+
+      const draftName = newDraftName();
+      let created: ScenarioDraft;
 
       if (state.source === 'template' && state.template) {
-        // Copy the template into a new saved config first (existing
-        // "Save As" endpoint) instead of passing templateName straight to
-        // startSimulation — the latter points the daemon's active config
-        // path at the built-in template file itself, so any device edit
-        // in step 2 would overwrite the shipped template on disk.
-        const applied = await applyTemplate({ templateName: state.template.name });
-        configPath = applied.configPath;
+        created = await createScenarioDraftFromTemplate(draftName, state.template.name);
       } else if (state.source === 'userConfig' && state.userConfig) {
-        // Library networks aren't exposed as a filesystem path, so fetch
-        // the picked network's content and send it inline. The daemon
-        // persists inline config to its own _running.inline.yaml and
-        // points the active config path there, so step 2's device edits
-        // land on that copy rather than mutating the saved network.
-        const network = await fetchLibraryNetworkContent(state.userConfig.name);
-        configData = network.content;
+        const content = (await fetchLibraryNetworkContent(state.userConfig.name)).content;
+        created = await createScenarioDraft(draftName, content);
       } else if (state.source === 'upload' && state.uploadFile) {
-        configData = await fileToText(state.uploadFile);
+        created = await createScenarioDraft(draftName, await fileToText(state.uploadFile));
       } else if (state.source === 'empty') {
-        // Same inline path as above — the daemon materialises the blank
-        // skeleton to _running.inline.yaml, giving step 2 a real, editable
-        // active config without minting a persistent named entry.
-        configData = EMPTY_CONFIG_YAML;
+        created = await createScenarioDraft(draftName, EMPTY_CONFIG_YAML);
       } else {
         throw new Error(t('newSimWizard.template.errorNoSource'));
       }
 
-      setPreparedRequest({
-        interface: state.selectedInterface,
-        configPath,
-        configData,
-      });
-      setState((s) => ({ ...s, step: 1, configPath: configPath ?? null, starting: false }));
+      setDraft(created);
+      setDraftContent(created.content);
+      setDraftDirty(false);
+      setDraftSourceKey(sourceKey);
+      setState((s) => ({ ...s, step: 1, starting: false }));
     } catch (err) {
       showError(err);
       setState((s) => ({ ...s, starting: false }));
     }
-  }, [state, showError, t]);
+  }, [draft, draftSourceKey, state, showError, t]);
+
+  const saveDraft = useCallback(async () => {
+    if (!draft || !draftDirty) return true;
+    setState((s) => ({ ...s, saving: true }));
+    try {
+      const saved = await replaceScenarioDraft(draft.name, draft.revision, draftContent);
+      setDraft(saved);
+      setDraftContent(saved.content);
+      setDraftDirty(false);
+      return true;
+    } catch (err) {
+      showError(err);
+      return false;
+    } finally {
+      setState((s) => ({ ...s, saving: false }));
+    }
+  }, [draft, draftContent, draftDirty, showError]);
+
+  const goBack = useCallback(async () => {
+    if (WIZARD_STEPS[state.step] === 'devices' && !(await saveDraft())) return;
+    setState((s) => ({ ...s, step: Math.max(0, s.step - 1) }));
+  }, [saveDraft, state.step]);
 
   const startPreparedSimulation = useCallback(
     async (request: SimulationRequest) => {
       setState((s) => ({ ...s, starting: true }));
       try {
         await startSimulation(request);
-        setState((s) => ({ ...s, step: 2, starting: false }));
+        setState((s) => ({ ...s, step: WIZARD_STEPS.indexOf('finish'), starting: false }));
       } catch (err) {
         showError(err);
         setState((s) => ({ ...s, starting: false }));
@@ -127,15 +147,18 @@ export const NewSimulationWizardPage: FC = () => {
     [showError],
   );
 
-  const goNext = useCallback(() => {
+  const goNext = useCallback(async () => {
     if (state.step === 0) {
-      void prepareConfig();
+      await prepareConfig();
       return;
     }
+    if (WIZARD_STEPS[state.step] === 'devices' && !(await saveDraft())) return;
     setState((s) => ({ ...s, step: Math.min(WIZARD_STEPS.length - 1, s.step + 1) }));
-  }, [state.step, prepareConfig]);
+  }, [state.step, prepareConfig, saveDraft]);
 
-  const canProceed = state.step === 0 ? isTemplateStepComplete(state) && !state.starting : true;
+  const currentStep = WIZARD_STEPS[state.step];
+  const canProceed =
+    state.step === 0 ? isTemplateStepComplete(state) && !state.starting : !state.saving;
 
   if (simStatus === null) {
     return (
@@ -198,33 +221,54 @@ export const NewSimulationWizardPage: FC = () => {
             }
           />
         )}
-        {state.step === 1 && preparedRequest && (
+        {currentStep === 'devices' && draft && (
+          <DevicesStep
+            draftName={draft.name}
+            content={draftContent}
+            dirty={draftDirty}
+            saving={state.saving}
+            onChange={(content) => {
+              setDraftContent(content);
+              setDraftDirty(content !== draft.content);
+            }}
+            onSave={() => void saveDraft()}
+          />
+        )}
+        {currentStep === 'protocols' && draft && (
+          <ProtocolsStep name={draft.name} content={draft.content} />
+        )}
+        {currentStep === 'review' && draft && (
+          <ReviewStep name={draft.name} content={draft.content} />
+        )}
+        {currentStep === 'preflight' && draft && (
           <PreflightStep
-            request={preparedRequest}
+            request={{ interface: state.selectedInterface, configData: draft.content }}
             onStart={(request) => void startPreparedSimulation(request)}
             starting={state.starting}
           />
         )}
-        {state.step === 2 && <DevicesStep />}
-        {state.step === 3 && <ProtocolsStep />}
-        {state.step === 4 && <ReviewStep />}
-        {state.step === 5 && <FinishStep />}
+        {currentStep === 'finish' && draft && <FinishStep draftName={draft.name} />}
       </div>
 
-      {state.step === 1 && (
+      {currentStep === 'preflight' && (
         <div className="flex justify-start">
-          <Button variant="outline" data-testid="wizard-back-button" onClick={goBack}>
+          <Button
+            variant="outline"
+            data-testid="wizard-back-button"
+            disabled={state.saving}
+            onClick={() => void goBack()}
+          >
             {t('newSimWizard.backLabel')}
           </Button>
         </div>
       )}
-      {state.step !== 1 && state.step < WIZARD_STEPS.length - 1 && (
+      {currentStep !== 'preflight' && currentStep !== 'finish' && (
         <div className="flex justify-between gap-default">
           <Button
             variant="outline"
             data-testid="wizard-back-button"
-            disabled={state.step === 0}
-            onClick={goBack}
+            disabled={state.step === 0 || state.saving}
+            onClick={() => void goBack()}
           >
             {t('newSimWizard.backLabel')}
           </Button>
@@ -232,18 +276,13 @@ export const NewSimulationWizardPage: FC = () => {
             tone="violet"
             data-testid="wizard-next-button"
             disabled={!canProceed}
-            onClick={goNext}
+            onClick={() => void goNext()}
           >
             {state.step === 0 && state.starting
               ? t('newSimWizard.template.startingLabel')
-              : t('newSimWizard.nextLabel')}
-          </Button>
-        </div>
-      )}
-      {state.step === WIZARD_STEPS.length - 1 && (
-        <div className="flex justify-start">
-          <Button variant="outline" data-testid="wizard-back-button" onClick={goBack}>
-            {t('newSimWizard.backLabel')}
+              : currentStep === 'devices' && state.saving
+                ? t('newSimWizard.devices.savingLabel')
+                : t('newSimWizard.nextLabel')}
           </Button>
         </div>
       )}

--- a/ui/src/pages/runtime/SelectedNetworkPreview.test.tsx
+++ b/ui/src/pages/runtime/SelectedNetworkPreview.test.tsx
@@ -53,4 +53,59 @@ describe('SelectedNetworkPreview', () => {
 
     expect(await screen.findByText('router1')).toBeInTheDocument();
   });
+
+  it('shows configured draft protocols without treating disabled services as active', async () => {
+    render(
+      <SelectedNetworkPreview
+        source="upload"
+        name="draft"
+        content={`devices:
+  - name: switch-1
+    type: switch
+    lldp:
+      enabled: true
+    http:
+      enabled: false
+    cdp:
+      advertise_interval: 30
+    dhcp:
+      pool_start: 192.0.2.10
+    reflector:
+      latency_ms: 2
+    netbios:
+      enabled: true
+`}
+        view="protocols"
+      />,
+    );
+
+    expect(await screen.findByText('switch-1')).toBeInTheDocument();
+    expect(screen.getByText('LLDP')).toBeInTheDocument();
+    expect(screen.getByText('DHCP')).toBeInTheDocument();
+    expect(screen.getByText('Reflector')).toBeInTheDocument();
+    expect(screen.getByText('NetBIOS')).toBeInTheDocument();
+    expect(screen.queryByText('HTTP')).not.toBeInTheDocument();
+    expect(screen.queryByText('CDP')).not.toBeInTheDocument();
+  });
+
+  it('includes devices nested under segments in the draft protocol view', async () => {
+    render(
+      <SelectedNetworkPreview
+        source="upload"
+        name="segmented-draft"
+        content={`segments:
+  - vlan: 200
+    devices:
+      - name: access-1
+        type: switch
+        lldp:
+          enabled: true
+`}
+        view="protocols"
+      />,
+    );
+
+    expect(await screen.findByText('access-1')).toBeInTheDocument();
+    expect(screen.getByText('LLDP')).toBeInTheDocument();
+  });
 });

--- a/ui/src/pages/runtime/SelectedNetworkPreview.tsx
+++ b/ui/src/pages/runtime/SelectedNetworkPreview.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { parse as parseYaml, YAMLParseError } from 'yaml';
 import { fetchTemplateContent } from '../../api/client';
 import { fetchLibraryNetworkContent } from '../../api/library-client';
+import type { DeviceSummary } from '../../api/types';
+import { DeviceTable } from '../../components/DeviceTable';
 import { iconSizes } from '../../constants/sizes';
 import type { ConfigSource } from '../../stores/ui-store';
 import { Card, CardContent } from '../../ui/Card';
@@ -23,10 +25,8 @@ import { H2, SmallText } from '../../ui/Typography';
  *   content (raw YAML)   → skip the fetch entirely and preview it as-is
  *   source null          → render nothing
  *
- * The `content` prop lets NewSimulationWizard's Review step reuse this
- * component for a config that's already live on the daemon (not a
- * template/userConfig/upload) — it has the YAML in hand from `fetchConfig()`
- * and just needs the same device-summary rendering.
+ * The `content` prop lets the draft-first wizard preview saved content without
+ * reading or changing the daemon's active configuration.
  */
 interface DevicePreview {
   name: string;
@@ -42,6 +42,7 @@ interface SelectedNetworkPreviewProps {
   uploadFile?: File | null;
   /** Raw YAML to preview directly, bypassing the source-based fetch. */
   content?: string;
+  view?: 'identity' | 'protocols';
 }
 
 // The YAML on disk uses snake_case (snmp_agent, netbios_status, …) which
@@ -58,6 +59,7 @@ type ParsedDevice = {
 
 interface ParsedYaml {
   devices?: ParsedDevice[];
+  segments?: { devices?: ParsedDevice[] }[];
 }
 
 function typeIconFor(type: string) {
@@ -65,6 +67,10 @@ function typeIconFor(type: string) {
   if (t.includes('router') || t.includes('rtr') || t.includes('gateway')) return Router;
   if (t.includes('ap') || t.includes('wifi') || t.includes('wireless')) return Wifi;
   return Server;
+}
+
+function hasEnabledProperty(value: unknown): value is { enabled?: unknown } {
+  return typeof value === 'object' && value !== null && 'enabled' in value;
 }
 
 function summariseDevice(d: ParsedDevice): DevicePreview {
@@ -75,16 +81,42 @@ function summariseDevice(d: ParsedDevice): DevicePreview {
   // YAML keys are snake_case; loop instead of indexing each one so
   // useLiteralKeys + useNamingConvention don't fight over the field names.
   const services: string[] = [];
-  const serviceKeys: [string, string][] = [
-    ['snmp_agent', 'SNMP'],
+  const explicitlyEnabledServices: [string, string][] = [
+    ['snmpv3', 'SNMPv3'],
+    ['lldp', 'LLDP'],
+    ['cdp', 'CDP'],
+    ['edp', 'EDP'],
+    ['fdp', 'FDP'],
+    ['stp', 'STP'],
+    ['dhcpv6', 'DHCPv6'],
+    ['http', 'HTTP'],
+    ['ftp', 'FTP'],
+    ['netbios', 'NetBIOS'],
+    ['icmp', 'ICMP'],
+    ['icmpv6', 'ICMPv6'],
+    ['ssh', 'SSH'],
+    ['syslog', 'Syslog'],
+    ['iperf3', 'iPerf3'],
+  ];
+  for (const [key, label] of explicitlyEnabledServices) {
+    const value = d[key];
+    if (value === true || (hasEnabledProperty(value) && value.enabled === true)) {
+      services.push(label);
+    }
+  }
+
+  const presenceEnabledServices: [string, string][] = [
     ['dhcp', 'DHCP'],
     ['dns', 'DNS'],
-    ['http', 'HTTP'],
-    ['netbios_status', 'NetBIOS'],
-    ['icmp', 'ICMP'],
+    ['reflector', 'Reflector'],
   ];
-  for (const [key, label] of serviceKeys) {
-    if (d[key]) services.push(label);
+  for (const [key, label] of presenceEnabledServices) {
+    if (d[key] !== undefined && d[key] !== null && d[key] !== false) services.push(label);
+  }
+
+  const snmp = d.snmp_agent;
+  if (snmp && typeof snmp === 'object' && (!hasEnabledProperty(snmp) || snmp.enabled !== false)) {
+    services.push('SNMP');
   }
 
   return {
@@ -101,6 +133,7 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
   name,
   uploadFile,
   content,
+  view = 'identity',
 }) => {
   const { t } = useTranslation('pages');
   const [yamlText, setYamlText] = useState<string | null>(null);
@@ -155,11 +188,19 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
     if (!yamlText) return { devices: [], parseError: null, parseErrorLine: null };
     try {
       const parsed = parseYaml(yamlText) as ParsedYaml;
-      if (!parsed?.devices || !Array.isArray(parsed.devices)) {
+      const devices = [
+        ...(Array.isArray(parsed?.devices) ? parsed.devices : []),
+        ...(Array.isArray(parsed?.segments)
+          ? parsed.segments.flatMap((segment) =>
+              Array.isArray(segment.devices) ? segment.devices : [],
+            )
+          : []),
+      ];
+      if (devices.length === 0) {
         return { devices: [], parseError: null, parseErrorLine: null };
       }
       return {
-        devices: parsed.devices.map(summariseDevice),
+        devices: devices.map(summariseDevice),
         parseError: null,
         parseErrorLine: null,
       };
@@ -182,9 +223,15 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
         <div className="flex items-baseline justify-between gap-default">
           <H2 className="flex items-center gap-compact text-lg">
             <Eye className={`${iconSizes.lg} text-brand-accent`} />
-            {t('runtime.preview.selectedPrefix')} {displayName}
+            {view === 'protocols'
+              ? t('newSimWizard.protocols.title')
+              : `${t('runtime.preview.selectedPrefix')} ${displayName}`}
           </H2>
-          <SmallText className="text-text-muted">{t('runtime.preview.previewOnly')}</SmallText>
+          <SmallText className="text-text-muted">
+            {view === 'protocols'
+              ? t('newSimWizard.protocols.subtitle')
+              : t('runtime.preview.previewOnly')}
+          </SmallText>
         </div>
 
         {loading && (
@@ -209,7 +256,7 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
           <SmallText className="text-text-muted italic">{t('runtime.preview.noDevices')}</SmallText>
         )}
 
-        {devices.length > 0 && (
+        {view === 'identity' && devices.length > 0 && (
           <ul className="grid grid-cols-1 gap-compact sm:grid-cols-2 lg:grid-cols-3">
             {devices.map((d) => {
               const Icon = typeIconFor(d.type);
@@ -245,6 +292,18 @@ export const SelectedNetworkPreview: FC<SelectedNetworkPreviewProps> = ({
               );
             })}
           </ul>
+        )}
+
+        {view === 'protocols' && devices.length > 0 && (
+          <DeviceTable
+            devices={devices.map<DeviceSummary>((device) => ({
+              name: device.name,
+              type: device.type,
+              ips: device.ips,
+              protocols: device.services,
+              ...(device.mac ? { mac: device.mac } : {}),
+            }))}
+          />
         )}
 
         {devices.length > 0 && (


### PR DESCRIPTION
## Summary

- migrate every selectable built-in and vendor template to the current strict schema
- create revisioned scenario drafts directly from templates while materializing relative resources
- make the simulation wizard author and save a draft before preflight or runtime activation
- preserve source, interface, and draft edits across back navigation and failed preflight retries
- show the selected draft in runtime preview without mutating the active simulation

## Linked Issue

Related to #1151

## Testing Evidence

```text
make verify
PASS — 81 backend linters, 45 Go packages with race detection, 70 frontend files / 342 tests, govulncheck, npm audit, gitleaks, production UI and Go builds, and schema drift checks

All 21 shipped templates pass the real template selection, YAML load, validation, LLDP interface identity, and vendor sysObjectID paths.
Independent review completed; failed-preflight recovery coverage was restored and revalidated.
```

## Security and Release Checklist

- [x] No secrets or sensitive files
- [x] No new dependencies
- [x] No authentication, authorization, CSRF, or CORS changes
- [x] Customer-facing copy checked against banned vocabulary
- [x] Runtime remains unchanged until explicit post-preflight start
- [x] Full build embeds the frontend successfully
