### PR TITLE
feat(daemon): report trunk capture health and degrade its sessions

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -353,6 +353,12 @@ type SimulationStatus struct {
 	Fabric         *SimulationFabricStatus `json:"fabric,omitempty"`
 	Recovery       *SimulationRecovery     `json:"recovery,omitempty"`
 	Sessions       []SimulationStatus      `json:"sessions,omitempty"`
+	// Degraded marks a session that is still running but cannot exchange
+	// frames, today only because the shared trunk capture it rides on has
+	// stopped. Running alone would read as healthy.
+	Degraded       bool                `json:"degraded,omitempty"`
+	DegradedReason string              `json:"degradedReason,omitempty"`
+	Capture        *TrunkCaptureHealth `json:"capture,omitempty"`
 }
 
 // SimulationRecovery reports the most recent daemon restart recovery attempt.
@@ -369,6 +375,32 @@ type SimulationFabricStatus struct {
 	Drops       uint64          `json:"drops"`
 	Received    uint64          `json:"received"`
 	Transmitted uint64          `json:"transmitted"`
+}
+
+// TrunkDropStats separates why the shared trunk discarded a frame. Frames
+// tagged for a VLAN nobody serves are ordinary on a shared trunk; a session
+// whose ingress queue overran is not. One aggregate counter cannot tell an
+// operator which is happening.
+type TrunkDropStats struct {
+	Total      uint64 `json:"total"`
+	Untagged   uint64 `json:"untagged"`
+	Unapproved uint64 `json:"unapproved"`
+	Overrun    uint64 `json:"overrun"`
+	// Keyed by VLAN. UnapprovedByVLAN names at most a bounded number of
+	// distinct tags, so traffic on the wire cannot size the map.
+	UnapprovedByVLAN map[uint16]uint64 `json:"unapprovedByVlan,omitempty"`
+	OverrunByVLAN    map[uint16]uint64 `json:"overrunByVlan,omitempty"`
+}
+
+// TrunkCaptureHealth reports one physical interface's shared capture. A session
+// bound to an unhealthy trunk can neither send nor receive, so this is what
+// stops it reporting as running when nothing can reach it.
+type TrunkCaptureHealth struct {
+	Interface    string         `json:"interface"`
+	Healthy      bool           `json:"healthy"`
+	Error        string         `json:"error,omitempty"`
+	SessionVLANs []uint16       `json:"sessionVlans,omitempty"`
+	Drops        TrunkDropStats `json:"drops"`
 }
 
 // DaemonController interface for daemon mode operations.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -774,10 +774,15 @@ func (d *Daemon) startTrunkSimulationResources(
 		managed = &managedTrunkCapture{capture: newTrunkCapture(engine), cancel: cancel}
 		d.trunks[iface] = managed
 		go func() {
-			if captureErr := managed.capture.run(ctx); captureErr != nil &&
-				!errors.Is(captureErr, context.Canceled) {
-				logging.Errorf("Trunk capture on %s stopped: %v", iface, captureErr)
+			captureErr := managed.capture.run(ctx)
+			if captureErr == nil || errors.Is(captureErr, context.Canceled) {
+				return
 			}
+			// Every session on this interface is now deaf and mute. Record it
+			// so their status says so, instead of reporting running while no
+			// frame can reach them.
+			logging.Errorf("Trunk capture on %s stopped: %v", iface, captureErr)
+			managed.capture.fail(captureErr)
 		}()
 	}
 
@@ -1041,19 +1046,42 @@ func (d *Daemon) GetStatus() api.SimulationStatus {
 		}
 		slices.Sort(ids)
 		for _, id := range ids {
-			status.Sessions = append(status.Sessions, simulationStatus(
-				d.sessions.get(id), d.simulation != nil && d.simulation.SessionID == id,
+			session := d.sessions.get(id)
+			status.Sessions = append(status.Sessions, d.simulationStatusLocked(
+				session, d.simulation != nil && d.simulation.SessionID == id,
 			))
 		}
 	}
 
 	if d.simulation != nil {
-		selected := simulationStatus(d.simulation, true)
+		selected := d.simulationStatusLocked(d.simulation, true)
 		selected.Sessions = status.Sessions
 		selected.Recovery = status.Recovery
 		return selected
 	}
 
+	return status
+}
+
+// simulationStatusLocked builds one session's status and attaches the health of
+// the shared trunk it rides on. A session whose trunk capture has died is still
+// "running" as a process but cannot exchange a single frame, so its status has
+// to carry that or an operator reads it as healthy. Caller holds d.mu.
+func (d *Daemon) simulationStatusLocked(sim *Simulation, selected bool) api.SimulationStatus {
+	status := simulationStatus(sim, selected)
+	if sim.Binding.Mode != fabric.ModeTrunk {
+		return status
+	}
+	managed, ok := d.trunks[sim.Interface]
+	if !ok {
+		return status
+	}
+	health := managed.capture.health(sim.Interface)
+	status.Capture = &health
+	if !health.Healthy {
+		status.Degraded = true
+		status.DegradedReason = health.Error
+	}
 	return status
 }
 

--- a/internal/daemon/trunk_capture.go
+++ b/internal/daemon/trunk_capture.go
@@ -5,10 +5,14 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 	"sync/atomic"
 
 	"github.com/gopacket/gopacket"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
 )
 
 const (
@@ -17,11 +21,19 @@ const (
 	dot1QHeaderLength    = 4
 	ethernetHeaderLength = 14
 	trunkIngressQueue    = 16384
+
+	// A trunk can carry frames on any of the 4094 valid tags, but only the
+	// operator-approved ones map to a session. Tracking every stray tag
+	// individually would let whatever is on the wire size our map, so only
+	// this many distinct unapproved tags are named; the rest are counted in
+	// the total.
+	maxTrackedUnapprovedVLANs = 16
 )
 
 var (
 	ErrTrunkVLANUnavailable = errors.New("trunk VLAN is not available")
 	ErrTrunkEgressVLAN      = errors.New("frame does not use the session's physical VLAN")
+	ErrTrunkCaptureFailed   = errors.New("shared trunk capture has stopped")
 )
 
 type trunkPhysicalCapture interface {
@@ -30,12 +42,35 @@ type trunkPhysicalCapture interface {
 	Close()
 }
 
+// trunkDrops separates why a frame was discarded. One aggregate counter cannot
+// distinguish "the wire carries tags we do not serve" — normal on a shared
+// trunk — from "a session cannot keep up", which is a real problem.
+type trunkDrops struct {
+	mu sync.Mutex
+	// Untagged frames, and frames whose tag is outside the valid 1..4094 range.
+	untagged uint64
+	// Frames tagged for a VLAN with no session, keyed by tag up to
+	// maxTrackedUnapprovedVLANs distinct tags.
+	unapproved      uint64
+	unapprovedByTag map[uint16]uint64
+	// Frames dropped because the session's ingress queue was full, keyed by
+	// the session's own VLAN and so bounded by the session count.
+	overrun      uint64
+	overrunByTag map[uint16]uint64
+}
+
 type trunkCapture struct {
 	physical trunkPhysicalCapture
 
 	mu       sync.RWMutex
 	sessions map[uint16]*trunkSessionTransport
-	drops    atomic.Uint64
+	drops    trunkDrops
+
+	// Set once the physical capture stops for any reason other than a
+	// deliberate cancel. Sessions bound to this trunk are dead once it is set,
+	// so they must report it rather than continue to look healthy.
+	failed  atomic.Bool
+	failure atomic.Pointer[string]
 }
 
 type managedTrunkCapture struct {
@@ -51,6 +86,11 @@ func newTrunkCapture(physical trunkPhysicalCapture) *trunkCapture {
 }
 
 func (c *trunkCapture) register(vlan uint16) (*trunkSessionTransport, error) {
+	// Starting a session on a trunk whose capture has died would report success
+	// and then carry nothing.
+	if c.failed.Load() {
+		return nil, fmt.Errorf("%w", ErrTrunkCaptureFailed)
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if _, exists := c.sessions[vlan]; exists {
@@ -108,14 +148,14 @@ func (c *trunkCapture) run(ctx context.Context) error {
 func (c *trunkCapture) dispatchFrame(frame []byte) bool {
 	vlan, ok := frameVLAN(frame)
 	if !ok {
-		c.drops.Add(1)
+		c.drops.recordUntagged()
 		return false
 	}
 	c.mu.RLock()
 	transport := c.sessions[vlan]
 	if transport == nil {
 		c.mu.RUnlock()
-		c.drops.Add(1)
+		c.drops.recordUnapproved(vlan)
 		return false
 	}
 	select {
@@ -124,9 +164,92 @@ func (c *trunkCapture) dispatchFrame(frame []byte) bool {
 		return true
 	default:
 		c.mu.RUnlock()
-		c.drops.Add(1)
+		c.drops.recordOverrun(vlan)
 		return false
 	}
+}
+
+func (d *trunkDrops) recordUntagged() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.untagged++
+}
+
+func (d *trunkDrops) recordUnapproved(vlan uint16) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.unapproved++
+	if d.unapprovedByTag == nil {
+		d.unapprovedByTag = make(map[uint16]uint64)
+	}
+	if _, tracked := d.unapprovedByTag[vlan]; !tracked &&
+		len(d.unapprovedByTag) >= maxTrackedUnapprovedVLANs {
+		return
+	}
+	d.unapprovedByTag[vlan]++
+}
+
+func (d *trunkDrops) recordOverrun(vlan uint16) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.overrun++
+	if d.overrunByTag == nil {
+		d.overrunByTag = make(map[uint16]uint64)
+	}
+	d.overrunByTag[vlan]++
+}
+
+func (d *trunkDrops) snapshot() api.TrunkDropStats {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	stats := api.TrunkDropStats{
+		Untagged:   d.untagged,
+		Unapproved: d.unapproved,
+		Overrun:    d.overrun,
+		Total:      d.untagged + d.unapproved + d.overrun,
+	}
+	if len(d.unapprovedByTag) > 0 {
+		stats.UnapprovedByVLAN = maps.Clone(d.unapprovedByTag)
+	}
+	if len(d.overrunByTag) > 0 {
+		stats.OverrunByVLAN = maps.Clone(d.overrunByTag)
+	}
+	return stats
+}
+
+// fail marks the trunk dead and wakes every session reading from it, so a
+// blocked ReadPacket returns instead of hanging on a capture that will never
+// deliver another frame.
+func (c *trunkCapture) fail(err error) {
+	if err == nil || !c.failed.CompareAndSwap(false, true) {
+		return
+	}
+	message := err.Error()
+	c.failure.Store(&message)
+	c.mu.RLock()
+	transports := make([]*trunkSessionTransport, 0, len(c.sessions))
+	for _, transport := range c.sessions {
+		transports = append(transports, transport)
+	}
+	c.mu.RUnlock()
+	for _, transport := range transports {
+		transport.close()
+	}
+}
+
+func (c *trunkCapture) health(iface string) api.TrunkCaptureHealth {
+	health := api.TrunkCaptureHealth{
+		Interface: iface,
+		Healthy:   !c.failed.Load(),
+		Drops:     c.drops.snapshot(),
+	}
+	if message := c.failure.Load(); message != nil {
+		health.Error = *message
+	}
+	c.mu.RLock()
+	health.SessionVLANs = slices.Sorted(maps.Keys(c.sessions))
+	c.mu.RUnlock()
+	return health
 }
 
 func (c *trunkCapture) close() {
@@ -156,6 +279,11 @@ func (t *trunkSessionTransport) ReadPacket(buffer []byte) ([]byte, error) {
 }
 
 func (t *trunkSessionTransport) SendPacket(frame []byte) error {
+	// A dead trunk cannot carry the frame. Say so rather than writing into a
+	// handle that will never deliver it.
+	if t.parent.failed.Load() {
+		return fmt.Errorf("%w on the interface serving VLAN %d", ErrTrunkCaptureFailed, t.vlan)
+	}
 	vlan, ok := frameVLAN(frame)
 	if !ok || vlan != t.vlan {
 		return fmt.Errorf("%w: expected VLAN %d", ErrTrunkEgressVLAN, t.vlan)

--- a/internal/daemon/trunk_capture_test.go
+++ b/internal/daemon/trunk_capture_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/gopacket/gopacket"
 )
@@ -61,8 +63,124 @@ func TestTrunkCaptureDropsUntaggedAndUnassignedFrames(t *testing.T) {
 	if capture.dispatchFrame(taggedTestFrame(299)) {
 		t.Fatal("unassigned dispatch = true, want false")
 	}
-	if got := capture.drops.Load(); got != 2 {
-		t.Fatalf("drops = %d, want 2", got)
+	drops := capture.drops.snapshot()
+	if drops.Total != 2 {
+		t.Fatalf("total drops = %d, want 2", drops.Total)
+	}
+	// The two drops have different causes and must not be conflated: one frame
+	// carried no tag, the other a tag no session serves.
+	if drops.Untagged != 1 {
+		t.Errorf("untagged drops = %d, want 1", drops.Untagged)
+	}
+	if drops.Unapproved != 1 {
+		t.Errorf("unapproved drops = %d, want 1", drops.Unapproved)
+	}
+	if got := drops.UnapprovedByVLAN[299]; got != 1 {
+		t.Errorf("unapproved drops on VLAN 299 = %d, want 1", got)
+	}
+}
+
+func TestTrunkDropsSeparateOverrunFromUnapproved(t *testing.T) {
+	capture := newTrunkCapture(&fakeTrunkPhysical{})
+	transport, err := capture.register(200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fill the session's ingress queue so the next frame for its own VLAN has
+	// nowhere to go. That is a session falling behind, not stray trunk traffic.
+	for range trunkIngressQueue {
+		transport.rx <- []byte{}
+	}
+	if capture.dispatchFrame(taggedTestFrame(200)) {
+		t.Fatal("dispatch into a full queue = true, want false")
+	}
+	drops := capture.drops.snapshot()
+	if drops.Overrun != 1 {
+		t.Fatalf("overrun drops = %d, want 1", drops.Overrun)
+	}
+	if drops.Unapproved != 0 {
+		t.Errorf("unapproved drops = %d, want 0 — an overrun is not stray traffic", drops.Unapproved)
+	}
+	if got := drops.OverrunByVLAN[200]; got != 1 {
+		t.Errorf("overrun drops on VLAN 200 = %d, want 1", got)
+	}
+}
+
+func TestTrunkUnapprovedVLANTrackingIsBounded(t *testing.T) {
+	capture := newTrunkCapture(&fakeTrunkPhysical{})
+	// Whatever is on the wire must not be able to size our map.
+	for vlan := 1; vlan <= maxTrackedUnapprovedVLANs*4; vlan++ {
+		capture.dispatchFrame(taggedTestFrame(uint16(vlan)))
+	}
+	drops := capture.drops.snapshot()
+	if len(drops.UnapprovedByVLAN) > maxTrackedUnapprovedVLANs {
+		t.Errorf("tracked %d distinct VLANs, want at most %d",
+			len(drops.UnapprovedByVLAN), maxTrackedUnapprovedVLANs)
+	}
+	// The total still counts every dropped frame; only the per-VLAN detail is capped.
+	if want := uint64(maxTrackedUnapprovedVLANs * 4); drops.Unapproved != want {
+		t.Errorf("unapproved total = %d, want %d", drops.Unapproved, want)
+	}
+}
+
+func TestTrunkCaptureFailureWakesSessionsAndReportsUnhealthy(t *testing.T) {
+	capture := newTrunkCapture(&fakeTrunkPhysical{})
+	transport, err := capture.register(200)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	read := make(chan struct{})
+	go func() {
+		// A session blocked here would hang forever on a dead capture.
+		_, _ = transport.ReadPacket(make([]byte, 2048))
+		close(read)
+	}()
+
+	capture.fail(errors.New("pcap handle closed"))
+
+	select {
+	case <-read:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadPacket still blocked after the capture failed")
+	}
+
+	health := capture.health("eth0")
+	if health.Healthy {
+		t.Error("health.Healthy = true after a capture failure, want false")
+	}
+	if health.Error != "pcap handle closed" {
+		t.Errorf("health.Error = %q, want the capture error", health.Error)
+	}
+	if !slices.Contains(health.SessionVLANs, uint16(200)) {
+		t.Errorf("health.SessionVLANs = %v, want it to name the affected session", health.SessionVLANs)
+	}
+}
+
+func TestTrunkCaptureFailureStopsSendAndNewSessions(t *testing.T) {
+	capture := newTrunkCapture(&fakeTrunkPhysical{})
+	transport, err := capture.register(200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture.fail(errors.New("interface went down"))
+
+	// A degraded session must not appear to transmit.
+	if sendErr := transport.SendPacket(taggedTestFrame(200)); !errors.Is(sendErr, ErrTrunkCaptureFailed) {
+		t.Errorf("SendPacket error = %v, want ErrTrunkCaptureFailed", sendErr)
+	}
+	// Nor should a new session start on a dead trunk and report success.
+	if _, regErr := capture.register(201); !errors.Is(regErr, ErrTrunkCaptureFailed) {
+		t.Errorf("register error = %v, want ErrTrunkCaptureFailed", regErr)
+	}
+}
+
+func TestTrunkCaptureFailureIsRecordedOnce(t *testing.T) {
+	capture := newTrunkCapture(&fakeTrunkPhysical{})
+	capture.fail(errors.New("first"))
+	capture.fail(errors.New("second"))
+	if got := capture.health("eth0").Error; got != "first" {
+		t.Errorf("health.Error = %q, want the first failure to be kept", got)
 	}
 }
 

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -799,6 +799,8 @@
     },
     "sessions": {
       "actions": "Actions",
+      "degraded": "Degraded",
+      "degradedHelp": "This scenario is running but its shared trunk capture has stopped, so it cannot send or receive.",
       "devices": "Devices",
       "help": "Each scenario stays isolated on its assigned physical VLAN.",
       "packetCounts": "RX {{received}} / TX {{transmitted}}",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -117,7 +117,9 @@
       "started": "Iniciado",
       "state": "Estado",
       "title": "Escenarios activos",
-      "vlan": "VLAN física"
+      "vlan": "VLAN física",
+      "degraded": "Degradado",
+      "degradedHelp": "Este escenario se está ejecutando, pero la captura del trunk compartido se detuvo, por lo que no puede enviar ni recibir."
     },
     "fabric": {
       "attachment": "Conexión",

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -342,6 +342,29 @@ export interface SimulationStatus {
   uptimeSeconds: number;
   fabric?: import('./fabric-types').SimulationFabricStatus;
   sessions?: SimulationStatus[];
+  /** Running, but unable to exchange frames — today only a dead shared trunk. */
+  degraded?: boolean;
+  degradedReason?: string;
+  capture?: TrunkCaptureHealth;
+}
+
+/** Per-reason trunk drop counts. Stray tags on a shared trunk are ordinary; a
+ * session overrunning its ingress queue is not. */
+export interface TrunkDropStats {
+  total: number;
+  untagged: number;
+  unapproved: number;
+  overrun: number;
+  unapprovedByVlan?: Record<string, number>;
+  overrunByVlan?: Record<string, number>;
+}
+
+export interface TrunkCaptureHealth {
+  interface: string;
+  healthy: boolean;
+  error?: string;
+  sessionVlans?: number[];
+  drops: TrunkDropStats;
 }
 
 /**

--- a/ui/src/pages/runtime/ConcurrentSessionsPanel.tsx
+++ b/ui/src/pages/runtime/ConcurrentSessionsPanel.tsx
@@ -67,11 +67,20 @@ export const ConcurrentSessionsPanel: FC<ConcurrentSessionsPanelProps> = ({
                     })}
                   </td>
                   <td className="px-cell py-row">
-                    <Tag colorScheme="green">
-                      {session.selected
-                        ? t('runtime.sessions.selected')
-                        : t('runtime.running.active')}
-                    </Tag>
+                    {session.degraded ? (
+                      <div className="stack-compact">
+                        <Tag colorScheme="red">{t('runtime.sessions.degraded')}</Tag>
+                        <SmallText>
+                          {session.degradedReason || t('runtime.sessions.degradedHelp')}
+                        </SmallText>
+                      </div>
+                    ) : (
+                      <Tag colorScheme="green">
+                        {session.selected
+                          ? t('runtime.sessions.selected')
+                          : t('runtime.running.active')}
+                      </Tag>
+                    )}
                   </td>
                   <td className="px-cell py-row flex gap-compact">
                     {!session.selected && (


### PR DESCRIPTION
## Summary

Closes program ledger items **M1-5** (expose capture health and drop counts by reason, interface, VLAN, session) and **M1-6** (fail/degrade dependent sessions when shared capture terminates).

A shared trunk capture that stopped was only logged (`daemon.go`, "Trunk capture on %s stopped"). Every session riding that interface kept reporting `running: true` while it could not exchange a single frame — an operator reads that as healthy. Sessions could also still "send", writing into a handle that would never deliver, and a new session could be started on the dead trunk and report success.

Now:

- the capture records terminal failure once, and keeps the first error
- it wakes any session blocked in `ReadPacket`, which would otherwise hang forever on a capture that will never deliver again
- `SendPacket` and `register` return `ErrTrunkCaptureFailed` instead of silently succeeding
- affected sessions report `degraded` with the failure as `degradedReason`, and carry the trunk's health
- the runtime session table shows a red Degraded tag with the reason as visible text

Drops were a single aggregate counter that could not distinguish three quite different situations. They are now separated:

| Reason | Meaning |
| --- | --- |
| `untagged` | no valid 802.1Q tag — dropped by policy |
| `unapproved` | tagged for a VLAN no session serves — **ordinary** on a shared trunk |
| `overrun` | a session's ingress queue was full — **a real problem** |

`unapproved` and `overrun` are also broken out per VLAN. Per-VLAN detail for unapproved tags is capped at 16 distinct tags so traffic on the wire cannot size the map; totals stay exact regardless.

## Linked Issue

Related to #882

## Testing Evidence

```
go test ./...                       green
go test -race ./internal/daemon/    green (33s)
golangci-lint run (v2.12.2)         0 issues
gofmt -l internal/ cmd/             clean
vitest                              79 files, 385 tests passed
biome check .                       406 files clean
tsgo --build --noEmit               clean
npm run i18n:check                  clean (extractor order)
scripts/i18n/validate.sh --ratchet  OK (1 pre-existing warn)
make schema                         NO DRIFT
check-json-casing/-output-escaping/-route-policy/-file-size/-filename-policy   PASS
```

Five new tests, each asserting behaviour rather than shape:

- untagged vs unapproved are counted separately, not conflated
- a queue overrun is counted as overrun and **not** as stray traffic
- per-VLAN tracking stays bounded under 64 distinct tags while the total stays exact
- a failed capture unblocks a goroutine parked in `ReadPacket` within 2s, and reports unhealthy naming the affected VLAN
- a failed capture refuses `SendPacket` and refuses to register a new session

## Security and Release Checklist

- The bounded per-VLAN map is the security-relevant part: an unbounded map keyed by attacker-influenced 802.1Q tags would be a memory-growth vector on a shared trunk. Capped at 16 distinct tags, with totals still exact.
- Failure handling is fail-closed: a degraded session refuses to transmit rather than appearing to.
- No new routes; no CSRF/scope surface change. `check-route-policy.sh` passes.
- No secrets, no default credentials, no phone-home.
- es strings keep `trunk` verbatim per the do-not-translate convention.

Release: no version bump; release-please owns tagging.
