### PR TITLE
feat(daemon): enforce device and session budgets across the whole daemon

### DIFF
--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -22,7 +22,22 @@ var (
 	)
 	ErrSimulationSessionIDRequired = errors.New("simulation session ID is required")
 	ErrSimulationSessionNotFound   = errors.New("simulation session was not found")
+	// ErrSimulationSessionCapacity and ErrSimulationDeviceCapacity are daemon-wide
+	// technical capacity limits, not entitlements. A per-config check cannot
+	// enforce them because several sessions run at once.
+	ErrSimulationSessionCapacity = errors.New("daemon session capacity exceeded")
+	ErrSimulationDeviceCapacity  = errors.New("daemon device capacity exceeded")
 )
+
+// DaemonCapacity reports what the daemon is currently carrying against its
+// aggregate safety budgets, so an operator can see how close a start is to
+// being refused before it is.
+type DaemonCapacity struct {
+	Sessions    int `json:"sessions"`
+	MaxSessions int `json:"maxSessions"`
+	Devices     int `json:"devices"`
+	MaxDevices  int `json:"maxDevices"`
+}
 
 // SimulationEntitlements captures paid grants evaluated for one atomic start.
 type SimulationEntitlements struct {
@@ -215,6 +230,12 @@ func (s *Server) handleSimulationStartError(w http.ResponseWriter, r *http.Reque
 	case errors.Is(err, ErrSimulationSessionIDRequired):
 		writeError(w, r, http.StatusBadRequest, "validation_failed",
 			"A scenario ID is required for a shared trunk", nil)
+	case errors.Is(err, ErrSimulationSessionCapacity):
+		writeError(w, r, http.StatusConflict, "session_capacity_reached",
+			"The daemon is already running its maximum number of scenarios", nil)
+	case errors.Is(err, ErrSimulationDeviceCapacity):
+		writeError(w, r, http.StatusConflict, "device_capacity_reached",
+			"Running this scenario would exceed the daemon's total device capacity", nil)
 	case errors.Is(err, config.ErrSSHPasswordUnavailable):
 		writeError(w, r, http.StatusBadRequest, "runtime_requirements_unmet",
 			"Configuration runtime requirements are not met",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -359,6 +359,9 @@ type SimulationStatus struct {
 	Degraded       bool                `json:"degraded,omitempty"`
 	DegradedReason string              `json:"degradedReason,omitempty"`
 	Capture        *TrunkCaptureHealth `json:"capture,omitempty"`
+	// Capacity is daemon-wide, so it is set on the top-level status only, not
+	// on each entry of Sessions.
+	Capacity *DaemonCapacity `json:"capacity,omitempty"`
 }
 
 // SimulationRecovery reports the most recent daemon restart recovery attempt.

--- a/internal/daemon/admission.go
+++ b/internal/daemon/admission.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// Safety bounds for the whole daemon, not for one session. Per-config limits
+// multiply once several sessions run at once: a 1000-device ceiling checked
+// against each config in turn permits 1000 devices per session, which is not a
+// ceiling at all. These are technical capacity limits, never an entitlement.
+const (
+	// maxActiveSessions bounds concurrent runtimes on one daemon. Each owns a
+	// protocol stack, goroutines and an ingress queue, so the count itself is a
+	// resource.
+	maxActiveSessions = 16
+)
+
+// admitSessionLocked decides whether a session may start given everything
+// already running. sessionID names the session being started; if it is already
+// active its own devices are excluded, because a replacement swaps a session
+// rather than adding one. Caller holds d.mu.
+func (d *Daemon) admitSessionLocked(sessionID string, cfg *config.Config) error {
+	if cfg == nil || d.sessions == nil {
+		return nil
+	}
+	incoming := cfg.DeviceCount()
+
+	active, devices := 0, 0
+	for id, sim := range d.sessions.sessions {
+		if id == sessionID {
+			// Replaced, not added.
+			continue
+		}
+		active++
+		if sim != nil && sim.cfg != nil {
+			devices += sim.cfg.DeviceCount()
+		}
+	}
+
+	if _, replacing := d.sessions.sessions[sessionID]; !replacing && active+1 > maxActiveSessions {
+		return fmt.Errorf("%w: %d sessions already running, limit is %d",
+			api.ErrSimulationSessionCapacity, active, maxActiveSessions)
+	}
+	if total := devices + incoming; total > api.MaxDeviceCount {
+		return fmt.Errorf(
+			"%w: %d devices already running plus %d requested exceeds the %d-device daemon limit",
+			api.ErrSimulationDeviceCapacity, devices, incoming, api.MaxDeviceCount)
+	}
+	return nil
+}
+
+// aggregateUsageLocked reports what the daemon is currently carrying, so an
+// operator can see how close to the budgets they are before a start is refused.
+// Caller holds d.mu.
+func (d *Daemon) aggregateUsageLocked() api.DaemonCapacity {
+	capacity := api.DaemonCapacity{
+		MaxSessions: maxActiveSessions,
+		MaxDevices:  api.MaxDeviceCount,
+	}
+	if d.sessions == nil {
+		return capacity
+	}
+	for _, sim := range d.sessions.sessions {
+		capacity.Sessions++
+		if sim != nil && sim.cfg != nil {
+			capacity.Devices += sim.cfg.DeviceCount()
+		}
+	}
+	return capacity
+}

--- a/internal/daemon/admission_test.go
+++ b/internal/daemon/admission_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+func configWithDevices(count int) *config.Config {
+	cfg := &config.Config{Devices: make([]config.Device, count)}
+	for index := range cfg.Devices {
+		cfg.Devices[index].Name = "device"
+	}
+	return cfg
+}
+
+func daemonWithSessions(t *testing.T, deviceCounts map[string]int) *Daemon {
+	t.Helper()
+	d := &Daemon{sessions: newSessionRegistry()}
+	for id, count := range deviceCounts {
+		d.sessions.sessions[id] = &Simulation{SessionID: id, cfg: configWithDevices(count)}
+	}
+	return d
+}
+
+func TestAdmissionSumsDevicesAcrossSessions(t *testing.T) {
+	// The absolute ceiling is a daemon budget. Checking it per config would let
+	// each session carry its own full allowance.
+	d := daemonWithSessions(t, map[string]int{"hospital": api.MaxDeviceCount - 10})
+
+	if err := d.admitSessionLocked("warehouse", configWithDevices(10)); err != nil {
+		t.Errorf("start that exactly fills the budget was refused: %v", err)
+	}
+	err := d.admitSessionLocked("warehouse", configWithDevices(11))
+	if !errors.Is(err, api.ErrSimulationDeviceCapacity) {
+		t.Errorf("error = %v, want ErrSimulationDeviceCapacity for a start that overruns the total", err)
+	}
+}
+
+func TestAdmissionExcludesTheSessionBeingReplaced(t *testing.T) {
+	// Restarting a session swaps it rather than adding one, so its own devices
+	// must not be counted against it.
+	d := daemonWithSessions(t, map[string]int{"hospital": api.MaxDeviceCount})
+
+	if err := d.admitSessionLocked("hospital", configWithDevices(api.MaxDeviceCount)); err != nil {
+		t.Errorf("replacing a session with the same size was refused: %v", err)
+	}
+	if err := d.admitSessionLocked("warehouse", configWithDevices(1)); !errors.Is(
+		err, api.ErrSimulationDeviceCapacity,
+	) {
+		t.Errorf("error = %v, want the budget to be full for a different session", err)
+	}
+}
+
+func TestAdmissionBoundsConcurrentSessionCount(t *testing.T) {
+	counts := make(map[string]int, maxActiveSessions)
+	for index := range maxActiveSessions {
+		counts[string(rune('a'+index))] = 1
+	}
+	d := daemonWithSessions(t, counts)
+
+	err := d.admitSessionLocked("one-too-many", configWithDevices(1))
+	if !errors.Is(err, api.ErrSimulationSessionCapacity) {
+		t.Errorf("error = %v, want ErrSimulationSessionCapacity", err)
+	}
+	// Replacing one of the existing sessions is still allowed at the cap.
+	if err = d.admitSessionLocked("a", configWithDevices(1)); err != nil {
+		t.Errorf("replacing an existing session at the cap was refused: %v", err)
+	}
+}
+
+func TestAggregateUsageReportsBudgets(t *testing.T) {
+	d := daemonWithSessions(t, map[string]int{"hospital": 75, "warehouse": 57})
+	usage := d.aggregateUsageLocked()
+
+	if usage.Sessions != 2 {
+		t.Errorf("sessions = %d, want 2", usage.Sessions)
+	}
+	if usage.Devices != 132 {
+		t.Errorf("devices = %d, want 132", usage.Devices)
+	}
+	if usage.MaxSessions != maxActiveSessions || usage.MaxDevices != api.MaxDeviceCount {
+		t.Errorf("budgets = %d/%d, want %d/%d",
+			usage.MaxSessions, usage.MaxDevices, maxActiveSessions, api.MaxDeviceCount)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -599,6 +599,12 @@ func (d *Daemon) StartSimulation(
 	if err != nil {
 		return err
 	}
+	// Per-config limits are already applied above. This is the daemon-wide
+	// budget: without it the device ceiling would apply once per session and
+	// so bound nothing.
+	if err = d.admitSessionLocked(sessionID, cfg); err != nil {
+		return err
+	}
 	compiledFabric, err := d.compileSimulationFabric(cfg, req)
 	if err != nil {
 		return err
@@ -1035,9 +1041,11 @@ func (d *Daemon) GetStatus() api.SimulationStatus {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
+	capacity := d.aggregateUsageLocked()
 	status := api.SimulationStatus{
 		Running:  d.simulation != nil,
 		Recovery: d.recovery,
+		Capacity: &capacity,
 	}
 	if d.sessions != nil {
 		ids := make([]string, 0, d.sessions.len())
@@ -1057,6 +1065,7 @@ func (d *Daemon) GetStatus() api.SimulationStatus {
 		selected := d.simulationStatusLocked(d.simulation, true)
 		selected.Sessions = status.Sessions
 		selected.Recovery = status.Recovery
+		selected.Capacity = status.Capacity
 		return selected
 	}
 

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -346,6 +346,18 @@ export interface SimulationStatus {
   degraded?: boolean;
   degradedReason?: string;
   capture?: TrunkCaptureHealth;
+  /** Daemon-wide, so present on the top-level status only — not per session. */
+  capacity?: DaemonCapacity;
+}
+
+/** Aggregate safety budgets for the whole daemon. These are technical capacity
+ * limits, not entitlements: a per-config check cannot bound them because
+ * several sessions run at once. */
+export interface DaemonCapacity {
+  sessions: number;
+  maxSessions: number;
+  devices: number;
+  maxDevices: number;
 }
 
 /** Per-reason trunk drop counts. Stray tags on a shared trunk are ordinary; a


### PR DESCRIPTION
## Summary

Closes program ledger item **M1-7** (enforce aggregate session, device, scheduled-action and queue admission budgets; expose telemetry).

`ValidateConfigEntitlements` checks `cfg.DeviceCount() > MaxDeviceCount` against **each config as it starts**. With a single simulation that was equivalent to a daemon limit. With concurrent sessions it is not: every session gets its own full allowance, so the documented 1000-device ceiling permitted 1000 devices *per session*. The limit bounded nothing.

Admission is now daemon-wide:

- sums devices already running and refuses a start that would take the total past `MaxDeviceCount`
- bounds concurrent sessions at 16 — each owns a protocol stack, goroutines and a 16384-frame ingress queue, so the count is itself a resource
- excludes the session being replaced from its own budget, because a restart swaps a session rather than adding one
- reports current usage against both budgets in status, so an operator can see how close a start is to refusal before it happens

Both limits are **technical capacity, never entitlement**. They sit beside the license check rather than inside it, so they survive Milestone 2's removal of runtime licensing unchanged — the program doc calls for exactly this ("replace `FreeTierDeviceCount` with aggregate resource validation plus the existing absolute safety ceiling").

New errors map to `409 Conflict` (`session_capacity_reached`, `device_capacity_reached`) rather than a generic failure, so a UI can say which budget was hit.

## Linked Issue

Related to #882

## Testing Evidence

```
go test ./...                       green
go test -race ./internal/daemon/    green (38s)
go test -race ./internal/api/       green (52s)
golangci-lint run (v2.12.2)         0 issues
gofmt -l internal/ cmd/             clean
vitest                              79 files, 385 tests passed
biome check .                       406 files clean
tsgo --build --noEmit               clean
make schema                         NO DRIFT
```

Four new tests, each pinning a behaviour that the per-config check got wrong:

- devices sum across sessions: a start that exactly fills the budget is admitted, one device more is refused
- a session being replaced is excluded from its own budget — restarting a max-size session succeeds, while a *different* session of one device is refused
- the concurrent-session cap refuses a new session but still permits replacing an existing one at the cap
- usage reports both current values and both budgets

## Security and Release Checklist

- This **is** the security fix: the previous per-config check allowed unbounded aggregate resource consumption by starting repeated sessions, each individually "within limits". Now bounded in aggregate.
- Fail-closed: admission refuses before any resource is allocated (checked before fabric compile and before the stack starts).
- No new routes. No CSRF/scope surface change.
- No entitlement semantics added — capacity errors are 409, not 402, and carry no upgrade hint.
- No secrets, no default credentials, no phone-home.

Release: no version bump; release-please owns tagging.
