### PR TITLE
feat: add visual draft topology composer

### DIFF
--- a/CODE_INDEX.md
+++ b/CODE_INDEX.md
@@ -69,6 +69,7 @@ parallel implementation. It is intentionally organized by purpose.
 | Capability | Canonical location | Notes |
 | --- | --- | --- |
 | Guided simulation flow | `ui/src/pages/NewSimulationWizardPage.tsx` | Extend instead of creating another lab builder |
+| Draft topology composer | `ui/src/components/wizard/DraftTopologyComposer.tsx` + `draft-topology.ts` | Visual-first, revision-safe device/link/position editing; YAML remains the advanced source view |
 | Physical binding preflight | `ui/src/components/wizard/PreflightStep.tsx` | Review direct/access attachment and gate start on server diagnostics |
 | Config source picker | `ui/src/components/simulation/ConfigPicker.tsx` | Templates, saved networks, and uploads |
 | API request boundary | `ui/src/api/client.ts` | Add typed sibling functions here |

--- a/internal/api/handlers_draft_topology.go
+++ b/internal/api/handlers_draft_topology.go
@@ -31,6 +31,10 @@ func (s *Server) handleLibraryDraftTopologyMutation(
 	if !decodeJSONStrict(w, r, &mutation, MaxRequestBodySize) {
 		return
 	}
+	if sourceErr := drafttopology.ValidateSource(draft.Content); sourceErr != nil {
+		writeDraftTopologyError(w, r, sourceErr)
+		return
+	}
 	cfg, err := config.LoadYAMLBytes([]byte(draft.Content))
 	if err != nil {
 		s.logger.ErrorContext(

--- a/internal/drafttopology/mutation.go
+++ b/internal/drafttopology/mutation.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
 
@@ -43,15 +45,16 @@ type Mutation struct {
 }
 
 type DeviceMutation struct {
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	Vendor     string            `json:"vendor,omitempty"`
-	MAC        string            `json:"mac,omitempty"`
-	MACSuffix  uint32            `json:"mac_suffix,omitempty"`
-	IPs        []string          `json:"ips,omitempty"`
-	VLAN       int               `json:"vlan,omitempty"`
-	Interfaces []Interface       `json:"interfaces,omitempty"`
-	Properties map[string]string `json:"properties,omitempty"`
+	Name        string            `json:"name"`
+	Type        string            `json:"type"`
+	Vendor      string            `json:"vendor,omitempty"`
+	MAC         string            `json:"mac,omitempty"`
+	MACSuffix   uint32            `json:"mac_suffix,omitempty"`
+	SysObjectID string            `json:"sys_object_id,omitempty"`
+	IPs         []string          `json:"ips,omitempty"`
+	VLAN        int               `json:"vlan,omitempty"`
+	Interfaces  []Interface       `json:"interfaces,omitempty"`
+	Properties  map[string]string `json:"properties,omitempty"`
 }
 
 type Interface struct {
@@ -101,6 +104,24 @@ type PositionMutation struct {
 func IsInvalid(err error) bool  { return errors.Is(err, errInvalid) }
 func IsNotFound(err error) bool { return errors.Is(err, errNotFound) }
 func IsConflict(err error) bool { return errors.Is(err, errConflict) }
+
+// ValidateSource rejects source forms that canonical runtime serialization cannot preserve.
+func ValidateSource(content string) error {
+	var source struct {
+		Segments []struct {
+			Config string `yaml:"config"`
+		} `yaml:"segments"`
+	}
+	if err := yaml.Unmarshal([]byte(content), &source); err != nil {
+		return invalid("draft YAML is invalid")
+	}
+	for _, segment := range source.Segments {
+		if strings.TrimSpace(segment.Config) != "" {
+			return invalid("visual mutations cannot preserve config-backed segments")
+		}
+	}
+	return nil
+}
 
 func Apply(cfg *config.Config, mutation Mutation) error {
 	if cfg == nil {
@@ -195,10 +216,17 @@ func addDevice(cfg *config.Config, input DeviceMutation) error {
 			OutUtilization: iface.OutUtilization, VLANs: slices.Clone(iface.VLANs),
 		}
 	}
+	properties := cloneMap(input.Properties)
+	if input.SysObjectID != "" {
+		if properties == nil {
+			properties = make(map[string]string)
+		}
+		properties["sysObjectID"] = input.SysObjectID
+	}
 	cfg.Devices = append(cfg.Devices, config.Device{
 		Name: input.Name, Type: input.Type, MACAddress: mac, MACVendor: input.Vendor, MACSuffix: input.MACSuffix,
 		IPAddresses: ips, VLAN: input.VLAN, Interfaces: interfaces,
-		Properties: cloneMap(input.Properties),
+		Properties: properties,
 	})
 	return nil
 }
@@ -208,8 +236,10 @@ func connect(cfg *config.Config, link LinkMutation) error {
 	if err != nil {
 		return err
 	}
-	if trunkIndex(left.device, left.endpoint.Interface) >= 0 ||
-		trunkIndex(right.device, right.endpoint.Interface) >= 0 {
+	if deviceSegment(cfg, left.endpoint.Device) != deviceSegment(cfg, right.endpoint.Device) {
+		return invalid("a link cannot cross isolated segments")
+	}
+	if endpointOccupied(cfg, left.endpoint) || endpointOccupied(cfg, right.endpoint) {
 		return conflict("one or both interfaces are already connected")
 	}
 	if validationErr := validateLinkProperties(link.Properties); validationErr != nil {
@@ -244,6 +274,12 @@ func updateLink(cfg *config.Config, link LinkMutation) error {
 	leftIndex, rightIndex := reciprocalIndices(left, right)
 	if leftIndex < 0 || rightIndex < 0 {
 		return conflict("reciprocal link does not exist")
+	}
+	if !sameTrunkProperties(
+		&left.device.TrunkPorts[leftIndex],
+		&right.device.TrunkPorts[rightIndex],
+	) {
+		return conflict("asymmetric link properties require YAML editing")
 	}
 	if validationErr := validateLinkProperties(link.Properties); validationErr != nil {
 		return validationErr
@@ -361,18 +397,33 @@ func setTrunkProperties(trunk *config.TrunkPort, properties LinkProperties) {
 	trunk.FDBOnly = properties.FDBOnly
 }
 
+func sameTrunkProperties(left, right *config.TrunkPort) bool {
+	leftVLANs := slices.Clone(left.VLANs)
+	rightVLANs := slices.Clone(right.VLANs)
+	slices.Sort(leftVLANs)
+	slices.Sort(rightVLANs)
+	return slices.Equal(leftVLANs, rightVLANs) && left.NativeVLAN == right.NativeVLAN &&
+		left.FDBOnly == right.FDBOnly
+}
+
 func reciprocalIndices(left, right resolvedEndpoint) (int, int) {
 	return exactTrunkIndex(left.device, left.endpoint.Interface, right.endpoint),
 		exactTrunkIndex(right.device, right.endpoint.Interface, left.endpoint)
 }
 
-func trunkIndex(device *config.Device, iface string) int {
-	for index := range device.TrunkPorts {
-		if device.TrunkPorts[index].Interface == iface {
-			return index
+func endpointOccupied(cfg *config.Config, endpoint Endpoint) bool {
+	for _, segment := range cfg.NormalizedSegments() {
+		for deviceIndex := range segment.Devices {
+			device := &segment.Devices[deviceIndex]
+			for _, trunk := range device.TrunkPorts {
+				if (device.Name == endpoint.Device && trunk.Interface == endpoint.Interface) ||
+					(trunk.RemoteDevice == endpoint.Device && trunk.RemoteInterface == endpoint.Interface) {
+					return true
+				}
+			}
 		}
 	}
-	return -1
+	return false
 }
 
 func exactTrunkIndex(device *config.Device, iface string, remote Endpoint) int {
@@ -408,6 +459,20 @@ func findDevice(cfg *config.Config, name string) *config.Device {
 		}
 	}
 	return nil
+}
+
+func deviceSegment(cfg *config.Config, name string) int {
+	if len(cfg.Segments) == 0 {
+		return 0
+	}
+	for segmentIndex := range cfg.Segments {
+		for deviceIndex := range cfg.Segments[segmentIndex].Devices {
+			if cfg.Segments[segmentIndex].Devices[deviceIndex].Name == name {
+				return segmentIndex
+			}
+		}
+	}
+	return -1
 }
 
 func cloneMap(source map[string]string) map[string]string {

--- a/internal/drafttopology/mutation_test.go
+++ b/internal/drafttopology/mutation_test.go
@@ -98,16 +98,95 @@ func TestApplyRejectsOccupiedAndImpossiblePorts(t *testing.T) {
 	}
 }
 
+func TestApplyRejectsRemoteEndpointOccupiedByOneSidedLink(t *testing.T) {
+	cfg := testConfig()
+	cfg.Devices[0].TrunkPorts = []config.TrunkPort{{
+		Interface: "Ethernet1/1", RemoteDevice: "dist-1", RemoteInterface: "Ethernet1/49",
+	}}
+	cfg.Devices = append(cfg.Devices, config.Device{
+		Name: "access-1", Type: "switch",
+		Interfaces: []config.Interface{{Name: "Ethernet1/1", Type: "ethernet"}},
+	})
+	err := drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.Connect,
+		Link: &drafttopology.LinkMutation{LinkEndpoints: drafttopology.LinkEndpoints{
+			Source: drafttopology.Endpoint{Device: "dist-1", Interface: "Ethernet1/49"},
+			Target: drafttopology.Endpoint{Device: "access-1", Interface: "Ethernet1/1"},
+		}},
+	})
+	if !drafttopology.IsConflict(err) {
+		t.Fatalf("connect error = %v, want occupied conflict", err)
+	}
+}
+
+func TestApplyRejectsCrossSegmentLink(t *testing.T) {
+	cfg := &config.Config{Segments: []config.Segment{
+		{Tag: 200, Devices: []config.Device{{
+			Name: "core-1", Type: "switch",
+			Interfaces: []config.Interface{{Name: "Ethernet1/1", Type: "ethernet"}},
+		}}},
+		{Tag: 300, Devices: []config.Device{{
+			Name: "dist-1", Type: "switch",
+			Interfaces: []config.Interface{{Name: "Ethernet1/49", Type: "ethernet"}},
+		}}},
+	}}
+	err := drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.Connect,
+		Link: &drafttopology.LinkMutation{LinkEndpoints: drafttopology.LinkEndpoints{
+			Source: drafttopology.Endpoint{Device: "core-1", Interface: "Ethernet1/1"},
+			Target: drafttopology.Endpoint{Device: "dist-1", Interface: "Ethernet1/49"},
+		}},
+	})
+	if !drafttopology.IsInvalid(err) {
+		t.Fatalf("connect error = %v, want invalid", err)
+	}
+}
+
+func TestApplyRejectsAsymmetricLinkUpdate(t *testing.T) {
+	cfg := testConfig()
+	cfg.Devices[0].TrunkPorts = []config.TrunkPort{{
+		Interface: "Ethernet1/1", RemoteDevice: "dist-1", RemoteInterface: "Ethernet1/49",
+		VLANs: []int{200},
+	}}
+	cfg.Devices[1].TrunkPorts = []config.TrunkPort{{
+		Interface: "Ethernet1/49", RemoteDevice: "core-1", RemoteInterface: "Ethernet1/1",
+		VLANs: []int{200, 210},
+	}}
+	err := drafttopology.Apply(cfg, drafttopology.Mutation{
+		Operation: drafttopology.UpdateLink,
+		Link: &drafttopology.LinkMutation{
+			LinkEndpoints: drafttopology.LinkEndpoints{
+				Source: drafttopology.Endpoint{Device: "core-1", Interface: "Ethernet1/1"},
+				Target: drafttopology.Endpoint{Device: "dist-1", Interface: "Ethernet1/49"},
+			},
+			Properties: drafttopology.LinkProperties{VLANs: []int{200}},
+		},
+	})
+	if !drafttopology.IsConflict(err) {
+		t.Fatalf("update error = %v, want conflict", err)
+	}
+}
+
+func TestValidateSourceRejectsConfigBackedSegments(t *testing.T) {
+	if err := drafttopology.ValidateSource("devices: []\n"); err != nil {
+		t.Fatalf("inline source: %v", err)
+	}
+	err := drafttopology.ValidateSource("segments:\n  - tag: 200\n    config: campus.yaml\n")
+	if !drafttopology.IsInvalid(err) {
+		t.Fatalf("config-backed source error = %v, want invalid", err)
+	}
+}
+
 func TestApplyAddAndMoveDevice(t *testing.T) {
 	cfg := &config.Config{}
 	err := drafttopology.Apply(cfg, drafttopology.Mutation{
 		Operation: drafttopology.AddDevice,
 		Device: &drafttopology.DeviceMutation{
 			Name: "access-1", Type: "switch", MAC: "00:11:22:33:44:55",
+			SysObjectID: "1.3.6.1.4.1.9.1.2494",
 			IPs: []string{
 				"192.0.2.10",
 			}, Interfaces: []drafttopology.Interface{{Name: "Ethernet1/1", Type: "ethernet", MTU: 1500, Speed: 1000, Duplex: "full", AdminStatus: "up", OperStatus: "up"}},
-			Properties: map[string]string{"role": "access"},
 		},
 	})
 	if err != nil {
@@ -115,6 +194,9 @@ func TestApplyAddAndMoveDevice(t *testing.T) {
 	}
 	if len(cfg.Devices) != 1 || cfg.Devices[0].Name != "access-1" {
 		t.Fatalf("devices = %+v", cfg.Devices)
+	}
+	if cfg.Devices[0].Properties["sysObjectID"] != "1.3.6.1.4.1.9.1.2494" {
+		t.Fatalf("sysObjectID = %q", cfg.Devices[0].Properties["sysObjectID"])
 	}
 
 	err = drafttopology.Apply(cfg, drafttopology.Mutation{

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -438,7 +438,10 @@
     "devices": {
       "help": "Edit the saved draft. Changes here do not affect the running simulation.",
       "saveLabel": "Save draft",
-      "savingLabel": "Saving…"
+      "savingLabel": "Saving…",
+      "viewLabel": "Draft editing view",
+      "visualLabel": "Visual topology",
+      "yamlLabel": "YAML"
     },
     "finish": {
       "gotoRuntime": "Go to Simulation",
@@ -510,7 +513,29 @@
       "startEmpty": "Start empty",
       "startingLabel": "Preparing draft…"
     },
-    "title": "New Simulation"
+    "title": "New Simulation",
+    "topology": {
+      "addDevice": "Add device",
+      "cancel": "Cancel",
+      "configBackedYamlOnly": "This draft references segment files, so it must be edited in YAML to preserve those references.",
+      "connectHint": "Drag between device handles to connect them, then choose one free port at each endpoint.",
+      "crossSegmentError": "Devices in different VLAN segments cannot be physically linked.",
+      "deviceName": "Device name",
+      "disconnect": "Disconnect",
+      "fdbOnly": "Learn the peer in the forwarding table without advertising it as a discovery neighbor",
+      "help": "Build the saved draft visually. Every change is revision checked and cannot affect the running simulation.",
+      "interface": "interface",
+      "interfaceCount": "Ethernet port count",
+      "linkTitle": "Edit physical link",
+      "nativeVlan": "Native VLAN",
+      "profile": "Device profile",
+      "profileLoadError": "Device profiles could not be loaded.",
+      "retry": "Retry",
+      "saveLink": "Save link",
+      "selectInterface": "Select a free interface",
+      "speed": "Port speed (Mbps)",
+      "vlans": "Allowed VLANs"
+    }
   },
   "packets": {
     "bpfFilter": {

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -171,7 +171,10 @@
     "devices": {
       "help": "Edita el borrador guardado. Los cambios aquí no afectan la simulación en ejecución.",
       "saveLabel": "Guardar borrador",
-      "savingLabel": "Guardando…"
+      "savingLabel": "Guardando…",
+      "viewLabel": "Vista de edición del borrador",
+      "visualLabel": "Topología visual",
+      "yamlLabel": "YAML"
     },
     "fleet": {
       "addSite": "Agregar sitio",
@@ -199,6 +202,28 @@
       "sites": "Sitios",
       "snmpCommunity": "Comunidad SNMP",
       "title": "Generar una flota multisitio"
+    },
+    "topology": {
+      "addDevice": "Agregar dispositivo",
+      "cancel": "Cancelar",
+      "connectHint": "Arrastra entre los conectores de los dispositivos y luego elige un puerto libre en cada extremo.",
+      "configBackedYamlOnly": "Este borrador hace referencia a archivos de segmentos, por lo que debe editarse en YAML para conservar esas referencias.",
+      "crossSegmentError": "Los dispositivos en segmentos VLAN diferentes no pueden enlazarse físicamente.",
+      "deviceName": "Nombre del dispositivo",
+      "disconnect": "Desconectar",
+      "fdbOnly": "Aprender el vecino en la tabla de reenvío sin anunciarlo como vecino de descubrimiento",
+      "help": "Crea visualmente el borrador guardado. Cada cambio valida la revisión y no puede afectar la simulación en ejecución.",
+      "interface": "interfaz",
+      "interfaceCount": "Cantidad de puertos Ethernet",
+      "linkTitle": "Editar enlace físico",
+      "nativeVlan": "VLAN nativa",
+      "profile": "Perfil del dispositivo",
+      "profileLoadError": "No se pudieron cargar los perfiles de dispositivos.",
+      "retry": "Reintentar",
+      "saveLink": "Guardar enlace",
+      "selectInterface": "Seleccionar una interfaz libre",
+      "speed": "Velocidad del puerto (Mbps)",
+      "vlans": "VLAN permitidas"
     },
     "protocols": {
       "title": "Protocolos",

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -267,6 +267,10 @@ export interface TopologyLink {
   targetInterface?: string;
   vlans?: number[];
   nativeVlan?: number;
+  /** True when the authored link exposes only forwarding-database neighbors. */
+  fdbOnly?: boolean;
+  /** True when both endpoints declare this authored link and it is safe to mutate. */
+  reciprocal?: boolean;
   /** Speed in Mbps as a string ("100", "1000", "10000", "25000", ...).
    *  When the device has an Interface declaration with a Speed field,
    *  the daemon includes it; otherwise omitted and the edge falls
@@ -274,12 +278,7 @@ export interface TopologyLink {
   speed?: string;
   duplex?: string;
   status?: string;
-  /** Link utilization, 0–100. Source = the daemon's json:"utilizationPercent"
-   *  on api.TopologyLink; the request layer's snake→camel converter rewrites
-   *  the wire field to utilizationPercent. Today the daemon emits 0 for
-   *  every link (counter wiring is a separate work item); when live counters
-   *  land, the topology page already styles edges based on this value
-   *  (thickness + amber/red tint at high utilisation). */
+  /** Link utilization, 0–100, projected from the authored interface. */
   utilizationPercent?: number;
 }
 

--- a/ui/src/api/library-client.test.ts
+++ b/ui/src/api/library-client.test.ts
@@ -120,4 +120,50 @@ describe('scenario draft client', () => {
       }),
     });
   });
+
+  it('applies topology mutations with the current draft revision', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'csrf-token' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            name: 'campus-draft',
+            content: 'devices: []\n',
+            format: 'yaml',
+            revision: 'revision-2',
+            modified_at: '2026-07-28T00:00:00Z',
+            size_bytes: 12,
+          }),
+      });
+
+    const { mutateScenarioDraftTopology } = await import('./library-client');
+    await mutateScenarioDraftTopology('campus-draft', 'revision-1', {
+      operation: 'add_device',
+      device: {
+        name: 'core-1',
+        type: 'switch',
+        vendor: 'cisco',
+        sysObjectId: '1.3.6.1.4.1.9.1.2494',
+      },
+    });
+
+    expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/library/drafts/campus-draft/topology');
+    const options = mockFetch.mock.calls[1][1];
+    const headers = options?.headers as Headers;
+    expect(options).toMatchObject({
+      method: 'PATCH',
+      body: JSON.stringify({
+        operation: 'add_device',
+        device: {
+          name: 'core-1',
+          type: 'switch',
+          vendor: 'cisco',
+          sys_object_id: '1.3.6.1.4.1.9.1.2494',
+        },
+      }),
+    });
+    expect(headers.get('If-Match')).toBe('"revision-1"');
+  });
 });

--- a/ui/src/api/library-client.ts
+++ b/ui/src/api/library-client.ts
@@ -65,6 +65,54 @@ export interface ScenarioDraft extends ScenarioDraftEntry {
   format: 'yaml';
 }
 
+export interface DraftTopologyEndpoint {
+  device: string;
+  interface: string;
+}
+
+export interface DraftTopologyLinkProperties {
+  vlans: number[];
+  nativeVlan: number;
+  fdbOnly: boolean;
+}
+
+export type DraftTopologyMutation =
+  | {
+      operation: 'add_device';
+      device: {
+        name: string;
+        type: string;
+        vendor?: string;
+        mac?: string;
+        macSuffix?: number;
+        sysObjectId?: string;
+        ips?: string[];
+        interfaces?: Array<{
+          name: string;
+          type: 'ethernet';
+          mtu: number;
+          speed: number;
+          duplex: 'full' | 'half';
+          adminStatus: 'up' | 'down';
+          operStatus: 'up' | 'down';
+        }>;
+        properties?: Record<string, string>;
+      };
+    }
+  | {
+      operation: 'connect' | 'update_link';
+      link: {
+        source: DraftTopologyEndpoint;
+        target: DraftTopologyEndpoint;
+        properties: DraftTopologyLinkProperties;
+      };
+    }
+  | {
+      operation: 'disconnect';
+      link: { source: DraftTopologyEndpoint; target: DraftTopologyEndpoint };
+    }
+  | { operation: 'move_device'; position: { device: string; x: number; y: number } };
+
 export const fetchScenarioDrafts = () =>
   deduplicatedGet<ScenarioDraftEntry[]>('/api/v1/library/drafts');
 
@@ -93,6 +141,17 @@ export const deleteScenarioDraft = (name: string, revision: string) =>
     method: 'DELETE',
     headers: { 'If-Match': `"${revision}"` },
   });
+
+export const mutateScenarioDraftTopology = (
+  name: string,
+  revision: string,
+  mutation: DraftTopologyMutation,
+) =>
+  requestJson<ScenarioDraft>(
+    `/api/v1/library/drafts/${encodeURIComponent(name)}/topology`,
+    mutation,
+    { method: 'PATCH', headers: { 'If-Match': `"${revision}"` } },
+  );
 
 /**
  * Revert a library walk to its preserved pristine original, discarding

--- a/ui/src/components/wizard/DevicesStep.test.tsx
+++ b/ui/src/components/wizard/DevicesStep.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { ScenarioDraft } from '../../api/library-client';
+import '../../i18n';
+import { DevicesStep } from './DevicesStep';
+
+vi.mock('./DraftTopologyComposer', () => ({
+  DraftTopologyComposer: () => <div data-testid="topology-composer" />,
+}));
+
+vi.mock('../config/YamlEditor', () => ({
+  YamlEditor: () => <div data-testid="yaml-editor" />,
+}));
+
+const draft: ScenarioDraft = {
+  name: 'campus-draft',
+  content: 'devices: []\n',
+  format: 'yaml',
+  revision: 'revision-1',
+  modifiedAt: '2026-07-29T12:00:00Z',
+  sizeBytes: 12,
+};
+
+describe('DevicesStep', () => {
+  it('keeps config-backed segmented drafts in YAML mode', () => {
+    const referencedDraft = {
+      ...draft,
+      content: 'segments:\n  - tag: 200\n    config: campus.yaml\n',
+    };
+    render(
+      <DevicesStep
+        draftName={referencedDraft.name}
+        draft={referencedDraft}
+        content={referencedDraft.content}
+        dirty={false}
+        saving={false}
+        onChange={vi.fn()}
+        onSave={vi.fn()}
+        onDraftUpdate={vi.fn()}
+        onBusyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('yaml-editor')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Visual topology' })).toBeDisabled();
+    expect(screen.getByText(/must be edited in YAML/)).toBeVisible();
+  });
+
+  it('defaults to visual editing and saves dirty YAML before returning to it', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(
+      <DevicesStep
+        draftName={draft.name}
+        draft={draft}
+        content={draft.content}
+        dirty={true}
+        saving={false}
+        onChange={vi.fn()}
+        onSave={onSave}
+        onDraftUpdate={vi.fn()}
+        onBusyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('topology-composer')).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'YAML' }));
+    expect(screen.getByTestId('yaml-editor')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('tab', { name: 'Visual topology' }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('topology-composer')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/wizard/DevicesStep.tsx
+++ b/ui/src/components/wizard/DevicesStep.tsx
@@ -1,35 +1,57 @@
 import { FileCog, Save } from 'lucide-react';
-import type { FC } from 'react';
+import { type FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { ScenarioDraft } from '../../api/library-client';
 import { iconSizes } from '../../constants/sizes';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { SmallText } from '../../ui/Typography';
 import { YamlEditor } from '../config/YamlEditor';
+import { DraftTopologyComposer } from './DraftTopologyComposer';
+import { parseDraftTopology } from './draft-topology';
 
 interface DevicesStepProps {
   draftName: string;
+  draft: ScenarioDraft;
   content: string;
   dirty: boolean;
   saving: boolean;
   onChange: (content: string) => void;
-  onSave: () => void;
+  onSave: () => Promise<boolean>;
+  onDraftUpdate: (draft: ScenarioDraft) => void;
+  onBusyChange: (busy: boolean) => void;
 }
 
-/**
- * Step 2 edits the saved draft directly. The visual device composer replaces
- * this YAML surface in Phase 3; until then, server validation and revision
- * matching keep this editor safe without touching the active runtime.
- */
+/** Step 2 edits the saved draft without touching the active runtime. */
 export const DevicesStep: FC<DevicesStepProps> = ({
   draftName,
+  draft,
   content,
   dirty,
   saving,
   onChange,
   onSave,
+  onDraftUpdate,
+  onBusyChange,
 }) => {
   const { t } = useTranslation('pages');
+  const visualSupported = useMemo(
+    () => !parseDraftTopology(draft.content).configBacked,
+    [draft.content],
+  );
+  const [view, setView] = useState<'visual' | 'yaml'>(() => (visualSupported ? 'visual' : 'yaml'));
+
+  useEffect(() => {
+    if (!visualSupported) setView('yaml');
+  }, [visualSupported]);
+
+  const switchView = async (next: 'visual' | 'yaml') => {
+    if (next === view) return;
+    if (next === 'visual' && !visualSupported) return;
+    if (next === 'visual' && dirty && !(await onSave())) return;
+    setView(next);
+  };
+
   return (
     <Card className="border-surface-border bg-bg-surface/70">
       <CardContent className="stack">
@@ -40,24 +62,64 @@ export const DevicesStep: FC<DevicesStepProps> = ({
             <SmallText className="text-text-muted">{t('newSimWizard.devices.help')}</SmallText>
           </div>
         </div>
-        <YamlEditor
-          value={content}
-          onChange={onChange}
-          readOnly={saving}
-          height="24rem"
-          className="mt-heading"
-        />
-        <div>
-          <Button
-            tone="violet"
-            leftIcon={<Save className={iconSizes.md} />}
-            disabled={!dirty || saving}
-            loading={saving}
-            onClick={onSave}
-          >
-            {saving ? t('newSimWizard.devices.savingLabel') : t('newSimWizard.devices.saveLabel')}
-          </Button>
+        <div
+          role="tablist"
+          aria-label={t('newSimWizard.devices.viewLabel')}
+          className="inline-flex w-fit rounded-lg border border-surface-border bg-bg-base/60 p-1"
+        >
+          {(['visual', 'yaml'] as const).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              role="tab"
+              aria-selected={view === tab}
+              disabled={tab === 'visual' && !visualSupported}
+              className={`min-h-11 rounded-md px-4 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-brand-primary ${
+                view === tab
+                  ? 'bg-brand-primary text-on-brand'
+                  : 'text-text-secondary hover:bg-surface-hover'
+              }`}
+              onClick={() => void switchView(tab)}
+            >
+              {t(`newSimWizard.devices.${tab}Label`)}
+            </button>
+          ))}
         </div>
+        {!visualSupported && (
+          <SmallText className="text-status-warning">
+            {t('newSimWizard.topology.configBackedYamlOnly')}
+          </SmallText>
+        )}
+        {view === 'visual' && visualSupported ? (
+          <DraftTopologyComposer
+            draft={draft}
+            onDraftUpdate={onDraftUpdate}
+            onBusyChange={onBusyChange}
+          />
+        ) : (
+          <>
+            <YamlEditor
+              value={content}
+              onChange={onChange}
+              readOnly={saving}
+              height="24rem"
+              className="mt-heading"
+            />
+            <div>
+              <Button
+                tone="violet"
+                leftIcon={<Save className={iconSizes.md} />}
+                disabled={!dirty || saving}
+                loading={saving}
+                onClick={() => void onSave()}
+              >
+                {saving
+                  ? t('newSimWizard.devices.savingLabel')
+                  : t('newSimWizard.devices.saveLabel')}
+              </Button>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/ui/src/components/wizard/DraftTopologyComposer.test.tsx
+++ b/ui/src/components/wizard/DraftTopologyComposer.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ScenarioDraft } from '../../api/library-client';
+import '../../i18n';
+import { DraftTopologyComposer } from './DraftTopologyComposer';
+
+const mutateScenarioDraftTopology = vi.hoisted(() => vi.fn());
+const fetchScenarioProfiles = vi.hoisted(() => vi.fn());
+const profiles = [
+  {
+    role: 'access',
+    deviceType: 'switch',
+    vendor: 'cisco',
+    model: 'C9300-48P',
+    platform: 'ios-xe',
+    software: '17.15.3',
+    sysObjectId: '1.3.6.1.4.1.9.1.2494',
+  },
+];
+
+vi.mock('../../api/library-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/library-client')>();
+  return { ...actual, mutateScenarioDraftTopology };
+});
+
+vi.mock('../../api/scenario-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/scenario-client')>();
+  return {
+    ...actual,
+    fetchScenarioProfiles,
+  };
+});
+
+vi.mock('@xyflow/react', () => ({
+  Background: () => null,
+  BackgroundVariant: { Dots: 'dots' },
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+  ReactFlow: ({
+    children,
+    edges,
+    onEdgeClick,
+  }: {
+    children: ReactNode;
+    edges: Array<{ source: string; target: string; data?: Record<string, unknown> }>;
+    onEdgeClick: (event: unknown, edge: (typeof edges)[number]) => void;
+  }) => (
+    <div>
+      {edges[0] && (
+        <button type="button" onClick={() => onEdgeClick({}, edges[0])}>
+          Edit first link
+        </button>
+      )}
+      {children}
+    </div>
+  ),
+  useEdgesState: <T,>(initial: T[]) => {
+    const [edges, setEdges] = useState(initial);
+    return [edges, setEdges, vi.fn()] as const;
+  },
+  useNodesState: <T,>(initial: T[]) => {
+    const [nodes, setNodes] = useState(initial);
+    return [nodes, setNodes, vi.fn()] as const;
+  },
+}));
+
+const draft: ScenarioDraft = {
+  name: 'campus-draft',
+  content: 'devices: []\n',
+  format: 'yaml',
+  revision: 'revision-1',
+  modifiedAt: '2026-07-29T12:00:00Z',
+  sizeBytes: 12,
+};
+
+describe('DraftTopologyComposer', () => {
+  beforeEach(() => {
+    mutateScenarioDraftTopology.mockReset();
+    fetchScenarioProfiles.mockReset().mockResolvedValue(profiles);
+  });
+
+  it('surfaces a profile-loading failure and recovers on retry', async () => {
+    const user = userEvent.setup();
+    fetchScenarioProfiles
+      .mockRejectedValueOnce(new Error('catalog unavailable'))
+      .mockResolvedValueOnce(profiles);
+
+    render(<DraftTopologyComposer draft={draft} onDraftUpdate={vi.fn()} onBusyChange={vi.fn()} />);
+
+    expect(await screen.findByText('Device profiles could not be loaded.')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Add device' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(fetchScenarioProfiles).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Add device' })).toBeEnabled());
+    expect(screen.queryByText('Device profiles could not be loaded.')).not.toBeInTheDocument();
+  });
+
+  it('adds a profile-backed device through a revision-safe topology mutation', async () => {
+    const user = userEvent.setup();
+    const updated = { ...draft, revision: 'revision-2' };
+    mutateScenarioDraftTopology.mockResolvedValue(updated);
+    const onDraftUpdate = vi.fn();
+    const onBusyChange = vi.fn();
+    render(
+      <DraftTopologyComposer
+        draft={draft}
+        onDraftUpdate={onDraftUpdate}
+        onBusyChange={onBusyChange}
+      />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Add device' }));
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByLabelText('Device name'), 'COS-ACCESS-SW01');
+    await user.click(within(dialog).getByRole('button', { name: 'Add device' }));
+
+    await waitFor(() => expect(mutateScenarioDraftTopology).toHaveBeenCalledTimes(1));
+    expect(mutateScenarioDraftTopology).toHaveBeenCalledWith(
+      'campus-draft',
+      'revision-1',
+      expect.objectContaining({
+        operation: 'add_device',
+        device: expect.objectContaining({
+          name: 'COS-ACCESS-SW01',
+          type: 'switch',
+          vendor: 'cisco',
+          sysObjectId: '1.3.6.1.4.1.9.1.2494',
+          interfaces: expect.arrayContaining([
+            expect.objectContaining({ name: 'Ethernet1/1', mtu: 1500, duplex: 'full' }),
+          ]),
+        }),
+      }),
+    );
+    expect(onDraftUpdate).toHaveBeenCalledWith(updated);
+    expect(onBusyChange.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it('preserves FDB-only behavior when editing an authored link', async () => {
+    const user = userEvent.setup();
+    const linkedDraft = {
+      ...draft,
+      content: `
+devices:
+  - name: core-1
+    type: switch
+    interfaces:
+      - { name: Ethernet1/1, type: ethernet, speed: 10000 }
+    trunk_ports:
+      - { interface: Ethernet1/1, remote_device: dist-1, remote_interface: Ethernet1/49, vlans: [200], fdb_only: true }
+  - name: dist-1
+    type: switch
+    interfaces:
+      - { name: Ethernet1/49, type: ethernet, speed: 10000 }
+    trunk_ports:
+      - { interface: Ethernet1/49, remote_device: core-1, remote_interface: Ethernet1/1, vlans: [200], fdb_only: true }
+`,
+    };
+    mutateScenarioDraftTopology.mockResolvedValue({ ...linkedDraft, revision: 'revision-2' });
+    render(
+      <DraftTopologyComposer draft={linkedDraft} onDraftUpdate={vi.fn()} onBusyChange={vi.fn()} />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Edit first link' }));
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('checkbox')).toBeChecked();
+    await user.click(within(dialog).getByRole('button', { name: 'Save link' }));
+
+    await waitFor(() => expect(mutateScenarioDraftTopology).toHaveBeenCalledTimes(1));
+    expect(mutateScenarioDraftTopology).toHaveBeenCalledWith(
+      'campus-draft',
+      'revision-1',
+      expect.objectContaining({
+        operation: 'update_link',
+        link: expect.objectContaining({
+          properties: { vlans: [200], nativeVlan: 0, fdbOnly: true },
+        }),
+      }),
+    );
+  });
+});

--- a/ui/src/components/wizard/DraftTopologyComposer.tsx
+++ b/ui/src/components/wizard/DraftTopologyComposer.tsx
@@ -1,0 +1,378 @@
+import {
+  Background,
+  BackgroundVariant,
+  type Connection,
+  type EdgeTypes,
+  type NodeTypes,
+  ReactFlow,
+  useEdgesState,
+  useNodesState,
+} from '@xyflow/react';
+import { Cable, Plus } from 'lucide-react';
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  type DraftTopologyEndpoint,
+  type DraftTopologyLinkProperties,
+  type DraftTopologyMutation,
+  mutateScenarioDraftTopology,
+  type ScenarioDraft,
+} from '../../api/library-client';
+import { fetchScenarioProfiles } from '../../api/scenario-client';
+import type { TopologyLink } from '../../api/types';
+import { iconSizes } from '../../constants/sizes';
+import { useApiResource } from '../../hooks/useApiResource';
+import { useErrorToast } from '../../hooks/useErrorToast';
+import {
+  createEdges,
+  DeviceNode,
+  type DeviceNodeType,
+  type LinkEdge,
+  layoutNodes,
+} from '../../pages/topology';
+import { TrunkEdge } from '../../pages/topology/TrunkEdge';
+import { Button } from '../../ui/Button';
+import { SmallText } from '../../ui/Typography';
+import {
+  DeviceEditorModal,
+  type DeviceEditorState,
+  LinkEditorModal,
+  type LinkEditorState,
+} from './DraftTopologyModals';
+import { parseDraftTopology } from './draft-topology';
+
+const nodeTypes: NodeTypes = { device: DeviceNode };
+const edgeTypes: EdgeTypes = { trunk: TrunkEdge };
+
+interface DraftTopologyComposerProps {
+  draft: ScenarioDraft;
+  onDraftUpdate: (draft: ScenarioDraft) => void;
+  onBusyChange: (busy: boolean) => void;
+}
+
+const emptyDevice: DeviceEditorState = {
+  name: '',
+  role: 'access',
+  interfaceCount: '4',
+  speed: '1000',
+};
+
+function deterministicMACSuffix(name: string) {
+  let hash = 2166136261;
+  for (const character of name) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash & 0xffffff || 1;
+}
+
+function parseVLANs(value: string): number[] | null {
+  if (!value.trim()) return [];
+  const parts = value.split(',').map((part) => part.trim());
+  if (parts.some((part) => !/^\d+$/.test(part))) return null;
+  const vlans = parts.map(Number);
+  return [...new Set(vlans)];
+}
+
+function linkState(link: TopologyLink): LinkEditorState {
+  return {
+    source: link.source,
+    target: link.target,
+    sourceInterface: link.sourceInterface ?? '',
+    targetInterface: link.targetInterface ?? '',
+    vlans: (link.vlans ?? []).join(', '),
+    nativeVlan: link.nativeVlan ? String(link.nativeVlan) : '',
+    fdbOnly: link.fdbOnly ?? false,
+    existing: true,
+  };
+}
+
+export const DraftTopologyComposer: FC<DraftTopologyComposerProps> = ({
+  draft,
+  onDraftUpdate,
+  onBusyChange,
+}) => {
+  const { t } = useTranslation('pages');
+  const showError = useErrorToast();
+  const {
+    data: profiles,
+    error: profilesError,
+    loading: profilesLoading,
+    refetch: refetchProfiles,
+  } = useApiResource(fetchScenarioProfiles, []);
+  const [busy, setBusy] = useState(false);
+  const [deviceEditor, setDeviceEditor] = useState<DeviceEditorState | null>(null);
+  const [linkEditor, setLinkEditor] = useState<LinkEditorState | null>(null);
+  const model = useMemo(() => parseDraftTopology(draft.content), [draft.content]);
+  const layoutedNodes = useMemo(() => {
+    const result = layoutNodes(model.devices, model.links);
+    return result.map((node) => ({
+      ...node,
+      position: model.positions[node.id] ?? node.position,
+    }));
+  }, [model]);
+  const layoutedEdges = useMemo(
+    () =>
+      createEdges(model.links).map((edge, index) => ({
+        ...edge,
+        selectable: model.links[index]?.reciprocal !== false,
+      })),
+    [model.links],
+  );
+  const [nodes, setNodes, onNodesChange] = useNodesState<DeviceNodeType>(layoutedNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<LinkEdge>(layoutedEdges);
+
+  useEffect(() => setNodes(layoutedNodes), [layoutedNodes, setNodes]);
+  useEffect(() => setEdges(layoutedEdges), [layoutedEdges, setEdges]);
+
+  const applyMutation = useCallback(
+    async (mutation: DraftTopologyMutation) => {
+      setBusy(true);
+      onBusyChange(true);
+      try {
+        const updated = await mutateScenarioDraftTopology(draft.name, draft.revision, mutation);
+        onDraftUpdate(updated);
+        return true;
+      } catch (error) {
+        showError(error);
+        setNodes(layoutedNodes);
+        return false;
+      } finally {
+        setBusy(false);
+        onBusyChange(false);
+      }
+    },
+    [draft.name, draft.revision, layoutedNodes, onBusyChange, onDraftUpdate, setNodes, showError],
+  );
+
+  const openConnection = useCallback(
+    (connection: Connection) => {
+      if (!(connection.source && connection.target) || connection.source === connection.target)
+        return;
+      if (
+        model.segmented &&
+        model.segmentByDevice[connection.source] !== model.segmentByDevice[connection.target]
+      ) {
+        showError(new Error(t('newSimWizard.topology.crossSegmentError')));
+        return;
+      }
+      setLinkEditor({
+        source: connection.source,
+        target: connection.target,
+        sourceInterface: '',
+        targetInterface: '',
+        vlans: '',
+        nativeVlan: '',
+        fdbOnly: false,
+        existing: false,
+      });
+    },
+    [model.segmentByDevice, model.segmented, showError, t],
+  );
+
+  const interfaceOptions = useCallback(
+    (device: string, selected: string) =>
+      (model.interfaces[device] ?? [])
+        .filter(
+          (iface) =>
+            (!iface.occupied || iface.name === selected) &&
+            ['ethernet', 'other', ''].includes(iface.type),
+        )
+        .map((iface) => ({
+          value: iface.name,
+          label: `${iface.name}${iface.speed ? ` · ${iface.speed} Mbps` : ''}`,
+        })),
+    [model.interfaces],
+  );
+
+  const saveLink = useCallback(async () => {
+    if (!linkEditor) return;
+    const vlans = parseVLANs(linkEditor.vlans);
+    if (!vlans) return;
+    const nativeVlan = linkEditor.nativeVlan ? Number.parseInt(linkEditor.nativeVlan, 10) : 0;
+    const properties: DraftTopologyLinkProperties = {
+      vlans,
+      nativeVlan,
+      fdbOnly: linkEditor.fdbOnly,
+    };
+    const source: DraftTopologyEndpoint = {
+      device: linkEditor.source,
+      interface: linkEditor.sourceInterface,
+    };
+    const target: DraftTopologyEndpoint = {
+      device: linkEditor.target,
+      interface: linkEditor.targetInterface,
+    };
+    if (
+      await applyMutation({
+        operation: linkEditor.existing ? 'update_link' : 'connect',
+        link: { source, target, properties },
+      })
+    ) {
+      setLinkEditor(null);
+    }
+  }, [applyMutation, linkEditor]);
+
+  const disconnect = useCallback(async () => {
+    if (!linkEditor?.existing) return;
+    const source = { device: linkEditor.source, interface: linkEditor.sourceInterface };
+    const target = { device: linkEditor.target, interface: linkEditor.targetInterface };
+    if (await applyMutation({ operation: 'disconnect', link: { source, target } })) {
+      setLinkEditor(null);
+    }
+  }, [applyMutation, linkEditor]);
+
+  const addDevice = useCallback(async () => {
+    if (!deviceEditor || !profiles) return;
+    const profile = profiles.find((item) => item.role === deviceEditor.role);
+    if (!profile) return;
+    const interfaceCount = Number.parseInt(deviceEditor.interfaceCount, 10);
+    const speed = Number.parseInt(deviceEditor.speed, 10);
+    const interfaces = Array.from({ length: interfaceCount }, (_, index) => ({
+      name: `Ethernet1/${index + 1}`,
+      type: 'ethernet' as const,
+      mtu: speed >= 10000 ? 9000 : 1500,
+      speed,
+      duplex: 'full' as const,
+      adminStatus: 'up' as const,
+      operStatus: 'up' as const,
+    }));
+    if (
+      await applyMutation({
+        operation: 'add_device',
+        device: {
+          name: deviceEditor.name.trim(),
+          type: profile.deviceType,
+          vendor: profile.vendor,
+          macSuffix: deterministicMACSuffix(deviceEditor.name.trim()),
+          sysObjectId: profile.sysObjectId,
+          interfaces,
+          properties: {
+            role: profile.role,
+            model: profile.model,
+            platform: profile.platform,
+            software: profile.software,
+          },
+        },
+      })
+    ) {
+      setDeviceEditor(null);
+    }
+  }, [applyMutation, deviceEditor, profiles]);
+
+  const linkValid = useMemo(() => {
+    if (!linkEditor?.sourceInterface || !linkEditor.targetInterface) return false;
+    const vlans = parseVLANs(linkEditor.vlans);
+    if (!vlans || vlans.some((vlan) => vlan < 1 || vlan > 4094)) return false;
+    if (!linkEditor.nativeVlan) return true;
+    return vlans.includes(Number.parseInt(linkEditor.nativeVlan, 10));
+  }, [linkEditor]);
+
+  const deviceValid = useMemo(() => {
+    if (!deviceEditor || !profiles) return false;
+    const count = Number.parseInt(deviceEditor.interfaceCount, 10);
+    const speed = Number.parseInt(deviceEditor.speed, 10);
+    return (
+      /^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$/.test(deviceEditor.name.trim()) &&
+      !model.devices.some((device) => device.name === deviceEditor.name.trim()) &&
+      profiles.some((profile) => profile.role === deviceEditor.role) &&
+      count >= 1 &&
+      count <= 64 &&
+      speed >= 10 &&
+      speed <= 400000
+    );
+  }, [deviceEditor, model.devices, profiles]);
+
+  return (
+    <div className="stack">
+      <div className="flex flex-wrap items-center justify-between gap-default">
+        <SmallText className="text-text-muted">{t('newSimWizard.topology.help')}</SmallText>
+        <Button
+          tone="violet"
+          leftIcon={<Plus className={iconSizes.md} />}
+          disabled={busy || !profiles || model.segmented}
+          onClick={() => setDeviceEditor(emptyDevice)}
+        >
+          {t('newSimWizard.topology.addDevice')}
+        </Button>
+      </div>
+      {profilesError && (
+        <div className="flex items-center justify-between gap-default rounded-lg border border-status-error/40 bg-status-error/10 px-3 py-2">
+          <SmallText className="text-status-error">
+            {t('newSimWizard.topology.profileLoadError')}
+          </SmallText>
+          <Button
+            size="sm"
+            variant="outline"
+            tone="red"
+            loading={profilesLoading}
+            onClick={() => void refetchProfiles()}
+          >
+            {t('newSimWizard.topology.retry')}
+          </Button>
+        </div>
+      )}
+      <div className="h-[36rem] overflow-hidden rounded-xl border border-surface-border bg-bg-base/50">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={openConnection}
+          onNodeDragStop={(_, node) =>
+            void applyMutation({
+              operation: 'move_device',
+              position: { device: node.id, x: node.position.x, y: node.position.y },
+            })
+          }
+          onEdgeClick={(_, edge) => {
+            const link = model.links.find(
+              (item) =>
+                item.source === edge.source &&
+                item.target === edge.target &&
+                item.sourceInterface === edge.data?.sourceInterface &&
+                item.targetInterface === edge.data?.targetInterface,
+            );
+            if (link && link.reciprocal !== false) setLinkEditor(linkState(link));
+          }}
+          nodesConnectable={!busy}
+          nodesDraggable={!busy}
+          elementsSelectable={!busy}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView={true}
+          minZoom={0.1}
+          maxZoom={2}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={20}
+            size={1}
+            color="var(--color-surface-border)"
+          />
+        </ReactFlow>
+      </div>
+      <SmallText className="flex items-center gap-inline text-text-muted">
+        <Cable className={iconSizes.sm} /> {t('newSimWizard.topology.connectHint')}
+      </SmallText>
+      <DeviceEditorModal
+        state={deviceEditor}
+        profiles={profiles ?? []}
+        valid={deviceValid}
+        busy={busy}
+        onChange={setDeviceEditor}
+        onSave={() => void addDevice()}
+      />
+      <LinkEditorModal
+        state={linkEditor}
+        valid={linkValid}
+        busy={busy}
+        interfaceOptions={interfaceOptions}
+        onChange={setLinkEditor}
+        onSave={() => void saveLink()}
+        onDisconnect={() => void disconnect()}
+      />
+    </div>
+  );
+};

--- a/ui/src/components/wizard/DraftTopologyModals.tsx
+++ b/ui/src/components/wizard/DraftTopologyModals.tsx
@@ -1,0 +1,193 @@
+import { type FC, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ScenarioDeviceProfile } from '../../api/scenario-client';
+import { Button } from '../../ui/Button';
+import { Input, Select } from '../../ui/Input';
+import { Modal, ModalBody, ModalFooter } from '../../ui/Modal';
+
+export interface LinkEditorState {
+  source: string;
+  target: string;
+  sourceInterface: string;
+  targetInterface: string;
+  vlans: string;
+  nativeVlan: string;
+  fdbOnly: boolean;
+  existing: boolean;
+}
+
+export interface DeviceEditorState {
+  name: string;
+  role: string;
+  interfaceCount: string;
+  speed: string;
+}
+
+interface DeviceEditorModalProps {
+  state: DeviceEditorState | null;
+  profiles: ScenarioDeviceProfile[];
+  valid: boolean;
+  busy: boolean;
+  onChange: (state: DeviceEditorState | null) => void;
+  onSave: () => void;
+}
+
+export const DeviceEditorModal: FC<DeviceEditorModalProps> = ({
+  state,
+  profiles,
+  valid,
+  busy,
+  onChange,
+  onSave,
+}) => {
+  const { t } = useTranslation('pages');
+  const close = useCallback(() => onChange(null), [onChange]);
+  return (
+    <Modal
+      isOpen={state !== null}
+      onClose={close}
+      title={t('newSimWizard.topology.addDevice')}
+      size="lg"
+    >
+      {state && (
+        <>
+          <ModalBody>
+            <Input
+              label={t('newSimWizard.topology.deviceName')}
+              value={state.name}
+              onChange={(event) => onChange({ ...state, name: event.target.value })}
+            />
+            <Select
+              label={t('newSimWizard.topology.profile')}
+              value={state.role}
+              options={profiles.map((profile) => ({
+                value: profile.role,
+                label: `${profile.role} · ${profile.model}`,
+              }))}
+              onChange={(role) => onChange({ ...state, role })}
+            />
+            <div className="grid gap-default sm:grid-cols-2">
+              <Input
+                label={t('newSimWizard.topology.interfaceCount')}
+                type="number"
+                min={1}
+                max={64}
+                value={state.interfaceCount}
+                onChange={(event) => onChange({ ...state, interfaceCount: event.target.value })}
+              />
+              <Input
+                label={t('newSimWizard.topology.speed')}
+                type="number"
+                min={10}
+                max={400000}
+                value={state.speed}
+                onChange={(event) => onChange({ ...state, speed: event.target.value })}
+              />
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="outline" onClick={close}>
+              {t('newSimWizard.topology.cancel')}
+            </Button>
+            <Button tone="violet" disabled={!valid || busy} onClick={onSave}>
+              {t('newSimWizard.topology.addDevice')}
+            </Button>
+          </ModalFooter>
+        </>
+      )}
+    </Modal>
+  );
+};
+
+interface LinkEditorModalProps {
+  state: LinkEditorState | null;
+  valid: boolean;
+  busy: boolean;
+  interfaceOptions: (device: string, selected: string) => Array<{ value: string; label: string }>;
+  onChange: (state: LinkEditorState | null) => void;
+  onSave: () => void;
+  onDisconnect: () => void;
+}
+
+export const LinkEditorModal: FC<LinkEditorModalProps> = ({
+  state,
+  valid,
+  busy,
+  interfaceOptions,
+  onChange,
+  onSave,
+  onDisconnect,
+}) => {
+  const { t } = useTranslation('pages');
+  const close = useCallback(() => onChange(null), [onChange]);
+  return (
+    <Modal
+      isOpen={state !== null}
+      onClose={close}
+      title={t('newSimWizard.topology.linkTitle')}
+      size="lg"
+    >
+      {state && (
+        <>
+          <ModalBody>
+            <div className="grid gap-default sm:grid-cols-2">
+              <Select
+                label={`${state.source} ${t('newSimWizard.topology.interface')}`}
+                value={state.sourceInterface}
+                disabled={state.existing}
+                options={interfaceOptions(state.source, state.sourceInterface)}
+                placeholder={t('newSimWizard.topology.selectInterface')}
+                onChange={(sourceInterface) => onChange({ ...state, sourceInterface })}
+              />
+              <Select
+                label={`${state.target} ${t('newSimWizard.topology.interface')}`}
+                value={state.targetInterface}
+                disabled={state.existing}
+                options={interfaceOptions(state.target, state.targetInterface)}
+                placeholder={t('newSimWizard.topology.selectInterface')}
+                onChange={(targetInterface) => onChange({ ...state, targetInterface })}
+              />
+            </div>
+            <div className="grid gap-default sm:grid-cols-2">
+              <Input
+                label={t('newSimWizard.topology.vlans')}
+                value={state.vlans}
+                placeholder="200, 210"
+                onChange={(event) => onChange({ ...state, vlans: event.target.value })}
+              />
+              <Input
+                label={t('newSimWizard.topology.nativeVlan')}
+                type="number"
+                min={1}
+                max={4094}
+                value={state.nativeVlan}
+                onChange={(event) => onChange({ ...state, nativeVlan: event.target.value })}
+              />
+            </div>
+            <label className="flex min-h-11 items-center gap-default text-sm text-text-secondary">
+              <input
+                type="checkbox"
+                checked={state.fdbOnly}
+                onChange={(event) => onChange({ ...state, fdbOnly: event.target.checked })}
+              />
+              {t('newSimWizard.topology.fdbOnly')}
+            </label>
+          </ModalBody>
+          <ModalFooter>
+            {state.existing && (
+              <Button tone="red" disabled={busy} onClick={onDisconnect}>
+                {t('newSimWizard.topology.disconnect')}
+              </Button>
+            )}
+            <Button variant="outline" onClick={close}>
+              {t('newSimWizard.topology.cancel')}
+            </Button>
+            <Button tone="violet" disabled={!valid || busy} onClick={onSave}>
+              {t('newSimWizard.topology.saveLink')}
+            </Button>
+          </ModalFooter>
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/ui/src/components/wizard/draft-topology.test.ts
+++ b/ui/src/components/wizard/draft-topology.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { parseDraftTopology } from './draft-topology';
+
+describe('parseDraftTopology', () => {
+  it('projects devices, reciprocal parallel links, interfaces, and saved positions', () => {
+    const model = parseDraftTopology(`
+devices:
+  - name: core-1
+    type: switch
+    ips: [192.0.2.1]
+    properties: { topology_x: "120.5", topology_y: "240" }
+    interfaces:
+      - { name: Ethernet1/1, type: ethernet, speed: 10000, duplex: full, in_utilization: 20, out_utilization: 32 }
+      - { name: Ethernet1/2, type: ethernet, speed: 10000, duplex: full }
+    trunk_ports:
+      - { interface: Ethernet1/1, remote_device: dist-1, remote_interface: Ethernet1/49, vlans: [200], fdb_only: true }
+      - { interface: Ethernet1/2, remote_device: dist-1, remote_interface: Ethernet1/50, vlans: [210] }
+  - name: dist-1
+    type: switch
+    ips: [192.0.2.2]
+    interfaces:
+      - { name: Ethernet1/49, type: ethernet }
+      - { name: Ethernet1/50, type: ethernet }
+      - { name: Ethernet1/51, type: ethernet }
+    trunk_ports:
+      - { interface: Ethernet1/49, remote_device: core-1, remote_interface: Ethernet1/1, vlans: [200], fdb_only: true }
+      - { interface: Ethernet1/50, remote_device: core-1, remote_interface: Ethernet1/2, vlans: [210] }
+`);
+    expect(model.devices).toHaveLength(2);
+    expect(model.links).toHaveLength(2);
+    expect(model.links[0]).toMatchObject({
+      source: 'core-1',
+      target: 'dist-1',
+      sourceInterface: 'Ethernet1/1',
+      targetInterface: 'Ethernet1/49',
+      utilizationPercent: 32,
+      fdbOnly: true,
+      reciprocal: true,
+    });
+    expect(model.positions['core-1']).toEqual({ x: 120.5, y: 240 });
+    expect(model.interfaces['core-1'][0].occupied).toBe(true);
+    expect(model.interfaces['dist-1'][2].occupied).toBe(false);
+    expect(model.segmented).toBe(false);
+  });
+
+  it('marks one-sided link declarations as read-only', () => {
+    const model = parseDraftTopology(`
+devices:
+  - name: core-1
+    type: switch
+    interfaces: [{ name: Ethernet1/1, type: ethernet }]
+    trunk_ports:
+      - { interface: Ethernet1/1, remote_device: dist-1, remote_interface: Ethernet1/49, vlans: [200] }
+  - name: dist-1
+    type: switch
+    interfaces: [{ name: Ethernet1/49, type: ethernet }]
+`);
+    expect(model.links).toHaveLength(1);
+    expect(model.links[0].reciprocal).toBe(false);
+    expect(model.interfaces['dist-1'][0].occupied).toBe(true);
+  });
+
+  it('marks reciprocal links with asymmetric properties as read-only', () => {
+    const model = parseDraftTopology(`
+devices:
+  - name: core-1
+    type: switch
+    interfaces: [{ name: Ethernet1/1, type: ethernet }]
+    trunk_ports:
+      - { interface: Ethernet1/1, remote_device: dist-1, remote_interface: Ethernet1/49, vlans: [200] }
+  - name: dist-1
+    type: switch
+    interfaces: [{ name: Ethernet1/49, type: ethernet }]
+    trunk_ports:
+      - { interface: Ethernet1/49, remote_device: core-1, remote_interface: Ethernet1/1, vlans: [200, 210] }
+`);
+    expect(model.links).toHaveLength(1);
+    expect(model.links[0].reciprocal).toBe(false);
+  });
+
+  it('projects devices from segmented drafts', () => {
+    const model = parseDraftTopology(`
+segments:
+  - vlan: 200
+    devices:
+      - name: access-1
+        type: switch
+`);
+    expect(model.devices.map((device) => device.name)).toEqual(['access-1']);
+    expect(model.segmentByDevice).toEqual({ 'access-1': 0 });
+    expect(model.segmented).toBe(true);
+  });
+
+  it('keeps config-backed segments reachable through the YAML view', () => {
+    const model = parseDraftTopology(`
+segments:
+  - tag: 200
+    config: campus.yaml
+`);
+    expect(model.devices).toEqual([]);
+    expect(model.segmented).toBe(true);
+    expect(model.configBacked).toBe(true);
+  });
+
+  it('treats a valid device-less document as an editable empty topology', () => {
+    expect(parseDraftTopology('{}')).toEqual({
+      devices: [],
+      links: [],
+      interfaces: {},
+      positions: {},
+      segmentByDevice: {},
+      segmented: false,
+      configBacked: false,
+    });
+    expect(parseDraftTopology('devices:')).toMatchObject({ devices: [], segmented: false });
+  });
+
+  it('uses non-empty segments instead of inactive top-level devices', () => {
+    const model = parseDraftTopology(`
+devices:
+  - { name: inactive-device, type: host }
+segments:
+  - tag: 200
+    devices:
+      - { name: active-device, type: switch }
+`);
+    expect(model.devices.map((device) => device.name)).toEqual(['active-device']);
+    expect(model.segmented).toBe(true);
+  });
+
+  it('rejects malformed YAML and unsupported document shapes', () => {
+    expect(() => parseDraftTopology('devices: [')).toThrow();
+    expect(() => parseDraftTopology('devices: nope')).toThrow('devices');
+  });
+});

--- a/ui/src/components/wizard/draft-topology.ts
+++ b/ui/src/components/wizard/draft-topology.ts
@@ -1,0 +1,240 @@
+import { parse } from 'yaml';
+import type { DeviceSummary, TopologyLink } from '../../api/types';
+
+export interface DraftInterface {
+  name: string;
+  type: string;
+  speed: number;
+  occupied: boolean;
+}
+
+export interface DraftTopologyModel {
+  devices: DeviceSummary[];
+  links: TopologyLink[];
+  interfaces: Record<string, DraftInterface[]>;
+  positions: Record<string, { x: number; y: number }>;
+  segmentByDevice: Record<string, number>;
+  segmented: boolean;
+  configBacked: boolean;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+const asRecord = (value: unknown): UnknownRecord | null =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+const asString = (value: unknown) => (typeof value === 'string' ? value : '');
+const asNumber = (value: unknown) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : 0;
+const asBoolean = (value: unknown) => value === true;
+const asStrings = (value: unknown) =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+const asNumbers = (value: unknown) =>
+  Array.isArray(value) ? value.filter((item): item is number => Number.isInteger(item)) : [];
+
+function records(value: unknown): UnknownRecord[] {
+  if (!Array.isArray(value)) throw new Error('Draft devices must be an array');
+  return value.map((device) => {
+    const record = asRecord(device);
+    if (!record) throw new Error('Draft device entries must be objects');
+    return record;
+  });
+}
+
+function deviceRecords(document: UnknownRecord): {
+  records: UnknownRecord[];
+  segmentByDevice: Record<string, number>;
+  segmented: boolean;
+  configBacked: boolean;
+} {
+  if ('segments' in document && document.segments !== null && !Array.isArray(document.segments))
+    throw new Error('Draft segments must be an array');
+  if (Array.isArray(document.segments) && document.segments.length > 0) {
+    const segmentByDevice: Record<string, number> = {};
+    const configBacked = document.segments.some(
+      (segment) => asString(asRecord(segment)?.config) !== '',
+    );
+    return {
+      records: document.segments.flatMap((segment, segmentIndex) => {
+        const devices = asRecord(segment)?.devices;
+        const segmentDevices = Array.isArray(devices) ? records(devices) : [];
+        for (const device of segmentDevices) {
+          const name = asString(device.name);
+          if (name) segmentByDevice[name] = segmentIndex;
+        }
+        return segmentDevices;
+      }),
+      segmentByDevice,
+      segmented: true,
+      configBacked,
+    };
+  }
+  if ('devices' in document) {
+    if (document.devices === null)
+      return { records: [], segmentByDevice: {}, segmented: false, configBacked: false };
+    if (!Array.isArray(document.devices)) throw new Error('Draft devices must be an array');
+    return {
+      records: records(document.devices),
+      segmentByDevice: {},
+      segmented: false,
+      configBacked: false,
+    };
+  }
+  return { records: [], segmentByDevice: {}, segmented: false, configBacked: false };
+}
+
+function endpointKey(device: string, iface: string, remoteDevice: string, remoteInterface: string) {
+  return [`${device}|${iface}`, `${remoteDevice}|${remoteInterface}`].sort().join('|');
+}
+
+function directedEndpointKey(
+  device: string,
+  iface: string,
+  remoteDevice: string,
+  remoteInterface: string,
+) {
+  return `${device}|${iface}>${remoteDevice}|${remoteInterface}`;
+}
+
+function deviceProtocols(device: UnknownRecord) {
+  const fields = [
+    ['snmp_agent', 'SNMP'],
+    ['lldp', 'LLDP'],
+    ['cdp', 'CDP'],
+    ['dhcp', 'DHCP'],
+    ['dns', 'DNS'],
+    ['http', 'HTTP'],
+    ['ssh', 'SSH'],
+  ] as const;
+  return fields.filter(([field]) => asRecord(device[field]) !== null).map(([, label]) => label);
+}
+
+function declaredTopology(devices: UnknownRecord[]) {
+  const links = new Set<string>();
+  const trunkByDirection = new Map<string, UnknownRecord>();
+  const occupied = new Set<string>();
+  for (const device of devices) {
+    const name = asString(device.name);
+    const deviceTrunks = Array.isArray(device.trunk_ports) ? device.trunk_ports : [];
+    for (const trunkValue of deviceTrunks) {
+      const trunk = asRecord(trunkValue);
+      if (!trunk) continue;
+      const localInterface = asString(trunk.interface);
+      const remoteDevice = asString(trunk.remote_device);
+      const remoteInterface = asString(trunk.remote_interface);
+      const key = directedEndpointKey(name, localInterface, remoteDevice, remoteInterface);
+      links.add(key);
+      trunkByDirection.set(key, trunk);
+      occupied.add(`${name}|${localInterface}`);
+      occupied.add(`${remoteDevice}|${remoteInterface}`);
+    }
+  }
+  return { links, trunks: trunkByDirection, occupied };
+}
+
+function sameLinkProperties(left: UnknownRecord, right: UnknownRecord) {
+  const leftVLANs = [...asNumbers(left.vlans)].sort((a, b) => a - b);
+  const rightVLANs = [...asNumbers(right.vlans)].sort((a, b) => a - b);
+  return (
+    leftVLANs.length === rightVLANs.length &&
+    leftVLANs.every((vlan, index) => vlan === rightVLANs[index]) &&
+    asNumber(left.native_vlan) === asNumber(right.native_vlan) &&
+    asBoolean(left.fdb_only) === asBoolean(right.fdb_only)
+  );
+}
+
+export function parseDraftTopology(content: string): DraftTopologyModel {
+  const document = asRecord(parse(content));
+  if (!document) throw new Error('Draft YAML must contain an object');
+  const { records, segmentByDevice, segmented, configBacked } = deviceRecords(document);
+  const devices: DeviceSummary[] = [];
+  const links: TopologyLink[] = [];
+  const interfaces: Record<string, DraftInterface[]> = {};
+  const positions: Record<string, { x: number; y: number }> = {};
+  const seenLinks = new Set<string>();
+  const {
+    links: declaredLinks,
+    trunks: declaredTrunks,
+    occupied: occupiedEndpoints,
+  } = declaredTopology(records);
+
+  for (const device of records) {
+    const name = asString(device.name);
+    if (!name) throw new Error('Every draft device requires a name');
+    const properties = asRecord(device.properties) ?? {};
+    const rawInterfaces = Array.isArray(device.interfaces) ? device.interfaces : [];
+    const rawTrunks = Array.isArray(device.trunk_ports) ? device.trunk_ports : [];
+    const interfaceRecords = rawInterfaces
+      .map(asRecord)
+      .filter((iface): iface is UnknownRecord => iface !== null);
+    const interfaceByName = new Map(interfaceRecords.map((iface) => [asString(iface.name), iface]));
+
+    devices.push({
+      name,
+      type: asString(device.type) || 'unknown',
+      ips: asStrings(device.ips),
+      protocols: deviceProtocols(device),
+      vendor: asString(device.vendor),
+      model: asString(properties.model),
+      properties: Object.fromEntries(
+        Object.entries(properties).filter(
+          (entry): entry is [string, string] => typeof entry[1] === 'string',
+        ),
+      ),
+    });
+    interfaces[name] = interfaceRecords.map((iface) => ({
+      name: asString(iface.name),
+      type: asString(iface.type),
+      speed: asNumber(iface.speed),
+      occupied: occupiedEndpoints.has(`${name}|${asString(iface.name)}`),
+    }));
+    const x = Number.parseFloat(asString(properties.topology_x));
+    const y = Number.parseFloat(asString(properties.topology_y));
+    if (Number.isFinite(x) && Number.isFinite(y)) positions[name] = { x, y };
+
+    for (const trunkValue of rawTrunks) {
+      const trunk = asRecord(trunkValue);
+      if (!trunk) continue;
+      const localInterface = asString(trunk.interface);
+      const remoteDevice = asString(trunk.remote_device);
+      const remoteInterface = asString(trunk.remote_interface);
+      if (!localInterface || !remoteDevice || !remoteInterface) continue;
+      const key = endpointKey(name, localInterface, remoteDevice, remoteInterface);
+      if (seenLinks.has(key)) continue;
+      seenLinks.add(key);
+      const iface = interfaceByName.get(localInterface);
+      const vlans = asNumbers(trunk.vlans);
+      links.push({
+        source: name,
+        target: remoteDevice,
+        label: `${localInterface} ↔ ${remoteInterface}`,
+        sourceInterface: localInterface,
+        targetInterface: remoteInterface,
+        linkType: vlans.length === 1 ? 'access' : 'trunk',
+        vlans,
+        nativeVlan: asNumber(trunk.native_vlan),
+        fdbOnly: asBoolean(trunk.fdb_only),
+        reciprocal: (() => {
+          const reverseKey = directedEndpointKey(
+            remoteDevice,
+            remoteInterface,
+            name,
+            localInterface,
+          );
+          const reverse = declaredTrunks.get(reverseKey);
+          return declaredLinks.has(reverseKey) && reverse !== undefined
+            ? sameLinkProperties(trunk, reverse)
+            : false;
+        })(),
+        speed: iface ? String(asNumber(iface.speed)) : undefined,
+        duplex: iface ? asString(iface.duplex) : undefined,
+        status: iface ? asString(iface.oper_status) : undefined,
+        utilizationPercent: iface
+          ? Math.max(asNumber(iface.in_utilization), asNumber(iface.out_utilization))
+          : undefined,
+      });
+    }
+  }
+  return { devices, links, interfaces, positions, segmentByDevice, segmented, configBacked };
+}

--- a/ui/src/pages/NewSimulationWizardPage.test.tsx
+++ b/ui/src/pages/NewSimulationWizardPage.test.tsx
@@ -106,6 +106,16 @@ vi.mock('../components/config/YamlEditor', () => ({
   ),
 }));
 
+vi.mock('../components/wizard/DraftTopologyComposer', () => ({
+  DraftTopologyComposer: ({ onBusyChange }: { onBusyChange: (busy: boolean) => void }) => (
+    <div data-testid="wizard-topology-composer">
+      <button type="button" onClick={() => onBusyChange(true)}>
+        Begin topology mutation
+      </button>
+    </div>
+  ),
+}));
+
 const wrapper = ({ children }: { children: ReactNode }) => (
   <MemoryRouter>
     <AppProvider>{children}</AppProvider>
@@ -114,6 +124,11 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 
 function renderWizard() {
   return render(<NewSimulationWizardPage />, { wrapper });
+}
+
+async function openYamlEditor(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole('tab', { name: 'YAML' }));
+  await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
 }
 
 beforeEach(() => {
@@ -199,7 +214,7 @@ describe('NewSimulationWizardPage — step navigation', () => {
     await user.click(screen.getByTestId('wizard-start-empty'));
     await user.click(screen.getByTestId('wizard-next-button'));
 
-    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await openYamlEditor(user);
     expect(createScenarioDraft).toHaveBeenCalledWith(
       expect.stringMatching(/^scenario-/),
       emptyDraftContent,
@@ -225,7 +240,21 @@ describe('NewSimulationWizardPage — step navigation', () => {
     expect(screen.getByTestId('wizard-step-protocols')).toHaveAttribute('data-status', 'active');
 
     await user.click(screen.getByTestId('wizard-back-button'));
-    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await openYamlEditor(user);
+  });
+
+  it('blocks navigation while a visual topology mutation is pending', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByTestId('wizard-interface-select')).not.toBeDisabled());
+    await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
+    await user.click(screen.getByTestId('wizard-start-empty'));
+    await user.click(screen.getByTestId('wizard-next-button'));
+    await user.click(await screen.findByRole('button', { name: 'Begin topology mutation' }));
+
+    expect(screen.getByTestId('wizard-next-button')).toBeDisabled();
+    expect(screen.getByTestId('wizard-back-button')).toBeDisabled();
   });
 
   it('generates a validated fleet and saves it as an isolated draft', async () => {
@@ -261,7 +290,7 @@ describe('NewSimulationWizardPage — step navigation', () => {
     await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
     await user.click(screen.getByTestId('wizard-start-empty'));
     await user.click(screen.getByTestId('wizard-next-button'));
-    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await openYamlEditor(user);
 
     fireEvent.change(screen.getByTestId('wizard-draft-editor'), {
       target: {
@@ -274,7 +303,7 @@ describe('NewSimulationWizardPage — step navigation', () => {
     expect(await screen.findByTestId('wizard-interface-select')).toHaveValue('lo0');
     await user.click(screen.getByTestId('wizard-next-button'));
 
-    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await openYamlEditor(user);
     expect(createScenarioDraft).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('wizard-draft-editor')).toHaveTextContent('edge-1');
   });
@@ -287,7 +316,7 @@ describe('NewSimulationWizardPage — step navigation', () => {
     await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
     await user.click(screen.getByTestId('wizard-start-empty'));
     await user.click(screen.getByTestId('wizard-next-button'));
-    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await openYamlEditor(user);
     await user.click(screen.getByTestId('wizard-next-button'));
     await user.click(screen.getByTestId('wizard-next-button'));
     await user.click(screen.getByTestId('wizard-next-button'));
@@ -321,7 +350,7 @@ describe('NewSimulationWizardPage — step navigation', () => {
     await user.selectOptions(screen.getByTestId('wizard-interface-select'), 'lo0');
     await user.click(screen.getByTestId('wizard-start-empty'));
     await user.click(screen.getByTestId('wizard-next-button'));
-    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await openYamlEditor(user);
     await user.click(screen.getByTestId('wizard-next-button'));
     await user.click(screen.getByTestId('wizard-next-button'));
     await user.click(screen.getByTestId('wizard-next-button'));
@@ -340,7 +369,7 @@ describe('NewSimulationWizardPage — step navigation', () => {
     expect(screen.getByTestId('wizard-next-button')).not.toBeDisabled();
 
     await user.click(screen.getByTestId('wizard-next-button'));
-    await waitFor(() => expect(screen.getByTestId('wizard-draft-editor')).toBeInTheDocument());
+    await openYamlEditor(user);
     expect(createScenarioDraft).toHaveBeenCalledTimes(1);
     await user.click(screen.getByTestId('wizard-next-button'));
     await user.click(screen.getByTestId('wizard-next-button'));

--- a/ui/src/pages/NewSimulationWizardPage.tsx
+++ b/ui/src/pages/NewSimulationWizardPage.tsx
@@ -241,6 +241,7 @@ export const NewSimulationWizardPage: FC = () => {
         {currentStep === 'devices' && draft && (
           <DevicesStep
             draftName={draft.name}
+            draft={draft}
             content={draftContent}
             dirty={draftDirty}
             saving={state.saving}
@@ -248,7 +249,13 @@ export const NewSimulationWizardPage: FC = () => {
               setDraftContent(content);
               setDraftDirty(content !== draft.content);
             }}
-            onSave={() => void saveDraft()}
+            onSave={saveDraft}
+            onDraftUpdate={(updated) => {
+              setDraft(updated);
+              setDraftContent(updated.content);
+              setDraftDirty(false);
+            }}
+            onBusyChange={(saving) => setState((s) => ({ ...s, saving }))}
           />
         )}
         {currentStep === 'protocols' && draft && (


### PR DESCRIPTION
## Summary
- Add a visual-first draft topology composer with profile-backed device creation, positioning, and revision-safe physical link mutations.
- Preserve topology data integrity across segmented, referenced, one-sided, cross-segment, and asymmetric configurations.
- Integrate the composer into the simulation wizard with YAML fallback, localization, navigation safety, and profile-load recovery.

## Linked Issue
Related to #1151

## Testing Evidence
```
make fmt-check  # passed
make lint       # 0 issues
make test       # 47 Go packages and 75 UI test files passed; 67.8% Go coverage
make security   # no Go vulnerabilities, 0 npm vulnerabilities, no leaked secrets
codex review    # No findings
```

## Security and Release Checklist
- [x] Revision preconditions remain mandatory for every draft mutation.
- [x] Config-backed segments are YAML-only and cannot be flattened by the mutation API.
- [x] Cross-segment and asymmetric-link mutations are rejected server-side.
- [x] No dependencies, secrets, auth boundaries, or release configuration changed.