### PR TITLE
feat: generate deterministic scenario fleets

### DIFF
--- a/CODE_INDEX.md
+++ b/CODE_INDEX.md
@@ -13,6 +13,7 @@ parallel implementation. It is intentionally organized by purpose.
 | Vendor-authored MAC identity | `internal/converter/types.go` + `internal/config/yaml_device.go` | `vendor` plus optional `mac_suffix` is resolved through the embedded IEEE registry while preserving the authored form on export |
 | Routed YAML adapters | `internal/config/yaml_fabric.go` | Converts authoring DTOs into runtime config |
 | Complete-config validation | `internal/config/validator.go` | Existing device validation; not routed semantics |
+| Deterministic scenario generation | `internal/scenario` | Typed sites and repeat controls produce validated portable YAML plus parity manifests; extend its role profiles and topology rules instead of adding fixture generators |
 
 ## Routed fabric and topology
 
@@ -58,6 +59,7 @@ parallel implementation. It is intentionally organized by purpose.
 | Simulation request contract | `internal/api/server.go` | Shared start and preflight request fields |
 | Simulation request validation | `internal/api/validation.go` | Interface/config source boundary validation |
 | Simulation lifecycle handlers | `internal/api/handlers_simulation.go` | Strict decoder and standard error envelope |
+| Scenario generation API | `internal/api/handlers_scenario.go` | Licensed profile catalog and CSRF-protected deterministic generation boundary; generated YAML remains a draft input and does not mutate runtime |
 | Route security policy | `internal/api/routes.go` | Methods, rate limits, and CSRF are registered here |
 | Config preparation and start | `internal/daemon/daemon.go` | Preflight must not persist or open capture |
 

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -36,6 +36,8 @@ Prometheus metrics share the daemon's HTTPS listener at `/metrics`; there is no 
 | `PUT` | `/api/v1/alerts` | Update alert threshold/webhook |
 | `GET` | `/api/v1/files?kind=walks|pcaps` | List available SNMP walk or PCAP files |
 | `GET` | `/api/v1/topology` | Simple topology graph derived from configuration |
+| `GET` | `/api/v1/scenario/profiles` | Reusable vendor, model, role, and discovery profiles |
+| `POST` | `/api/v1/scenario/generate` | Generate deterministic validated YAML from sites and repeat controls |
 | `GET` | `/api/v1/version` | Version information |
 | `GET` | `/api/v1/errors` | Available error types and active error injections |
 | `POST` | `/api/v1/errors` | Inject network errors on device interfaces |
@@ -47,6 +49,19 @@ Include `Authorization: Bearer <token>` or append `?token=<token>` when authenti
 The statistics stream publishes once per second while a simulation is active
 and at least one client is subscribed. Each `stats` event carries the same
 authoritative snapshot shape as `GET /api/v1/stats`.
+
+### Scenario generation
+
+`GET /api/v1/scenario/profiles` returns the role profiles used by the visual
+authoring flow. `POST /api/v1/scenario/generate` accepts sites, infrastructure
+counts, endpoint repeat counts, a domain, an SNMP community, and an attachment
+name. It returns portable YAML plus a manifest containing device, network, and
+link counts and deterministic SHA-256 fingerprints.
+
+Generation is side-effect free: it does not replace the active configuration,
+start a simulation, or save a draft. The returned `content` can be reviewed and
+then stored through the draft API. The generate route requires a read-write
+token, the `config_templates` entitlement, and a CSRF token.
 
 ## Web UI
 

--- a/internal/api/handlers_scenario.go
+++ b/internal/api/handlers_scenario.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+type scenarioGenerateResponse struct {
+	Content  string            `json:"content"`
+	Manifest scenario.Manifest `json:"manifest"`
+}
+
+func (s *Server) handleScenarioProfiles(w http.ResponseWriter, _ *http.Request) {
+	s.writeJSON(w, scenario.Profiles())
+}
+
+func (s *Server) handleScenarioGenerate(w http.ResponseWriter, r *http.Request) {
+	var request scenario.Request
+	if !decodeJSONStrict(w, r, &request, MaxRequestBodySize) {
+		return
+	}
+
+	result, err := scenario.Generate(request)
+	if err != nil {
+		status := scenarioGenerationErrorStatus(err)
+		message := err.Error()
+		if status == http.StatusInternalServerError {
+			message = "Scenario generation failed"
+			if s.logger != nil {
+				s.logger.ErrorContext(r.Context(), "Scenario generation failed", "error", err)
+			}
+		}
+		writeError(w, r, status, "scenario_generation_failed", message, nil)
+		return
+	}
+	s.writeJSON(w, scenarioGenerateResponse{Content: string(result.YAML), Manifest: result.Manifest})
+}
+
+func scenarioGenerationErrorStatus(err error) int {
+	if errors.Is(err, scenario.ErrInvalidRequest) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}

--- a/internal/api/handlers_scenario_test.go
+++ b/internal/api/handlers_scenario_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+func TestScenarioGenerationErrorStatusSeparatesInputFromInternalFailures(t *testing.T) {
+	invalidRequest := fmt.Errorf("bad request: %w", scenario.ErrInvalidRequest)
+	if got := scenarioGenerationErrorStatus(invalidRequest); got != http.StatusBadRequest {
+		t.Fatalf("invalid request status = %d, want 400", got)
+	}
+	if got := scenarioGenerationErrorStatus(errors.New("marshal failed")); got != http.StatusInternalServerError {
+		t.Fatalf("internal failure status = %d, want 500", got)
+	}
+}
+
+func TestScenarioGenerationHandlersReturnValidatedFleet(t *testing.T) {
+	server := &Server{}
+
+	profilesRecorder := httptest.NewRecorder()
+	server.handleScenarioProfiles(
+		profilesRecorder,
+		httptest.NewRequest(http.MethodGet, "/api/v1/scenario/profiles", nil),
+	)
+	if profilesRecorder.Code != http.StatusOK {
+		t.Fatalf("profiles status = %d, want 200", profilesRecorder.Code)
+	}
+	var profiles []scenario.DeviceProfile
+	if err := json.NewDecoder(profilesRecorder.Body).Decode(&profiles); err != nil {
+		t.Fatalf("decode profiles: %v", err)
+	}
+	if len(profiles) != len(scenario.Profiles()) {
+		t.Fatalf("profiles = %d, want %d", len(profiles), len(scenario.Profiles()))
+	}
+
+	body, err := json.Marshal(scenario.EnterpriseReferenceRequest())
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	generateRecorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/scenario/generate", bytes.NewReader(body))
+	server.handleScenarioGenerate(generateRecorder, request)
+	if generateRecorder.Code != http.StatusOK {
+		t.Fatalf("generate status = %d, want 200; body=%s", generateRecorder.Code, generateRecorder.Body.String())
+	}
+	var response scenarioGenerateResponse
+	if err = json.NewDecoder(generateRecorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode generated scenario: %v", err)
+	}
+	if response.Manifest.DeviceCount != 531 {
+		t.Fatalf("device count = %d, want 531", response.Manifest.DeviceCount)
+	}
+	if _, err = config.LoadYAMLBytes([]byte(response.Content)); err != nil {
+		t.Fatalf("generated content does not load: %v", err)
+	}
+}
+
+func TestScenarioGenerateRejectsUnknownRequestFields(t *testing.T) {
+	server := &Server{}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/scenario/generate",
+		bytes.NewBufferString(`{"sites":[],"unknown":true}`),
+	)
+	server.handleScenarioGenerate(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestScenarioRoutesCarryTemplateAuthoringPolicy(t *testing.T) {
+	routes := fetchRouteManifest(t)
+	profiles := routes["/api/v1/scenario/profiles"]
+	if profiles.Feature != "config_templates" || profiles.CSRF || profiles.RateLimited {
+		t.Fatalf("profiles policy = %+v, want config_templates read", profiles)
+	}
+	generate := routes["/api/v1/scenario/generate"]
+	if generate.Feature != "config_templates" || !generate.CSRF || !generate.RateLimited || generate.Admin {
+		t.Fatalf("generate policy = %+v, want config_templates+csrf+rateLimited", generate)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -33,6 +33,7 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 	s.registerWriteProtectedRoutes(mux)
 	s.registerReadOnlyRoutes(mux)
 	s.registerLibraryRoutes(mux)
+	s.registerScenarioRoutes(mux)
 	s.registerWalkRoutes(mux)
 	s.registerPcapRoutes(mux)
 	s.registerSSERoutes(mux)
@@ -63,6 +64,25 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 			s.methodGate([]string{http.MethodGet, http.MethodHead}, s.serveSPA()),
 		),
 	))
+}
+
+func (s *Server) registerScenarioRoutes(mux *http.ServeMux) {
+	s.registerAll(mux, []apiRoute{
+		{
+			path:    "/api/v1/scenario/profiles",
+			handler: s.handleScenarioProfiles,
+			methods: []string{http.MethodGet},
+			feature: "config_templates",
+		},
+		{
+			path:    "/api/v1/scenario/generate",
+			handler: s.handleScenarioGenerate,
+			methods: []string{http.MethodPost},
+			rl:      rlWrite,
+			csrf:    true,
+			feature: "config_templates",
+		},
+	})
 }
 
 func (s *Server) handleAPINotFound(w http.ResponseWriter, r *http.Request) {

--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -1,0 +1,194 @@
+package scenario
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+)
+
+type deviceSpec struct {
+	name       string
+	role       string
+	index      int
+	ips        []string
+	site       *Site
+	interfaces []converter.Interface
+	routes     []converter.Route
+	vlan       int
+	sysDescr   string
+	model      string
+	platform   string
+	software   string
+	dhcp       *converter.DhcpServer
+	dns        *converter.DNSServer
+	http       *converter.HTTPConfig
+	netbios    *converter.NetbiosConfig
+	iperf3     *converter.IPerf3Config
+	reflector  *converter.ReflectorConfig
+}
+
+func managedDevice(request Request, spec deviceSpec, links linkMap) converter.Device {
+	profile := profileByRole(spec.role)
+	model, platform, software := profile.Model, profile.Platform, profile.Software
+	if spec.model != "" {
+		model = spec.model
+	}
+	if spec.platform != "" {
+		platform = spec.platform
+	}
+	if spec.software != "" {
+		software = spec.software
+	}
+	interfaces := append([]converter.Interface(nil), spec.interfaces...)
+	interfaces = addLinkedInterfaces(interfaces, links[spec.name])
+	properties := map[string]string{
+		"role": spec.role, "model": model, "platform": platform,
+		"software": software, "sysObjectID": profile.SysObjectID,
+	}
+	if spec.site != nil {
+		properties["site"] = spec.site.Code
+	}
+	if spec.role == "ap" {
+		properties["wifiStandard"] = "Wi-Fi 7"
+	}
+
+	location := "Global WAN"
+	if spec.site != nil {
+		location = spec.site.Location
+	}
+	device := converter.Device{
+		Name: spec.name, Type: profile.DeviceType, Vendor: profile.Vendor,
+		MACSuffix: identitySuffix(spec.site, spec.role, spec.index), IPs: spec.ips,
+		VLAN: spec.vlan, Interfaces: interfaces, Routes: spec.routes,
+		SnmpAgent: &converter.SnmpAgent{
+			Community: request.SNMPCommunity, SysName: spec.name, SysDescr: spec.sysDescr,
+			SysLocation: location, SysContact: "netops@" + request.Domain,
+		},
+		Icmp:       &converter.IcmpConfig{Enabled: true, TTL: managedDeviceTTL},
+		TrunkPorts: authoredTrunkPorts(links[spec.name]), Properties: properties,
+		Dhcp: spec.dhcp, DNS: spec.dns, HTTP: spec.http, Netbios: spec.netbios,
+		IPerf3: spec.iperf3, Reflector: spec.reflector,
+	}
+	if platform != "" {
+		device.Lldp = &converter.LldpConfig{
+			Enabled: true, SystemDescription: platform + " - " + spec.name,
+		}
+		if profile.Vendor == "cisco" {
+			device.Cdp = &converter.CdpConfig{
+				Enabled: true, Platform: platform, SoftwareVersion: software,
+			}
+		}
+	}
+	return device
+}
+
+func endpointDevice(site Site, index int, name, address string) converter.Device {
+	profile := profileByRole("workstation")
+	return converter.Device{
+		Name: name, Type: profile.DeviceType, Vendor: profile.Vendor,
+		MACSuffix: identitySuffix(&site, "workstation", index), IPs: []string{address}, VLAN: vlanData,
+		Interfaces: []converter.Interface{newInterface(
+			"eth0", siteNetworkName(site, "data"), address+"/24", speedOneGigabit, "Wired client access",
+		)},
+		Icmp: &converter.IcmpConfig{Enabled: true, TTL: windowsTTL},
+		OSFingerprint: &converter.OSFingerprintConfig{
+			OSType: "windows", TTL: windowsTTL, WindowSize: windowsTCPWindowSize,
+			MSS: windowsMSS, DontFragment: true,
+		},
+		Properties: map[string]string{
+			"role": "workstation", "site": site.Code, "model": profile.Model,
+			"platform": profile.Platform, "software": profile.Software,
+		},
+	}
+}
+
+func newInterface(name, network, address string, speed int, description string) converter.Interface {
+	interfaceType := "ethernet"
+	mtu := 1500
+	switch {
+	case strings.HasPrefix(name, "Vlan"):
+		interfaceType = "l2vlan"
+		mtu = 9000
+	case strings.HasPrefix(name, "Loopback"):
+		interfaceType = "loopback"
+		mtu = 65535
+	case speed >= speedTenGigabit:
+		mtu = 9000
+	}
+	inUtilization, outUtilization := utilization(name)
+	return converter.Interface{
+		Name: name, Type: interfaceType, Network: network, Address: address,
+		MTU: mtu, Speed: speed, Duplex: "full", AdminStatus: "up", OperStatus: "up",
+		Description: description, InUtilization: inUtilization, OutUtilization: outUtilization,
+	}
+}
+
+func addLinkedInterfaces(interfaces []converter.Interface, links []link) []converter.Interface {
+	byName := make(map[string]int, len(interfaces))
+	for index := range interfaces {
+		byName[interfaces[index].Name] = index
+	}
+	for _, peer := range links {
+		description := fmt.Sprintf("to %s %s", peer.remoteDevice, peer.remoteInterface)
+		if index, found := byName[peer.localInterface]; found {
+			interfaces[index].Description = description
+			interfaces[index].VLANs = append([]int(nil), peer.vlans...)
+			continue
+		}
+		speed := interfaceSpeed(peer.localInterface)
+		iface := newInterface(peer.localInterface, "", "", speed, description)
+		iface.VLANs = append([]int(nil), peer.vlans...)
+		byName[peer.localInterface] = len(interfaces)
+		interfaces = append(interfaces, iface)
+	}
+	return interfaces
+}
+
+func interfaceSpeed(name string) int {
+	switch {
+	case strings.HasPrefix(name, "HundredGigabit"):
+		return speedHundredGigabit
+	case strings.HasPrefix(name, "TenGigabit"), strings.HasPrefix(name, "mGigabit"):
+		return speedTenGigabit
+	default:
+		return speedOneGigabit
+	}
+}
+
+func utilization(name string) (float64, float64) {
+	const (
+		minimumInUtilization  = 5
+		inUtilizationSpread   = 26
+		minimumOutUtilization = 4
+		outUtilizationFactor  = 7
+		outUtilizationSpread  = 25
+	)
+	sum := 0
+	for _, value := range []byte(name) {
+		sum += int(value)
+	}
+	return float64(minimumInUtilization + sum%inUtilizationSpread),
+		float64(minimumOutUtilization + (sum*outUtilizationFactor)%outUtilizationSpread)
+}
+
+func authoredTrunkPorts(links []link) []converter.TrunkPort {
+	ports := make([]converter.TrunkPort, 0, len(links))
+	for _, peer := range links {
+		ports = append(ports, converter.TrunkPort{
+			Interface: peer.localInterface, VLANs: append([]int(nil), peer.vlans...),
+			NativeVLAN: nativeVLAN(peer.vlans), RemoteDevice: peer.remoteDevice,
+			RemoteInterface: peer.remoteInterface, FDBOnly: peer.fdbOnly,
+		})
+	}
+	return ports
+}
+
+func nativeVLAN(vlans []int) int {
+	for _, vlan := range vlans {
+		if vlan == vlanManagement {
+			return vlan
+		}
+	}
+	return vlans[0]
+}

--- a/internal/scenario/devices_endpoints.go
+++ b/internal/scenario/devices_endpoints.go
@@ -1,0 +1,120 @@
+package scenario
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+)
+
+func serviceRoles() []string {
+	return []string{"DNS", "DHCP", "APP", "FILE", "NMS", "PERF"}
+}
+
+func buildSiteEndpoints(request Request, site Site, links linkMap) []converter.Device {
+	workstationCount := request.Counts.AccessSwitches * request.Counts.WorkstationsPerAccess
+	devices := make([]converter.Device, 0,
+		workstationCount+len(serviceRoles())+request.Counts.WirelessControllers)
+	for accessIndex := 1; accessIndex <= request.Counts.AccessSwitches; accessIndex++ {
+		for slot := 1; slot <= request.Counts.WorkstationsPerAccess; slot++ {
+			index := (accessIndex-1)*request.Counts.WorkstationsPerAccess + slot
+			devices = append(devices, endpointDevice(
+				site, index, workstationName(site, accessIndex, slot),
+				siteIP(site, vlanData, workstationHostOffset+index),
+			))
+		}
+	}
+	for index, role := range serviceRoles() {
+		devices = append(devices, serviceServer(request, site, role, index+1, links))
+	}
+	for index := 1; index <= request.Counts.WirelessControllers; index++ {
+		devices = append(devices, wirelessController(request, site, index, links))
+	}
+	return devices
+}
+
+func serviceServer(request Request, site Site, role string, index int, links linkMap) converter.Device {
+	vlan, network := servicePlacement(role)
+	address := siteIP(site, vlan, serviceHostOffset+index)
+	spec := deviceSpec{
+		name: site.Code + "-" + role + "01", role: "server", index: index,
+		ips: []string{address}, site: &site,
+		sysDescr: fmt.Sprintf("Dell PowerEdge R660 %s %s service", site.Code, role),
+		interfaces: []converter.Interface{newInterface(
+			"eth0", siteNetworkName(site, network), address+"/24", speedTenGigabit, role+" service uplink",
+		)},
+		vlan: vlan,
+	}
+	applyServiceCapabilities(request, site, role, &spec)
+	return managedDevice(request, spec, links)
+}
+
+func servicePlacement(role string) (int, string) {
+	if role == "DHCP" {
+		return vlanData, "data"
+	}
+	return vlanServers, "servers"
+}
+
+func applyServiceCapabilities(request Request, site Site, role string, spec *deviceSpec) {
+	switch role {
+	case "DNS":
+		spec.dns = &converter.DNSServer{ForwardRecords: siteDNSRecords(request, site)}
+	case "DHCP":
+		spec.dhcp = &converter.DhcpServer{
+			ServerIdentifier: siteIP(site, vlanData, dhcpServerHost),
+			Router:           siteIP(site, vlanData, primaryCoreGatewayHost),
+			SubnetMask:       "255.255.255.0",
+			DomainNameServer: siteIP(site, vlanServers, dnsServerHost),
+			PoolStart:        siteIP(site, vlanData, dhcpPoolStartHost),
+			PoolEnd:          siteIP(site, vlanData, dhcpPoolEndHost),
+		}
+	case "APP":
+		spec.http = &converter.HTTPConfig{Enabled: true, ServerName: "Microsoft-IIS/10.0"}
+	case "FILE":
+		spec.netbios = &converter.NetbiosConfig{
+			Enabled: true, Name: site.Code + "-FILE01", Workgroup: "DEMO", NodeType: "H",
+			Services: []string{"workstation", "fileserver"},
+		}
+	case "NMS":
+		spec.http = &converter.HTTPConfig{Enabled: true, ServerName: "Grafana"}
+	case "PERF":
+		spec.iperf3 = &converter.IPerf3Config{
+			Enabled: true, Port: performanceTestPort, MaxBandwidthMbps: performanceBandwidthMbps,
+			TypicalLatencyMs: performanceLatencyMillis, JitterMs: performanceJitterMillis,
+			PacketLossPercent: performancePacketLoss,
+		}
+		spec.reflector = &converter.ReflectorConfig{
+			LatencyMs: performanceLatencyMillis, JitterMs: performanceJitterMillis, DSCP: true,
+		}
+	default:
+		panic("unknown service role: " + role)
+	}
+}
+
+func siteDNSRecords(request Request, site Site) []converter.DNSRecord {
+	roles := serviceRoles()
+	records := make([]converter.DNSRecord, len(roles))
+	for index, role := range roles {
+		vlan, _ := servicePlacement(role)
+		records[index] = converter.DNSRecord{
+			Name: fmt.Sprintf("%s-%s01.%s", strings.ToLower(site.Code), strings.ToLower(role), request.Domain),
+			IP:   siteIP(site, vlan, serviceHostOffset+index+1), TTL: dnsRecordTTL,
+		}
+	}
+	return records
+}
+
+func wirelessController(request Request, site Site, index int, links linkMap) converter.Device {
+	address := siteIP(site, vlanServers, controllerHostOffset+index)
+	return managedDevice(request, deviceSpec{
+		name: numberedName(site.Code+"-WLC", index), role: "controller", index: index,
+		ips: []string{address}, site: &site,
+		sysDescr: fmt.Sprintf("Cisco Catalyst 9800-L %s wireless controller %d", site.Code, index),
+		interfaces: []converter.Interface{newInterface(
+			"TenGigabitEthernet0/0/0", siteNetworkName(site, "servers"), address+"/24", speedTenGigabit,
+			"Wireless control plane",
+		)},
+		vlan: vlanServers, http: &converter.HTTPConfig{Enabled: true, ServerName: "Cisco IOS XE"},
+	}, links)
+}

--- a/internal/scenario/devices_lan.go
+++ b/internal/scenario/devices_lan.go
@@ -1,0 +1,121 @@
+package scenario
+
+import (
+	"fmt"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+)
+
+func buildSiteLAN(request Request, site Site, siteIndex int, links linkMap) []converter.Device {
+	specs := make([]deviceSpec, 0,
+		request.Counts.CoreSwitches+request.Counts.DistributionSwitches+
+			request.Counts.AccessSwitches+request.Counts.ServerSwitches+
+			request.Counts.AccessSwitches*request.Counts.AccessPointsPerAccess)
+	for index := 1; index <= request.Counts.CoreSwitches; index++ {
+		specs = append(specs, coreSwitch(site, siteIndex, index))
+	}
+	for index := 1; index <= request.Counts.DistributionSwitches; index++ {
+		specs = append(specs, distributionSwitch(site, index))
+	}
+	for index := 1; index <= request.Counts.AccessSwitches; index++ {
+		specs = append(specs, accessSwitch(site, index))
+	}
+	for index := 1; index <= request.Counts.ServerSwitches; index++ {
+		specs = append(specs, serverSwitch(site, index))
+	}
+	accessPointCount := request.Counts.AccessSwitches * request.Counts.AccessPointsPerAccess
+	for index := 1; index <= accessPointCount; index++ {
+		specs = append(specs, accessPoint(site, index, request.Counts.AccessPointsPerAccess))
+	}
+
+	devices := make([]converter.Device, len(specs))
+	for index, spec := range specs {
+		devices[index] = managedDevice(request, spec, links)
+	}
+	return devices
+}
+
+func coreSwitch(site Site, siteIndex, index int) deviceSpec {
+	coreNetwork, _, coreBase := transit(site, "core", siteIndex)
+	addresses := make([]string, 0, len(vlanDefinitions()))
+	interfaces := make([]converter.Interface, 0, len(vlanDefinitions())+1)
+	for _, vlan := range vlanDefinitions() {
+		address := siteIP(site, vlan.thirdOctet, index+1)
+		addresses = append(addresses, address)
+		interfaces = append(interfaces, newInterface(
+			fmt.Sprintf("Vlan%d", vlan.id), siteNetworkName(site, vlan.slug), address+"/24",
+			speedHundredGigabit, "Gateway for "+vlan.slug,
+		))
+	}
+	transitAddress := fmt.Sprintf("203.0.113.%d", coreBase+index+transitPeerOffset)
+	interfaces = append(interfaces, newInterface(
+		"HundredGigabitEthernet0/0/1", coreNetwork, transitAddress+"/29", speedHundredGigabit,
+		"Firewall transit",
+	))
+	return deviceSpec{
+		name: numberedName(site.Code+"-CORE-SW", index), role: "core", index: index,
+		ips: append(addresses, transitAddress), site: &site,
+		sysDescr:   fmt.Sprintf("Cisco Nexus 9508 %s modular core %d", site.Code, index),
+		interfaces: interfaces,
+		routes: []converter.Route{route(
+			"0.0.0.0/0", "HundredGigabitEthernet0/0/1",
+			fmt.Sprintf("203.0.113.%d", coreBase+index),
+		)},
+		vlan: vlanManagement,
+	}
+}
+
+func distributionSwitch(site Site, index int) deviceSpec {
+	address := siteIP(site, vlanManagement, distributionHostOffset+index)
+	return deviceSpec{
+		name: numberedName(site.Code+"-DIST-SW", index), role: "distribution", index: index,
+		ips: []string{address}, site: &site,
+		sysDescr: fmt.Sprintf("Cisco Catalyst C9606R %s distribution block %d", site.Code, index),
+		interfaces: []converter.Interface{newInterface(
+			"Vlan200", siteNetworkName(site, "mgmt"), address+"/24", speedHundredGigabit, "Network management",
+		)},
+		vlan: vlanManagement,
+	}
+}
+
+func accessSwitch(site Site, index int) deviceSpec {
+	address := siteIP(site, vlanManagement, accessHostOffset+index)
+	return deviceSpec{
+		name: accessName(site, index), role: "access", index: index,
+		ips: []string{address}, site: &site,
+		sysDescr: fmt.Sprintf("Cisco C9350-48HX %s multigigabit access %d", site.Code, index),
+		interfaces: []converter.Interface{newInterface(
+			"Vlan200", siteNetworkName(site, "mgmt"), address+"/24", speedHundredGigabit, "Network management",
+		)},
+		vlan: vlanManagement,
+	}
+}
+
+func serverSwitch(site Site, index int) deviceSpec {
+	address := siteIP(site, vlanManagement, serverSwitchHostOffset+index)
+	return deviceSpec{
+		name: numberedName(site.Code+"-SRV-SW", index), role: "server-switch", index: index,
+		ips: []string{address}, site: &site,
+		sysDescr: fmt.Sprintf("Cisco Nexus 93180YC-FX3 %s server leaf %d", site.Code, index),
+		interfaces: []converter.Interface{newInterface(
+			"Vlan200", siteNetworkName(site, "mgmt"), address+"/24", speedHundredGigabit, "Network management",
+		)},
+		vlan: vlanManagement,
+	}
+}
+
+func accessPoint(site Site, index, perAccess int) deviceSpec {
+	accessIndex := (index-1)/perAccess + 1
+	slot := (index-1)%perAccess + 1
+	address := siteIP(site, vlanManagement, accessPointHostOffset+index)
+	return deviceSpec{
+		name: accessPointName(site, accessIndex, slot), role: "ap", index: index,
+		ips: []string{address}, site: &site,
+		sysDescr: fmt.Sprintf("Cisco Wireless CW9178I Wi-Fi 7 access point %d", index),
+		interfaces: []converter.Interface{newInterface(
+			"mGigabitEthernet0", siteNetworkName(site, "mgmt"), address+"/24", speedTenGigabit,
+			"Multigigabit PoE uplink",
+		)},
+		vlan: vlanManagement,
+	}
+}

--- a/internal/scenario/devices_network.go
+++ b/internal/scenario/devices_network.go
@@ -1,0 +1,191 @@
+package scenario
+
+import (
+	"fmt"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+)
+
+func labEdge(request Request, links linkMap) converter.Device {
+	routes := make([]converter.Route, 0, len(request.Sites)+1)
+	for _, site := range request.Sites {
+		routes = append(routes, route(
+			fmt.Sprintf("10.%d.0.0/16", site.Octet),
+			"HundredGigabitEthernet0/0/1", "203.0.113.2",
+		))
+	}
+	routes = append(routes, route("0.0.0.0/0", "HundredGigabitEthernet0/0/1", "203.0.113.2"))
+	return managedDevice(request, deviceSpec{
+		name: "LAB-EDGE-R1", role: "lab", index: 1,
+		ips:      []string{transitGateway, "203.0.113.1"},
+		sysDescr: "Cisco Catalyst 8500L isolated lab edge",
+		interfaces: []converter.Interface{
+			newInterface(
+				"TenGigabitEthernet0/0/0",
+				"lab-transit",
+				transitGateway+"/24",
+				speedTenGigabit,
+				"CyberScope VLAN 200 attachment",
+			),
+			newInterface(
+				"HundredGigabitEthernet0/0/1",
+				"lab-wan",
+				"203.0.113.1/29",
+				speedHundredGigabit,
+				"Provider WAN uplink",
+			),
+		},
+		routes: routes,
+		dhcp: &converter.DhcpServer{
+			ServerIdentifier: transitGateway, Router: transitGateway, SubnetMask: "255.255.255.0",
+			DomainNameServer: transitGateway, PoolStart: "10.254.200.100", PoolEnd: "10.254.200.199",
+		},
+		dns: &converter.DNSServer{ForwardRecords: internetDNSRecords()},
+	}, links)
+}
+
+func providerWANRouter(request Request, index int, links linkMap) converter.Device {
+	labAddress := fmt.Sprintf("203.0.113.%d", index+1)
+	interfaces := []converter.Interface{
+		newInterface(
+			"HundredGigabitEthernet0/0/1",
+			"lab-wan",
+			labAddress+"/29",
+			speedHundredGigabit,
+			"Lab edge transit",
+		),
+	}
+	routes := []converter.Route{route(transitSubnet, "HundredGigabitEthernet0/0/1", "203.0.113.1")}
+	ips := []string{labAddress}
+	for siteIndex, site := range request.Sites {
+		if index > request.Counts.SiteWANRouters {
+			continue
+		}
+		network, _, base := transit(site, "wan", siteIndex)
+		address := fmt.Sprintf("203.0.113.%d", base+index)
+		interfaceName := fmt.Sprintf("HundredGigabitEthernet0/0/%d", siteIndex+firstSiteInterfaceIndex)
+		interfaces = append(interfaces, newInterface(
+			interfaceName, network, address+"/29", speedHundredGigabit, "Site WAN transit",
+		))
+		routes = append(routes, route(
+			fmt.Sprintf("10.%d.0.0/16", site.Octet), interfaceName,
+			fmt.Sprintf("203.0.113.%d", base+index+transitPeerOffset),
+		))
+		ips = append(ips, address)
+	}
+
+	spec := deviceSpec{
+		name: fmt.Sprintf("WAN-R%d", index), role: "wan", index: index, ips: ips,
+		sysDescr: fmt.Sprintf("Cisco 8201 global WAN provider edge %d", index),
+		model:    "8201-32FH", platform: "Cisco 8201-32FH", software: "IOS XR 24.4",
+		interfaces: interfaces, routes: routes,
+	}
+	if index == 1 {
+		spec.ips = append(spec.ips, internetLoopback)
+		spec.interfaces = append(spec.interfaces, newInterface(
+			"Loopback0",
+			"internet-loopback",
+			internetLoopback+"/32",
+			speedHundredGigabit,
+			"Internet reachability target",
+		))
+		spec.http = &converter.HTTPConfig{Enabled: true, ServerName: "nginx"}
+		spec.dns = &converter.DNSServer{ForwardRecords: internetDNSRecords()}
+	}
+	return managedDevice(request, spec, links)
+}
+
+func siteWANRouter(site Site, siteIndex, index int) deviceSpec {
+	wanNetwork, _, wanBase := transit(site, "wan", siteIndex)
+	securityNetwork, _, securityBase := transit(site, "security", siteIndex)
+	management := siteIP(site, vlanManagement, wanManagementHostOffset+index)
+	return deviceSpec{
+		name: numberedName(site.Code+"-WAN-R", index), role: "wan",
+		index: siteIndex*maxRedundantPeers + index + wanIdentityOffset,
+		ips: []string{
+			management,
+			fmt.Sprintf("203.0.113.%d", wanBase+index+transitPeerOffset),
+			fmt.Sprintf("203.0.113.%d", securityBase+index),
+		},
+		site: &site, sysDescr: fmt.Sprintf("Cisco Catalyst 8500-12X %s WAN edge %d", site.Code, index),
+		interfaces: []converter.Interface{
+			newInterface(
+				"TenGigabitEthernet0/0/0",
+				siteNetworkName(site, "mgmt"),
+				management+"/24",
+				speedTenGigabit,
+				"Network management",
+			),
+			newInterface(
+				"HundredGigabitEthernet0/0/1",
+				wanNetwork,
+				fmt.Sprintf("203.0.113.%d/29", wanBase+index+transitPeerOffset),
+				speedHundredGigabit,
+				"Provider WAN",
+			),
+			newInterface(
+				"HundredGigabitEthernet0/0/2",
+				securityNetwork,
+				fmt.Sprintf("203.0.113.%d/29", securityBase+index),
+				speedHundredGigabit,
+				"Firewall transit",
+			),
+		},
+		routes: []converter.Route{
+			route(
+				fmt.Sprintf("10.%d.0.0/16", site.Octet),
+				"HundredGigabitEthernet0/0/2",
+				fmt.Sprintf("203.0.113.%d", securityBase+index+transitPeerOffset),
+			),
+			route("0.0.0.0/0", "HundredGigabitEthernet0/0/1", fmt.Sprintf("203.0.113.%d", wanBase+index)),
+		},
+		vlan: vlanManagement,
+	}
+}
+
+func siteFirewall(site Site, siteIndex, index int) deviceSpec {
+	securityNetwork, _, securityBase := transit(site, "security", siteIndex)
+	coreNetwork, _, coreBase := transit(site, "core", siteIndex)
+	management := siteIP(site, vlanManagement, firewallManagementHostOffset+index)
+	return deviceSpec{
+		name: numberedName(site.Code+"-FW", index), role: "firewall", index: siteIndex*2 + index,
+		ips: []string{
+			management,
+			fmt.Sprintf("203.0.113.%d", securityBase+index+transitPeerOffset),
+			fmt.Sprintf("203.0.113.%d", coreBase+index),
+		},
+		site: &site, sysDescr: fmt.Sprintf("Palo Alto PA-5450 %s perimeter firewall %d", site.Code, index),
+		interfaces: []converter.Interface{
+			newInterface(
+				"management",
+				siteNetworkName(site, "mgmt"),
+				management+"/24",
+				speedOneGigabit,
+				"Network management",
+			),
+			newInterface(
+				"ethernet1/1",
+				securityNetwork,
+				fmt.Sprintf("203.0.113.%d/29", securityBase+index+transitPeerOffset),
+				speedHundredGigabit,
+				"WAN security zone",
+			),
+			newInterface(
+				"ethernet1/2",
+				coreNetwork,
+				fmt.Sprintf("203.0.113.%d/29", coreBase+index),
+				speedHundredGigabit,
+				"Trusted core zone",
+			),
+		},
+		routes: []converter.Route{
+			route(
+				fmt.Sprintf("10.%d.0.0/16", site.Octet),
+				"ethernet1/2",
+				fmt.Sprintf("203.0.113.%d", coreBase+index+transitPeerOffset),
+			),
+			route("0.0.0.0/0", "ethernet1/1", fmt.Sprintf("203.0.113.%d", securityBase+index)),
+		},
+		vlan: vlanManagement,
+	}
+}

--- a/internal/scenario/dns.go
+++ b/internal/scenario/dns.go
@@ -1,0 +1,15 @@
+package scenario
+
+import "github.com/MustardSeedNetworks/niac-go/internal/converter"
+
+func internetDNSRecords() []converter.DNSRecord {
+	hostnames := []string{
+		"google.com", "www.google.com", "cloudflare.com",
+		"www.msftconnecttest.com", "connectivitycheck.gstatic.com",
+	}
+	records := make([]converter.DNSRecord, len(hostnames))
+	for index, hostname := range hostnames {
+		records[index] = converter.DNSRecord{Name: hostname, IP: internetLoopback, TTL: dnsRecordTTL}
+	}
+	return records
+}

--- a/internal/scenario/generator.go
+++ b/internal/scenario/generator.go
@@ -1,0 +1,198 @@
+package scenario
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+)
+
+const (
+	transitSubnet    = "10.254.200.0/24"
+	transitGateway   = "10.254.200.1"
+	internetLoopback = "8.8.8.8"
+)
+
+// ErrInvalidRequest identifies authoring input that cannot produce a valid scenario.
+var ErrInvalidRequest = errors.New("invalid scenario request")
+
+type vlanDefinition struct {
+	id         int
+	slug       string
+	thirdOctet int
+}
+
+func vlanDefinitions() []vlanDefinition {
+	return []vlanDefinition{
+		{vlanManagement, "mgmt", vlanManagement},
+		{vlanData, "data", vlanData},
+		{vlanWiFiCorp, "wifi-corp", vlanWiFiCorp},
+		{vlanWiFiGuest, "wifi-guest", vlanWiFiGuest},
+		{vlanServers, "servers", vlanServers},
+		{vlanVoiceIoT, "voice-iot", vlanVoiceIoT},
+	}
+}
+
+// Generate builds and validates one portable scenario. It has no filesystem,
+// runtime, or network side effects.
+func Generate(request Request) (Result, error) {
+	if err := validateRequest(request); err != nil {
+		return Result{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+
+	links := buildLinks(request)
+	authored := converter.Config{
+		Networks: buildNetworks(request),
+		Attachments: []converter.LogicalAttachment{{
+			Name: request.AttachmentName, Connect: "lab-transit",
+		}},
+		Devices: buildDevices(request, links),
+	}
+	if err := converter.ValidateConfig(&authored); err != nil {
+		return Result{}, fmt.Errorf("generated authoring config: %w", err)
+	}
+
+	data, err := yaml.Marshal(authored)
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal generated scenario: %w", err)
+	}
+	runtimeConfig, err := config.LoadYAMLBytes(data)
+	if err != nil {
+		return Result{}, fmt.Errorf("load generated scenario: %w", err)
+	}
+	validation := config.NewValidator("generated-scenario.yaml").Validate(runtimeConfig)
+	if !validation.Valid {
+		return Result{}, errors.New(validation.Format())
+	}
+
+	return Result{YAML: data, Manifest: buildManifest(&authored)}, nil
+}
+
+func buildDevices(request Request, links linkMap) []converter.Device {
+	devices := []converter.Device{
+		labEdge(request, links),
+		providerWANRouter(request, 1, links),
+		providerWANRouter(request, secondProviderWANRouterIndex, links),
+	}
+	for siteIndex := range request.Sites {
+		site := request.Sites[siteIndex]
+		for index := 1; index <= request.Counts.SiteWANRouters; index++ {
+			devices = append(devices, managedDevice(request, siteWANRouter(site, siteIndex, index), links))
+		}
+		for index := 1; index <= request.Counts.Firewalls; index++ {
+			devices = append(devices, managedDevice(request, siteFirewall(site, siteIndex, index), links))
+		}
+		devices = append(devices, buildSiteLAN(request, site, siteIndex, links)...)
+		devices = append(devices, buildSiteEndpoints(request, site, links)...)
+	}
+	return devices
+}
+
+func buildNetworks(request Request) []converter.Network {
+	networks := []converter.Network{
+		{Name: "lab-transit", Subnet: transitSubnet, VirtualVLAN: vlanManagement},
+		{Name: "lab-wan", Subnet: "203.0.113.0/29"},
+		{Name: "internet-loopback", Subnet: internetLoopback + "/32"},
+	}
+	for siteIndex, site := range request.Sites {
+		for _, kind := range []string{"wan", "security", "core"} {
+			name, subnet, _ := transit(site, kind, siteIndex)
+			networks = append(networks, converter.Network{Name: name, Subnet: subnet})
+		}
+		for _, vlan := range vlanDefinitions() {
+			networks = append(networks, converter.Network{
+				Name:        siteNetworkName(site, vlan.slug),
+				Subnet:      fmt.Sprintf("10.%d.%d.0/24", site.Octet, vlan.thirdOctet),
+				VirtualVLAN: vlan.id,
+			})
+		}
+	}
+	return networks
+}
+
+func buildManifest(authored *converter.Config) Manifest {
+	names := make([]string, 0, len(authored.Devices))
+	for _, device := range authored.Devices {
+		names = append(names, device.Name)
+	}
+	sort.Strings(names)
+
+	networks := make([]string, 0, len(authored.Networks))
+	for _, network := range authored.Networks {
+		networks = append(networks, fmt.Sprintf("%s|%s|%d", network.Name, network.Subnet, network.VirtualVLAN))
+	}
+	sort.Strings(networks)
+
+	edgeSet := make(map[string]bool)
+	for _, device := range authored.Devices {
+		for _, port := range device.TrunkPorts {
+			local := device.Name + "|" + port.Interface
+			remote := port.RemoteDevice + "|" + port.RemoteInterface
+			vlans := intList(port.VLANs)
+			if port.FDBOnly {
+				edgeSet["FDB|"+local+"|"+remote+"|"+vlans] = true
+				continue
+			}
+			if remote < local {
+				local, remote = remote, local
+			}
+			edgeSet["LINK|"+local+"|"+remote+"|"+vlans] = true
+		}
+	}
+	edges := make([]string, 0, len(edgeSet))
+	for edge := range edgeSet {
+		edges = append(edges, edge)
+	}
+	sort.Strings(edges)
+
+	return Manifest{
+		DeviceCount: len(authored.Devices), NetworkCount: len(authored.Networks), LinkCount: len(edges),
+		DeviceNamesSHA256: hashLines(names), NetworksSHA256: hashLines(networks), LinksSHA256: hashLines(edges),
+	}
+}
+
+func hashLines(lines []string) string {
+	hash := sha256.Sum256([]byte(strings.Join(lines, "\n") + "\n"))
+	return hex.EncodeToString(hash[:])
+}
+
+func intList(values []int) string {
+	parts := make([]string, len(values))
+	for index, value := range values {
+		parts[index] = strconv.Itoa(value)
+	}
+	return strings.Join(parts, ",")
+}
+
+func siteIP(site Site, thirdOctet, host int) string {
+	return fmt.Sprintf("10.%d.%d.%d", site.Octet, thirdOctet, host)
+}
+
+func siteNetworkName(site Site, slug string) string {
+	return strings.ToLower(site.Code) + "-" + slug
+}
+
+func transit(site Site, kind string, siteIndex int) (string, string, int) {
+	var base int
+	switch kind {
+	case "wan":
+		base = 8
+	case "security":
+		base = 40
+	case "core":
+		base = 72
+	default:
+		panic("invalid transit kind: " + kind)
+	}
+	base += transitBlockSize * siteIndex
+	return strings.ToLower(site.Code) + "-" + kind + "-transit",
+		fmt.Sprintf("203.0.113.%d/29", base), base
+}

--- a/internal/scenario/generator_test.go
+++ b/internal/scenario/generator_test.go
@@ -1,0 +1,138 @@
+package scenario_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+func TestGenerateEnterpriseReferenceMatchesAcceptedTopology(t *testing.T) {
+	request := scenario.EnterpriseReferenceRequest()
+	first, err := scenario.Generate(request)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	second, err := scenario.Generate(request)
+	if err != nil {
+		t.Fatalf("second Generate() error = %v", err)
+	}
+	if !bytes.Equal(first.YAML, second.YAML) {
+		t.Fatal("same request produced different YAML")
+	}
+
+	want := scenario.Manifest{
+		DeviceCount:       531,
+		NetworkCount:      39,
+		LinkCount:         634,
+		DeviceNamesSHA256: "77acffce1504dfc6b3a684b70af5a2d6bd4f07778fcd24718395006010042dd9",
+		NetworksSHA256:    "e879b7ba38e40f925809edc3bf98d2044959df5d2f76d492e6f2019cbcba5555",
+		// The accepted reference's WLC FDB rows named a nonexistent eth0.
+		// This fingerprint records the corrected TenGigabitEthernet endpoint.
+		LinksSHA256: "e9b594d484730136f88a5f8af8dec64db673a83cada6c50cf5560f78faedda0e",
+	}
+	if first.Manifest != want {
+		t.Fatalf("manifest = %#v, want %#v", first.Manifest, want)
+	}
+
+	cfg, err := config.LoadYAMLBytes(first.YAML)
+	if err != nil {
+		t.Fatalf("generated YAML does not load: %v", err)
+	}
+	if result := config.NewValidator("generated-enterprise.yaml").Validate(cfg); !result.Valid {
+		t.Fatalf("generated config is invalid: %s", result.Format())
+	}
+	assertEnterpriseDeviceMix(t, cfg)
+	assertAuthoredInterfacesAndLinks(t, cfg)
+	assertServiceDNS(t, cfg)
+	assertUniqueIdentityAndRoutes(t, cfg)
+}
+
+func TestGenerateHonorsFleetRepeatControls(t *testing.T) {
+	request := scenario.EnterpriseReferenceRequest()
+	request.Sites = request.Sites[:2]
+	request.Counts = scenario.Counts{
+		SiteWANRouters:        2,
+		Firewalls:             2,
+		CoreSwitches:          2,
+		DistributionSwitches:  2,
+		AccessSwitches:        4,
+		ServerSwitches:        2,
+		AccessPointsPerAccess: 3,
+		WorkstationsPerAccess: 5,
+		WirelessControllers:   2,
+	}
+
+	result, err := scenario.Generate(request)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	cfg, err := config.LoadYAMLBytes(result.YAML)
+	if err != nil {
+		t.Fatalf("generated YAML does not load: %v", err)
+	}
+	// Three global devices plus 54 devices at each site.
+	if got, want := cfg.DeviceCount(), 111; got != want {
+		t.Fatalf("device count = %d, want %d", got, want)
+	}
+	for _, site := range request.Sites {
+		if got := countNamed(cfg, site.Code+"-WAP-"); got != 12 {
+			t.Fatalf("%s access points = %d, want 12", site.Code, got)
+		}
+		if got := countNamed(cfg, site.Code+"-WS-"); got != 20 {
+			t.Fatalf("%s workstations = %d, want 20", site.Code, got)
+		}
+	}
+	assertUniqueIdentityAndRoutes(t, cfg)
+}
+
+func TestGenerateSingleSiteRouterDoesNotRouteThroughMissingPeer(t *testing.T) {
+	request := scenario.EnterpriseReferenceRequest()
+	request.Sites = request.Sites[:1]
+	request.Counts.SiteWANRouters = 1
+	request.Counts.Firewalls = 1
+	request.Counts.CoreSwitches = 1
+
+	result, err := scenario.Generate(request)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	cfg, err := config.LoadYAMLBytes(result.YAML)
+	if err != nil {
+		t.Fatalf("generated YAML does not load: %v", err)
+	}
+	assertUniqueIdentityAndRoutes(t, cfg)
+}
+
+func TestProfileCatalogUsesUniqueRoles(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, profile := range scenario.Profiles() {
+		if profile.Role == "" || profile.DeviceType == "" || profile.Vendor == "" || profile.Model == "" {
+			t.Errorf("incomplete profile: %+v", profile)
+		}
+		if seen[profile.Role] {
+			t.Errorf("duplicate role profile %q", profile.Role)
+		}
+		if profile.Vendor == "cisco" && !strings.HasPrefix(profile.SysObjectID, "1.3.6.1.4.1.9.1.") {
+			t.Errorf("%s Cisco profile has non-Cisco sysObjectID %q", profile.Role, profile.SysObjectID)
+		}
+		seen[profile.Role] = true
+	}
+	for _, role := range []string{
+		"lab", "wan", "firewall", "core", "distribution", "access",
+		"server-switch", "ap", "workstation", "server", "controller",
+	} {
+		if !seen[role] {
+			t.Errorf("missing profile for role %q", role)
+		}
+	}
+}
+
+func ExampleGenerate() {
+	result, _ := scenario.Generate(scenario.EnterpriseReferenceRequest())
+	fmt.Println(result.Manifest.DeviceCount)
+	// Output: 531
+}

--- a/internal/scenario/identity.go
+++ b/internal/scenario/identity.go
@@ -1,0 +1,47 @@
+package scenario
+
+import (
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
+)
+
+func identitySuffix(site *Site, role string, index int) uint32 {
+	octet := 0
+	if site != nil {
+		octet = site.Octet
+	}
+	return safeconv.Uint32(octet<<16 | roleCode(role)<<8 | index)
+}
+
+func roleCode(role string) int {
+	switch role {
+	case "lab":
+		return roleLabCode
+	case "wan":
+		return roleWANCode
+	case "firewall":
+		return roleFirewallCode
+	case "core":
+		return roleCoreCode
+	case "distribution":
+		return roleDistributionCode
+	case "access":
+		return roleAccessCode
+	case "server-switch":
+		return roleServerSwitchCode
+	case "ap":
+		return roleAccessPointCode
+	case "workstation":
+		return roleWorkstationCode
+	case "server":
+		return roleServerCode
+	case "controller":
+		return roleControllerCode
+	default:
+		panic("unknown scenario role: " + role)
+	}
+}
+
+func route(destination, via, nextHop string) converter.Route {
+	return converter.Route{Destination: destination, Via: via, NextHop: nextHop}
+}

--- a/internal/scenario/identity_truth_test.go
+++ b/internal/scenario/identity_truth_test.go
@@ -1,0 +1,106 @@
+package scenario_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+func assertUniqueIdentityAndRoutes(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	addresses := collectUniqueAddresses(t, cfg)
+	assertUniqueMACs(t, cfg)
+	assertOwnedRoutes(t, cfg, addresses)
+}
+
+func collectUniqueAddresses(t *testing.T, cfg *config.Config) map[string]string {
+	t.Helper()
+	addresses := make(map[string]string)
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		for _, address := range device.IPAddresses {
+			key := address.String()
+			if owner, exists := addresses[key]; exists {
+				t.Errorf("IP %s belongs to both %s and %s", key, owner, device.Name)
+			}
+			addresses[key] = device.Name
+		}
+	}
+	return addresses
+}
+
+func assertUniqueMACs(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	macs := make(map[string]string)
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		mac := device.MACAddress.String()
+		if owner, exists := macs[mac]; exists {
+			t.Errorf("MAC %s belongs to both %s and %s", mac, owner, device.Name)
+		}
+		macs[mac] = device.Name
+	}
+}
+
+func assertOwnedRoutes(t *testing.T, cfg *config.Config, addresses map[string]string) {
+	t.Helper()
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		if device.DHCPConfig != nil && device.DHCPConfig.Router != nil {
+			gateway := device.DHCPConfig.Router.String()
+			if _, exists := addresses[gateway]; !exists {
+				t.Errorf("%s advertises unowned DHCP gateway %s", device.Name, gateway)
+			}
+		}
+		for _, route := range device.Routes {
+			if findInterface(device, route.Via) == nil {
+				t.Errorf("%s route %s uses missing interface %s", device.Name, route.Destination, route.Via)
+			}
+			if _, exists := addresses[route.NextHop]; !exists {
+				t.Errorf("%s route %s uses unowned next hop %s", device.Name, route.Destination, route.NextHop)
+			}
+		}
+	}
+}
+
+func assertServiceDNS(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	for _, site := range []string{"COS", "EVT", "EHV", "LON"} {
+		dns := findDevice(cfg, site+"-DNS01")
+		dhcp := findDevice(cfg, site+"-DHCP01")
+		if dns == nil || dhcp == nil || dns.DNSConfig == nil || len(dhcp.IPAddresses) == 0 {
+			t.Fatalf("%s service DNS prerequisites are missing", site)
+		}
+		name := strings.ToLower(site) + "-dhcp01.demo.lab"
+		var resolved string
+		for _, record := range dns.DNSConfig.ForwardRecords {
+			if record.Name == name {
+				resolved = record.IP.String()
+				break
+			}
+		}
+		if got, want := resolved, dhcp.IPAddresses[0].String(); got != want {
+			t.Errorf("%s resolves to %s, want DHCP address %s", name, got, want)
+		}
+	}
+}
+
+func countNamed(cfg *config.Config, prefix string) int {
+	count := 0
+	for _, device := range cfg.Devices {
+		if strings.HasPrefix(device.Name, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func findDevice(cfg *config.Config, name string) *config.Device {
+	for index := range cfg.Devices {
+		if cfg.Devices[index].Name == name {
+			return &cfg.Devices[index]
+		}
+	}
+	return nil
+}

--- a/internal/scenario/naming.go
+++ b/internal/scenario/naming.go
@@ -1,0 +1,33 @@
+package scenario
+
+import "fmt"
+
+func numberedNames(prefix string, count int) []string {
+	names := make([]string, count)
+	for index := range count {
+		names[index] = numberedName(prefix, index+1)
+	}
+	return names
+}
+
+func numberedName(prefix string, index int) string {
+	return fmt.Sprintf("%s%02d", prefix, index)
+}
+
+func accessName(site Site, index int) string {
+	return numberedName(site.Code+"-ACC-SW", index)
+}
+
+func location(index int) (int, int) {
+	return (index-1)/4 + 1, (index-1)%4 + 1
+}
+
+func accessPointName(site Site, accessIndex, slot int) string {
+	building, floor := location(accessIndex)
+	return fmt.Sprintf("%s-WAP-B%02d-F%02d-%02d", site.Code, building, floor, slot)
+}
+
+func workstationName(site Site, accessIndex, slot int) string {
+	building, floor := location(accessIndex)
+	return fmt.Sprintf("%s-WS-B%02d-F%02d-%02d", site.Code, building, floor, slot)
+}

--- a/internal/scenario/naming.go
+++ b/internal/scenario/naming.go
@@ -3,9 +3,13 @@ package scenario
 import "fmt"
 
 func numberedNames(prefix string, count int) []string {
-	names := make([]string, count)
-	for index := range count {
-		names[index] = numberedName(prefix, index+1)
+	if count < 1 || count > maxRedundantPeers {
+		return nil
+	}
+
+	names := make([]string, 0, maxRedundantPeers)
+	for index := 1; index <= count; index++ {
+		names = append(names, numberedName(prefix, index))
 	}
 	return names
 }

--- a/internal/scenario/profiles.go
+++ b/internal/scenario/profiles.go
@@ -1,0 +1,62 @@
+package scenario
+
+import "github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp/synth"
+
+// DeviceProfile is the reusable vendor, model, role, and discovery identity.
+type DeviceProfile struct {
+	Role        string `json:"role"`
+	DeviceType  string `json:"deviceType"`
+	Vendor      string `json:"vendor"`
+	Model       string `json:"model"`
+	Platform    string `json:"platform"`
+	Software    string `json:"software"`
+	SysObjectID string `json:"sysObjectId"`
+}
+
+// EnterpriseReferenceRequest returns the accepted four-site Link-Live lab shape.
+func EnterpriseReferenceRequest() Request {
+	return Request{
+		Sites: []Site{
+			{Code: "COS", Octet: enterpriseCOSOctet, Location: "Colorado Springs, CO"},
+			{Code: "EVT", Octet: enterpriseEVTOctet, Location: "Everett, WA"},
+			{Code: "EHV", Octet: enterpriseEHVOctet, Location: "Eindhoven, Netherlands"},
+			{Code: "LON", Octet: enterpriseLONOctet, Location: "London, UK"},
+		},
+		Counts: Counts{
+			SiteWANRouters: maxRedundantPeers, Firewalls: maxRedundantPeers, CoreSwitches: maxRedundantPeers,
+			DistributionSwitches: enterpriseDistributionSwitches, AccessSwitches: enterpriseAccessSwitches,
+			ServerSwitches: maxRedundantPeers, AccessPointsPerAccess: maxRedundantPeers,
+			WorkstationsPerAccess: enterpriseWorkstationsPerAccess, WirelessControllers: maxRedundantPeers,
+		},
+		Domain: defaultDomain, SNMPCommunity: defaultCommunity, AttachmentName: defaultAttachmentName,
+	}
+}
+
+// Profiles returns the generator's role catalog using synthesized-walk identities.
+func Profiles() []DeviceProfile {
+	profiles := networkProfiles()
+	profiles = append(profiles, campusProfiles()...)
+	return append(profiles, endpointProfiles()...)
+}
+
+func newProfile(role, deviceType, vendor, model, platform, software string,
+	synthVendor synth.Vendor, synthType synth.DeviceType,
+) DeviceProfile {
+	walkProfile, err := synth.Pick(synthVendor, synthType)
+	if err != nil {
+		panic(err)
+	}
+	return DeviceProfile{
+		Role: role, DeviceType: deviceType, Vendor: vendor, Model: model,
+		Platform: platform, Software: software, SysObjectID: walkProfile.SysObjectID,
+	}
+}
+
+func profileByRole(role string) DeviceProfile {
+	for _, profile := range Profiles() {
+		if profile.Role == role {
+			return profile
+		}
+	}
+	panic("unknown scenario profile: " + role)
+}

--- a/internal/scenario/profiles_catalog.go
+++ b/internal/scenario/profiles_catalog.go
@@ -1,0 +1,40 @@
+package scenario
+
+import "github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp/synth"
+
+func networkProfiles() []DeviceProfile {
+	return []DeviceProfile{
+		newProfile("lab", "router", "cisco", "Catalyst C8500L-8S4X", "Cisco Catalyst C8500L-8S4X",
+			"IOS XE 17.15", synth.VendorCiscoIOS, synth.TypeRouter),
+		newProfile("wan", "router", "cisco", "Catalyst C8500-12X", "Cisco Catalyst C8500-12X",
+			"IOS XE 17.15", synth.VendorCiscoIOS, synth.TypeRouter),
+		newProfile("firewall", "firewall", "palo alto", "PA-5450", "Palo Alto PA-5450",
+			"PAN-OS 11.2", synth.VendorPaloAlto, synth.TypeFirewall),
+		newProfile("core", "router", "cisco", "Nexus 9508", "Cisco Nexus 9508",
+			"NX-OS 10.5", synth.VendorCiscoIOS, synth.TypeRouter),
+	}
+}
+
+func campusProfiles() []DeviceProfile {
+	return []DeviceProfile{
+		newProfile("distribution", "switch", "cisco", "Catalyst C9606R", "Cisco Catalyst C9606R",
+			"IOS XE 17.15", synth.VendorCiscoIOS, synth.TypeSwitch),
+		newProfile("access", "switch", "cisco", "Catalyst C9350-48HX", "Cisco Catalyst C9350-48HX",
+			"IOS XE 17.18", synth.VendorCiscoIOS, synth.TypeSwitch),
+		newProfile("server-switch", "switch", "cisco", "Nexus 93180YC-FX3", "Cisco Nexus 93180YC-FX3",
+			"NX-OS 10.5", synth.VendorCiscoIOS, synth.TypeSwitch),
+		newProfile("ap", "access-point", "cisco", "Wireless CW9178I", "Cisco Wireless CW9178I",
+			"IOS XE 17.15.3", synth.VendorCiscoIOS, synth.TypeAccessPoint),
+	}
+}
+
+func endpointProfiles() []DeviceProfile {
+	return []DeviceProfile{
+		newProfile("workstation", "host", "dell", "OptiPlex 7020", "Dell OptiPlex 7020",
+			"Windows 11 Enterprise", synth.VendorGeneric, synth.TypeHost),
+		newProfile("server", "server", "dell", "PowerEdge R660", "Dell PowerEdge R660",
+			"Ubuntu Server 26.04", synth.VendorGeneric, synth.TypeServer),
+		newProfile("controller", "server", "cisco", "Catalyst 9800-L", "Cisco Catalyst 9800-L",
+			"IOS XE 17.15.3", synth.VendorCiscoIOS, synth.TypeRouter),
+	}
+}

--- a/internal/scenario/topology.go
+++ b/internal/scenario/topology.go
@@ -1,0 +1,171 @@
+package scenario
+
+import (
+	"fmt"
+	"strings"
+)
+
+func allTrunkVLANs() []int {
+	return []int{vlanManagement, vlanData, vlanWiFiCorp, vlanWiFiGuest, vlanServers, vlanVoiceIoT}
+}
+
+type link struct {
+	localInterface  string
+	remoteDevice    string
+	remoteInterface string
+	vlans           []int
+	fdbOnly         bool
+}
+
+type linkMap map[string][]link
+
+func buildLinks(request Request) linkMap {
+	links := make(linkMap)
+	addEdge(links,
+		endpoint{"LAB-EDGE-R1", "HundredGigabitEthernet0/0/1"},
+		endpoint{"WAN-R1", "HundredGigabitEthernet0/0/1"}, nil)
+	addEdge(links,
+		endpoint{"LAB-EDGE-R1", "HundredGigabitEthernet0/0/2"},
+		endpoint{"WAN-R2", "HundredGigabitEthernet0/0/1"}, nil)
+	for siteIndex, site := range request.Sites {
+		addSiteBackbone(links, site, siteIndex, request.Counts)
+		addSiteLAN(links, site, request.Counts)
+		addSiteEndpoints(links, site, request.Counts)
+	}
+	return links
+}
+
+type endpoint struct {
+	device        string
+	interfaceName string
+}
+
+func addEdge(links linkMap, left, right endpoint, vlans []int) {
+	if vlans == nil {
+		vlans = allTrunkVLANs()
+	}
+	leftVLANs := append([]int(nil), vlans...)
+	rightVLANs := append([]int(nil), vlans...)
+	links[left.device] = append(links[left.device], link{
+		localInterface: left.interfaceName, remoteDevice: right.device,
+		remoteInterface: right.interfaceName, vlans: leftVLANs,
+	})
+	links[right.device] = append(links[right.device], link{
+		localInterface: right.interfaceName, remoteDevice: left.device,
+		remoteInterface: left.interfaceName, vlans: rightVLANs,
+	})
+}
+
+func addFDB(links linkMap, sw, interfaceName, remote, remoteInterface string, vlan int) {
+	links[sw] = append(links[sw], link{
+		localInterface: interfaceName, remoteDevice: remote, remoteInterface: remoteInterface,
+		vlans: []int{vlan}, fdbOnly: true,
+	})
+}
+
+func addMesh(links linkMap, left, right []string, prefix string) {
+	index := 1
+	for _, leftName := range left {
+		for _, rightName := range right {
+			interfaceName := fmt.Sprintf("%s%d", prefix, index)
+			addEdge(links, endpoint{leftName, interfaceName}, endpoint{rightName, interfaceName}, nil)
+			index++
+		}
+	}
+}
+
+func addSiteBackbone(links linkMap, site Site, siteIndex int, counts Counts) {
+	wan := numberedNames(site.Code+"-WAN-R", counts.SiteWANRouters)
+	firewalls := numberedNames(site.Code+"-FW", counts.Firewalls)
+	cores := numberedNames(site.Code+"-CORE-SW", counts.CoreSwitches)
+	for index, wanName := range wan {
+		provider := index%maxRedundantPeers + 1
+		addEdge(links,
+			endpoint{
+				fmt.Sprintf("WAN-R%d", provider),
+				fmt.Sprintf("HundredGigabitEthernet0/0/%d", siteIndex+firstSiteInterfaceIndex),
+			},
+			endpoint{wanName, "HundredGigabitEthernet0/0/1"}, nil)
+	}
+	addMesh(links, wan, firewalls, "TenGigabitEthernet0/1/")
+	addMesh(links, firewalls, cores, "HundredGigabitEthernet0/2/")
+}
+
+func addSiteLAN(links linkMap, site Site, counts Counts) {
+	cores := numberedNames(site.Code+"-CORE-SW", counts.CoreSwitches)
+	for distribution := 1; distribution <= counts.DistributionSwitches; distribution++ {
+		distName := numberedName(site.Code+"-DIST-SW", distribution)
+		for coreIndex, coreName := range cores {
+			addEdge(links,
+				endpoint{coreName, fmt.Sprintf("HundredGigabitEthernet1/0/%d", distribution)},
+				endpoint{distName, fmt.Sprintf("HundredGigabitEthernet1/0/%d", coreIndex+1)}, nil)
+		}
+	}
+
+	distributionPairs := counts.DistributionSwitches / maxRedundantPeers
+	accessPerPair := (counts.AccessSwitches + distributionPairs - 1) / distributionPairs
+	for accessIndex := 1; accessIndex <= counts.AccessSwitches; accessIndex++ {
+		pair := min((accessIndex-1)/accessPerPair, distributionPairs-1)
+		firstDistribution := pair*maxRedundantPeers + 1
+		distributionPort := (accessIndex-1)%accessPerPair + firstDistributionAccessPort
+		for uplink := range maxRedundantPeers {
+			distribution := firstDistribution + uplink
+			addEdge(
+				links,
+				endpoint{
+					numberedName(site.Code+"-DIST-SW", distribution),
+					fmt.Sprintf("HundredGigabitEthernet1/0/%d", distributionPort),
+				},
+				endpoint{
+					accessName(site, accessIndex),
+					fmt.Sprintf("HundredGigabitEthernet1/0/%d", uplink+accessUplinkPortStart),
+				},
+				nil,
+			)
+		}
+	}
+
+	for serverSwitch := 1; serverSwitch <= counts.ServerSwitches; serverSwitch++ {
+		name := numberedName(site.Code+"-SRV-SW", serverSwitch)
+		for coreIndex, coreName := range cores {
+			addEdge(links,
+				endpoint{coreName, fmt.Sprintf("HundredGigabitEthernet1/0/%d", serverSwitch+coreServerPortOffset)},
+				endpoint{name, fmt.Sprintf("HundredGigabitEthernet1/0/%d", coreIndex+1)}, nil)
+		}
+	}
+}
+
+func addSiteEndpoints(links linkMap, site Site, counts Counts) {
+	for accessIndex := 1; accessIndex <= counts.AccessSwitches; accessIndex++ {
+		switchName := accessName(site, accessIndex)
+		for slot := 1; slot <= counts.AccessPointsPerAccess; slot++ {
+			addEdge(links,
+				endpoint{switchName, fmt.Sprintf("TenGigabitEthernet1/0/%d", slot)},
+				endpoint{accessPointName(site, accessIndex, slot), "mGigabitEthernet0"},
+				[]int{vlanManagement, vlanWiFiCorp, vlanWiFiGuest})
+		}
+		for slot := 1; slot <= counts.WorkstationsPerAccess; slot++ {
+			addFDB(links, switchName, fmt.Sprintf("GigabitEthernet1/0/%d", slot+workstationPortOffset),
+				workstationName(site, accessIndex, slot), "eth0", vlanData)
+		}
+	}
+
+	services := []string{"DNS01", "DHCP01", "APP01", "FILE01", "NMS01", "PERF01"}
+	for index := 1; index <= counts.WirelessControllers; index++ {
+		services = append(services, fmt.Sprintf("WLC%02d", index))
+	}
+	for index, service := range services {
+		switchIndex := index%counts.ServerSwitches + 1
+		vlan := vlanServers
+		if service == "DHCP01" {
+			vlan = vlanData
+		}
+		remoteInterface := "eth0"
+		if strings.HasPrefix(service, "WLC") {
+			remoteInterface = "TenGigabitEthernet0/0/0"
+		}
+		addFDB(links, numberedName(site.Code+"-SRV-SW", switchIndex),
+			fmt.Sprintf("TenGigabitEthernet1/0/%d", index+serverPortOffset), site.Code+"-"+service,
+			remoteInterface, vlan)
+	}
+}

--- a/internal/scenario/topology_truth_test.go
+++ b/internal/scenario/topology_truth_test.go
@@ -1,0 +1,105 @@
+package scenario_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+func assertEnterpriseDeviceMix(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	for _, site := range []string{"COS", "EVT", "EHV", "LON"} {
+		checks := map[string]int{
+			site + "-WAN-R": 2, site + "-FW": 2, site + "-CORE-SW": 2, site + "-DIST-SW": 4,
+			site + "-ACC-SW": 16, site + "-SRV-SW": 2, site + "-WAP-": 32, site + "-WS-": 64,
+		}
+		for prefix, want := range checks {
+			if got := countNamed(cfg, prefix); got != want {
+				t.Errorf("devices matching %q = %d, want %d", prefix, got, want)
+			}
+		}
+		for _, role := range []string{"DNS01", "DHCP01", "APP01", "FILE01", "NMS01", "PERF01"} {
+			if findDevice(cfg, site+"-"+role) == nil {
+				t.Errorf("missing %s-%s", site, role)
+			}
+		}
+	}
+	for _, device := range cfg.Devices {
+		if strings.Contains(device.Name, "-WAP-") &&
+			(device.Properties["wifiStandard"] != "Wi-Fi 7" || !strings.Contains(device.SNMPConfig.SysDescr, "Wi-Fi 7")) {
+			t.Errorf("%s does not identify as Wi-Fi 7", device.Name)
+		}
+	}
+}
+
+func assertAuthoredInterfacesAndLinks(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		for _, iface := range device.Interfaces {
+			if iface.MTU == 0 || iface.Speed == 0 || iface.Duplex != "full" ||
+				iface.AdminStatus != "up" || iface.OperStatus != "up" {
+				t.Errorf("%s %s lacks explicit link state: %+v", device.Name, iface.Name, iface)
+			}
+			if iface.Type == "ethernet" && (iface.InUtilization <= 0 || iface.OutUtilization <= 0) {
+				t.Errorf("%s %s lacks live utilization: %+v", device.Name, iface.Name, iface)
+			}
+		}
+	}
+	assertAuthoredLinks(t, cfg)
+}
+
+func assertAuthoredLinks(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	devices := make(map[string]*config.Device, len(cfg.Devices))
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		devices[device.Name] = device
+	}
+	for deviceIndex := range cfg.Devices {
+		device := &cfg.Devices[deviceIndex]
+		seen := make(map[string]bool)
+		for _, port := range device.TrunkPorts {
+			if seen[port.Interface] {
+				t.Errorf("%s interface %s has multiple physical peers", device.Name, port.Interface)
+			}
+			seen[port.Interface] = true
+			if findInterface(device, port.Interface) == nil {
+				t.Errorf("%s trunk %s is absent from authored interfaces", device.Name, port.Interface)
+			}
+			remote := devices[port.RemoteDevice]
+			if remote == nil {
+				t.Errorf("%s trunk references missing device %s", device.Name, port.RemoteDevice)
+				continue
+			}
+			if findInterface(remote, port.RemoteInterface) == nil {
+				t.Errorf("%s trunk references missing interface %s %s", device.Name, remote.Name, port.RemoteInterface)
+			}
+			if !port.FDBOnly && !hasReciprocalPort(remote, device.Name, port.RemoteInterface, port.Interface) {
+				t.Errorf(
+					"%s %s has no reciprocal link on %s %s",
+					device.Name, port.Interface, remote.Name, port.RemoteInterface,
+				)
+			}
+		}
+	}
+}
+
+func findInterface(device *config.Device, name string) *config.Interface {
+	for index := range device.Interfaces {
+		if device.Interfaces[index].Name == name {
+			return &device.Interfaces[index]
+		}
+	}
+	return nil
+}
+
+func hasReciprocalPort(device *config.Device, remote, localInterface, remoteInterface string) bool {
+	for _, port := range device.TrunkPorts {
+		if port.Interface == localInterface && port.RemoteDevice == remote && port.RemoteInterface == remoteInterface {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -1,0 +1,136 @@
+// Package scenario builds deterministic, validated simulation configurations
+// from typed customer authoring requests.
+package scenario
+
+const (
+	defaultDomain            = "demo.lab"
+	defaultCommunity         = "NetAllyDemo"
+	defaultAttachmentName    = "cyberscope"
+	maxSites                 = 4
+	maxSiteAccessPoints      = 154
+	maxSiteWorkstations      = 79
+	maxRedundantPeers        = 2
+	maxDistributionSwitches  = 8
+	maxAccessSwitches        = 20
+	maxServerSwitches        = 8
+	maxAccessPointsPerAccess = 9
+	maxWorkstationsPerAccess = 39
+	maxWirelessControllers   = 8
+	maxScenarioDomainLength  = 237
+	maxSNMPCommunityLength   = 255
+	maxAttachmentNameLength  = 64
+	maxSiteLocationLength    = 128
+
+	vlanManagement = 200
+	vlanData       = 210
+	vlanWiFiCorp   = 220
+	vlanWiFiGuest  = 230
+	vlanServers    = 240
+	vlanVoiceIoT   = 250
+
+	speedOneGigabit     = 1000
+	speedTenGigabit     = 10000
+	speedHundredGigabit = 100000
+
+	transitPeerOffset            = 2
+	secondProviderWANRouterIndex = 2
+	firstSiteInterfaceIndex      = 2
+	wanManagementHostOffset      = 3
+	firewallManagementHostOffset = 5
+	distributionHostOffset       = 10
+	accessHostOffset             = 20
+	serverSwitchHostOffset       = 40
+	accessPointHostOffset        = 99
+	workstationHostOffset        = 20
+	serviceHostOffset            = 9
+	controllerHostOffset         = 19
+	accessUplinkPortStart        = 49
+	coreServerPortOffset         = 8
+	workstationPortOffset        = 9
+	serverPortOffset             = 11
+	primaryCoreGatewayHost       = 2
+	dnsServerHost                = 10
+	dhcpServerHost               = 11
+	dhcpPoolStartHost            = 100
+	dhcpPoolEndHost              = 199
+	managedDeviceTTL             = 255
+	windowsTTL                   = 128
+	windowsTCPWindowSize         = 64240
+	windowsMSS                   = 1460
+	dnsRecordTTL                 = 300
+	performanceTestPort          = 5201
+	performanceBandwidthMbps     = 10000
+	performanceLatencyMillis     = 2
+	performanceJitterMillis      = 1
+	performancePacketLoss        = 0.01
+	wanIdentityOffset            = 10
+	transitBlockSize             = 8
+	firstDistributionAccessPort  = 3
+
+	enterpriseCOSOctet              = 240
+	enterpriseEVTOctet              = 241
+	enterpriseEHVOctet              = 242
+	enterpriseLONOctet              = 243
+	enterpriseDistributionSwitches  = 4
+	enterpriseAccessSwitches        = 16
+	enterpriseWorkstationsPerAccess = 4
+)
+
+const (
+	roleLabCode = 1 + iota
+	roleWANCode
+	roleFirewallCode
+	roleCoreCode
+	roleDistributionCode
+	roleAccessCode
+	roleServerSwitchCode
+	roleAccessPointCode
+	roleWorkstationCode
+	roleServerCode
+	roleControllerCode
+)
+
+// Site identifies one generated location and its second IPv4 octet.
+type Site struct {
+	Code     string `json:"code"`
+	Octet    int    `json:"octet"`
+	Location string `json:"location"`
+}
+
+// Counts controls how many devices the generator repeats at each site.
+type Counts struct {
+	SiteWANRouters        int `json:"siteWanRouters"`
+	Firewalls             int `json:"firewalls"`
+	CoreSwitches          int `json:"coreSwitches"`
+	DistributionSwitches  int `json:"distributionSwitches"`
+	AccessSwitches        int `json:"accessSwitches"`
+	ServerSwitches        int `json:"serverSwitches"`
+	AccessPointsPerAccess int `json:"accessPointsPerAccess"`
+	WorkstationsPerAccess int `json:"workstationsPerAccess"`
+	WirelessControllers   int `json:"wirelessControllers"`
+}
+
+// Request is the complete deterministic fleet-generation contract.
+type Request struct {
+	Sites          []Site `json:"sites"`
+	Counts         Counts `json:"counts"`
+	Domain         string `json:"domain"`
+	SNMPCommunity  string `json:"snmpCommunity"`
+	AttachmentName string `json:"attachmentName"`
+}
+
+// Manifest summarizes authored identity and topology for parity checks.
+type Manifest struct {
+	DeviceCount       int    `json:"deviceCount"`
+	NetworkCount      int    `json:"networkCount"`
+	LinkCount         int    `json:"linkCount"`
+	DeviceNamesSHA256 string `json:"deviceNamesSha256"`
+	NetworksSHA256    string `json:"networksSha256"`
+	LinksSHA256       string `json:"linksSha256"`
+}
+
+// Result contains portable YAML plus its deterministic parity manifest.
+type Result struct {
+	YAML     []byte   `json:"-"`
+	Manifest Manifest `json:"manifest"`
+}

--- a/internal/scenario/validation.go
+++ b/internal/scenario/validation.go
@@ -1,0 +1,125 @@
+package scenario
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func validateRequest(request Request) error {
+	if len(request.Sites) == 0 || len(request.Sites) > maxSites {
+		return fmt.Errorf("sites must contain 1 to %d entries", maxSites)
+	}
+	if !validDomainSuffix(request.Domain) {
+		return fmt.Errorf("domain must be a valid DNS suffix no longer than %d bytes", maxScenarioDomainLength)
+	}
+	if strings.TrimSpace(request.SNMPCommunity) == "" || len(request.SNMPCommunity) > maxSNMPCommunityLength {
+		return fmt.Errorf("SNMP community is required and must not exceed %d bytes", maxSNMPCommunityLength)
+	}
+	if strings.TrimSpace(request.AttachmentName) == "" || len(request.AttachmentName) > maxAttachmentNameLength {
+		return fmt.Errorf("attachment name is required and must not exceed %d bytes", maxAttachmentNameLength)
+	}
+	if err := validateSites(request.Sites); err != nil {
+		return err
+	}
+	return validateCounts(request.Counts)
+}
+
+func validateSites(sites []Site) error {
+	codes := make(map[string]bool, len(sites))
+	octets := make(map[int]bool, len(sites))
+	for _, site := range sites {
+		if !validSiteCode(site.Code) {
+			return fmt.Errorf("site code %q must be 2 to 8 uppercase letters or digits", site.Code)
+		}
+		if codes[site.Code] {
+			return fmt.Errorf("site code %q is duplicated", site.Code)
+		}
+		codes[site.Code] = true
+		if site.Octet < 1 || site.Octet > 253 {
+			return fmt.Errorf("site octet %d must be between 1 and 253", site.Octet)
+		}
+		if octets[site.Octet] {
+			return fmt.Errorf("site octet %d is duplicated", site.Octet)
+		}
+		octets[site.Octet] = true
+		if strings.TrimSpace(site.Location) == "" || len(site.Location) > maxSiteLocationLength {
+			return fmt.Errorf(
+				"site %s location is required and must not exceed %d bytes",
+				site.Code, maxSiteLocationLength,
+			)
+		}
+	}
+	return nil
+}
+
+func validateCounts(c Counts) error {
+	if c.SiteWANRouters != c.Firewalls || c.SiteWANRouters != c.CoreSwitches {
+		return errors.New("WAN, firewall, and core counts must match")
+	}
+	if c.SiteWANRouters < 1 || c.SiteWANRouters > maxRedundantPeers {
+		return errors.New("WAN, firewall, and core counts must be 1 or 2")
+	}
+	if c.DistributionSwitches < maxRedundantPeers || c.DistributionSwitches > maxDistributionSwitches {
+		return errors.New("distribution switch count must be between 2 and 8")
+	}
+	if c.DistributionSwitches%maxRedundantPeers != 0 {
+		return errors.New("distribution switch count must be even")
+	}
+	if c.AccessSwitches < 1 || c.AccessSwitches > maxAccessSwitches {
+		return errors.New("access switch count must be between 1 and 20")
+	}
+	if c.ServerSwitches < 1 || c.ServerSwitches > maxServerSwitches {
+		return errors.New("server switch count must be between 1 and 8")
+	}
+	if c.AccessPointsPerAccess < 0 || c.WorkstationsPerAccess < 0 || c.WirelessControllers < 0 {
+		return errors.New("endpoint counts cannot be negative")
+	}
+	if c.AccessPointsPerAccess > maxAccessPointsPerAccess {
+		return errors.New("access points per access switch must be between 0 and 9")
+	}
+	if c.WorkstationsPerAccess > maxWorkstationsPerAccess {
+		return errors.New("workstations per access switch must be between 0 and 39")
+	}
+	if c.WirelessControllers > maxWirelessControllers {
+		return errors.New("wireless controller count must be between 0 and 8")
+	}
+	if c.AccessSwitches*c.AccessPointsPerAccess > maxSiteAccessPoints {
+		return fmt.Errorf("site access point count must not exceed %d", maxSiteAccessPoints)
+	}
+	if c.AccessSwitches*c.WorkstationsPerAccess > maxSiteWorkstations {
+		return fmt.Errorf("site workstation count must not exceed %d", maxSiteWorkstations)
+	}
+	return nil
+}
+
+func validSiteCode(code string) bool {
+	if len(code) < 2 || len(code) > 8 || code[0] < 'A' || code[0] > 'Z' {
+		return false
+	}
+	for index := 1; index < len(code); index++ {
+		if (code[index] < 'A' || code[index] > 'Z') && (code[index] < '0' || code[index] > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func validDomainSuffix(domain string) bool {
+	if domain == "" || len(domain) > maxScenarioDomainLength || strings.TrimSpace(domain) != domain {
+		return false
+	}
+	for label := range strings.SplitSeq(domain, ".") {
+		if len(label) == 0 || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for index := range len(label) {
+			character := label[index]
+			if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+				(character < '0' || character > '9') && character != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/scenario/validation_test.go
+++ b/internal/scenario/validation_test.go
@@ -1,6 +1,7 @@
 package scenario_test
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -58,6 +59,9 @@ func TestGenerateRejectsImpossibleFleetCounts(t *testing.T) {
 		}},
 		{"peer limit", "WAN, firewall, and core counts must be 1 or 2", func(r *scenario.Request) {
 			r.Counts.SiteWANRouters, r.Counts.Firewalls, r.Counts.CoreSwitches = 3, 3, 3
+		}},
+		{"excessive peer count", "WAN, firewall, and core counts must be 1 or 2", func(r *scenario.Request) {
+			r.Counts.SiteWANRouters, r.Counts.Firewalls, r.Counts.CoreSwitches = math.MaxInt, math.MaxInt, math.MaxInt
 		}},
 		{"distribution pairs", "distribution switch count must be even", func(r *scenario.Request) {
 			r.Counts.DistributionSwitches = 3

--- a/internal/scenario/validation_test.go
+++ b/internal/scenario/validation_test.go
@@ -1,0 +1,84 @@
+package scenario_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+func TestGenerateRejectsOversizedRepeatedFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		want   string
+		mutate func(*scenario.Request)
+	}{
+		{"domain", "domain", func(r *scenario.Request) { r.Domain = strings.Repeat("a.", 118) + "aa" }},
+		{"SNMP community", "SNMP community", func(r *scenario.Request) { r.SNMPCommunity = strings.Repeat("c", 256) }},
+		{"attachment name", "attachment name", func(r *scenario.Request) {
+			r.AttachmentName = strings.Repeat("a", 65)
+		}},
+		{"site location", "location", func(r *scenario.Request) { r.Sites[0].Location = strings.Repeat("l", 129) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := scenario.EnterpriseReferenceRequest()
+			test.mutate(&request)
+			if _, err := scenario.Generate(request); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Generate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestGenerateRejectsAmbiguousSiteIdentity(t *testing.T) {
+	request := scenario.EnterpriseReferenceRequest()
+	request.Sites[1].Code = request.Sites[0].Code
+	if _, err := scenario.Generate(request); err == nil || !strings.Contains(err.Error(), "site code") {
+		t.Fatalf("Generate() error = %v, want duplicate site code", err)
+	}
+	request = scenario.EnterpriseReferenceRequest()
+	request.Sites[1].Octet = request.Sites[0].Octet
+	if _, err := scenario.Generate(request); err == nil || !strings.Contains(err.Error(), "site octet") {
+		t.Fatalf("Generate() error = %v, want duplicate site octet", err)
+	}
+}
+
+func TestGenerateRejectsImpossibleFleetCounts(t *testing.T) {
+	tests := []struct {
+		name   string
+		want   string
+		mutate func(*scenario.Request)
+	}{
+		{"site limit", "sites must contain 1 to 4 entries", func(r *scenario.Request) {
+			r.Sites = append(r.Sites, scenario.Site{Code: "NYC", Octet: 244, Location: "New York, NY"})
+		}},
+		{"unequal redundancy", "WAN, firewall, and core counts must match", func(r *scenario.Request) {
+			r.Counts.Firewalls = 1
+		}},
+		{"peer limit", "WAN, firewall, and core counts must be 1 or 2", func(r *scenario.Request) {
+			r.Counts.SiteWANRouters, r.Counts.Firewalls, r.Counts.CoreSwitches = 3, 3, 3
+		}},
+		{"distribution pairs", "distribution switch count must be even", func(r *scenario.Request) {
+			r.Counts.DistributionSwitches = 3
+		}},
+		{"access limit", "access switch count must be between 1 and 20", func(r *scenario.Request) {
+			r.Counts.AccessSwitches = 21
+		}},
+		{"AP port limit", "access points per access switch must be between 0 and 9", func(r *scenario.Request) {
+			r.Counts.AccessPointsPerAccess = 10
+		}},
+		{"workstation pool", "site workstation count must not exceed 79", func(r *scenario.Request) {
+			r.Counts.WorkstationsPerAccess = 5
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := scenario.EnterpriseReferenceRequest()
+			test.mutate(&request)
+			if _, err := scenario.Generate(request); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Generate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add validated device profiles and deterministic multisite fleet generation
- generate realistic L2/L3 hierarchy, Wi-Fi 7 APs, endpoints, services, links, and interface telemetry
- expose entitlement-gated profile and generation APIs without mutating the running simulation
- document the new API and canonical implementation locations

## Linked Issue

Related to #1151

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

## Testing Evidence

```text
make fmt-check  # passed
make lint       # passed: backend 0 issues; frontend 330 files clean
make test       # passed: 46 Go packages under race; frontend 70 test files
make build      # passed: Vite 2642 modules; NIAC binary built
pre-commit      # passed: gitleaks, gofmt, golangci-lint, gosec, race tests, file and sensitive-file gates
scenario coverage: 95.2%
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.