### PR TITLE
perf: cache deterministic OUI allocation

### DIFF
--- a/internal/oui/registry.go
+++ b/internal/oui/registry.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"slices"
 	"strings"
+	"sync"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
 )
@@ -26,6 +26,16 @@ var (
 
 type prefix [3]byte
 
+type organization struct {
+	name       string
+	normalized string
+}
+
+type prefixMatch struct {
+	prefix prefix
+	found  bool
+}
+
 const (
 	prefixBytes     = 3
 	maxSuffix       = 0xffffff
@@ -35,7 +45,9 @@ const (
 
 // Registry indexes IEEE MA-L assignments by their 24-bit prefix.
 type Registry struct {
-	organizations map[prefix]string
+	organizations map[prefix]organization
+	matchMu       sync.RWMutex
+	matches       map[string]prefixMatch
 }
 
 // LoadEmbedded parses the IEEE snapshot shipped with NIAC.
@@ -45,12 +57,17 @@ func LoadEmbedded() (*Registry, error) {
 
 // Parse reads the public IEEE oui.txt format.
 func Parse(reader io.Reader) (*Registry, error) {
-	registry := &Registry{organizations: make(map[prefix]string)}
+	registry := &Registry{
+		organizations: make(map[prefix]organization),
+		matches:       make(map[string]prefixMatch),
+	}
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		parsedPrefix, organization, ok := parseLine(scanner.Text())
+		parsedPrefix, parsedOrganization, ok := parseLine(scanner.Text())
 		if ok {
-			registry.organizations[parsedPrefix] = organization
+			registry.organizations[parsedPrefix] = organization{
+				name: parsedOrganization, normalized: strings.ToLower(parsedOrganization),
+			}
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -64,8 +81,8 @@ func (r *Registry) Lookup(mac net.HardwareAddr) (string, bool) {
 	if len(mac) < prefixBytes {
 		return "", false
 	}
-	organization, ok := r.organizations[prefix{mac[0], mac[1], mac[2]}]
-	return organization, ok
+	entry, ok := r.organizations[prefix{mac[0], mac[1], mac[2]}]
+	return entry.name, ok
 }
 
 // Allocate returns a deterministic isolated-lab MAC for a vendor and suffix.
@@ -73,11 +90,10 @@ func (r *Registry) Allocate(vendor string, ordinal uint32) (net.HardwareAddr, er
 	if ordinal > maxSuffix {
 		return nil, ErrOrdinalRange
 	}
-	prefixes := r.matchingPrefixes(vendorSearch(vendor))
-	if len(prefixes) == 0 {
+	selected, found := r.matchingPrefix(vendorSearch(vendor))
+	if !found {
 		return nil, fmt.Errorf("%w: %s", ErrUnknownVendor, vendor)
 	}
-	selected := prefixes[0]
 	return net.HardwareAddr{
 		selected[0], selected[1], selected[2],
 		safeconv.ByteFromUint32(ordinal >> highByteShift),
@@ -86,15 +102,36 @@ func (r *Registry) Allocate(vendor string, ordinal uint32) (net.HardwareAddr, er
 	}, nil
 }
 
-func (r *Registry) matchingPrefixes(search string) []prefix {
-	matches := make([]prefix, 0)
+func (r *Registry) matchingPrefix(search string) (prefix, bool) {
+	r.matchMu.RLock()
+	match, cached := r.matches[search]
+	r.matchMu.RUnlock()
+	if cached {
+		return match.prefix, match.found
+	}
+
+	var selected prefix
+	found := false
 	for candidate, organization := range r.organizations {
-		if strings.Contains(strings.ToLower(organization), search) {
-			matches = append(matches, candidate)
+		if strings.Contains(organization.normalized, search) &&
+			(!found || comparePrefix(candidate, selected) < 0) {
+			selected = candidate
+			found = true
 		}
 	}
-	slices.SortFunc(matches, comparePrefix)
-	return matches
+
+	r.matchMu.Lock()
+	if r.matches == nil {
+		r.matches = make(map[string]prefixMatch)
+	}
+	if existing, ok := r.matches[search]; ok {
+		match = existing
+	} else {
+		match = prefixMatch{prefix: selected, found: found}
+		r.matches[search] = match
+	}
+	r.matchMu.Unlock()
+	return match.prefix, match.found
 }
 
 func parseLine(line string) (prefix, string, bool) {

--- a/internal/oui/registry_test.go
+++ b/internal/oui/registry_test.go
@@ -3,6 +3,7 @@ package oui_test
 import (
 	"net"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/oui"
@@ -64,5 +65,52 @@ func TestAllocateRejectsUnknownVendor(t *testing.T) {
 	}
 	if _, err = registry.Allocate("not-a-vendor", 1); err == nil {
 		t.Fatal("Allocate() error = nil, want unknown vendor error")
+	}
+}
+
+func TestZeroRegistryRejectsVendorWithoutPanicking(t *testing.T) {
+	var registry oui.Registry
+	if _, err := registry.Allocate("cisco", 1); err == nil {
+		t.Fatal("Allocate() error = nil, want unknown vendor error")
+	}
+}
+
+func TestAllocateIsSafeForConcurrentReuse(t *testing.T) {
+	registry, err := oui.LoadEmbedded()
+	if err != nil {
+		t.Fatalf("LoadEmbedded() error = %v", err)
+	}
+
+	const allocations = 100
+	var waitGroup sync.WaitGroup
+	errors := make(chan error, allocations)
+	for index := range allocations {
+		waitGroup.Go(func() {
+			_, allocateErr := registry.Allocate("cisco", uint32(index))
+			errors <- allocateErr
+		})
+	}
+	waitGroup.Wait()
+	close(errors)
+	for allocateErr := range errors {
+		if allocateErr != nil {
+			t.Errorf("Allocate() error = %v", allocateErr)
+		}
+	}
+}
+
+func BenchmarkAllocateCachedVendor(b *testing.B) {
+	registry, err := oui.LoadEmbedded()
+	if err != nil {
+		b.Fatalf("LoadEmbedded() error = %v", err)
+	}
+	if _, err = registry.Allocate("cisco", 0); err != nil {
+		b.Fatalf("prime Allocate() error = %v", err)
+	}
+	b.ResetTimer()
+	for index := range b.N {
+		if _, err = registry.Allocate("cisco", uint32(index&0xffffff)); err != nil {
+			b.Fatalf("Allocate() error = %v", err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- cache the deterministic vendor-prefix match used by generated device MAC allocation
- preserve smallest-prefix selection and zero-value Registry behavior
- add concurrent reuse coverage and a cached-allocation benchmark

## Linked Issue
Related to #1151

## Testing Evidence
```text
make fmt-check: passed
make lint: 81 backend linters, 0 issues; 330 frontend files clean
make test: 46 backend packages plus 70 frontend test files passed; scenario coverage 95.2%
make build: frontend and Go binary built successfully
pre-commit: secrets, gosec, race tests, file-size and sensitive-file checks passed
```

## Security and Release Checklist
- [x] No secrets or credentials added
- [x] No authentication, authorization, CSRF, or CORS behavior changed
- [x] Concurrent cache behavior is race-tested
- [x] No dependency or release workflow changes