### PR TITLE
feat: add revision-safe draft topology mutations

### DIFF
--- a/CODE_INDEX.md
+++ b/CODE_INDEX.md
@@ -22,7 +22,7 @@ parallel implementation. It is intentionally organized by purpose.
 | Routed semantic compiler | `internal/fabric/compiler.go` | Pure config plus binding to immutable topology |
 | Routed device compilation | `internal/fabric/compiler_devices.go` | Interfaces, routes, and DHCP ownership |
 | Fabric domain and diagnostics | `internal/fabric/types.go` | Physical binding is distinct from virtual networks |
-| Device/link UI graph | `internal/topology/topology.go` | Projection only; not a forwarding compiler |
+| Device/link UI graph | `internal/topology/topology.go` | Projection only; preserves parallel endpoint pairs and authored interface telemetry, not a forwarding compiler |
 | Physical VLAN engines | `internal/protocols/stack_init.go` | ADR 0008 segments; not routed virtual networks |
 | Routed reply Ethernet identity | `internal/protocols/stack.go` | One source for gateway/device source MAC, requester destination MAC, and ingress VLAN |
 | Final wire egress policy | `internal/protocols/stack_threads.go` | Last enforcement point for direct/access untagged frames and observer-visible bytes |
@@ -60,6 +60,7 @@ parallel implementation. It is intentionally organized by purpose.
 | Simulation request validation | `internal/api/validation.go` | Interface/config source boundary validation |
 | Simulation lifecycle handlers | `internal/api/handlers_simulation.go` | Strict decoder and standard error envelope |
 | Scenario generation API | `internal/api/handlers_scenario.go` | Licensed profile catalog and CSRF-protected deterministic generation boundary; generated YAML remains a draft input and does not mutate runtime |
+| Draft topology mutations | `internal/drafttopology` + `internal/api/handlers_draft_topology.go` | Typed add, connect, disconnect, move, and link-property edits; reciprocal peer ports and draft revisions remain authoritative |
 | Route security policy | `internal/api/routes.go` | Methods, rate limits, and CSRF are registered here |
 | Config preparation and start | `internal/daemon/daemon.go` | Preflight must not persist or open capture |
 

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -38,6 +38,7 @@ Prometheus metrics share the daemon's HTTPS listener at `/metrics`; there is no 
 | `GET` | `/api/v1/topology` | Simple topology graph derived from configuration |
 | `GET` | `/api/v1/scenario/profiles` | Reusable vendor, model, role, and discovery profiles |
 | `POST` | `/api/v1/scenario/generate` | Generate deterministic validated YAML from sites and repeat controls |
+| `PATCH` | `/api/v1/library/drafts/{name}/topology` | Apply one revision-safe topology edit to an isolated draft |
 | `GET` | `/api/v1/version` | Version information |
 | `GET` | `/api/v1/errors` | Available error types and active error injections |
 | `POST` | `/api/v1/errors` | Inject network errors on device interfaces |
@@ -62,6 +63,33 @@ Generation is side-effect free: it does not replace the active configuration,
 start a simulation, or save a draft. The returned `content` can be reviewed and
 then stored through the draft API. The generate route requires a read-write
 token, the `config_templates` entitlement, and a CSRF token.
+
+### Draft topology mutations
+
+`PATCH /api/v1/library/drafts/{name}/topology` applies one `add_device`,
+`connect`, `disconnect`, `move_device`, or `update_link` operation. Send the
+current quoted draft revision in `If-Match`; the response contains the updated
+draft and its new `ETag`. A stale revision returns `412 Precondition Failed`.
+
+Connections name both device/interface endpoints. NIAC refuses missing,
+non-physical, or already occupied ports and writes reciprocal `trunk_ports`
+records so the local and remote interface identities cannot drift. Link VLAN,
+native VLAN, and FDB-only properties are updated on both endpoints together.
+
+```json
+{
+  "operation": "connect",
+  "link": {
+    "source": { "device": "core-1", "interface": "Ethernet1/1" },
+    "target": { "device": "dist-1", "interface": "Ethernet1/49" },
+    "properties": { "vlans": [200, 210], "native_vlan": 200 }
+  }
+}
+```
+
+The route requires a read-write token, CSRF protection, and the normal draft
+entitlement checks. It replaces only the named draft; it does not apply or
+restart the running simulation.
 
 ## Web UI
 

--- a/internal/api/handlers_draft_topology.go
+++ b/internal/api/handlers_draft_topology.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/drafttopology"
+	"github.com/MustardSeedNetworks/niac-go/internal/library"
+)
+
+func (s *Server) handleLibraryDraftTopologyMutation(
+	w http.ResponseWriter,
+	r *http.Request,
+	name string,
+) {
+	revision, ok := requireDraftIfMatch(w, r)
+	if !ok {
+		return
+	}
+	draft, err := s.library.ReadDraft(name)
+	if err != nil {
+		s.writeDraftStoreError(w, r, "read topology", name, err)
+		return
+	}
+	if draft.Revision != revision {
+		s.writeDraftStoreError(w, r, "mutate topology", name, library.ErrRevisionMismatch)
+		return
+	}
+
+	var mutation drafttopology.Mutation
+	if !decodeJSONStrict(w, r, &mutation, MaxRequestBodySize) {
+		return
+	}
+	cfg, err := config.LoadYAMLBytes([]byte(draft.Content))
+	if err != nil {
+		s.logger.ErrorContext(
+			r.Context(),
+			"Draft topology source is invalid",
+			"name",
+			name,
+			"error",
+			err,
+		)
+		writeError(
+			w,
+			r,
+			http.StatusBadRequest,
+			"config_invalid",
+			"Draft configuration is invalid",
+			nil,
+		)
+		return
+	}
+	if mutationErr := drafttopology.Apply(cfg, mutation); mutationErr != nil {
+		writeDraftTopologyError(w, r, mutationErr)
+		return
+	}
+	content, err := config.MarshalConfigYAML(cfg)
+	if err != nil {
+		s.logger.ErrorContext(
+			r.Context(),
+			"Draft topology serialization failed",
+			"name",
+			name,
+			"error",
+			err,
+		)
+		writeError(w, r, http.StatusInternalServerError, "draft_serialization_failed",
+			"Failed to serialize draft configuration", nil)
+		return
+	}
+	if !s.validateDraftContent(w, r, string(content)) {
+		return
+	}
+	updated, err := s.library.ReplaceDraft(name, revision, string(content))
+	if err != nil {
+		s.writeDraftStoreError(w, r, "mutate topology", name, err)
+		return
+	}
+	s.writeDraft(w, http.StatusOK, updated)
+}
+
+func writeDraftTopologyError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case drafttopology.IsInvalid(err):
+		writeError(
+			w,
+			r,
+			http.StatusBadRequest,
+			"topology_mutation_invalid",
+			"Topology mutation is invalid",
+			nil,
+		)
+	case drafttopology.IsNotFound(err):
+		writeError(
+			w,
+			r,
+			http.StatusNotFound,
+			"topology_resource_not_found",
+			"Topology resource not found",
+			nil,
+		)
+	case drafttopology.IsConflict(err):
+		writeError(
+			w,
+			r,
+			http.StatusConflict,
+			"topology_conflict",
+			"Topology mutation conflicts with the draft",
+			nil,
+		)
+	default:
+		writeError(
+			w,
+			r,
+			http.StatusInternalServerError,
+			"topology_mutation_failed",
+			"Topology mutation failed",
+			nil,
+		)
+	}
+}

--- a/internal/api/handlers_draft_topology_test.go
+++ b/internal/api/handlers_draft_topology_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api/ratelimit"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+const topologyDraftYAML = `devices:
+  - name: core-1
+    type: switch
+    mac: "02:00:00:00:00:01"
+    ips: ["192.0.2.1"]
+    interfaces:
+      - name: Ethernet1/1
+        type: ethernet
+  - name: dist-1
+    type: switch
+    mac: "02:00:00:00:00:02"
+    ips: ["192.0.2.2"]
+    interfaces:
+      - name: Ethernet1/49
+        type: ethernet
+`
+
+func TestDraftTopologyMutationPersistsReciprocalLinkWithoutApplyingRuntime(t *testing.T) {
+	server, _ := newTestServer(t)
+	lib := attachDraftLibrary(t, server)
+	draft, err := lib.CreateDraft("topology", topologyDraftYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+	applied := false
+	server.cfg.ApplyConfig = func(_ *config.Config) error {
+		applied = true
+		return nil
+	}
+
+	body := `{
+      "operation":"connect",
+      "link":{
+        "source":{"device":"core-1","interface":"Ethernet1/1"},
+        "target":{"device":"dist-1","interface":"Ethernet1/49"},
+        "properties":{"vlans":[200,210],"native_vlan":200}
+      }
+    }`
+	rec := httptest.NewRecorder()
+	server.handleLibraryDraftByName(rec, draftRequest(
+		http.MethodPatch, "/api/v1/library/drafts/topology/topology", body, draft.Revision,
+	))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	updated := decodeDraftResponse(t, rec)
+	if updated.Revision == draft.Revision {
+		t.Fatal("topology mutation did not advance draft revision")
+	}
+	cfg, loadErr := config.LoadYAMLBytes([]byte(updated.Content))
+	if loadErr != nil {
+		t.Fatalf("mutated draft is invalid: %v", loadErr)
+	}
+	if len(cfg.Devices[0].TrunkPorts) != 1 || len(cfg.Devices[1].TrunkPorts) != 1 {
+		t.Fatalf(
+			"trunk counts = %d, %d",
+			len(cfg.Devices[0].TrunkPorts),
+			len(cfg.Devices[1].TrunkPorts),
+		)
+	}
+	if cfg.Devices[0].TrunkPorts[0].RemoteDevice != "dist-1" ||
+		cfg.Devices[1].TrunkPorts[0].RemoteDevice != "core-1" {
+		t.Fatalf(
+			"link is not reciprocal: %+v %+v",
+			cfg.Devices[0].TrunkPorts,
+			cfg.Devices[1].TrunkPorts,
+		)
+	}
+	if applied {
+		t.Fatal("draft topology mutation applied the running configuration")
+	}
+}
+
+func TestDraftTopologyMutationRequiresRevisionAndPreservesDraftOnFailure(t *testing.T) {
+	server, _ := newTestServer(t)
+	lib := attachDraftLibrary(t, server)
+	draft, err := lib.CreateDraft("topology", topologyDraftYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+	body := `{"operation":"connect","link":{"source":{"device":"core-1","interface":"missing"},"target":{"device":"dist-1","interface":"Ethernet1/49"},"properties":{}}}`
+
+	for _, test := range []struct {
+		name     string
+		revision string
+		want     int
+	}{
+		{name: "missing revision", want: http.StatusPreconditionRequired},
+		{name: "stale revision", revision: "stale", want: http.StatusPreconditionFailed},
+		{name: "missing interface", revision: draft.Revision, want: http.StatusNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			server.handleLibraryDraftByName(rec, draftRequest(
+				http.MethodPatch, "/api/v1/library/drafts/topology/topology", body, test.revision,
+			))
+			if rec.Code != test.want {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, test.want, rec.Body.String())
+			}
+		})
+	}
+
+	stored, readErr := lib.ReadDraft("topology")
+	if readErr != nil {
+		t.Fatalf("ReadDraft: %v", readErr)
+	}
+	if stored.Revision != draft.Revision || stored.Content != topologyDraftYAML {
+		t.Fatal("failed mutation changed the draft")
+	}
+}
+
+func TestDraftTopologyRouteUsesDraftWritePolicy(t *testing.T) {
+	policy := fetchRouteManifest(t)["/api/v1/library/drafts/"]
+	if !policy.CSRF || !policy.RateLimited || policy.Admin {
+		t.Fatalf("draft topology route policy = %+v, want csrf+rateLimited without admin", policy)
+	}
+
+	server, _, rwToken := newTestServerWithAuth(t)
+	lib := attachDraftLibrary(t, server)
+	server.writeLimiter = ratelimit.NewRateLimiter(WriteRateLimit, WriteBurst)
+	draft, err := lib.CreateDraft("topology", topologyDraftYAML)
+	if err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+	mux := http.NewServeMux()
+	server.registerAPIRoutes(mux)
+	body := `{"operation":"move_device","position":{"device":"core-1","x":10,"y":20}}`
+	req := draftRequest(
+		http.MethodPatch,
+		"/api/v1/library/drafts/topology/topology",
+		body,
+		draft.Revision,
+	)
+	req.Header.Set("Authorization", "Bearer "+rwToken)
+	req.Header.Set("X-Csrf-Token", testCSRFToken(t, server, rwToken))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authorized PATCH status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("ETag"); got == "" {
+		t.Fatal("topology mutation response did not include an ETag")
+	}
+}

--- a/internal/api/handlers_drafts.go
+++ b/internal/api/handlers_drafts.go
@@ -51,6 +51,19 @@ func (s *Server) handleLibraryDraftByName(w http.ResponseWriter, r *http.Request
 		writeError(w, r, http.StatusBadRequest, "invalid_request", "Draft name required", nil)
 		return
 	}
+	if draftName, action, found := strings.Cut(name, "/"); found {
+		if action != "topology" || strings.Contains(draftName, "/") {
+			writeError(w, r, http.StatusNotFound, "not_found", "Draft operation not found", nil)
+			return
+		}
+		if r.Method != http.MethodPatch {
+			w.Header().Set("Allow", "PATCH")
+			writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+			return
+		}
+		s.handleLibraryDraftTopologyMutation(w, r, draftName)
+		return
+	}
 
 	switch r.Method {
 	case http.MethodGet:

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -195,7 +195,7 @@ func (s *Server) registerLibraryRoutes(mux *http.ServeMux) {
 		{
 			path:    "/api/v1/library/drafts/",
 			handler: s.handleLibraryDraftByName,
-			methods: []string{http.MethodGet, http.MethodPut, http.MethodDelete},
+			methods: []string{http.MethodGet, http.MethodPut, http.MethodPatch, http.MethodDelete},
 			rl:      rlWrite,
 			csrf:    true,
 		},

--- a/internal/drafttopology/mutation.go
+++ b/internal/drafttopology/mutation.go
@@ -1,0 +1,427 @@
+// Package drafttopology applies typed visual topology edits to an isolated configuration draft.
+package drafttopology
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+	"net"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+const (
+	maxCoordinate = 1_000_000
+	maxMACSuffix  = 0xFFFFFF
+)
+
+var (
+	errInvalid  = errors.New("invalid topology mutation")
+	errNotFound = errors.New("topology resource not found")
+	errConflict = errors.New("topology mutation conflict")
+)
+
+type Operation string
+
+const (
+	AddDevice  Operation = "add_device"
+	Connect    Operation = "connect"
+	Disconnect Operation = "disconnect"
+	MoveDevice Operation = "move_device"
+	UpdateLink Operation = "update_link"
+)
+
+type Mutation struct {
+	Operation Operation         `json:"operation"`
+	Device    *DeviceMutation   `json:"device,omitempty"`
+	Link      *LinkMutation     `json:"link,omitempty"`
+	Position  *PositionMutation `json:"position,omitempty"`
+}
+
+type DeviceMutation struct {
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Vendor     string            `json:"vendor,omitempty"`
+	MAC        string            `json:"mac,omitempty"`
+	MACSuffix  uint32            `json:"mac_suffix,omitempty"`
+	IPs        []string          `json:"ips,omitempty"`
+	VLAN       int               `json:"vlan,omitempty"`
+	Interfaces []Interface       `json:"interfaces,omitempty"`
+	Properties map[string]string `json:"properties,omitempty"`
+}
+
+type Interface struct {
+	Name           string  `json:"name"`
+	Type           string  `json:"type,omitempty"`
+	Network        string  `json:"network,omitempty"`
+	Address        string  `json:"address,omitempty"`
+	MTU            int     `json:"mtu,omitempty"`
+	Speed          int     `json:"speed,omitempty"`
+	Duplex         string  `json:"duplex,omitempty"`
+	AdminStatus    string  `json:"admin_status,omitempty"`
+	OperStatus     string  `json:"oper_status,omitempty"`
+	Description    string  `json:"description,omitempty"`
+	InUtilization  float64 `json:"in_utilization,omitempty"`
+	OutUtilization float64 `json:"out_utilization,omitempty"`
+	VLANs          []int   `json:"vlans,omitempty"`
+}
+
+type Endpoint struct {
+	Device    string `json:"device"`
+	Interface string `json:"interface"`
+}
+
+type LinkEndpoints struct {
+	Source Endpoint `json:"source"`
+	Target Endpoint `json:"target"`
+}
+
+type LinkMutation struct {
+	LinkEndpoints
+
+	Properties LinkProperties `json:"properties"`
+}
+
+type LinkProperties struct {
+	VLANs      []int `json:"vlans,omitempty"`
+	NativeVLAN int   `json:"native_vlan,omitempty"`
+	FDBOnly    bool  `json:"fdb_only,omitempty"`
+}
+
+type PositionMutation struct {
+	Device string  `json:"device"`
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+}
+
+func IsInvalid(err error) bool  { return errors.Is(err, errInvalid) }
+func IsNotFound(err error) bool { return errors.Is(err, errNotFound) }
+func IsConflict(err error) bool { return errors.Is(err, errConflict) }
+
+func Apply(cfg *config.Config, mutation Mutation) error {
+	if cfg == nil {
+		return invalid("configuration is required")
+	}
+	if err := validatePayload(mutation); err != nil {
+		return err
+	}
+
+	switch mutation.Operation {
+	case AddDevice:
+		return addDevice(cfg, *mutation.Device)
+	case Connect:
+		return connect(cfg, *mutation.Link)
+	case Disconnect:
+		return disconnect(cfg, mutation.Link.LinkEndpoints)
+	case MoveDevice:
+		return moveDevice(cfg, *mutation.Position)
+	case UpdateLink:
+		return updateLink(cfg, *mutation.Link)
+	default:
+		return invalid("unsupported operation %q", mutation.Operation)
+	}
+}
+
+func validatePayload(mutation Mutation) error {
+	device, link, position := mutation.Device != nil, mutation.Link != nil, mutation.Position != nil
+	switch mutation.Operation {
+	case AddDevice:
+		if !device || link || position {
+			return invalid("add_device requires only device")
+		}
+	case Connect, Disconnect, UpdateLink:
+		if device || !link || position {
+			return invalid("%s requires only link", mutation.Operation)
+		}
+	case MoveDevice:
+		if device || link || !position {
+			return invalid("move_device requires only position")
+		}
+	default:
+		return invalid("unsupported operation %q", mutation.Operation)
+	}
+	return nil
+}
+
+func addDevice(cfg *config.Config, input DeviceMutation) error {
+	if len(cfg.Segments) != 0 {
+		return invalid("add_device is not supported for segmented drafts")
+	}
+	if strings.TrimSpace(input.Name) == "" || input.Name != strings.TrimSpace(input.Name) {
+		return invalid("device name is required without surrounding whitespace")
+	}
+	if strings.TrimSpace(input.Type) == "" {
+		return invalid("device type is required")
+	}
+	if input.MAC != "" && input.Vendor != "" {
+		return invalid("device identity must use either mac or vendor")
+	}
+	if input.MAC == "" && input.Vendor == "" {
+		return invalid("device identity requires mac or vendor")
+	}
+	if input.MACSuffix > maxMACSuffix {
+		return invalid("MAC suffix must fit within 24 bits")
+	}
+	if findDevice(cfg, input.Name) != nil {
+		return conflict("device %q already exists", input.Name)
+	}
+
+	var mac net.HardwareAddr
+	var err error
+	if input.MAC != "" {
+		mac, err = net.ParseMAC(input.MAC)
+		if err != nil {
+			return invalid("invalid MAC address")
+		}
+	}
+	ips := make([]net.IP, len(input.IPs))
+	for index, raw := range input.IPs {
+		ips[index] = net.ParseIP(raw)
+		if ips[index] == nil {
+			return invalid("invalid IP address at index %d", index)
+		}
+	}
+	interfaces := make([]config.Interface, len(input.Interfaces))
+	for index, iface := range input.Interfaces {
+		interfaces[index] = config.Interface{
+			Name: iface.Name, Type: iface.Type, Network: iface.Network, Address: iface.Address,
+			MTU: iface.MTU, Speed: iface.Speed, Duplex: iface.Duplex,
+			AdminStatus: iface.AdminStatus, OperStatus: iface.OperStatus,
+			Description: iface.Description, InUtilization: iface.InUtilization,
+			OutUtilization: iface.OutUtilization, VLANs: slices.Clone(iface.VLANs),
+		}
+	}
+	cfg.Devices = append(cfg.Devices, config.Device{
+		Name: input.Name, Type: input.Type, MACAddress: mac, MACVendor: input.Vendor, MACSuffix: input.MACSuffix,
+		IPAddresses: ips, VLAN: input.VLAN, Interfaces: interfaces,
+		Properties: cloneMap(input.Properties),
+	})
+	return nil
+}
+
+func connect(cfg *config.Config, link LinkMutation) error {
+	left, right, err := linkDevicesAndInterfaces(cfg, link.LinkEndpoints)
+	if err != nil {
+		return err
+	}
+	if trunkIndex(left.device, left.endpoint.Interface) >= 0 ||
+		trunkIndex(right.device, right.endpoint.Interface) >= 0 {
+		return conflict("one or both interfaces are already connected")
+	}
+	if validationErr := validateLinkProperties(link.Properties); validationErr != nil {
+		return validationErr
+	}
+	appendTrunk(left, right, link.Properties)
+	appendTrunk(right, left, link.Properties)
+	return nil
+}
+
+func disconnect(cfg *config.Config, endpoints LinkEndpoints) error {
+	left, right, err := linkDevicesAndInterfaces(cfg, endpoints)
+	if err != nil {
+		return err
+	}
+	leftIndex, rightIndex := reciprocalIndices(left, right)
+	if leftIndex < 0 || rightIndex < 0 {
+		return conflict("reciprocal link does not exist")
+	}
+	left.device.TrunkPorts = slices.Delete(left.device.TrunkPorts, leftIndex, leftIndex+1)
+	right.device.TrunkPorts = slices.Delete(right.device.TrunkPorts, rightIndex, rightIndex+1)
+	clearInterfaceLink(left.iface, right.endpoint)
+	clearInterfaceLink(right.iface, left.endpoint)
+	return nil
+}
+
+func updateLink(cfg *config.Config, link LinkMutation) error {
+	left, right, err := linkDevicesAndInterfaces(cfg, link.LinkEndpoints)
+	if err != nil {
+		return err
+	}
+	leftIndex, rightIndex := reciprocalIndices(left, right)
+	if leftIndex < 0 || rightIndex < 0 {
+		return conflict("reciprocal link does not exist")
+	}
+	if validationErr := validateLinkProperties(link.Properties); validationErr != nil {
+		return validationErr
+	}
+	setTrunkProperties(&left.device.TrunkPorts[leftIndex], link.Properties)
+	setTrunkProperties(&right.device.TrunkPorts[rightIndex], link.Properties)
+	left.iface.VLANs = slices.Clone(link.Properties.VLANs)
+	right.iface.VLANs = slices.Clone(link.Properties.VLANs)
+	return nil
+}
+
+func moveDevice(cfg *config.Config, position PositionMutation) error {
+	if math.IsNaN(position.X) || math.IsNaN(position.Y) || math.IsInf(position.X, 0) ||
+		math.IsInf(position.Y, 0) ||
+		math.Abs(position.X) > maxCoordinate ||
+		math.Abs(position.Y) > maxCoordinate {
+		return invalid("position coordinates must be finite and within bounds")
+	}
+	device := findDevice(cfg, position.Device)
+	if device == nil {
+		return notFound("device %q", position.Device)
+	}
+	if device.Properties == nil {
+		device.Properties = make(map[string]string)
+	}
+	device.Properties["topology_x"] = strconv.FormatFloat(position.X, 'f', -1, 64)
+	device.Properties["topology_y"] = strconv.FormatFloat(position.Y, 'f', -1, 64)
+	return nil
+}
+
+type resolvedEndpoint struct {
+	endpoint Endpoint
+	device   *config.Device
+	iface    *config.Interface
+}
+
+func linkDevicesAndInterfaces(
+	cfg *config.Config,
+	endpoints LinkEndpoints,
+) (resolvedEndpoint, resolvedEndpoint, error) {
+	if endpoints.Source.Device == endpoints.Target.Device {
+		return resolvedEndpoint{}, resolvedEndpoint{}, invalid(
+			"a link requires two different devices",
+		)
+	}
+	left, err := resolveEndpoint(cfg, endpoints.Source)
+	if err != nil {
+		return resolvedEndpoint{}, resolvedEndpoint{}, err
+	}
+	right, err := resolveEndpoint(cfg, endpoints.Target)
+	if err != nil {
+		return resolvedEndpoint{}, resolvedEndpoint{}, err
+	}
+	return left, right, nil
+}
+
+func resolveEndpoint(cfg *config.Config, endpoint Endpoint) (resolvedEndpoint, error) {
+	device := findDevice(cfg, endpoint.Device)
+	if device == nil {
+		return resolvedEndpoint{}, notFound("device %q", endpoint.Device)
+	}
+	for index := range device.Interfaces {
+		iface := &device.Interfaces[index]
+		if iface.Name != endpoint.Interface {
+			continue
+		}
+		if iface.Type != "" && iface.Type != "ethernet" && iface.Type != "other" {
+			return resolvedEndpoint{}, invalid(
+				"interface %q on %q cannot carry a physical link",
+				endpoint.Interface,
+				endpoint.Device,
+			)
+		}
+		return resolvedEndpoint{endpoint: endpoint, device: device, iface: iface}, nil
+	}
+	return resolvedEndpoint{}, notFound(
+		"interface %q on device %q",
+		endpoint.Interface,
+		endpoint.Device,
+	)
+}
+
+func validateLinkProperties(properties LinkProperties) error {
+	seen := make(map[int]struct{}, len(properties.VLANs))
+	for _, vlan := range properties.VLANs {
+		if vlan < 1 || vlan > 4094 {
+			return invalid("VLAN %d is outside 1-4094", vlan)
+		}
+		if _, found := seen[vlan]; found {
+			return invalid("VLAN %d is duplicated", vlan)
+		}
+		seen[vlan] = struct{}{}
+	}
+	if properties.NativeVLAN != 0 {
+		if _, found := seen[properties.NativeVLAN]; !found {
+			return invalid("native VLAN must be in the allowed VLAN list")
+		}
+	}
+	return nil
+}
+
+func appendTrunk(local, remote resolvedEndpoint, properties LinkProperties) {
+	local.device.TrunkPorts = append(local.device.TrunkPorts, config.TrunkPort{
+		Interface: local.endpoint.Interface, RemoteDevice: remote.endpoint.Device,
+		RemoteInterface: remote.endpoint.Interface,
+	})
+	setTrunkProperties(&local.device.TrunkPorts[len(local.device.TrunkPorts)-1], properties)
+	local.iface.Description = "to " + remote.endpoint.Device + " " + remote.endpoint.Interface
+	local.iface.VLANs = slices.Clone(properties.VLANs)
+}
+
+func setTrunkProperties(trunk *config.TrunkPort, properties LinkProperties) {
+	trunk.VLANs = slices.Clone(properties.VLANs)
+	trunk.NativeVLAN = properties.NativeVLAN
+	trunk.FDBOnly = properties.FDBOnly
+}
+
+func reciprocalIndices(left, right resolvedEndpoint) (int, int) {
+	return exactTrunkIndex(left.device, left.endpoint.Interface, right.endpoint),
+		exactTrunkIndex(right.device, right.endpoint.Interface, left.endpoint)
+}
+
+func trunkIndex(device *config.Device, iface string) int {
+	for index := range device.TrunkPorts {
+		if device.TrunkPorts[index].Interface == iface {
+			return index
+		}
+	}
+	return -1
+}
+
+func exactTrunkIndex(device *config.Device, iface string, remote Endpoint) int {
+	for index := range device.TrunkPorts {
+		trunk := &device.TrunkPorts[index]
+		if trunk.Interface == iface && trunk.RemoteDevice == remote.Device &&
+			trunk.RemoteInterface == remote.Interface {
+			return index
+		}
+	}
+	return -1
+}
+
+func clearInterfaceLink(iface *config.Interface, remote Endpoint) {
+	if iface.Description == "to "+remote.Device+" "+remote.Interface {
+		iface.Description = ""
+	}
+	iface.VLANs = nil
+}
+
+func findDevice(cfg *config.Config, name string) *config.Device {
+	for index := range cfg.Devices {
+		if cfg.Devices[index].Name == name {
+			return &cfg.Devices[index]
+		}
+	}
+	for segmentIndex := range cfg.Segments {
+		for deviceIndex := range cfg.Segments[segmentIndex].Devices {
+			device := &cfg.Segments[segmentIndex].Devices[deviceIndex]
+			if device.Name == name {
+				return device
+			}
+		}
+	}
+	return nil
+}
+
+func cloneMap(source map[string]string) map[string]string {
+	return maps.Clone(source)
+}
+
+func invalid(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", errInvalid, fmt.Sprintf(format, args...))
+}
+
+func notFound(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", errNotFound, fmt.Sprintf(format, args...))
+}
+
+func conflict(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", errConflict, fmt.Sprintf(format, args...))
+}

--- a/internal/drafttopology/mutation_test.go
+++ b/internal/drafttopology/mutation_test.go
@@ -1,0 +1,167 @@
+package drafttopology_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/drafttopology"
+)
+
+func testConfig() *config.Config {
+	return &config.Config{Devices: []config.Device{
+		{
+			Name:       "core-1",
+			Type:       "switch",
+			Interfaces: []config.Interface{{Name: "Ethernet1/1", Type: "ethernet"}},
+		},
+		{
+			Name:       "dist-1",
+			Type:       "switch",
+			Interfaces: []config.Interface{{Name: "Ethernet1/49", Type: "ethernet"}},
+		},
+	}}
+}
+
+func TestApplyConnectUpdateDisconnect(t *testing.T) {
+	cfg := testConfig()
+	endpoints := drafttopology.LinkEndpoints{
+		Source: drafttopology.Endpoint{Device: "core-1", Interface: "Ethernet1/1"},
+		Target: drafttopology.Endpoint{Device: "dist-1", Interface: "Ethernet1/49"},
+	}
+
+	err := drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.Connect,
+		Link: &drafttopology.LinkMutation{
+			LinkEndpoints: endpoints,
+			Properties:    drafttopology.LinkProperties{VLANs: []int{200, 210}, NativeVLAN: 200},
+		},
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	assertReciprocalLink(t, cfg, []int{200, 210}, 200)
+
+	err = drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.UpdateLink,
+		Link: &drafttopology.LinkMutation{
+			LinkEndpoints: endpoints,
+			Properties: drafttopology.LinkProperties{
+				VLANs:      []int{220},
+				NativeVLAN: 220,
+				FDBOnly:    true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	assertReciprocalLink(t, cfg, []int{220}, 220)
+	if !cfg.Devices[0].TrunkPorts[0].FDBOnly || !cfg.Devices[1].TrunkPorts[0].FDBOnly {
+		t.Fatal("updated FDB-only flag was not mirrored")
+	}
+
+	err = drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.Disconnect,
+		Link:      &drafttopology.LinkMutation{LinkEndpoints: endpoints},
+	})
+	if err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	if len(cfg.Devices[0].TrunkPorts) != 0 || len(cfg.Devices[1].TrunkPorts) != 0 {
+		t.Fatal("disconnect did not remove both link endpoints")
+	}
+}
+
+func TestApplyRejectsOccupiedAndImpossiblePorts(t *testing.T) {
+	cfg := testConfig()
+	connect := drafttopology.Mutation{
+		Operation: drafttopology.Connect,
+		Link: &drafttopology.LinkMutation{
+			LinkEndpoints: drafttopology.LinkEndpoints{
+				Source: drafttopology.Endpoint{Device: "core-1", Interface: "Ethernet1/1"},
+				Target: drafttopology.Endpoint{Device: "dist-1", Interface: "Ethernet1/49"},
+			},
+			Properties: drafttopology.LinkProperties{VLANs: []int{200}, NativeVLAN: 200},
+		},
+	}
+	if err := drafttopology.Apply(cfg, connect); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+	if err := drafttopology.Apply(cfg, connect); !drafttopology.IsConflict(err) {
+		t.Fatalf("second connect error = %v, want conflict", err)
+	}
+
+	bad := testConfig()
+	bad.Devices[1].Interfaces[0].Type = "loopback"
+	if err := drafttopology.Apply(bad, connect); !drafttopology.IsInvalid(err) {
+		t.Fatalf("loopback connect error = %v, want invalid", err)
+	}
+}
+
+func TestApplyAddAndMoveDevice(t *testing.T) {
+	cfg := &config.Config{}
+	err := drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.AddDevice,
+		Device: &drafttopology.DeviceMutation{
+			Name: "access-1", Type: "switch", MAC: "00:11:22:33:44:55",
+			IPs: []string{
+				"192.0.2.10",
+			}, Interfaces: []drafttopology.Interface{{Name: "Ethernet1/1", Type: "ethernet", MTU: 1500, Speed: 1000, Duplex: "full", AdminStatus: "up", OperStatus: "up"}},
+			Properties: map[string]string{"role": "access"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if len(cfg.Devices) != 1 || cfg.Devices[0].Name != "access-1" {
+		t.Fatalf("devices = %+v", cfg.Devices)
+	}
+
+	err = drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.MoveDevice,
+		Position:  &drafttopology.PositionMutation{Device: "access-1", X: 125.5, Y: -42},
+	})
+	if err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	if cfg.Devices[0].Properties["topology_x"] != "125.5" ||
+		cfg.Devices[0].Properties["topology_y"] != "-42" {
+		t.Fatalf("position properties = %+v", cfg.Devices[0].Properties)
+	}
+}
+
+func TestApplyRejectsUnknownOrMismatchedOperations(t *testing.T) {
+	tests := []drafttopology.Mutation{
+		{Operation: "rename"},
+		{Operation: drafttopology.AddDevice},
+		{
+			Operation: drafttopology.MoveDevice,
+			Device:    &drafttopology.DeviceMutation{Name: "unexpected"},
+		},
+	}
+	for _, mutation := range tests {
+		if err := drafttopology.Apply(testConfig(), mutation); !drafttopology.IsInvalid(err) {
+			t.Errorf("Apply(%q) error = %v, want invalid", mutation.Operation, err)
+		}
+	}
+}
+
+func assertReciprocalLink(t *testing.T, cfg *config.Config, vlans []int, native int) {
+	t.Helper()
+	if len(cfg.Devices[0].TrunkPorts) != 1 || len(cfg.Devices[1].TrunkPorts) != 1 {
+		t.Fatalf(
+			"trunk counts = %d, %d",
+			len(cfg.Devices[0].TrunkPorts),
+			len(cfg.Devices[1].TrunkPorts),
+		)
+	}
+	left, right := cfg.Devices[0].TrunkPorts[0], cfg.Devices[1].TrunkPorts[0]
+	if left.RemoteDevice != "dist-1" || left.RemoteInterface != "Ethernet1/49" ||
+		right.RemoteDevice != "core-1" || right.RemoteInterface != "Ethernet1/1" {
+		t.Fatalf("link is not reciprocal: left=%+v right=%+v", left, right)
+	}
+	if left.NativeVLAN != native || right.NativeVLAN != native || len(left.VLANs) != len(vlans) ||
+		len(right.VLANs) != len(vlans) {
+		t.Fatalf("link properties are not mirrored: left=%+v right=%+v", left, right)
+	}
+}

--- a/internal/topology/topology.go
+++ b/internal/topology/topology.go
@@ -122,16 +122,16 @@ func abbreviateInterface(name string) string {
 	return name
 }
 
-// getInterfaceDetails retrieves speed, duplex, and status from interface map.
+// getInterfaceDetails retrieves presentation data from the authored interface.
 func getInterfaceDetails(
 	interfaceMap map[string]map[string]config.Interface,
 	deviceName, ifaceName string,
-) (int, string, string) {
+) (int, string, string, float64) {
 	const defaultStatus = "up"
 
 	iface, ok := interfaceMap[deviceName][ifaceName]
 	if !ok {
-		return 0, "", defaultStatus
+		return 0, "", defaultStatus, 0
 	}
 
 	status := defaultStatus
@@ -143,16 +143,15 @@ func getInterfaceDetails(
 		status = iface.OperStatus
 	}
 
-	return iface.Speed, iface.Duplex, status
+	return iface.Speed, iface.Duplex, status, max(iface.InUtilization, iface.OutUtilization)
 }
 
-// sortedPairKey returns a canonical "a|b" key where a < b so reverse
-// declarations of the same physical adjacency collapse to one entry.
-func sortedPairKey(a, b string) string {
-	if a <= b {
-		return a + "|" + b
+func sortedEndpointKey(a, aInterface, b, bInterface string) string {
+	left, right := a+"|"+aInterface, b+"|"+bInterface
+	if left <= right {
+		return left + "|" + right
 	}
-	return b + "|" + a
+	return right + "|" + left
 }
 
 // processTrunkPort creates a Link from a trunk port configuration.
@@ -161,7 +160,11 @@ func processTrunkPort(
 	deviceName string,
 	interfaceMap map[string]map[string]config.Interface,
 ) Link {
-	speed, duplex, status := getInterfaceDetails(interfaceMap, deviceName, trunk.Interface)
+	speed, duplex, status, utilization := getInterfaceDetails(
+		interfaceMap,
+		deviceName,
+		trunk.Interface,
+	)
 
 	return Link{
 		Source: deviceName,
@@ -179,7 +182,7 @@ func processTrunkPort(
 		Speed:           speed,
 		Duplex:          duplex,
 		Status:          status,
-		Utilization:     0.0,
+		Utilization:     utilization,
 	}
 }
 
@@ -188,8 +191,9 @@ func processTrunkPort(
 // Trunk links are inherently bidirectional — both switches declare a
 // trunk_port pointing at each other, so we'd otherwise emit two
 // Link entries for one physical wire and ReactFlow would draw
-// a second edge looping back around the cards. We dedupe via a
-// sorted-pair key so each physical adjacency yields exactly one link.
+// a second edge looping back around the cards. We dedupe via a canonical
+// endpoint key so reciprocal declarations collapse without hiding parallel
+// links between the same pair of devices.
 func Build(cfg *config.Config) Graph {
 	nodes := make(map[string]Node)
 	links := make([]Link, 0)
@@ -211,7 +215,12 @@ func Build(cfg *config.Config) Graph {
 			// collapse to one entry. First-seen direction wins so the
 			// Source/Target on the emitted link matches the device that
 			// declared the trunk_port we found first in the YAML.
-			pair := sortedPairKey(dev.Name, trunk.RemoteDevice)
+			pair := sortedEndpointKey(
+				dev.Name,
+				trunk.Interface,
+				trunk.RemoteDevice,
+				trunk.RemoteInterface,
+			)
 			if seenLinks[pair] {
 				continue
 			}

--- a/internal/topology/topology_test.go
+++ b/internal/topology/topology_test.go
@@ -237,6 +237,54 @@ func TestBuildTopology(t *testing.T) {
 	}
 }
 
+func TestBuildTopologyPreservesParallelLinksAndInterfaceUtilization(t *testing.T) {
+	cfg := &config.Config{Devices: []config.Device{
+		{
+			Name: "core-1", Type: "switch",
+			Interfaces: []config.Interface{
+				{
+					Name:           "Ethernet1/1",
+					Speed:          10000,
+					Duplex:         "full",
+					InUtilization:  24,
+					OutUtilization: 31,
+				},
+				{
+					Name:           "Ethernet1/2",
+					Speed:          10000,
+					Duplex:         "full",
+					InUtilization:  18,
+					OutUtilization: 27,
+				},
+			},
+			TrunkPorts: []config.TrunkPort{
+				{Interface: "Ethernet1/1", RemoteDevice: "dist-1", RemoteInterface: "Ethernet1/49"},
+				{Interface: "Ethernet1/2", RemoteDevice: "dist-1", RemoteInterface: "Ethernet1/50"},
+			},
+		},
+		{
+			Name: "dist-1", Type: "switch",
+			Interfaces: []config.Interface{{Name: "Ethernet1/49"}, {Name: "Ethernet1/50"}},
+			TrunkPorts: []config.TrunkPort{
+				{Interface: "Ethernet1/49", RemoteDevice: "core-1", RemoteInterface: "Ethernet1/1"},
+				{Interface: "Ethernet1/50", RemoteDevice: "core-1", RemoteInterface: "Ethernet1/2"},
+			},
+		},
+	}}
+
+	graph := Build(cfg)
+	if len(graph.Links) != 2 {
+		t.Fatalf("links count = %d, want 2 parallel physical links", len(graph.Links))
+	}
+	if graph.Links[0].Utilization != 31 || graph.Links[1].Utilization != 27 {
+		t.Fatalf(
+			"link utilization = %.1f, %.1f; want 31, 27",
+			graph.Links[0].Utilization,
+			graph.Links[1].Utilization,
+		)
+	}
+}
+
 func TestBuildTopologyEmptyConfig(t *testing.T) {
 	cfg := &config.Config{
 		Devices: []config.Device{},
@@ -332,7 +380,11 @@ func TestEscapeXML(t *testing.T) {
 		{name: "greater than", input: "a > b", want: "a &gt; b"},
 		{name: "double quote", input: `say "hello"`, want: "say &quot;hello&quot;"},
 		{name: "single quote", input: "it's", want: "it&apos;s"},
-		{name: "multiple special chars", input: `<tag attr="value">`, want: "&lt;tag attr=&quot;value&quot;&gt;"},
+		{
+			name:  "multiple special chars",
+			input: `<tag attr="value">`,
+			want:  "&lt;tag attr=&quot;value&quot;&gt;",
+		},
 		{name: "empty string", input: "", want: ""},
 	}
 


### PR DESCRIPTION
## Summary

- add typed add, connect, disconnect, move, and link-property mutations for isolated scenario drafts
- require current draft ETags and atomically persist validated reciprocal peer-port edits
- preserve parallel physical links in topology projection and surface authored interface utilization
- keep all mutations behind the existing read-write, CSRF, rate-limit, entitlement, and runtime-isolation boundary

## Linked Issue

Related to #1151

## Type of Change

- [x] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [x] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

## Testing Evidence

```text
make fmt-check
make lint
make test
make security
go test -race ./internal/drafttopology ./internal/api
go test ./internal/topology ./internal/drafttopology ./internal/api -run "TestBuildTopology|TestApply|TestDraftTopology" -count=1
git diff --check

All passed. An initial make test run exceeded an existing SNMP timing threshold while make security ran concurrently; the timing test passed in 1.786s and the complete make test command then passed sequentially.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.