### PR TITLE
docs: sync dependency metadata

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "extends": ["./ui/biome.json"],
   "files": {
     "includes": ["ui/**"]

--- a/docs/DEPENDENCY_NOTES.md
+++ b/docs/DEPENDENCY_NOTES.md
@@ -5,7 +5,7 @@ NiAC targets the current project toolchain:
 - Go: 1.26.4 or newer within the 1.26 line.
 - Node.js: 26.5.0 or newer.
 - npm: 11.7.0 or newer.
-- Tailwind CSS: 4.3.2.
+- Tailwind CSS: 4.3.3.
 
 The UI dependency graph is pinned in `ui/package-lock.json` and should be updated with npm so the lockfile remains authoritative. Use the repo's Node version requirement before running npm commands; older local Node 26 builds can install and test successfully, but npm will warn if the runtime is below `26.5.0`.
 

--- a/ui/biome.json
+++ b/ui/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

- Align both Biome schema references with the installed 2.5.6 tool.
- Document the already-pinned Tailwind CSS 4.3.3 release.

## Linked Issue

Related to #1151

## Testing Evidence

```text
make fmt-check
All formatting checks passed

make lint
Backend: 0 issues
Frontend: Checked 353 files. No fixes applied.
```

## Security and Release Checklist

- [x] No runtime or security-boundary changes.
- [x] No dependency graph changes; metadata now matches existing exact pins.
- [x] Formatting and lint gates pass.
- [x] Release behavior is unchanged.