### PR TITLE
feat: add fleet generation to scenario wizard

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -445,6 +445,33 @@
       "help": "The simulation started from the validated draft. The saved draft remains available for future editing.",
       "title": "All set"
     },
+    "fleet": {
+      "addSite": "Add site",
+      "attachmentName": "Attachment name",
+      "counts": {
+        "accessPointsPerAccess": "Wi-Fi 7 APs per access switch",
+        "accessSwitches": "Access switches per site",
+        "coreSwitches": "Core switches per site",
+        "distributionSwitches": "Distribution switches per site",
+        "firewalls": "Firewalls per site",
+        "serverSwitches": "Server switches per site",
+        "siteWanRouters": "Redundant WAN, firewall, and core pairs",
+        "wirelessControllers": "Wireless controllers per site",
+        "workstationsPerAccess": "Wired workstations per access switch"
+      },
+      "domain": "DNS domain",
+      "help": "Start with the validated enterprise design, then adjust sites and device counts. NIAC assigns identities, addressing, ports, VLANs, services, and links consistently.",
+      "invalid": "Resolve the fleet values before continuing.",
+      "removeSite": "Remove site",
+      "select": "Use generated fleet",
+      "selected": "Generated fleet selected",
+      "siteCode": "Site code",
+      "siteLocation": "Location",
+      "siteOctet": "Address octet",
+      "sites": "Sites",
+      "snmpCommunity": "SNMP community",
+      "title": "Generate a multisite fleet"
+    },
     "label": "New Simulation",
     "nextLabel": "Next",
     "preflight": {

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -173,6 +173,33 @@
       "saveLabel": "Guardar borrador",
       "savingLabel": "Guardando…"
     },
+    "fleet": {
+      "addSite": "Agregar sitio",
+      "attachmentName": "Nombre de conexión",
+      "counts": {
+        "accessPointsPerAccess": "AP Wi-Fi 7 por switch de acceso",
+        "accessSwitches": "Switches de acceso por sitio",
+        "coreSwitches": "Switches de núcleo por sitio",
+        "distributionSwitches": "Switches de distribución por sitio",
+        "firewalls": "Firewalls por sitio",
+        "serverSwitches": "Switches de servidores por sitio",
+        "siteWanRouters": "Pares redundantes de WAN, firewall y núcleo",
+        "wirelessControllers": "Controladores inalámbricos por sitio",
+        "workstationsPerAccess": "Estaciones cableadas por switch de acceso"
+      },
+      "domain": "Dominio DNS",
+      "help": "Comienza con el diseño empresarial validado y ajusta los sitios y las cantidades. NIAC asigna identidades, direcciones, puertos, VLAN, servicios y enlaces de forma coherente.",
+      "invalid": "Corrige los valores de la flota antes de continuar.",
+      "removeSite": "Quitar sitio",
+      "select": "Usar flota generada",
+      "selected": "Flota generada seleccionada",
+      "siteCode": "Código del sitio",
+      "siteLocation": "Ubicación",
+      "siteOctet": "Octeto de dirección",
+      "sites": "Sitios",
+      "snmpCommunity": "Comunidad SNMP",
+      "title": "Generar una flota multisitio"
+    },
     "protocols": {
       "title": "Protocolos",
       "subtitle": "Resumen de protocolos por dispositivo para la configuración que acabas de construir"

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -99,15 +99,15 @@ type Site struct {
 
 // Counts controls how many devices the generator repeats at each site.
 type Counts struct {
-	SiteWANRouters        int `json:"siteWanRouters"`
+	SiteWANRouters        int `json:"site_wan_routers"`
 	Firewalls             int `json:"firewalls"`
-	CoreSwitches          int `json:"coreSwitches"`
-	DistributionSwitches  int `json:"distributionSwitches"`
-	AccessSwitches        int `json:"accessSwitches"`
-	ServerSwitches        int `json:"serverSwitches"`
-	AccessPointsPerAccess int `json:"accessPointsPerAccess"`
-	WorkstationsPerAccess int `json:"workstationsPerAccess"`
-	WirelessControllers   int `json:"wirelessControllers"`
+	CoreSwitches          int `json:"core_switches"`
+	DistributionSwitches  int `json:"distribution_switches"`
+	AccessSwitches        int `json:"access_switches"`
+	ServerSwitches        int `json:"server_switches"`
+	AccessPointsPerAccess int `json:"access_points_per_access"`
+	WorkstationsPerAccess int `json:"workstations_per_access"`
+	WirelessControllers   int `json:"wireless_controllers"`
 }
 
 // Request is the complete deterministic fleet-generation contract.
@@ -115,8 +115,8 @@ type Request struct {
 	Sites          []Site `json:"sites"`
 	Counts         Counts `json:"counts"`
 	Domain         string `json:"domain"`
-	SNMPCommunity  string `json:"snmpCommunity"`
-	AttachmentName string `json:"attachmentName"`
+	SNMPCommunity  string `json:"snmp_community"`
+	AttachmentName string `json:"attachment_name"`
 }
 
 // Manifest summarizes authored identity and topology for parity checks.

--- a/ui/src/api/scenario-client.test.ts
+++ b/ui/src/api/scenario-client.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('scenario generator client', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+  });
+
+  it('submits the enterprise repeat controls to the protected generator', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'csrf-token' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ content: 'devices: []\n', manifest: { device_count: 0 } }),
+      });
+
+    const { enterpriseScenarioRequest, generateScenario } = await import('./scenario-client');
+    const request = enterpriseScenarioRequest();
+    const response = await generateScenario(request);
+
+    expect(response.manifest.deviceCount).toBe(0);
+    expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/scenario/generate');
+    const payload = JSON.parse(mockFetch.mock.calls[1][1]?.body as string);
+    expect(payload).toMatchObject({
+      counts: { access_switches: 16, access_points_per_access: 2 },
+      attachment_name: 'cyberscope',
+    });
+    expect(payload.sites).toHaveLength(4);
+    expect(payload.sites[0]).toMatchObject({ code: 'COS', octet: 240 });
+  });
+
+  it('rejects cross-field combinations the generator cannot build', async () => {
+    const { enterpriseScenarioRequest, isScenarioRequestValid } = await import('./scenario-client');
+    const request = enterpriseScenarioRequest();
+    expect(isScenarioRequestValid(request)).toBe(true);
+
+    request.counts.accessSwitches = 20;
+    expect(isScenarioRequestValid(request)).toBe(false);
+    request.counts.workstationsPerAccess = 3;
+    expect(isScenarioRequestValid(request)).toBe(true);
+
+    request.counts.firewalls = 1;
+    expect(isScenarioRequestValid(request)).toBe(false);
+    request.counts.siteWanRouters = 1;
+    request.counts.coreSwitches = 1;
+    expect(isScenarioRequestValid(request)).toBe(true);
+
+    request.sites[0].octet = 254;
+    expect(isScenarioRequestValid(request)).toBe(false);
+  });
+
+  it('matches the generator integer and UTF-8 byte limits', async () => {
+    const { enterpriseScenarioRequest, isScenarioRequestValid } = await import('./scenario-client');
+    const request = enterpriseScenarioRequest();
+
+    request.counts.accessSwitches = 1.5;
+    expect(isScenarioRequestValid(request)).toBe(false);
+    request.counts.accessSwitches = 16;
+
+    request.snmpCommunity = 'é'.repeat(128);
+    expect(isScenarioRequestValid(request)).toBe(false);
+    request.snmpCommunity = 'NetAllyDemo';
+
+    request.attachmentName = 'é'.repeat(33);
+    expect(isScenarioRequestValid(request)).toBe(false);
+    request.attachmentName = 'cyberscope';
+
+    request.sites[0].location = 'é'.repeat(65);
+    expect(isScenarioRequestValid(request)).toBe(false);
+  });
+});

--- a/ui/src/api/scenario-client.ts
+++ b/ui/src/api/scenario-client.ts
@@ -1,0 +1,137 @@
+import { deduplicatedGet, requestJson } from './requestCore';
+
+export interface ScenarioSite {
+  code: string;
+  octet: number;
+  location: string;
+}
+
+export interface ScenarioCounts {
+  siteWanRouters: number;
+  firewalls: number;
+  coreSwitches: number;
+  distributionSwitches: number;
+  accessSwitches: number;
+  serverSwitches: number;
+  accessPointsPerAccess: number;
+  workstationsPerAccess: number;
+  wirelessControllers: number;
+}
+
+export interface ScenarioGenerateRequest {
+  sites: ScenarioSite[];
+  counts: ScenarioCounts;
+  domain: string;
+  snmpCommunity: string;
+  attachmentName: string;
+}
+
+export interface ScenarioManifest {
+  deviceCount: number;
+  networkCount: number;
+  linkCount: number;
+  deviceNamesSha256: string;
+  networksSha256: string;
+  linksSha256: string;
+}
+
+export interface ScenarioGenerateResponse {
+  content: string;
+  manifest: ScenarioManifest;
+}
+
+export interface ScenarioDeviceProfile {
+  role: string;
+  deviceType: string;
+  vendor: string;
+  model: string;
+  platform: string;
+  software: string;
+  sysObjectId: string;
+}
+
+export const enterpriseScenarioRequest = (): ScenarioGenerateRequest => ({
+  sites: [
+    { code: 'COS', octet: 240, location: 'Colorado Springs, CO' },
+    { code: 'EVT', octet: 241, location: 'Everett, WA' },
+    { code: 'EHV', octet: 242, location: 'Eindhoven, Netherlands' },
+    { code: 'LON', octet: 243, location: 'London, UK' },
+  ],
+  counts: {
+    siteWanRouters: 2,
+    firewalls: 2,
+    coreSwitches: 2,
+    distributionSwitches: 4,
+    accessSwitches: 16,
+    serverSwitches: 2,
+    accessPointsPerAccess: 2,
+    workstationsPerAccess: 4,
+    wirelessControllers: 2,
+  },
+  domain: 'demo.lab',
+  snmpCommunity: 'NetAllyDemo',
+  attachmentName: 'cyberscope',
+});
+
+const validDomain = (domain: string) =>
+  domain.length > 0 &&
+  domain.length <= 237 &&
+  domain.trim() === domain &&
+  domain.split('.').every((label) => /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(label));
+
+const utf8Length = (value: string) => new TextEncoder().encode(value).length;
+
+export const isScenarioRequestValid = (request: ScenarioGenerateRequest) => {
+  if (request.sites.length < 1 || request.sites.length > 4 || !validDomain(request.domain)) {
+    return false;
+  }
+  if (!request.snmpCommunity.trim() || utf8Length(request.snmpCommunity) > 255) return false;
+  if (!request.attachmentName.trim() || utf8Length(request.attachmentName) > 64) return false;
+
+  const codes = new Set<string>();
+  const octets = new Set<number>();
+  for (const site of request.sites) {
+    if (!/^[A-Z][A-Z0-9]{1,7}$/.test(site.code) || codes.has(site.code)) return false;
+    if (
+      !Number.isInteger(site.octet) ||
+      site.octet < 1 ||
+      site.octet > 253 ||
+      octets.has(site.octet)
+    ) {
+      return false;
+    }
+    if (!site.location.trim() || utf8Length(site.location) > 128) return false;
+    codes.add(site.code);
+    octets.add(site.octet);
+  }
+
+  const counts = request.counts;
+  if (!Object.values(counts).every(Number.isInteger)) return false;
+  return (
+    counts.siteWanRouters === counts.firewalls &&
+    counts.siteWanRouters === counts.coreSwitches &&
+    counts.siteWanRouters >= 1 &&
+    counts.siteWanRouters <= 2 &&
+    counts.distributionSwitches >= 2 &&
+    counts.distributionSwitches <= 8 &&
+    counts.distributionSwitches % 2 === 0 &&
+    counts.accessSwitches >= 1 &&
+    counts.accessSwitches <= 20 &&
+    counts.serverSwitches >= 1 &&
+    counts.serverSwitches <= 8 &&
+    counts.accessPointsPerAccess >= 0 &&
+    counts.accessPointsPerAccess <= 9 &&
+    counts.workstationsPerAccess >= 0 &&
+    counts.workstationsPerAccess <= 39 &&
+    counts.wirelessControllers >= 0 &&
+    counts.wirelessControllers <= 8 &&
+    counts.accessSwitches * counts.accessPointsPerAccess <= 154 &&
+    counts.accessSwitches * counts.workstationsPerAccess <= 79
+  );
+};
+
+export const fetchScenarioProfiles = () =>
+  deduplicatedGet<ScenarioDeviceProfile[]>('/api/v1/scenario/profiles');
+
+export const generateScenario = (payload: ScenarioGenerateRequest) =>
+  requestJson<ScenarioGenerateResponse>('/api/v1/scenario/generate', payload, { method: 'POST' });

--- a/ui/src/components/wizard/FleetGeneratorCard.test.tsx
+++ b/ui/src/components/wizard/FleetGeneratorCard.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { enterpriseScenarioRequest } from '../../api/scenario-client';
+import '../../i18n';
+import { FleetGeneratorCard } from './FleetGeneratorCard';
+
+describe('FleetGeneratorCard', () => {
+  it('exposes bounded repeat controls and reports edits', () => {
+    const onChange = vi.fn();
+    render(
+      <FleetGeneratorCard
+        request={enterpriseScenarioRequest()}
+        selected={false}
+        onChange={onChange}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const accessSwitches = screen.getByRole('spinbutton', {
+      name: 'Access switches per site',
+    });
+    expect(accessSwitches).toHaveAttribute('min', '1');
+    expect(accessSwitches).toHaveAttribute('max', '20');
+    fireEvent.change(accessSwitches, { target: { value: '8' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ counts: expect.objectContaining({ accessSwitches: 8 }) }),
+    );
+  });
+
+  it('keeps the site count within the supported range', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <FleetGeneratorCard
+        request={enterpriseScenarioRequest()}
+        selected
+        onChange={onChange}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Add site' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Remove site' }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sites: expect.arrayContaining([expect.objectContaining({ code: 'COS' })]),
+      }),
+    );
+    expect(onChange.mock.calls[0][0].sites).toHaveLength(3);
+  });
+
+  it('keeps redundant layers and endpoint totals valid', () => {
+    const onChange = vi.fn();
+    render(
+      <FleetGeneratorCard
+        request={enterpriseScenarioRequest()}
+        selected
+        onChange={onChange}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByRole('spinbutton', { name: 'Redundant WAN, firewall, and core pairs' }),
+      { target: { value: '1' } },
+    );
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        counts: expect.objectContaining({ siteWanRouters: 1, firewalls: 1, coreSwitches: 1 }),
+      }),
+    );
+
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Access switches per site' }), {
+      target: { value: '20' },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        counts: expect.objectContaining({ accessSwitches: 20, workstationsPerAccess: 3 }),
+      }),
+    );
+  });
+});

--- a/ui/src/components/wizard/FleetGeneratorCard.tsx
+++ b/ui/src/components/wizard/FleetGeneratorCard.tsx
@@ -1,0 +1,216 @@
+import { Network } from 'lucide-react';
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  isScenarioRequestValid,
+  type ScenarioCounts,
+  type ScenarioGenerateRequest,
+} from '../../api/scenario-client';
+import { iconSizes } from '../../constants/sizes';
+import { Button } from '../../ui/Button';
+import { Card, CardContent } from '../../ui/Card';
+import { SmallText } from '../../ui/Typography';
+
+interface FleetGeneratorCardProps {
+  request: ScenarioGenerateRequest;
+  selected: boolean;
+  onChange: (request: ScenarioGenerateRequest) => void;
+  onSelect: () => void;
+}
+
+const countFields: Array<keyof ScenarioCounts> = [
+  'siteWanRouters',
+  'distributionSwitches',
+  'accessSwitches',
+  'serverSwitches',
+  'accessPointsPerAccess',
+  'workstationsPerAccess',
+  'wirelessControllers',
+];
+
+const inputClass =
+  'min-h-11 w-full rounded border border-surface-border bg-bg-elevated px-3 py-row text-sm text-text-primary focus:border-brand-accent focus:outline-none focus:ring-2 focus:ring-brand-primary/60';
+
+const countLimits: Record<keyof ScenarioCounts, { min: number; max: number; step?: number }> = {
+  siteWanRouters: { min: 1, max: 2 },
+  firewalls: { min: 1, max: 2 },
+  coreSwitches: { min: 1, max: 2 },
+  distributionSwitches: { min: 2, max: 8, step: 2 },
+  accessSwitches: { min: 1, max: 20 },
+  serverSwitches: { min: 1, max: 8 },
+  accessPointsPerAccess: { min: 0, max: 9 },
+  workstationsPerAccess: { min: 0, max: 39 },
+  wirelessControllers: { min: 0, max: 8 },
+};
+
+export const FleetGeneratorCard: FC<FleetGeneratorCardProps> = ({
+  request,
+  selected,
+  onChange,
+  onSelect,
+}) => {
+  const { t } = useTranslation('pages');
+  const updateCount = (field: keyof ScenarioCounts, value: number) => {
+    const counts = { ...request.counts, [field]: value };
+    if (field === 'siteWanRouters') {
+      counts.firewalls = value;
+      counts.coreSwitches = value;
+    }
+    if (field === 'accessSwitches') {
+      counts.accessPointsPerAccess = Math.min(
+        counts.accessPointsPerAccess,
+        Math.floor(154 / value),
+      );
+      counts.workstationsPerAccess = Math.min(counts.workstationsPerAccess, Math.floor(79 / value));
+    }
+    onChange({ ...request, counts });
+  };
+  const updateSite = (
+    index: number,
+    field: 'code' | 'octet' | 'location',
+    value: string | number,
+  ) =>
+    onChange({
+      ...request,
+      sites: request.sites.map((site, siteIndex) =>
+        siteIndex === index ? { ...site, [field]: value } : site,
+      ),
+    });
+
+  return (
+    <Card className={selected ? 'border-brand-accent bg-brand-primary/10' : undefined}>
+      <CardContent className="stack-lg">
+        <div className="flex flex-wrap items-start justify-between gap-default">
+          <div className="flex items-start gap-default">
+            <Network className={`${iconSizes.lg} text-brand-accent`} />
+            <div>
+              <div className="font-medium text-text-primary">{t('newSimWizard.fleet.title')}</div>
+              <SmallText className="text-text-muted">{t('newSimWizard.fleet.help')}</SmallText>
+            </div>
+          </div>
+          <Button
+            type="button"
+            tone="violet"
+            className="min-h-11"
+            data-testid="wizard-select-fleet"
+            disabled={!isScenarioRequestValid(request)}
+            onClick={onSelect}
+          >
+            {selected ? t('newSimWizard.fleet.selected') : t('newSimWizard.fleet.select')}
+          </Button>
+        </div>
+
+        <div className="grid gap-default md:grid-cols-3">
+          {(['domain', 'snmpCommunity', 'attachmentName'] as const).map((field) => (
+            <label key={field} className="stack-xs text-xs text-text-muted">
+              {t(`newSimWizard.fleet.${field}`)}
+              <input
+                data-testid={`fleet-${field}`}
+                className={inputClass}
+                value={request[field]}
+                maxLength={field === 'domain' ? 237 : field === 'snmpCommunity' ? 255 : 64}
+                onChange={(event) => onChange({ ...request, [field]: event.target.value })}
+              />
+            </label>
+          ))}
+        </div>
+
+        <div className="stack-sm">
+          <div className="flex items-center justify-between gap-default">
+            <span className="text-sm font-medium text-text-primary">
+              {t('newSimWizard.fleet.sites')}
+            </span>
+            <div className="flex gap-sm">
+              <Button
+                type="button"
+                variant="outline"
+                className="min-h-11"
+                disabled={request.sites.length === 1}
+                onClick={() => onChange({ ...request, sites: request.sites.slice(0, -1) })}
+              >
+                {t('newSimWizard.fleet.removeSite')}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="min-h-11"
+                disabled={request.sites.length === 4}
+                onClick={() => {
+                  const next = request.sites.length + 1;
+                  onChange({
+                    ...request,
+                    sites: [
+                      ...request.sites,
+                      { code: `SITE${next}`, octet: 239 + next, location: `Site ${next}` },
+                    ],
+                  });
+                }}
+              >
+                {t('newSimWizard.fleet.addSite')}
+              </Button>
+            </div>
+          </div>
+          {request.sites.map((site, index) => (
+            <div key={index} className="grid gap-default md:grid-cols-[1fr_8rem_2fr]">
+              <label className="stack-xs text-xs text-text-muted">
+                {t('newSimWizard.fleet.siteCode')}
+                <input
+                  className={inputClass}
+                  value={site.code}
+                  onChange={(event) => updateSite(index, 'code', event.target.value.toUpperCase())}
+                />
+              </label>
+              <label className="stack-xs text-xs text-text-muted">
+                {t('newSimWizard.fleet.siteOctet')}
+                <input
+                  className={inputClass}
+                  type="number"
+                  min={1}
+                  max={253}
+                  value={site.octet}
+                  onChange={(event) => updateSite(index, 'octet', Number(event.target.value))}
+                />
+              </label>
+              <label className="stack-xs text-xs text-text-muted">
+                {t('newSimWizard.fleet.siteLocation')}
+                <input
+                  className={inputClass}
+                  value={site.location}
+                  onChange={(event) => updateSite(index, 'location', event.target.value)}
+                />
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-default sm:grid-cols-2 lg:grid-cols-3">
+          {countFields.map((field) => (
+            <label key={field} className="stack-xs text-xs text-text-muted">
+              {t(`newSimWizard.fleet.counts.${field}`)}
+              <input
+                className={inputClass}
+                type="number"
+                min={countLimits[field].min}
+                max={
+                  field === 'accessPointsPerAccess'
+                    ? Math.min(9, Math.floor(154 / request.counts.accessSwitches))
+                    : field === 'workstationsPerAccess'
+                      ? Math.min(39, Math.floor(79 / request.counts.accessSwitches))
+                      : countLimits[field].max
+                }
+                step={countLimits[field].step}
+                value={request.counts[field]}
+                onChange={(event) => updateCount(field, Number(event.target.value))}
+              />
+            </label>
+          ))}
+        </div>
+        {!isScenarioRequestValid(request) && (
+          <SmallText role="alert" className="text-status-error">
+            {t('newSimWizard.fleet.invalid')}
+          </SmallText>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/components/wizard/TemplateStep.tsx
+++ b/ui/src/components/wizard/TemplateStep.tsx
@@ -7,6 +7,7 @@ import { iconSizes } from '../../constants/sizes';
 import { Card, CardContent } from '../../ui/Card';
 import { SmallText } from '../../ui/Typography';
 import { ConfigPicker } from '../simulation/ConfigPicker';
+import { FleetGeneratorCard } from './FleetGeneratorCard';
 import type { WizardState } from './wizard-types';
 
 interface TemplateStepProps {
@@ -15,6 +16,8 @@ interface TemplateStepProps {
   onSelectUserConfig: (config: LibraryNetwork) => void;
   onUpload: (file: File | null) => void;
   onSelectEmpty: () => void;
+  onSelectFleet: () => void;
+  onFleetChange: (request: WizardState['fleetRequest']) => void;
   onInterfaceChange: (iface: string) => void;
 }
 
@@ -30,6 +33,8 @@ export const TemplateStep: FC<TemplateStepProps> = ({
   onSelectUserConfig,
   onUpload,
   onSelectEmpty,
+  onSelectFleet,
+  onFleetChange,
   onInterfaceChange,
 }) => {
   const { t } = useTranslation('pages');
@@ -55,7 +60,12 @@ export const TemplateStep: FC<TemplateStepProps> = ({
   }, []);
 
   const selection = {
-    source: state.uploadFile ? ('upload' as const) : state.source === 'empty' ? null : state.source,
+    source:
+      state.uploadFile || state.source === 'upload'
+        ? ('upload' as const)
+        : state.source === 'template' || state.source === 'userConfig'
+          ? state.source
+          : null,
     name: state.uploadFile
       ? state.uploadFile.name
       : (state.template?.name ?? state.userConfig?.name ?? ''),
@@ -110,6 +120,13 @@ export const TemplateStep: FC<TemplateStepProps> = ({
           <SmallText className="text-text-muted">{t('newSimWizard.template.help')}</SmallText>
         </CardContent>
       </Card>
+
+      <FleetGeneratorCard
+        request={state.fleetRequest}
+        selected={state.source === 'generated'}
+        onChange={onFleetChange}
+        onSelect={onSelectFleet}
+      />
 
       <ConfigPicker
         selection={selection}

--- a/ui/src/components/wizard/wizard-types.ts
+++ b/ui/src/components/wizard/wizard-types.ts
@@ -1,3 +1,8 @@
+import {
+  enterpriseScenarioRequest,
+  isScenarioRequestValid,
+  type ScenarioGenerateRequest,
+} from '../../api/scenario-client';
 import type { LibraryNetwork, Template } from '../../api/types';
 
 /**
@@ -20,7 +25,7 @@ export type WizardStepId = (typeof WIZARD_STEPS)[number];
  * equivalent — it's a one-line addition (a blank devices: [] skeleton)
  * so the wizard doesn't force a template pick.
  */
-export type WizardSource = 'template' | 'userConfig' | 'upload' | 'empty';
+export type WizardSource = 'template' | 'userConfig' | 'upload' | 'empty' | 'generated';
 
 /**
  * WizardState is held locally in the container. Draft content and its
@@ -33,6 +38,7 @@ export interface WizardState {
   template: Template | null;
   userConfig: LibraryNetwork | null;
   uploadFile: File | null;
+  fleetRequest: ScenarioGenerateRequest;
   selectedInterface: string;
   starting: boolean;
   saving: boolean;
@@ -44,6 +50,7 @@ export const initialWizardState: WizardState = {
   template: null,
   userConfig: null,
   uploadFile: null,
+  fleetRequest: enterpriseScenarioRequest(),
   selectedInterface: '',
   starting: false,
   saving: false,
@@ -56,5 +63,6 @@ export function isTemplateStepComplete(state: WizardState): boolean {
   if (state.source === 'template') return state.template !== null;
   if (state.source === 'userConfig') return state.userConfig !== null;
   if (state.source === 'upload') return state.uploadFile !== null;
+  if (state.source === 'generated') return isScenarioRequestValid(state.fleetRequest);
   return false;
 }

--- a/ui/src/pages/NewSimulationWizardPage.test.tsx
+++ b/ui/src/pages/NewSimulationWizardPage.test.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ScenarioDraft } from '../api/library-client';
+import type { ScenarioGenerateRequest } from '../api/scenario-client';
 import type { LibraryNetwork, SimulationStatus, Template } from '../api/types';
 import { AppProvider } from '../contexts/AppContext';
 import '../i18n';
@@ -47,6 +48,8 @@ const createScenarioDraftFromTemplate =
   vi.fn<(name: string, templateName: string) => Promise<ScenarioDraft>>();
 const replaceScenarioDraft =
   vi.fn<(name: string, revision: string, content: string) => Promise<ScenarioDraft>>();
+const generateScenario =
+  vi.fn<(request: ScenarioGenerateRequest) => Promise<{ content: string }>>();
 const emptyDraftContent = `devices:
   - name: new-device
     type: host
@@ -84,6 +87,14 @@ vi.mock('../api/library-client', () => ({
   replaceScenarioDraft: (name: string, revision: string, content: string) =>
     replaceScenarioDraft(name, revision, content),
 }));
+
+vi.mock('../api/scenario-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/scenario-client')>();
+  return {
+    ...actual,
+    generateScenario: (request: ScenarioGenerateRequest) => generateScenario(request),
+  };
+});
 
 vi.mock('../components/config/YamlEditor', () => ({
   YamlEditor: ({ value, onChange }: { value: string; onChange?: (value: string) => void }) => (
@@ -136,6 +147,7 @@ beforeEach(() => {
     modifiedAt: '2026-07-28T12:01:00Z',
     sizeBytes: 76,
   });
+  generateScenario.mockResolvedValue({ content: 'devices:\n  - name: COS-CORE-SW01\n' });
   startSimulation.mockResolvedValue({
     running: true,
     interface: 'lo0',
@@ -214,6 +226,31 @@ describe('NewSimulationWizardPage — step navigation', () => {
 
     await user.click(screen.getByTestId('wizard-back-button'));
     await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+  });
+
+  it('generates a validated fleet and saves it as an isolated draft', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByTestId('wizard-interface-select')).not.toBeDisabled());
+    await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
+    await user.clear(screen.getByTestId('fleet-domain'));
+    await user.type(screen.getByTestId('fleet-domain'), 'customer.lab');
+    await user.click(screen.getByTestId('wizard-select-fleet'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+
+    await waitFor(() => expect(generateScenario).toHaveBeenCalledTimes(1));
+    expect(generateScenario).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'customer.lab',
+        sites: expect.arrayContaining([expect.objectContaining({ code: 'COS' })]),
+      }),
+    );
+    expect(createScenarioDraft).toHaveBeenCalledWith(
+      expect.stringMatching(/^scenario-/),
+      'devices:\n  - name: COS-CORE-SW01\n',
+    );
+    expect(startSimulation).not.toHaveBeenCalled();
   });
 
   it('saves dirty edits before Back and resumes the same draft for an unchanged source', async () => {

--- a/ui/src/pages/NewSimulationWizardPage.tsx
+++ b/ui/src/pages/NewSimulationWizardPage.tsx
@@ -8,6 +8,7 @@ import {
   replaceScenarioDraft,
   type ScenarioDraft,
 } from '../api/library-client';
+import { generateScenario } from '../api/scenario-client';
 import type { LibraryNetwork, SimulationRequest, Template } from '../api/types';
 import { DevicesStep } from '../components/wizard/DevicesStep';
 import { FinishStep } from '../components/wizard/FinishStep';
@@ -45,6 +46,7 @@ function selectedSourceKey(state: WizardState) {
   if (state.source === 'upload' && state.uploadFile) {
     return `upload:${state.uploadFile.name}:${state.uploadFile.size}:${state.uploadFile.lastModified}`;
   }
+  if (state.source === 'generated') return `generated:${JSON.stringify(state.fleetRequest)}`;
   return state.source === 'empty' ? 'empty' : null;
 }
 
@@ -96,6 +98,9 @@ export const NewSimulationWizardPage: FC = () => {
         created = await createScenarioDraft(draftName, await fileToText(state.uploadFile));
       } else if (state.source === 'empty') {
         created = await createScenarioDraft(draftName, EMPTY_CONFIG_YAML);
+      } else if (state.source === 'generated') {
+        const generated = await generateScenario(state.fleetRequest);
+        created = await createScenarioDraft(draftName, generated.content);
       } else {
         throw new Error(t('newSimWizard.template.errorNoSource'));
       }
@@ -215,6 +220,18 @@ export const NewSimulationWizardPage: FC = () => {
                 userConfig: null,
                 uploadFile: null,
               }))
+            }
+            onSelectFleet={() =>
+              setState((s) => ({
+                ...s,
+                source: 'generated',
+                template: null,
+                userConfig: null,
+                uploadFile: null,
+              }))
+            }
+            onFleetChange={(fleetRequest) =>
+              setState((s) => ({ ...s, source: 'generated', fleetRequest }))
             }
             onInterfaceChange={(iface: string) =>
               setState((s) => ({ ...s, selectedInterface: iface }))


### PR DESCRIPTION
## Summary

- add enterprise fleet generation to the existing draft-first scenario wizard
- expose bounded site and device repeat controls with browser validation matching the generator contract
- save generated YAML as an isolated draft without mutating the active runtime
- use the canonical snake_case request contract and preserve camelCase responses

## Linked Issue

Related to #1151

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

## Testing Evidence

```text
go test -race ./internal/scenario ./internal/api
npm test -- --run src/api/scenario-client.test.ts
npm test -- --run src/components/wizard/FleetGeneratorCard.test.tsx
npm test -- --run src/pages/NewSimulationWizardPage.test.tsx
npm test -- --run src/i18n/i18n.parity.test.ts src/i18n/i18n.test.ts
npm run lint
npm run typecheck
npm run build
git diff --check

All passed.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.