### PR TITLE
test(e2e): replace weak page assertions

### DIFF
--- a/ui/e2e/language-switch.spec.ts
+++ b/ui/e2e/language-switch.spec.ts
@@ -93,9 +93,9 @@ test.describe('Language switching', () => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
 
-    // Either Spanish device-count phrasing should be on the page, OR
-    // the noInterface fallback if no simulation is running. Both are
-    // valid post-Phase-5 ES outputs.
-    await expect(page.locator('body')).toContainText(/dispositivo|Sin interfaz/i);
+    await expect
+      .poll(async () => page.evaluate((key) => localStorage.getItem(key), LOCAL_STORAGE_KEY))
+      .toBe('es');
+    await expect(page.getByTestId('dashboard-device-count')).toHaveText(/^\d+ dispositivos?$/i);
   });
 });

--- a/ui/e2e/responsive.spec.ts
+++ b/ui/e2e/responsive.spec.ts
@@ -54,6 +54,7 @@ test.describe('Responsive Design', () => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
 
+    await expect(page.getByTestId('page-header-title')).toHaveText('Dashboard');
     await checkTouchTargets(page);
   });
 
@@ -61,6 +62,8 @@ test.describe('Responsive Design', () => {
     await page.setViewportSize(viewports.desktop);
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.getByTestId('page-header-title')).toHaveText('Dashboard');
   });
 
   test('should show mobile navigation on small screens', async ({ page }) => {
@@ -76,16 +79,20 @@ test.describe('Responsive Design', () => {
   });
 
   test('should maintain navigation on all pages', async ({ page }) => {
-    const pages = ['/', '/devices', '/topology', '/templates'];
+    const pages = [
+      { path: '/', title: 'Dashboard' },
+      { path: '/devices', title: 'Running Devices' },
+      { path: '/topology', title: 'Topology' },
+      { path: '/device-config', title: 'Device Library' },
+    ];
 
-    for (const url of pages) {
+    for (const route of pages) {
       await page.setViewportSize(viewports.mobile);
-      await page.goto(url);
+      await page.goto(route.path);
       await page.waitForLoadState('domcontentloaded');
 
-      // Page should not be completely blank
-      const content = await page.locator('body').textContent();
-      expect(content?.length).toBeGreaterThan(0);
+      await expect(page).toHaveURL((url) => url.pathname === route.path);
+      await expect(page.getByTestId('page-header-title')).toHaveText(route.title);
     }
   });
 });

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -58,7 +58,9 @@ export const DashboardPage: FC = () => {
                 </p>
                 <p className="text-sm text-text-muted">
                   {stats?.interface ?? t('dashboard.status.noInterface')} •{' '}
-                  {t('dashboard.status.deviceCount', { count: stats?.deviceCount ?? 0 })}
+                  <span data-testid="dashboard-device-count">
+                    {t('dashboard.status.deviceCount', { count: stats?.deviceCount ?? 0 })}
+                  </span>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Re-audit the current 23-file Playwright suite and replace both surviving body-text-only assertions with behavior-level checks.

- Spanish pluralization now proves the persisted locale and a scoped translated device count.
- Responsive navigation now proves the requested pathname and page identity.
- The obsolete `/templates` route is replaced by the real `/device-config` route.
- One `body` locator remains solely for the mobile horizontal-overflow measurement; it does not assert generic visibility or text.

## Linked Issue

Fixes #1152

## Type of Change

- [x] Defect fix
- [x] Chore / refactor / dependency update

## Risk

- [x] Low

## Testing Evidence

```text
npm run test -- src/pages/DashboardPage.test.tsx
6 passed

npm run lint
Checked 353 files. No fixes applied.

npm run typecheck
passed

npm run test:e2e -- language-switch.spec.ts responsive.spec.ts
24 tests across Chromium, WebKit, and Firefox; passed

make fmt-check
passed

make lint
passed

.git/hooks/pre-commit
Race-enabled Go suite passed; coverage 49.7%; build passed.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched; none are touched.
- [x] Dependencies are pinned and justified if changed; none are changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed; product behavior is unchanged.
