### PR TITLE
fix: align generated topology with Link-Live

### DIFF
--- a/internal/acceptance/linklive/auth.go
+++ b/internal/acceptance/linklive/auth.go
@@ -1,0 +1,68 @@
+package linklive
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type loginResponse struct {
+	AccessToken string `json:"accessToken"`
+}
+
+func (c *Client) accessToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.token != "" {
+		return c.token, nil
+	}
+	token, err := c.login(ctx)
+	if err == nil {
+		c.token = token
+	}
+	return token, err
+}
+
+func (c *Client) login(ctx context.Context) (string, error) {
+	claims := map[string]string{"app": linkLiveAppClaim}
+	if c.config.OrganizationID != "" {
+		claims["org"] = c.config.OrganizationID
+	}
+	body, err := json.Marshal(map[string]any{"claims": claims})
+	if err != nil {
+		return "", errors.New("encode Link-Live login request")
+	}
+	return c.sendLogin(ctx, body)
+}
+
+func (c *Client) sendLogin(ctx context.Context, body []byte) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.config.IdentityURL+"/v2/auth/login", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create Link-Live login request: %w", err)
+	}
+	req.SetBasicAuth(c.config.Username, c.config.Password)
+	req.Header.Set("Content-Type", "application/json")
+	if c.config.MFACode != "" {
+		req.Header.Set("X-Bedrock-Otpcode", c.config.MFACode)
+	}
+	data, err := c.do(req)
+	if err != nil {
+		return "", err
+	}
+	return decodeToken(data)
+}
+
+func decodeToken(data []byte) (string, error) {
+	var response loginResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return "", errors.New("Link-Live login returned invalid JSON")
+	}
+	if response.AccessToken == "" {
+		return "", errors.New("Link-Live login response omitted access token")
+	}
+	return response.AccessToken, nil
+}

--- a/internal/acceptance/linklive/client.go
+++ b/internal/acceptance/linklive/client.go
@@ -2,7 +2,6 @@
 package linklive
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -32,13 +31,15 @@ var ErrMFARequired = errors.New("Link-Live login requires MFA")
 
 // Config contains credentials and endpoint overrides for acceptance testing.
 type Config struct {
-	IdentityURL   string
-	APIURL        string
-	Username      string
-	Password      string
-	MFACode       string
-	HTTPClient    *http.Client
-	AllowInsecure bool
+	IdentityURL    string
+	APIURL         string
+	Username       string
+	Password       string
+	MFACode        string
+	OrganizationID string
+	AccessToken    string
+	HTTPClient     *http.Client
+	AllowInsecure  bool
 }
 
 // Client reads Link-Live analysis data without mutating it.
@@ -48,13 +49,9 @@ type Client struct {
 	token  string
 }
 
-type loginResponse struct {
-	AccessToken string `json:"accessToken"`
-}
-
 // New validates configuration and constructs a Link-Live client.
 func New(config Config) (*Client, error) {
-	if strings.TrimSpace(config.Username) == "" || config.Password == "" {
+	if config.AccessToken == "" && (strings.TrimSpace(config.Username) == "" || config.Password == "") {
 		return nil, errors.New("Link-Live username and password are required")
 	}
 	if err := validateBaseURL(config.IdentityURL, config.AllowInsecure); err != nil {
@@ -64,7 +61,7 @@ func New(config Config) (*Client, error) {
 		return nil, fmt.Errorf("API URL: %w", err)
 	}
 	config.HTTPClient = redirectSafeClient(config.HTTPClient)
-	return &Client{config: config}, nil
+	return &Client{config: config, token: config.AccessToken}, nil
 }
 
 // Analyses returns the unmodified analysis-list response.
@@ -98,42 +95,6 @@ func (c *Client) get(ctx context.Context, path string) (json.RawMessage, error) 
 	return c.do(req)
 }
 
-func (c *Client) accessToken(ctx context.Context) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.token != "" {
-		return c.token, nil
-	}
-	token, err := c.login(ctx)
-	if err == nil {
-		c.token = token
-	}
-	return token, err
-}
-
-func (c *Client) login(ctx context.Context) (string, error) {
-	body := []byte(`{"claims":{"app":"` + linkLiveAppClaim + `"}}`)
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		c.config.IdentityURL+"/v2/auth/login",
-		bytes.NewReader(body),
-	)
-	if err != nil {
-		return "", fmt.Errorf("create Link-Live login request: %w", err)
-	}
-	req.SetBasicAuth(c.config.Username, c.config.Password)
-	req.Header.Set("Content-Type", "application/json")
-	if c.config.MFACode != "" {
-		req.Header.Set("X-Bedrock-Otpcode", c.config.MFACode)
-	}
-	data, err := c.do(req)
-	if err != nil {
-		return "", err
-	}
-	return decodeToken(data)
-}
-
 func (c *Client) do(req *http.Request) (json.RawMessage, error) {
 	resp, err := c.config.HTTPClient.Do(req)
 	if err != nil {
@@ -154,17 +115,6 @@ func (c *Client) do(req *http.Request) (json.RawMessage, error) {
 		return nil, errors.New("Link-Live response exceeds size limit")
 	}
 	return data, nil
-}
-
-func decodeToken(data []byte) (string, error) {
-	var response loginResponse
-	if err := json.Unmarshal(data, &response); err != nil {
-		return "", errors.New("Link-Live login returned invalid JSON")
-	}
-	if response.AccessToken == "" {
-		return "", errors.New("Link-Live login response omitted access token")
-	}
-	return response.AccessToken, nil
 }
 
 func validateBaseURL(rawURL string, allowInsecure bool) error {

--- a/internal/acceptance/linklive/client_test.go
+++ b/internal/acceptance/linklive/client_test.go
@@ -41,6 +41,60 @@ func TestClientAuthenticatesAndFetchesTopology(t *testing.T) {
 	}
 }
 
+func TestClientUsesConfiguredAccessTokenWithoutLogin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/auth/login" {
+			t.Fatal("client attempted login with a configured access token")
+		}
+		if got := r.Header.Get("Authorization"); got != "Access cached-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := linklive.New(linklive.Config{
+		IdentityURL: server.URL, APIURL: server.URL,
+		AccessToken: "cached-token", AllowInsecure: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = client.Analyses(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientLoginIncludesOrganizationClaim(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/auth/login" {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		var body map[string]map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if got := body["claims"]["org"]; got != "org-7" {
+			t.Fatalf("org claim = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": "token"})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := linklive.New(linklive.Config{
+		IdentityURL: server.URL, APIURL: server.URL,
+		Username: "tester@example.com", Password: "test-password",
+		OrganizationID: "org-7", AllowInsecure: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = client.Analyses(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func assertTopologyQuery(t *testing.T, r *http.Request) {
 	t.Helper()
 	var query map[string]string

--- a/internal/acceptance/linklive/compare.go
+++ b/internal/acceptance/linklive/compare.go
@@ -1,8 +1,6 @@
 package linklive
 
 import (
-	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 )
@@ -39,14 +37,14 @@ func compareDevice(expected AuthoredDevice, actual ObservedHost) []Finding {
 		}
 	}
 	var findings []Finding
-	if actual.Name != expected.Name {
+	if !namesMatch(actual.Name, expected.Name) {
 		findings = append(
 			findings,
 			conflict(FindingNameConflict, expected.Name, expected.Name, actual.Name),
 		)
 	}
 	wantType := displayedType(expected.Type)
-	if wantType != "" && actual.Type != wantType {
+	if wantType != "" && !displayedTypeMatches(expected.Type, actual.Type) {
 		findings = append(
 			findings,
 			conflict(FindingTypeConflict, expected.Name, wantType, actual.Type),
@@ -184,53 +182,6 @@ func findConnection(host ObservedHost, targetMAC string) (ObservedConnection, bo
 		}
 	}
 	return ObservedConnection{}, false
-}
-
-func displayedType(deviceType string) string {
-	switch deviceType {
-	case "switch", "layer3-switch":
-		return "Switch"
-	case "router", "firewall":
-		return "Router"
-	case "ap", "access-point":
-		return "AP"
-	case "host", "workstation", "iot":
-		return "Host/Client"
-	default:
-		return ""
-	}
-}
-
-func parseSpeedMbps(value string) int {
-	var number float64
-	var unit string
-	if _, err := fmt.Sscan(value, &number, &unit); err != nil {
-		return 0
-	}
-	switch strings.ToLower(unit) {
-	case "gb", "gbps":
-		number *= 1000
-	case "mb", "mbps":
-	default:
-		return 0
-	}
-	return int(number)
-}
-
-func parseVLAN(value string) int {
-	vlan, err := strconv.Atoi(strings.TrimSpace(value))
-	if err != nil {
-		return 0
-	}
-	return vlan
-}
-
-func portsMatch(actual, left, right string) bool {
-	return strings.Contains(actual, left) && strings.Contains(actual, right)
-}
-
-func contains(values []string, want string) bool {
-	return slices.Contains(values, want)
 }
 
 func conflict(kind FindingKind, device, expected, observed string) Finding {

--- a/internal/acceptance/linklive/compare_equivalence_test.go
+++ b/internal/acceptance/linklive/compare_equivalence_test.go
@@ -1,0 +1,65 @@
+package linklive_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/acceptance/linklive"
+)
+
+func TestCompareAcceptsCaseInsensitiveFQDN(t *testing.T) {
+	authored := authoredPair(t)
+	observed := observedPair("Switch", "Full", "100 Gb")
+	observed.Hosts[0].Name = "cos-core-sw01.demo.lab"
+
+	if findings := linklive.Compare(authored, observed); len(findings) != 0 {
+		t.Fatalf("findings = %+v", findings)
+	}
+}
+
+func TestCompareRejectsDifferentAuthoredFQDN(t *testing.T) {
+	authored := authoredPair(t)
+	authored.Devices[0].Name = "core.site-a.example"
+	observed := observedPair("Switch", "Full", "100 Gb")
+	observed.Hosts[0].Name = "core.site-b.example"
+
+	findings := linklive.Compare(authored, observed)
+	assertFinding(t, findings, linklive.FindingNameConflict)
+}
+
+func TestCompareAcceptsRenderedPortFromEitherEndpoint(t *testing.T) {
+	authored := authoredPair(t)
+	authored.Links[0].TargetPort = "eth0"
+	observed := observedPair("Switch", "Full", "100 Gb")
+
+	if findings := linklive.Compare(authored, observed); len(findings) != 0 {
+		t.Fatalf("findings = %+v", findings)
+	}
+}
+
+func TestCompareRejectsPortWithMatchingPrefix(t *testing.T) {
+	authored := authoredPair(t)
+	observed := observedPair("Switch", "Full", "100 Gb")
+	observed.Hosts[0].Connections[0].Edge.Port = "HundredGigabitEthernet1/0/10"
+
+	findings := linklive.Compare(authored, observed)
+	assertFinding(t, findings, linklive.FindingPortConflict)
+}
+
+func TestCompareRejectsMissingObservedPort(t *testing.T) {
+	authored := authoredPair(t)
+	authored.Links[0].TargetPort = ""
+	observed := observedPair("Switch", "Full", "100 Gb")
+	observed.Hosts[0].Connections[0].Edge.Port = ""
+
+	findings := linklive.Compare(authored, observed)
+	assertFinding(t, findings, linklive.FindingPortConflict)
+}
+
+func TestCompareAcceptsRouterClassificationForLayer3Switch(t *testing.T) {
+	authored := authoredPair(t)
+	observed := observedPair("Router", "Full", "100 Gb")
+
+	if findings := linklive.Compare(authored, observed); len(findings) != 0 {
+		t.Fatalf("findings = %+v", findings)
+	}
+}

--- a/internal/acceptance/linklive/compare_test.go
+++ b/internal/acceptance/linklive/compare_test.go
@@ -20,6 +20,7 @@ func TestCompareAcceptsMatchingLayer3SwitchAndLink(t *testing.T) {
 
 func TestCompareReportsIdentityClassificationAndLinkTelemetry(t *testing.T) {
 	authored := authoredPair(t)
+	authored.Devices[0].Type = "switch"
 	observed := observedPair("Router", "Unknown", "")
 	observed.Hosts[0].Name = "WRONG-CORE"
 

--- a/internal/acceptance/linklive/compare_values.go
+++ b/internal/acceptance/linklive/compare_values.go
@@ -1,0 +1,86 @@
+package linklive
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+func contains(values []string, want string) bool {
+	return slices.Contains(values, want)
+}
+
+func namesMatch(left, right string) bool {
+	authored := normalizeHostname(right)
+	observed := normalizeHostname(left)
+	if strings.Contains(authored, ".") {
+		return observed == authored
+	}
+	return hostLabel(observed) == authored
+}
+
+func hostLabel(value string) string {
+	label, _, _ := strings.Cut(normalizeHostname(value), ".")
+	return label
+}
+
+func normalizeHostname(value string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(value)), ".")
+}
+
+func displayedType(deviceType string) string {
+	switch deviceType {
+	case "switch", "layer3-switch":
+		return "Switch"
+	case "router", "firewall":
+		return "Router"
+	case "ap", "access-point":
+		return "AP"
+	case "host", "workstation", "iot":
+		return "Host/Client"
+	default:
+		return ""
+	}
+}
+
+func displayedTypeMatches(deviceType, actual string) bool {
+	if deviceType == "layer3-switch" {
+		return actual == "Switch" || actual == "Router"
+	}
+	return displayedType(deviceType) == actual
+}
+
+func parseSpeedMbps(value string) int {
+	var number float64
+	var unit string
+	if _, err := fmt.Sscan(value, &number, &unit); err != nil {
+		return 0
+	}
+	switch strings.ToLower(unit) {
+	case "gb", "gbps":
+		number *= 1000
+	case "mb", "mbps":
+	default:
+		return 0
+	}
+	return int(number)
+}
+
+func parseVLAN(value string) int {
+	vlan, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0
+	}
+	return vlan
+}
+
+func portsMatch(actual, left, right string) bool {
+	actual = strings.TrimSpace(actual)
+	left, right = strings.TrimSpace(left), strings.TrimSpace(right)
+	if actual == "" {
+		return false
+	}
+	return left != "" && strings.EqualFold(actual, left) ||
+		right != "" && strings.EqualFold(actual, right)
+}

--- a/internal/config/topology_link.go
+++ b/internal/config/topology_link.go
@@ -1,0 +1,14 @@
+package config
+
+// IsRoutedTopologyLink reports whether a peer link carries no Layer 2 VLAN state.
+func IsRoutedTopologyLink(deviceType string, port TrunkPort) bool {
+	if port.FDBOnly || len(port.VLANs) != 0 || port.NativeVLAN != 0 {
+		return false
+	}
+	switch deviceType {
+	case "router", "firewall", "layer3-switch":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -608,6 +608,9 @@ func (v *Validator) validateTrunkPorts(device *Device, prefix string, deviceName
 	for i, trunk := range device.TrunkPorts {
 		trunkPrefix := fmt.Sprintf("%s.trunk_ports[%d]", prefix, i)
 		v.validateSingleTrunkPort(&trunk, trunkPrefix, seenInterfaces, deviceNames)
+		if !IsRoutedTopologyLink(device.Type, trunk) {
+			v.validateTrunkVLANs(trunk.VLANs, trunkPrefix)
+		}
 	}
 }
 
@@ -619,7 +622,6 @@ func (v *Validator) validateSingleTrunkPort(
 	deviceNames map[string]bool,
 ) {
 	v.validateTrunkInterface(trunk.Interface, trunkPrefix, seenInterfaces)
-	v.validateTrunkVLANs(trunk.VLANs, trunkPrefix)
 	v.validateTrunkNativeVLAN(trunk.NativeVLAN, trunkPrefix)
 	v.validateTrunkRemoteDevice(trunk.RemoteDevice, trunk.RemoteInterface, trunkPrefix, deviceNames)
 }

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -255,6 +255,32 @@ func TestValidate_ResolvesForwardTopologyReference(t *testing.T) {
 	}
 }
 
+func TestValidate_AllowsRoutedTopologyLinkWithoutVLANs(t *testing.T) {
+	cfg := &Config{Devices: []Device{
+		{
+			Name: "router-a", Type: "router",
+			Interfaces: []Interface{{Name: "Ethernet1"}},
+			TrunkPorts: []TrunkPort{{
+				Interface: "Ethernet1", RemoteDevice: "router-b", RemoteInterface: "Ethernet1",
+			}},
+		},
+		{Name: "router-b", Type: "router"},
+	}}
+
+	result := NewValidator("routed.yaml").Validate(cfg)
+
+	if result.HasWarnings() {
+		t.Fatalf("warnings = %#v, want none for a routed topology link", result.Warnings)
+	}
+}
+
+func TestIsRoutedTopologyLinkPreservesFDBOnlyMode(t *testing.T) {
+	port := TrunkPort{FDBOnly: true}
+	if IsRoutedTopologyLink("layer3-switch", port) {
+		t.Fatal("FDB-only link classified as routed")
+	}
+}
+
 func TestValidate_SNMPRequiresExplicitCommunity(t *testing.T) {
 	enabled := true
 	disabled := false

--- a/internal/protocols/snmp/mib_discovery.go
+++ b/internal/protocols/snmp/mib_discovery.go
@@ -323,16 +323,16 @@ func (a *Agent) createCDPCacheEntry(
 		Value: "",
 	})
 
-	// cdpCacheNativeVLAN
-	nativeVLAN := trunk.NativeVLAN
-	if nativeVLAN == 0 {
-		nativeVLAN = 1
+	if !config.IsRoutedTopologyLink(a.device.Type, trunk) {
+		nativeVLAN := trunk.NativeVLAN
+		if nativeVLAN == 0 {
+			nativeVLAN = 1
+		}
+		a.mib.Set(entryBase+".11."+indexStr, &OIDValue{
+			Type:  gosnmp.Integer,
+			Value: nativeVLAN,
+		})
 	}
-
-	a.mib.Set(entryBase+".11."+indexStr, &OIDValue{
-		Type:  gosnmp.Integer,
-		Value: nativeVLAN,
-	})
 
 	// cdpCacheDuplex (1=unknown, 2=half, 3=full)
 	a.mib.Set(entryBase+".12."+indexStr, &OIDValue{

--- a/internal/protocols/snmp/mib_identity.go
+++ b/internal/protocols/snmp/mib_identity.go
@@ -39,19 +39,32 @@ func (a *Agent) refreshPhysicalAddresses(oids []string, mac []byte) {
 		oidValueBytes(a.mib.Get(dot1dBaseBridgeAddress)),
 		oidValueBytes(a.mib.Get(lldpLocChassisID)),
 	}
-	lowest := a.lowestPhysicalAddress(oids)
+	primary := a.primaryPhysicalAddress(oids)
 	for _, oid := range oids {
 		value := oidValueBytes(a.mib.Get(oid))
-		if !strings.HasPrefix(oid, ifPhysAddress+".") ||
-			len(value) != MACAddressOctets || bytes.Equal(value, make([]byte, MACAddressOctets)) {
+		if !strings.HasPrefix(oid, ifPhysAddress+".") || !hasPhysicalAddress(value) {
 			continue
 		}
 		address := derivedPhysicalAddress(mac, oid)
-		if oid == lowest || bytes.Equal(value, identities[0]) || bytes.Equal(value, identities[1]) {
+		if oid == primary || bytes.Equal(value, identities[0]) || bytes.Equal(value, identities[1]) {
 			address = mac
 		}
 		a.mib.Set(oid, &OIDValue{Type: gosnmp.OctetString, Value: address})
 	}
+}
+
+func (a *Agent) primaryPhysicalAddress(oids []string) string {
+	for _, iface := range a.device.Interfaces {
+		index, ok := a.ifIndexForInterface(iface.Name)
+		if !ok {
+			continue
+		}
+		oid := ifPhysAddress + "." + index
+		if hasPhysicalAddress(oidValueBytes(a.mib.Get(oid))) {
+			return oid
+		}
+	}
+	return a.lowestPhysicalAddress(oids)
 }
 
 func (a *Agent) lowestPhysicalAddress(oids []string) string {
@@ -59,8 +72,7 @@ func (a *Agent) lowestPhysicalAddress(oids []string) string {
 	lowestOID := ""
 	for _, oid := range oids {
 		value := oidValueBytes(a.mib.Get(oid))
-		if !strings.HasPrefix(oid, ifPhysAddress+".") ||
-			len(value) != MACAddressOctets || bytes.Equal(value, make([]byte, MACAddressOctets)) {
+		if !strings.HasPrefix(oid, ifPhysAddress+".") || !hasPhysicalAddress(value) {
 			continue
 		}
 		index, err := strconv.Atoi(strings.TrimPrefix(oid, ifPhysAddress+"."))
@@ -69,6 +81,10 @@ func (a *Agent) lowestPhysicalAddress(oids []string) string {
 		}
 	}
 	return lowestOID
+}
+
+func hasPhysicalAddress(value []byte) bool {
+	return len(value) == MACAddressOctets && !bytes.Equal(value, make([]byte, MACAddressOctets))
 }
 
 func oidValueBytes(value *OIDValue) []byte {

--- a/internal/protocols/snmp/mib_qbridge.go
+++ b/internal/protocols/snmp/mib_qbridge.go
@@ -75,6 +75,9 @@ func (a *Agent) initializeQBridgePVIDs() {
 	offset, hasOffset := a.basePortOffset()
 	maxPort := 0
 	for _, trunk := range a.device.TrunkPorts {
+		if config.IsRoutedTopologyLink(a.device.Type, trunk) {
+			continue
+		}
 		vlan := forwardingVLAN(trunk)
 		if vlan == 0 {
 			continue
@@ -99,6 +102,9 @@ func configuredVLANs(device *config.Device) []int {
 	seen := make(map[int]struct{})
 	vlans := make([]int, 0)
 	for _, trunk := range device.TrunkPorts {
+		if config.IsRoutedTopologyLink(device.Type, trunk) {
+			continue
+		}
 		candidates := append([]int(nil), trunk.VLANs...)
 		candidates = append(candidates, forwardingVLAN(trunk))
 		for _, vlan := range candidates {

--- a/internal/protocols/snmp/peer_topology.go
+++ b/internal/protocols/snmp/peer_topology.go
@@ -81,7 +81,7 @@ func (a *Agent) SynthesizePeerTopology(resolve PeerResolver) {
 			remoteIndex,
 		) || changed
 
-		if !a.supportsBridgeTopology() {
+		if !a.supportsBridgeLink(trunk) {
 			continue
 		}
 		if trunk.Interface == "" || len(peer.MAC) == 0 {

--- a/internal/protocols/snmp/peer_topology_bridge.go
+++ b/internal/protocols/snmp/peer_topology_bridge.go
@@ -1,0 +1,7 @@
+package snmp
+
+import "github.com/MustardSeedNetworks/niac-go/internal/config"
+
+func (a *Agent) supportsBridgeLink(port config.TrunkPort) bool {
+	return !config.IsRoutedTopologyLink(a.device.Type, port) && a.supportsBridgeTopology()
+}

--- a/internal/protocols/snmp/peer_topology_test.go
+++ b/internal/protocols/snmp/peer_topology_test.go
@@ -186,6 +186,38 @@ func TestQBridgeUsesDefaultNativeVLAN(t *testing.T) {
 	}
 }
 
+func TestRoutedTopologyLinkDoesNotPublishBridgeFDB(t *testing.T) {
+	dev := createTestDevice()
+	dev.Type = "layer3-switch"
+	dev.LLDPConfig = &config.LLDPConfig{Enabled: true}
+	dev.CDPConfig = &config.CDPConfig{Enabled: true}
+	dev.Interfaces = []config.Interface{{Name: "HundredGigabitEthernet0/2/1"}}
+	dev.TrunkPorts = []config.TrunkPort{{
+		Interface: "HundredGigabitEthernet0/2/1", RemoteDevice: "FW01",
+		RemoteInterface: "ethernet1/2",
+	}}
+	agent := NewAgent(dev, 0)
+	peerMAC, _ := net.ParseMAC("aa:bb:cc:00:00:41")
+	agent.SynthesizePeerTopology(func(string, string) (PeerIdentity, bool) {
+		return PeerIdentity{MAC: peerMAC, Type: "firewall"}, true
+	})
+
+	assertMIBValue(t, agent, lldpRemTable+".1.9.0.1.1", "FW01")
+	macIndex := macBytesToOIDIndex(peerMAC)
+	if value := agent.mib.Get(dot1dTpFdbPort + "." + macIndex); value != nil {
+		t.Fatalf("routed link published bridge FDB port: %v", value.Value)
+	}
+	if value := agent.mib.Get(dot1qTpFDBPort + ".1." + macIndex); value != nil {
+		t.Fatalf("routed link published VLAN 1 FDB port: %v", value.Value)
+	}
+	if value := agent.mib.Get(dot1qPVID + ".1"); value != nil {
+		t.Fatalf("routed link published VLAN 1 PVID: %v", value.Value)
+	}
+	if value := agent.mib.Get(cdpCacheTable + ".1.11.1.1"); value != nil {
+		t.Fatalf("routed link published CDP native VLAN: %v", value.Value)
+	}
+}
+
 func TestSynthesizePeerTopologyPublishesResolvedLLDPIdentity(t *testing.T) {
 	dev := createTestDevice()
 	dev.Type = "switch"

--- a/internal/protocols/snmp/walk_identity_test.go
+++ b/internal/protocols/snmp/walk_identity_test.go
@@ -3,6 +3,8 @@ package snmp
 import (
 	"errors"
 	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
 
 const capturedIdentityWalk = `.1.3.6.1.2.1.2.2.1.6.1 = Hex-STRING: 00 0C CE 88 23 C7
@@ -52,4 +54,30 @@ func TestLoadWalkFileDoesNotInventLLDPIdentity(t *testing.T) {
 	if !errors.Is(err, ErrNoSuchObject) {
 		t.Fatalf("LLDP chassis ID error = %v, want ErrNoSuchObject", err)
 	}
+}
+
+func TestLoadWalkFileUsesAuthoredMACOnConfiguredUplink(t *testing.T) {
+	walk := `.1.3.6.1.2.1.2.2.1.2.1 = STRING: "Dot11Radio0"
+.1.3.6.1.2.1.2.2.1.2.5 = STRING: "mGigabitEthernet0"
+.1.3.6.1.2.1.2.2.1.6.1 = Hex-STRING: 00 00 0C F0 08 01
+.1.3.6.1.2.1.2.2.1.6.5 = Hex-STRING: 00 00 0C F0 08 05`
+	fixture := loadCapturedIdentity(t, "00:00:0c:f0:08:01", walk)
+	fixture.agent.device.Interfaces = []config.Interface{{Name: "mGigabitEthernet0"}}
+	fixture.agent.refreshAuthoredPhysicalIdentity()
+
+	assertAuthoredPhysicalAddress(t, fixture, 5)
+}
+
+func TestLoadWalkFileSkipsZeroMACOnConfiguredInterface(t *testing.T) {
+	walk := `.1.3.6.1.2.1.2.2.1.2.1 = STRING: "Vlan1"
+.1.3.6.1.2.1.2.2.1.2.5 = STRING: "mGigabitEthernet0"
+.1.3.6.1.2.1.2.2.1.6.1 = Hex-STRING: 00 00 00 00 00 00
+.1.3.6.1.2.1.2.2.1.6.5 = Hex-STRING: 00 00 0C F0 08 05`
+	fixture := loadCapturedIdentity(t, "00:00:0c:f0:08:01", walk)
+	fixture.agent.device.Interfaces = []config.Interface{{Name: "Vlan1"}, {Name: "mGigabitEthernet0"}}
+	fixture.agent.mib.Set(ifPhysAddress+".1", &OIDValue{Value: []byte{0, 0, 0, 0, 0, 0}})
+	fixture.agent.mib.Set(ifPhysAddress+".5", &OIDValue{Value: []byte{0, 0, 0x0c, 0xf0, 8, 5}})
+	fixture.agent.refreshAuthoredPhysicalIdentity()
+
+	assertAuthoredPhysicalAddress(t, fixture, 5)
 }

--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -185,6 +185,9 @@ func authoredTrunkPorts(links []link) []converter.TrunkPort {
 }
 
 func nativeVLAN(vlans []int) int {
+	if len(vlans) == 0 {
+		return 0
+	}
 	for _, vlan := range vlans {
 		if vlan == vlanManagement {
 			return vlan

--- a/internal/scenario/generator_test.go
+++ b/internal/scenario/generator_test.go
@@ -30,9 +30,8 @@ func TestGenerateEnterpriseReferenceMatchesAcceptedTopology(t *testing.T) {
 		LinkCount:         634,
 		DeviceNamesSHA256: "77acffce1504dfc6b3a684b70af5a2d6bd4f07778fcd24718395006010042dd9",
 		NetworksSHA256:    "e879b7ba38e40f925809edc3bf98d2044959df5d2f76d492e6f2019cbcba5555",
-		// The accepted reference's WLC FDB rows named a nonexistent eth0.
-		// This fingerprint records the corrected TenGigabitEthernet endpoint.
-		LinksSHA256: "e9b594d484730136f88a5f8af8dec64db673a83cada6c50cf5560f78faedda0e",
+		// Routed WAN edges carry no VLAN metadata; switched links retain their trunks.
+		LinksSHA256: "5d39f3b580edf0271e558f4f972f5567030412875d674c47b502f87163738cfe",
 	}
 	if first.Manifest != want {
 		t.Fatalf("manifest = %#v, want %#v", first.Manifest, want)
@@ -42,8 +41,8 @@ func TestGenerateEnterpriseReferenceMatchesAcceptedTopology(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generated YAML does not load: %v", err)
 	}
-	if result := config.NewValidator("generated-enterprise.yaml").Validate(cfg); !result.Valid {
-		t.Fatalf("generated config is invalid: %s", result.Format())
+	if result := config.NewValidator("generated-enterprise.yaml").Validate(cfg); !result.Valid || result.HasWarnings() {
+		t.Fatalf("generated config is not strict-clean: %s", result.Format())
 	}
 	assertEnterpriseDeviceMix(t, cfg)
 	assertAuthoredInterfacesAndLinks(t, cfg)

--- a/internal/scenario/packs.go
+++ b/internal/scenario/packs.go
@@ -1,7 +1,7 @@
 package scenario
 
 const (
-	scenarioPackManifestVersion = 1
+	scenarioPackManifestVersion = 2
 	hospitalSiteOctet           = 51
 	warehouseSiteOctet          = 61
 	campusSiteOctet             = 71
@@ -104,7 +104,7 @@ func customerScenarioPacks() []Pack {
 				DeviceCount: hospitalDeviceCount, NetworkCount: hospitalNetworkCount, LinkCount: hospitalLinkCount,
 				DeviceNamesSHA256: "46da2595721bae0ef4a4d20ec3d95a12bb1b3e09be71e618cebecbf7ff59860b",
 				NetworksSHA256:    "3903357b0345fa756d65a537dffd67dfbf361ad414305a99137762e26f4816a4",
-				LinksSHA256:       "234a96797daa9728d71efd3d18abe5ef51a0c7cc5308dbc76ec99878663cdd6b",
+				LinksSHA256:       "83b19407c072afdb45cd9665d7c9c76975dde503626f423f0f40b70a587e1e28",
 			},
 		),
 		newScenarioPack(
@@ -128,7 +128,7 @@ func customerScenarioPacks() []Pack {
 				DeviceCount: warehouseDeviceCount, NetworkCount: warehouseNetworkCount, LinkCount: warehouseLinkCount,
 				DeviceNamesSHA256: "19e88c9625d3d38c2a864786ab6f76d43a23f7d6723ae9af014b64eb4c106bc9",
 				NetworksSHA256:    "2647fd6b5e33c0d7177be982854a7571d8d173d64677b6177c33afb5a7607aac",
-				LinksSHA256:       "fd9bae5c8b68b23feb766b9434113c6109de5101c24adc0e47be29473e5ae49d",
+				LinksSHA256:       "22836ae0988c218259b60c8e94e55b4ad61d2beff5e179f47da1a6d93e75a676",
 			},
 		),
 		newScenarioPack(
@@ -149,7 +149,7 @@ func customerScenarioPacks() []Pack {
 				DeviceCount: campusDeviceCount, NetworkCount: campusNetworkCount, LinkCount: campusLinkCount,
 				DeviceNamesSHA256: "ff1862a05edded994e0d6ca5962a0f602c052f24002260ddd1becc2f89964947",
 				NetworksSHA256:    "7262a118fbb0f2d4977d02895b839d0cbce5fd1161201b0f27a5b37fc3eb72ce",
-				LinksSHA256:       "36c9eac0b9675aa07ddac8bf52e8e00148f973ff631f9cd4993b86e479ed7390",
+				LinksSHA256:       "ee50d491a344adf6f7069de069c8d7b0be91c222505244aff7c9ce34afbb37c2",
 			},
 		),
 	}
@@ -175,7 +175,7 @@ func verticalScenarioPacks() []Pack {
 				DeviceCount: retailDeviceCount, NetworkCount: retailNetworkCount, LinkCount: retailLinkCount,
 				DeviceNamesSHA256: "972c99c87edd3fc07c128b19e2347d8692011605ef2fad7495b07a779495ca24",
 				NetworksSHA256:    "ff97ea73b175dd19168b1500d97165a5f44ee9d4f7337db67edc700a0ba0a829",
-				LinksSHA256:       "2ba69ec095b9f0f731bd96ad02dd2fe4e36152e776a6e0f5223f5528b04aab08",
+				LinksSHA256:       "108edbda094f681ea78f25912f26375ffbd6742cc7ec7a4fb5e35ff06917ccf6",
 			},
 		),
 		newScenarioPack(
@@ -201,7 +201,7 @@ func verticalScenarioPacks() []Pack {
 				LinkCount:         industrialLinkCount,
 				DeviceNamesSHA256: "6cc2ddcaa3671c6791b13c569ba04ef49c26a9b92a3b86c0c5a01ecef3d426f2",
 				NetworksSHA256:    "0259604d06e92b16ef8d4d1d6a2b0d9893963b23f936f7b65c7abd11562bc4e0",
-				LinksSHA256:       "62ddff222093eacbbbfdfbe4d400f3fd704e5459827f1e64203b70d0d684be3a",
+				LinksSHA256:       "6f0ae7af17e5a726169f835936c11f621af7e61371e45f28bc3f841b78b87d80",
 			},
 		),
 		newScenarioPack(
@@ -224,7 +224,7 @@ func verticalScenarioPacks() []Pack {
 				LinkCount:         serviceProviderLinkCount,
 				DeviceNamesSHA256: "c799d4b5fb95310c477721262a80043ed67e55785ea02e28f64d550d566bdb7c",
 				NetworksSHA256:    "95a2b3c773f6492777efba084054781170ec2b9b01745308bd7f061e658d0bd4",
-				LinksSHA256:       "62b843cd1b0e3ed09fd51c5e3f0e5a9ecba898396142a51c3bce4a2b7f8555ff",
+				LinksSHA256:       "3afe4b8ed0af88ade74971972a853a1a3bb6b6af54600bc6836c5279bbfc750c",
 			},
 		),
 	}
@@ -254,7 +254,7 @@ func newScenarioPack(
 	manifest Manifest,
 ) Pack {
 	return Pack{
-		ID: id, Version: "1.0.0", ManifestVersion: scenarioPackManifestVersion,
+		ID: id, Version: "1.1.0", ManifestVersion: scenarioPackManifestVersion,
 		Name: name, Description: description,
 		Request: Request{
 			Sites: sites, Counts: counts, Domain: domain,

--- a/internal/scenario/packs_test.go
+++ b/internal/scenario/packs_test.go
@@ -26,7 +26,7 @@ func TestScenarioPackManifestsMatchComposerOutput(t *testing.T) {
 		if result.Manifest != pack.Manifest {
 			t.Errorf("%s manifest = %#v", pack.ID, result.Manifest)
 		}
-		if pack.ManifestVersion != 1 || pack.Version != "1.0.0" {
+		if pack.ManifestVersion != 2 || pack.Version != "1.1.0" {
 			t.Errorf("%s versions = %q/%d", pack.ID, pack.Version, pack.ManifestVersion)
 		}
 	}

--- a/internal/scenario/profiles_catalog.go
+++ b/internal/scenario/profiles_catalog.go
@@ -10,7 +10,7 @@ func networkProfiles() []DeviceProfile {
 			"IOS XE 17.15", synth.VendorCiscoIOS, synth.TypeRouter),
 		newProfile("firewall", "firewall", "palo alto", "PA-5450", "Palo Alto PA-5450",
 			"PAN-OS 11.2", synth.VendorPaloAlto, synth.TypeFirewall),
-		newProfile("core", "router", "cisco", "Nexus 9508", "Cisco Nexus 9508",
+		newProfile("core", "layer3-switch", "cisco", "Nexus 9508", "Cisco Nexus 9508",
 			"NX-OS 10.5", synth.VendorCiscoIOS, synth.TypeRouter),
 	}
 }

--- a/internal/scenario/topology.go
+++ b/internal/scenario/topology.go
@@ -23,10 +23,10 @@ func buildLinks(request Request) linkMap {
 	links := make(linkMap)
 	addEdge(links,
 		endpoint{"LAB-EDGE-R1", "HundredGigabitEthernet0/0/1"},
-		endpoint{"WAN-R1", "HundredGigabitEthernet0/0/1"}, nil)
+		endpoint{"WAN-R1", "HundredGigabitEthernet0/0/1"}, []int{})
 	addEdge(links,
 		endpoint{"LAB-EDGE-R1", "HundredGigabitEthernet0/0/2"},
-		endpoint{"WAN-R2", "HundredGigabitEthernet0/0/1"}, nil)
+		endpoint{"WAN-R2", "HundredGigabitEthernet0/0/1"}, []int{})
 	for siteIndex, site := range request.Sites {
 		addSiteBackbone(links, site, siteIndex, request.Counts)
 		addSiteLAN(links, site, request.Counts)
@@ -63,12 +63,12 @@ func addFDB(links linkMap, sw, interfaceName, remote, remoteInterface string, vl
 	})
 }
 
-func addMesh(links linkMap, left, right []string, prefix string) {
+func addMesh(links linkMap, left, right []string, prefix string, vlans []int) {
 	index := 1
 	for _, leftName := range left {
 		for _, rightName := range right {
 			interfaceName := fmt.Sprintf("%s%d", prefix, index)
-			addEdge(links, endpoint{leftName, interfaceName}, endpoint{rightName, interfaceName}, nil)
+			addEdge(links, endpoint{leftName, interfaceName}, endpoint{rightName, interfaceName}, vlans)
 			index++
 		}
 	}
@@ -85,10 +85,10 @@ func addSiteBackbone(links linkMap, site Site, siteIndex int, counts Counts) {
 				fmt.Sprintf("WAN-R%d", provider),
 				fmt.Sprintf("HundredGigabitEthernet0/0/%d", siteIndex+firstSiteInterfaceIndex),
 			},
-			endpoint{wanName, "HundredGigabitEthernet0/0/1"}, nil)
+			endpoint{wanName, "HundredGigabitEthernet0/0/1"}, []int{})
 	}
-	addMesh(links, wan, firewalls, "TenGigabitEthernet0/1/")
-	addMesh(links, firewalls, cores, "HundredGigabitEthernet0/2/")
+	addMesh(links, wan, firewalls, "TenGigabitEthernet0/1/", []int{})
+	addMesh(links, firewalls, cores, "HundredGigabitEthernet0/2/", []int{})
 }
 
 func addSiteLAN(links linkMap, site Site, counts Counts) {

--- a/internal/scenario/topology_truth_test.go
+++ b/internal/scenario/topology_truth_test.go
@@ -24,6 +24,7 @@ func assertEnterpriseDeviceMix(t *testing.T, cfg *config.Config) {
 				t.Errorf("missing %s-%s", site, role)
 			}
 		}
+		assertCoreTypes(t, cfg, site)
 	}
 	for _, device := range cfg.Devices {
 		if strings.Contains(device.Name, "-WAP-") &&
@@ -31,6 +32,23 @@ func assertEnterpriseDeviceMix(t *testing.T, cfg *config.Config) {
 			t.Errorf("%s does not identify as Wi-Fi 7", device.Name)
 		}
 	}
+}
+
+func assertCoreTypes(t *testing.T, cfg *config.Config, site string) {
+	t.Helper()
+	for _, suffix := range []string{"CORE-SW01", "CORE-SW02"} {
+		device := findDevice(cfg, site+"-"+suffix)
+		if device == nil || device.Type != "layer3-switch" {
+			t.Errorf("%s-%s type = %q, want layer3-switch", site, suffix, deviceType(device))
+		}
+	}
+}
+
+func deviceType(device *config.Device) string {
+	if device == nil {
+		return ""
+	}
+	return device.Type
 }
 
 func assertAuthoredInterfacesAndLinks(t *testing.T, cfg *config.Config) {
@@ -48,6 +66,33 @@ func assertAuthoredInterfacesAndLinks(t *testing.T, cfg *config.Config) {
 		}
 	}
 	assertAuthoredLinks(t, cfg)
+	assertRoutedEdgesUntagged(t, cfg)
+}
+
+func assertRoutedEdgesUntagged(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	pairs := [][2]string{
+		{"LAB-EDGE-R1", "WAN-R1"},
+		{"WAN-R1", "COS-WAN-R01"},
+		{"COS-WAN-R01", "COS-FW01"},
+		{"COS-FW01", "COS-CORE-SW01"},
+	}
+	for _, pair := range pairs {
+		device := findDevice(cfg, pair[0])
+		port := findRemotePort(device, pair[1])
+		if port == nil || port.NativeVLAN != 0 || len(port.VLANs) != 0 {
+			t.Errorf("routed edge %s -> %s carries VLAN metadata: %+v", pair[0], pair[1], port)
+		}
+	}
+}
+
+func findRemotePort(device *config.Device, remote string) *config.TrunkPort {
+	for index := range device.TrunkPorts {
+		if device.TrunkPorts[index].RemoteDevice == remote {
+			return &device.TrunkPorts[index]
+		}
+	}
+	return nil
 }
 
 func assertAuthoredLinks(t *testing.T, cfg *config.Config) {

--- a/tools/linklive-acceptance/runner.go
+++ b/tools/linklive-acceptance/runner.go
@@ -82,12 +82,14 @@ func (r runner) compare(ctx context.Context, opts options) (report, error) {
 
 func (r runner) client() (*linklive.Client, error) {
 	return linklive.New(linklive.Config{
-		IdentityURL:   valueOr(r.getenv("LINKLIVE_IDENTITY_URL"), "https://id.link-live.com"),
-		APIURL:        valueOr(r.getenv("LINKLIVE_API_URL"), "https://link-live.com"),
-		Username:      r.getenv("LINKLIVE_USERNAME"),
-		Password:      r.getenv("LINKLIVE_PASSWORD"),
-		MFACode:       r.getenv("LINKLIVE_MFA_CODE"),
-		AllowInsecure: r.allowInsecure,
+		IdentityURL:    valueOr(r.getenv("LINKLIVE_IDENTITY_URL"), "https://id.link-live.com"),
+		APIURL:         valueOr(r.getenv("LINKLIVE_API_URL"), "https://link-live.com"),
+		Username:       r.getenv("LINKLIVE_USERNAME"),
+		Password:       r.getenv("LINKLIVE_PASSWORD"),
+		MFACode:        r.getenv("LINKLIVE_MFA_CODE"),
+		OrganizationID: r.getenv("LINKLIVE_ORGANIZATION_ID"),
+		AccessToken:    r.getenv("LINKLIVE_ACCESS_TOKEN"),
+		AllowInsecure:  r.allowInsecure,
 	})
 }
 

--- a/tools/linklive-acceptance/runner_test.go
+++ b/tools/linklive-acceptance/runner_test.go
@@ -43,8 +43,35 @@ func TestRunnerFailsOnMismatch(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "mismatches") {
 		t.Fatalf("error = %v", err)
 	}
-	if !strings.Contains(output.String(), "type-conflict") {
+	if !strings.Contains(output.String(), "duplex-conflict") {
 		t.Fatalf("output = %s", output.String())
+	}
+}
+
+func TestRunnerUsesAccessTokenEnvironment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/auth/login" {
+			t.Fatal("runner attempted login with a configured access token")
+		}
+		if got := r.Header.Get("Authorization"); got != "Access cached-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		_, _ = w.Write([]byte(topologyJSON("Switch", "Full", "100 Gb")))
+	}))
+	t.Cleanup(server.Close)
+
+	environment := testEnvironment(server.URL)
+	executor := newRunner(func(key string) string {
+		if key == "LINKLIVE_ACCESS_TOKEN" {
+			return "cached-token"
+		}
+		return environment(key)
+	}, &bytes.Buffer{})
+	executor.allowInsecure = true
+	if err := executor.run(context.Background(), []string{
+		"-config", writeConfig(t), "-analysis", "analysis-7",
+	}); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add organization-scoped access-token support to the Link-Live acceptance client
- make topology comparison exact for device names, ports, roles, and rendered link telemetry
- correct generated core roles, routed-link VLAN behavior, AP physical identity, and FDB-only handling
- refresh versioned scenario manifests and add regression coverage for the accepted customer-generated topology

## Linked Issue

Related to #1151

## Root Cause

The hand-authored lab configuration and the customer generator had diverged. Generated routed edges leaked Layer-2 VLAN state, core switches identified as routers, captured AP walks assigned the authored MAC to the wrong interface, and acceptance matching allowed false positives.

## Testing Evidence

```
make fmt-check: passed
make lint: 0 issues
make test: passed, backend coverage 68.3 percent
make security: no Go or npm vulnerabilities; no secret leaks
make test-e2e: 198 passed, 6 intentional skips; authenticated matrix 3 passed
native Chrome and Edge: 132 passed, 4 intentional skips; authenticated matrix 2 passed
make build: passed
post-rebase affected package suites: passed
```

## Security and Release Checklist

- [x] No credentials or tokens committed
- [x] Go vulnerability scan passed
- [x] npm audit passed
- [x] gitleaks passed
- [x] CSRF, authorization, and output-encoding boundaries unchanged
- [x] Full production build passed
- [x] Protected auto-merge enabled
- [x] PR template validated

## Impact

The customer-facing generator now emits topology semantics that match the known-good Link-Live model, and the acceptance tool can validate an MFA-protected organization with a stored access token.
