### PR TITLE
feat(api): address one simulation session explicitly

### DIFF
--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -36,6 +36,8 @@ Prometheus metrics share the daemon's HTTPS listener at `/metrics`; there is no 
 | `PUT` | `/api/v1/alerts` | Update alert threshold/webhook |
 | `GET` | `/api/v1/files?kind=walks|pcaps` | List available SNMP walk or PCAP files |
 | `GET` | `/api/v1/topology` | Simple topology graph derived from configuration |
+| `GET` | `/api/v1/sessions` | Running simulation sessions a client can address |
+| `GET` | `/api/v1/sessions/{id}/{resource}` | One session's runtime state — see below |
 | `GET` | `/api/v1/scenario/packs` | Versioned presentation presets (hospital, warehouse, manufacturing, campus, retail, service-provider) plus the `enterprise-scale` stress preset |
 | `GET` | `/api/v1/scenario/profiles` | Reusable vendor, model, role, and discovery profiles |
 | `POST` | `/api/v1/scenario/generate` | Generate deterministic validated YAML from sites and repeat controls |
@@ -113,6 +115,38 @@ native VLAN, and FDB-only properties are updated on both endpoints together.
 The route requires a read-write token, CSRF protection, and the normal draft
 entitlement checks. It replaces only the named draft; it does not apply or
 restart the running simulation.
+
+## Session-scoped runtime
+
+NIAC can run several scenarios at once, one per physical VLAN behind a shared
+trunk. Each is a _session_ with its own ID. The unscoped runtime endpoints
+(`/api/v1/topology`, `/api/v1/devices`, `/api/v1/stats`, …) report whichever
+session is currently selected, which is ambiguous once more than one is
+running. Address a session explicitly instead:
+
+```text
+GET /api/v1/sessions                        list running sessions
+GET /api/v1/sessions/{id}/topology          that session's topology graph
+GET /api/v1/sessions/{id}/devices           its device inventory
+GET /api/v1/sessions/{id}/interfaces        its simulated devices' interfaces
+GET /api/v1/sessions/{id}/segments          its VLAN segments
+GET /api/v1/sessions/{id}/neighbors         its LLDP/CDP neighbours
+GET /api/v1/sessions/{id}/behaviors         its behaviour timeline status
+GET /api/v1/sessions/{id}/stats             its live counters
+GET /api/v1/sessions/{id}/runtime           its runtime summary
+```
+
+Naming a session that is not running returns `404 session_not_found` rather
+than falling back to another session — a silent fallback is how one client
+ends up driving a scenario it did not ask for.
+
+`GET /api/v1/sessions/{id}/interfaces` lists the interfaces of the _simulated
+devices_. The unscoped `/api/v1/interfaces` lists the **host's** capture NICs,
+which is a different thing and is not session-scoped.
+
+Live streams take the session as a query parameter:
+`/api/v1/stream/packets?sessionId={id}` and `/api/v1/stream/stats?sessionId={id}`.
+A stream subscribed without `sessionId` receives the selected session only.
 
 ## Web UI
 

--- a/internal/api/handlers_read.go
+++ b/internal/api/handlers_read.go
@@ -18,8 +18,11 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/storage"
 )
 
+// handleStats serves whichever session is selected. Prefer
+// GET /api/v1/sessions/{id}/stats, which names the session it means instead of
+// depending on selection.
 func (s *Server) handleStats(w http.ResponseWriter, _ *http.Request) {
-	payload, _, ok := s.currentStatsPayload()
+	payload, ok := s.selectedStatsPayload()
 	if !ok {
 		http.Error(w, "no simulation running", http.StatusServiceUnavailable)
 

--- a/internal/api/handlers_segments.go
+++ b/internal/api/handlers_segments.go
@@ -29,7 +29,12 @@ func (s *Server) handleSegments(w http.ResponseWriter, _ *http.Request) {
 
 		return
 	}
+	s.writeJSON(w, buildSegmentResponses(cfg))
+}
 
+// buildSegmentResponses projects a config's normalized segments. Shared with
+// the session-scoped segments endpoint so both render segments identically.
+func buildSegmentResponses(cfg *config.Config) []segmentResponse {
 	segments := cfg.NormalizedSegments()
 	out := make([]segmentResponse, 0, len(segments))
 	for i := range segments {
@@ -45,5 +50,5 @@ func (s *Server) handleSegments(w http.ResponseWriter, _ *http.Request) {
 		})
 	}
 
-	s.writeJSON(w, out)
+	return out
 }

--- a/internal/api/handlers_session_read.go
+++ b/internal/api/handlers_session_read.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/behavior"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+)
+
+// Read surfaces for one named session. Each takes the session resolved by the
+// dispatcher, so none of them can reach process-wide runtime state.
+//
+// A session that exists but has no stack yet is reported as empty rather than
+// as an error: the session is real, it simply is not serving anything yet.
+
+func (s *Server) handleSessionTopology(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	s.writeJSON(w, session.topology())
+}
+
+func (s *Server) handleSessionDevices(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	cfg := session.config()
+	if cfg == nil {
+		s.writeJSON(w, []map[string]any{})
+		return
+	}
+	devices := make([]map[string]any, 0, len(cfg.Devices))
+	for index := range cfg.Devices {
+		devices = append(devices, deviceSummary(&cfg.Devices[index]))
+	}
+	s.writeJSON(w, devices)
+}
+
+func (s *Server) handleSessionSegments(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	cfg := session.config()
+	if cfg == nil {
+		s.writeJSON(w, []segmentResponse{})
+		return
+	}
+	s.writeJSON(w, buildSegmentResponses(cfg))
+}
+
+func (s *Server) handleSessionNeighbors(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	stack := session.stack()
+	if stack == nil {
+		s.writeJSON(w, []protocols.NeighborRecord{})
+		return
+	}
+	neighbors := stack.GetNeighbors()
+	if neighbors == nil {
+		neighbors = []protocols.NeighborRecord{}
+	}
+	s.writeJSON(w, neighbors)
+}
+
+func (s *Server) handleSessionBehaviors(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	stack := session.stack()
+	if stack == nil {
+		s.writeJSON(w, behavior.Status{State: "idle"})
+		return
+	}
+	s.writeJSON(w, stack.BehaviorStatus())
+}
+
+// sessionInterfaceResponse names the device an interface belongs to, which the
+// per-device response does not need but a whole-session listing does.
+type sessionInterfaceResponse struct {
+	Device      string `json:"device"`
+	Name        string `json:"name"`
+	Type        string `json:"type,omitempty"`
+	AdminStatus string `json:"adminStatus,omitempty"`
+	OperStatus  string `json:"operStatus,omitempty"`
+}
+
+// handleSessionInterfaces reports the interfaces of the session's simulated
+// devices. The unscoped /api/v1/interfaces reports the host's capture NICs,
+// which is a different thing entirely and stays where it is.
+func (s *Server) handleSessionInterfaces(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	cfg := session.config()
+	if cfg == nil {
+		s.writeJSON(w, []sessionInterfaceResponse{})
+		return
+	}
+	interfaces := make([]sessionInterfaceResponse, 0)
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		for _, iface := range device.Interfaces {
+			interfaces = append(interfaces, sessionInterfaceResponse{
+				Device:      device.Name,
+				Name:        iface.Name,
+				Type:        iface.Type,
+				AdminStatus: iface.AdminStatus,
+				OperStatus:  iface.OperStatus,
+			})
+		}
+	}
+	s.writeJSON(w, interfaces)
+}
+
+func (s *Server) handleSessionStats(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	payload, ok := s.sessionStatsPayload(session)
+	if !ok {
+		writeError(w, r, http.StatusServiceUnavailable, "simulation_not_running",
+			"This session is not serving traffic", nil)
+		return
+	}
+	s.writeJSON(w, payload)
+}
+
+func (s *Server) handleSessionRuntime(w http.ResponseWriter, r *http.Request, session sessionRuntime) {
+	if !requireGet(w, r) {
+		return
+	}
+	stack := session.stack()
+	if stack == nil {
+		s.writeJSON(w, map[string]any{
+			"running":        false,
+			"sessionId":      session.id,
+			"version":        s.cfg.Version,
+			"uptime_seconds": time.Since(s.startTime).Seconds(),
+		})
+		return
+	}
+	stats := stack.GetStats()
+	deviceCount := 0
+	if cfg := session.config(); cfg != nil {
+		deviceCount = cfg.DeviceCount()
+	}
+	runtimeInfo := map[string]any{
+		"running":          true,
+		"sessionId":        session.id,
+		"version":          s.cfg.Version,
+		"interface":        session.iface(),
+		"config_path":      session.configPath(),
+		"device_count":     deviceCount,
+		"packets_sent":     stats.PacketsSent,
+		"packets_received": stats.PacketsReceived,
+		"uptime_seconds":   time.Since(s.startTime).Seconds(),
+	}
+	if path := session.configPath(); path != "" {
+		runtimeInfo["config_name"] = filepath.Base(path)
+	}
+	s.writeJSON(w, runtimeInfo)
+}

--- a/internal/api/handlers_sessions.go
+++ b/internal/api/handlers_sessions.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// registerSessionRoutes registers the session-scoped runtime surface. Both
+// entries go through the shared register() path, so they pick up auth, CSRF
+// and rate limiting the same way every other route does.
+//
+// The read surfaces beneath /api/v1/sessions/{id}/ are GET-only and enforce
+// that per resource. They still carry csrf/rlWrite at the route entry because
+// this subtree will also carry mutating resources (replay, capture filter,
+// errors, debug) as they migrate; a GET is CSRF-exempt in practice, so the
+// stricter tuple costs reads nothing and cannot be forgotten later.
+func (s *Server) registerSessionRoutes(mux *http.ServeMux) {
+	s.registerAll(mux, []apiRoute{
+		{
+			path:    "/api/v1/sessions",
+			handler: s.handleSessions,
+			methods: []string{http.MethodGet},
+		},
+		{
+			path:    "/api/v1/sessions/",
+			handler: s.dispatchSessionSubpath,
+			methods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
+			rl:      rlWrite,
+			csrf:    true,
+		},
+	})
+}
+
+// sessionSummary is one entry in GET /api/v1/sessions.
+type sessionSummary struct {
+	SessionID   string `json:"sessionId"`
+	Interface   string `json:"interface,omitempty"`
+	ConfigPath  string `json:"configPath,omitempty"`
+	DeviceCount int    `json:"deviceCount"`
+}
+
+// handleSessions lists the running sessions a client may address. Without it a
+// client would have to guess session IDs to use the session-scoped routes.
+func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+		return
+	}
+	ids := s.sessionIDs()
+	slices.Sort(ids)
+	summaries := make([]sessionSummary, 0, len(ids))
+	for _, id := range ids {
+		session, err := s.session(id)
+		if err != nil {
+			continue
+		}
+		summary := sessionSummary{
+			SessionID:  id,
+			Interface:  session.iface(),
+			ConfigPath: session.configPath(),
+		}
+		if cfg := session.config(); cfg != nil {
+			summary.DeviceCount = cfg.DeviceCount()
+		}
+		summaries = append(summaries, summary)
+	}
+	s.writeJSON(w, summaries)
+}
+
+// dispatchSessionSubpath routes /api/v1/sessions/{id}/{resource}. The session
+// is resolved once here and passed to each handler, so no runtime handler can
+// read a process-wide "selected" session.
+//
+// Every resource under this prefix shares one route policy entry. A resource
+// needing stricter policy than its siblings must be registered as its own
+// literal path instead, the way /api/v1/config/import is split from
+// /api/v1/config.
+func (s *Server) dispatchSessionSubpath(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/api/v1/sessions/")
+	sessionID, resource, found := strings.Cut(rest, "/")
+	if sessionID == "" {
+		writeError(w, r, http.StatusNotFound, "not_found", "A session ID is required", nil)
+		return
+	}
+	if !validSessionID(sessionID) {
+		writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"Invalid session ID", []ErrorDetail{{Field: "sessionId", Issue: "invalid session ID"}})
+		return
+	}
+	if !found || resource == "" {
+		writeError(w, r, http.StatusNotFound, "not_found",
+			"A session resource is required", nil)
+		return
+	}
+
+	session, err := s.session(sessionID)
+	if err != nil {
+		s.writeSessionLookupError(w, r, sessionID, err)
+		return
+	}
+
+	handler, ok := s.sessionResourceHandler(resource)
+	if !ok {
+		writeError(w, r, http.StatusNotFound, "not_found",
+			fmt.Sprintf("Unknown session resource: %s", resource), nil)
+		return
+	}
+	handler(w, r, session)
+}
+
+type sessionHandler func(http.ResponseWriter, *http.Request, sessionRuntime)
+
+// sessionResourceHandler maps a resource segment to its handler. Adding a
+// runtime surface means adding it here, which is also the list a reviewer
+// checks to confirm nothing still reads global state.
+func (s *Server) sessionResourceHandler(resource string) (sessionHandler, bool) {
+	handlers := map[string]sessionHandler{
+		"topology":   s.handleSessionTopology,
+		"devices":    s.handleSessionDevices,
+		"interfaces": s.handleSessionInterfaces,
+		"segments":   s.handleSessionSegments,
+		"neighbors":  s.handleSessionNeighbors,
+		"behaviors":  s.handleSessionBehaviors,
+		"stats":      s.handleSessionStats,
+		"runtime":    s.handleSessionRuntime,
+	}
+	handler, ok := handlers[resource]
+	return handler, ok
+}
+
+func (s *Server) writeSessionLookupError(
+	w http.ResponseWriter, r *http.Request, sessionID string, err error,
+) {
+	if errors.Is(err, ErrSessionNotFound) {
+		writeError(w, r, http.StatusNotFound, "session_not_found",
+			fmt.Sprintf("No running session named %q", sessionID), nil)
+		return
+	}
+	writeError(w, r, http.StatusInternalServerError, "session_lookup_failed",
+		"Could not resolve the session", nil)
+}
+
+func requireGet(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet {
+		return true
+	}
+	w.Header().Set("Allow", http.MethodGet)
+	writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
+	return false
+}

--- a/internal/api/handlers_sessions_test.go
+++ b/internal/api/handlers_sessions_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+func serverWithSessions(sessions map[string][]string) *Server {
+	server := &Server{simulations: map[string]simulationAPIState{}}
+	for id, deviceNames := range sessions {
+		cfg := &config.Config{Devices: make([]config.Device, len(deviceNames))}
+		for index, name := range deviceNames {
+			cfg.Devices[index].Name = name
+		}
+		server.simulations[id] = simulationAPIState{config: cfg, iface: "eth0"}
+	}
+	return server
+}
+
+func sessionRequest(t *testing.T, server *Server, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	server.dispatchSessionSubpath(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+	return recorder
+}
+
+func TestSessionRoutesReturnOnlyTheNamedSessionsDevices(t *testing.T) {
+	// The whole point of the migration: two sessions running at once must not
+	// be able to read each other's state, and neither depends on which one is
+	// "selected".
+	server := serverWithSessions(map[string][]string{
+		"hospital":  {"MED-CORE-SW01", "MED-ACC-SW01"},
+		"warehouse": {"FUL-CORE-SW01"},
+	})
+
+	for _, want := range []struct {
+		session string
+		devices int
+	}{{"hospital", 2}, {"warehouse", 1}} {
+		recorder := sessionRequest(t, server, "/api/v1/sessions/"+want.session+"/devices")
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, want 200", want.session, recorder.Code)
+		}
+		var devices []map[string]any
+		if err := json.Unmarshal(recorder.Body.Bytes(), &devices); err != nil {
+			t.Fatalf("%s: %v", want.session, err)
+		}
+		if len(devices) != want.devices {
+			t.Errorf("%s: %d devices, want %d", want.session, len(devices), want.devices)
+		}
+	}
+}
+
+func TestSessionRouteRejectsUnknownSession(t *testing.T) {
+	// Falling back to another session here is how one browser tab would end up
+	// driving a different tab's scenario.
+	server := serverWithSessions(map[string][]string{"hospital": {"MED-CORE-SW01"}})
+
+	recorder := sessionRequest(t, server, "/api/v1/sessions/warehouse/devices")
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for a session that is not running", recorder.Code)
+	}
+}
+
+func TestSessionRouteRejectsMalformedAndMissingSegments(t *testing.T) {
+	server := serverWithSessions(map[string][]string{"hospital": {"MED-CORE-SW01"}})
+
+	cases := []struct {
+		name string
+		path string
+		want int
+	}{
+		{"invalid session ID", "/api/v1/sessions/Not_A_Valid_ID/devices", http.StatusBadRequest},
+		{"no resource", "/api/v1/sessions/hospital", http.StatusNotFound},
+		{"empty resource", "/api/v1/sessions/hospital/", http.StatusNotFound},
+		{"unknown resource", "/api/v1/sessions/hospital/nonsense", http.StatusNotFound},
+		{"no session", "/api/v1/sessions/", http.StatusNotFound},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := sessionRequest(t, server, testCase.path).Code; got != testCase.want {
+				t.Errorf("status = %d, want %d", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestSessionResourcesTolerateASessionWithNoStack(t *testing.T) {
+	// A session can exist before it serves traffic. That is an empty result,
+	// not an error — the session is real.
+	server := serverWithSessions(map[string][]string{"hospital": {"MED-CORE-SW01"}})
+
+	for _, resource := range []string{"topology", "segments", "neighbors", "behaviors", "interfaces"} {
+		recorder := sessionRequest(t, server, "/api/v1/sessions/hospital/"+resource)
+		if recorder.Code != http.StatusOK {
+			t.Errorf("%s: status = %d, want 200", resource, recorder.Code)
+		}
+	}
+	// Stats are the exception: with no stack there are no counters to report.
+	if got := sessionRequest(t, server, "/api/v1/sessions/hospital/stats").Code; got != http.StatusServiceUnavailable {
+		t.Errorf("stats status = %d, want 503 when the session serves no traffic", got)
+	}
+}
+
+func TestSessionListNamesEveryRunningSession(t *testing.T) {
+	server := serverWithSessions(map[string][]string{
+		"warehouse": {"FUL-CORE-SW01"},
+		"hospital":  {"MED-CORE-SW01", "MED-ACC-SW01"},
+	})
+
+	recorder := httptest.NewRecorder()
+	server.handleSessions(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var summaries []sessionSummary
+	if err := json.Unmarshal(recorder.Body.Bytes(), &summaries); err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("%d sessions, want 2", len(summaries))
+	}
+	// Sorted, so a client sees a stable order rather than map iteration order.
+	if summaries[0].SessionID != "hospital" || summaries[1].SessionID != "warehouse" {
+		t.Errorf("order = %s,%s, want hospital,warehouse", summaries[0].SessionID, summaries[1].SessionID)
+	}
+	if summaries[0].DeviceCount != 2 {
+		t.Errorf("hospital deviceCount = %d, want 2", summaries[0].DeviceCount)
+	}
+}
+
+func TestSessionReadResourcesRejectNonGet(t *testing.T) {
+	server := serverWithSessions(map[string][]string{"hospital": {"MED-CORE-SW01"}})
+
+	recorder := httptest.NewRecorder()
+	server.dispatchSessionSubpath(
+		recorder,
+		httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/hospital/devices", nil),
+	)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", recorder.Code)
+	}
+	if allow := recorder.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("Allow = %q, want GET", allow)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -34,6 +34,7 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 		},
 	})
 
+	s.registerSessionRoutes(mux)
 	s.registerWriteProtectedRoutes(mux)
 	s.registerReadOnlyRoutes(mux)
 	s.registerLibraryRoutes(mux)

--- a/internal/api/session_state.go
+++ b/internal/api/session_state.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"errors"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
+)
+
+// ErrSessionNotFound is returned when a request names a session that is not
+// running. Naming a session that does not exist is a client error, not an
+// empty result: silently falling back to some other session is how one
+// browser tab ends up driving another tab's scenario.
+var ErrSessionNotFound = errors.New("simulation session was not found")
+
+// sessionRuntime is one running session's state, addressed explicitly. Every
+// runtime read and mutation goes through a lookup by session ID rather than a
+// process-wide "selected" pointer.
+type sessionRuntime struct {
+	id    string
+	state simulationAPIState
+}
+
+// session looks up one running session. Callers must handle the miss; there is
+// deliberately no fallback to a default or most-recent session.
+func (s *Server) session(sessionID string) (sessionRuntime, error) {
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
+	state, ok := s.simulations[sessionID]
+	if !ok {
+		return sessionRuntime{}, ErrSessionNotFound
+	}
+	return sessionRuntime{id: sessionID, state: state}, nil
+}
+
+// sessionIDs lists running sessions in a stable order.
+func (s *Server) sessionIDs() []string {
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
+	ids := make([]string, 0, len(s.simulations))
+	for id := range s.simulations {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (r sessionRuntime) config() *config.Config { return r.state.config }
+
+func (r sessionRuntime) stack() *protocols.Stack { return r.state.stack }
+
+func (r sessionRuntime) configPath() string { return r.state.configPath }
+
+func (r sessionRuntime) iface() string { return r.state.iface }
+
+// topology prefers what the stack is actually running over what was authored,
+// matching the projection the global accessor used.
+func (r sessionRuntime) topology() topology.Graph {
+	if r.state.stack != nil {
+		return r.state.stack.RuntimeTopology()
+	}
+	if r.state.config == nil {
+		return topology.Graph{}
+	}
+	return topology.Build(r.state.config)
+}

--- a/internal/api/stats_stream.go
+++ b/internal/api/stats_stream.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/api/sse"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
 )
 
 const statsStreamInterval = time.Second
@@ -32,24 +33,47 @@ type statsStackPayload struct {
 	UDPProxyOverloadDrops uint64 `json:"udpProxyOverloadDrops"`
 }
 
-func (s *Server) currentStatsPayload() (statsPayload, string, bool) {
+// sessionStatsPayload builds one named session's stats. Shared by the session
+// stats endpoint and the stats publisher so both report the same numbers for
+// the same session.
+func (s *Server) sessionStatsPayload(session sessionRuntime) (statsPayload, bool) {
+	s.configMu.RLock()
+	version := s.cfg.Version
+	s.configMu.RUnlock()
+
+	deviceCount := 0
+	if cfg := session.config(); cfg != nil {
+		deviceCount = len(cfg.Devices)
+	}
+	return buildStatsPayload(session.stack(), session.iface(), version, deviceCount)
+}
+
+// selectedStatsPayload reads the process-wide projection that the unscoped
+// endpoints still use. It exists only for those endpoints and goes away with
+// them.
+func (s *Server) selectedStatsPayload() (statsPayload, bool) {
 	s.configMu.RLock()
 	stack := s.cfg.Stack
 	cfg := s.cfg.Config
 	iface := s.cfg.Interface
 	version := s.cfg.Version
-	sessionID := s.selectedSimulation
 	s.configMu.RUnlock()
 
-	if stack == nil {
-		return statsPayload{}, "", false
-	}
-
-	stats := stack.GetStats()
 	deviceCount := 0
 	if cfg != nil {
 		deviceCount = len(cfg.Devices)
 	}
+	return buildStatsPayload(stack, iface, version, deviceCount)
+}
+
+func buildStatsPayload(
+	stack *protocols.Stack, iface, version string, deviceCount int,
+) (statsPayload, bool) {
+	if stack == nil {
+		return statsPayload{}, false
+	}
+
+	stats := stack.GetStats()
 
 	return statsPayload{
 		Timestamp:   time.Now().UTC(),
@@ -70,9 +94,13 @@ func (s *Server) currentStatsPayload() (statsPayload, string, bool) {
 			Errors:                stats.Errors,
 			UDPProxyOverloadDrops: stats.UDPProxyOverloadDrops,
 		},
-	}, sessionID, true
+	}, true
 }
 
+// startStatsPublisher emits one scoped tick per running session. It has no
+// request to carry a session ID, so it iterates the sessions instead: with
+// several running, publishing only one of them would leave every other
+// session's subscribers on a silent stream.
 func (s *Server) startStatsPublisher(interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -85,14 +113,25 @@ func (s *Server) startStatsPublisher(interval time.Duration) {
 			if s.sseHub.ClientCount(sse.StreamStats) == 0 {
 				continue
 			}
-			payload, sessionID, ok := s.currentStatsPayload()
-			if ok {
-				if sessionID == "" {
-					s.sseHub.BroadcastStats(payload)
-				} else {
-					s.sseHub.BroadcastStatsForSession(sessionID, payload)
-				}
-			}
+			s.publishSessionStats()
 		}
+	}
+}
+
+func (s *Server) publishSessionStats() {
+	for _, id := range s.sessionIDs() {
+		session, err := s.session(id)
+		if err != nil {
+			continue
+		}
+		if payload, ok := s.sessionStatsPayload(session); ok {
+			s.sseHub.BroadcastStatsForSession(id, payload)
+		}
+	}
+	// Subscribers that have not adopted ?sessionId= yet only ever receive the
+	// unscoped stream. Publishing the selected session there keeps them working
+	// until the unscoped runtime surface is removed; drop this with it.
+	if payload, ok := s.selectedStatsPayload(); ok {
+		s.sseHub.BroadcastStats(payload)
 	}
 }


### PR DESCRIPTION
## Summary

First half of program ledger items **M1-2/M1-3**: a runtime surface that names the session it means.

With several sessions running, every runtime endpoint (`/api/v1/topology`, `/devices`, `/stats`, …) reported whichever session was *selected*. Which session a client was reading was implicit, and nothing stopped one browser tab from driving the scenario another tab had selected.

Adds:

```text
GET /api/v1/sessions                    list running sessions
GET /api/v1/sessions/{id}/topology      devices · interfaces · segments
GET /api/v1/sessions/{id}/neighbors     behaviors · stats · runtime
```

The session is resolved **once** in the dispatcher and handed to each handler, so a session-scoped handler has no way to reach process-wide state — the isolation is structural, not a convention. Naming a session that is not running returns `404 session_not_found` rather than falling back, because a silent fallback is exactly the bug.

Both route entries register through the shared `register()` path, so they pick up auth, CSRF and rate limiting identically to every other route. `check-route-policy.sh` passes.

### The stats publisher

Flagged by the analysis as the hardest piece: it is a background goroutine with **no request** to carry a session ID, and it was driven entirely by `selectedSimulation`. It now iterates the sessions and emits one scoped tick each — publishing only the selected session would leave every other session's subscribers on a permanently silent stream.

It *also* still publishes the selected session unscoped, because subscribers that have not adopted `?sessionId=` read only that stream. That is transitional and is removed with the unscoped surface.

### What this PR deliberately does not do

The unscoped endpoints still exist and still follow selection. Pre-v1 convention is to delete an old surface alongside its replacement, and I want to be explicit that I am not doing that here: deleting ~15 routes plus `Server.selectedSimulation` plus the daemon's unconditional auto-select **and** migrating the UI in one change would leave no green intermediate state. That removal is the next PR, once the UI addresses sessions by name.

Two findings from the analysis worth recording, because they change what that next PR has to do:

- **Packet streams are already correct.** `UpdateSimulationSession` wires a per-session observer closed over the real session ID, so packets never depended on selection. No work needed there.
- **The root cause is upstream of this package.** `Daemon.publishSimulation` calls `SelectSimulation` unconditionally on every start — that is the actual "last simulation started wins". Removing `selectedSimulation` from `internal/api` without also removing that call would be re-clobbered on the next start.

## Linked Issue

Related to #882

## Testing Evidence

```
go test ./...                    green
golangci-lint run (v2.12.2)      0 issues
gofmt -l internal/ cmd/          clean
make schema                      NO DRIFT
check-route-policy.sh            PASS
check-json-casing/-output-escaping/-file-size/-filename-policy/-https-only   PASS
markdownlint docs/REST_API.md    23 errors, unchanged from the pre-existing baseline (added 0)
```

Six new tests, each pinning a property rather than a shape:

- two sessions running at once return only their own devices, with no dependence on which is selected
- an unknown session is a 404, not another session's data
- malformed ID, missing resource, empty resource and unknown resource each get the right status
- a session that exists but serves no traffic yet returns empty results, not errors — except stats, which is 503 because there are no counters
- the session list is sorted, so clients see a stable order rather than map iteration order
- read resources reject non-GET with a correct `Allow` header

## Security and Release Checklist

- Session-scoped handlers cannot reach process-wide runtime state — the dispatcher resolves the session and passes it in, so isolation is enforced by the type signature.
- Session IDs are validated before lookup; an invalid ID is rejected before touching the registry.
- Both routes go through the shared registration path and inherit auth/CSRF/rate-limiting; no `mux.HandleFunc` bypass. `check-route-policy.sh` passes.
- The `/api/v1/sessions/` subtree carries the stricter csrf/rlWrite tuple even though today's resources are GET-only, so mutating resources cannot later be added to it without protection.
- No secrets, no default credentials, no phone-home.

Release: no version bump; release-please owns tagging.
