### PR TITLE
fix(daemon,ui): read runtime state from a named session

### DIFF
--- a/internal/daemon/concurrent_sessions_test.go
+++ b/internal/daemon/concurrent_sessions_test.go
@@ -34,7 +34,10 @@ func TestDaemonRunsDistinctTrunkSessionsConcurrently(t *testing.T) {
 		t.Fatalf("concurrent sessions share config path %q", d.sessions.get("hospital").ConfigPath)
 	}
 	status := d.GetStatus()
-	if status.SessionID != "warehouse" || len(status.Sessions) != 2 {
+	// Starting warehouse must not take the default away from hospital.
+	// Adopting every new session repointed anyone reading the unscoped
+	// surface away from the scenario they were already watching.
+	if status.SessionID != "hospital" || len(status.Sessions) != 2 {
 		t.Fatalf("GetStatus() session = %q, sessions = %#v", status.SessionID, status.Sessions)
 	}
 	if status.Sessions[0].SessionID != "hospital" || status.Sessions[0].PhysicalVLAN != 200 ||
@@ -115,5 +118,52 @@ func trunkSessionRequest(sessionID string, vlan uint16) api.SimulationRequest {
 		AttachmentMode: fabric.ModeTrunk,
 		AccessVLAN:     vlan,
 		ConfigData:     "devices:\n  - name: demo-device\n    type: host\n    mac: 02:00:00:00:00:01\n",
+	}
+}
+
+func TestStartingASessionDoesNotStealTheDefaultFromAnother(t *testing.T) {
+	// Whoever reads the unscoped surface picked their scenario. Launching a
+	// different one must not silently move them onto it — that is what made
+	// "start the warehouse demo" change what the hospital demo was showing.
+	t.Setenv(e2eDryRunEnv, "true")
+	t.Setenv("NIAC_CONFIGS_DIR", t.TempDir())
+	d, err := NewDaemon(Config{AttachmentPolicies: []fabric.PhysicalAttachmentPolicy{{
+		Interface: "eth0", Mode: fabric.ModeTrunk, AllowedVLANs: []uint16{200, 201},
+	}}})
+	if err != nil {
+		t.Fatalf("NewDaemon(): %v", err)
+	}
+	for _, session := range []struct {
+		id   string
+		vlan uint16
+	}{{"hospital", 200}, {"warehouse", 201}} {
+		if err = d.StartSimulation(
+			trunkSessionRequest(session.id, session.vlan), fullSimulationEntitlements(),
+		); err != nil {
+			t.Fatalf("StartSimulation(%s): %v", session.id, err)
+		}
+	}
+
+	if got := d.GetStatus().SessionID; got != "hospital" {
+		t.Fatalf("default session = %q, want hospital to keep it", got)
+	}
+
+	// Restarting the session that holds the default keeps it, rather than
+	// leaving the daemon with no default at all.
+	if err = d.StartSimulation(
+		trunkSessionRequest("hospital", 200), fullSimulationEntitlements(),
+	); err != nil {
+		t.Fatalf("StartSimulation(hospital) restart: %v", err)
+	}
+	if got := d.GetStatus().SessionID; got != "hospital" {
+		t.Errorf("after restart default session = %q, want hospital", got)
+	}
+
+	// Selecting explicitly is still honoured — this is a default, not a lock.
+	if err = d.SelectSimulation("warehouse"); err != nil {
+		t.Fatal(err)
+	}
+	if got := d.GetStatus().SessionID; got != "warehouse" {
+		t.Errorf("after explicit select = %q, want warehouse", got)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -631,8 +631,15 @@ func (d *Daemon) StartSimulation(
 	}
 
 	active = d.sessions.replace(sessionID, replacement)
-	d.simulation = replacement
-	d.publishSimulation(replacement)
+	// Adopt the new session as the default for unscoped readers only when
+	// nothing else holds that spot, or when this start replaces the session
+	// already in it. Adopting unconditionally meant launching a second
+	// scenario silently repointed everyone watching the first.
+	adopt := d.simulation == nil || d.simulation.SessionID == sessionID
+	if adopt {
+		d.simulation = replacement
+	}
+	d.publishSimulation(replacement, adopt)
 	if active != nil {
 		d.stopSimulation(active)
 	}
@@ -983,7 +990,10 @@ func (d *Daemon) stopSimulationLocked(clearIntent bool) error {
 	return nil
 }
 
-func (d *Daemon) publishSimulation(sim *Simulation) {
+// publishSimulation makes a session readable through the API. adopt also makes
+// it the default the unscoped surface reports; clients that name their session
+// are unaffected either way.
+func (d *Daemon) publishSimulation(sim *Simulation, adopt bool) {
 	if d.apiServer == nil || sim == nil {
 		return
 	}
@@ -995,7 +1005,9 @@ func (d *Daemon) publishSimulation(sim *Simulation) {
 		sim.Interface,
 		sim.replay,
 	)
-	d.apiServer.SelectSimulation(sim.SessionID)
+	if adopt {
+		d.apiServer.SelectSimulation(sim.SessionID)
+	}
 }
 
 // SelectSimulation makes one running session the target of runtime API surfaces.

--- a/ui/src/api/api-response-types.ts
+++ b/ui/src/api/api-response-types.ts
@@ -350,6 +350,14 @@ export interface SimulationStatus {
   capacity?: DaemonCapacity;
 }
 
+/** One running simulation session a client can address by name. */
+export interface SessionSummary {
+  sessionId: string;
+  interface?: string;
+  configPath?: string;
+  deviceCount: number;
+}
+
 /** Aggregate safety budgets for the whole daemon. These are technical capacity
  * limits, not entitlements: a per-config check cannot bound them because
  * several sessions run at once. */

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -95,7 +95,7 @@ describe('API Client', () => {
       });
 
       const { fetchDevices } = await import('./client');
-      const result = await fetchDevices();
+      const result = await fetchDevices('hospital');
       expect(result).toHaveLength(2);
     });
   });

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -33,6 +33,7 @@ import type {
   ReplayState,
   RuntimeStatus,
   SegmentSummary,
+  SessionSummary,
   SimulationPreflightReport,
   SimulationPreflightRequest,
   SimulationRequest,
@@ -67,14 +68,26 @@ import type {
 // Stats, devices, history, neighbors, config
 // =====================================================================
 
-export const fetchStats = () => deduplicatedGet<StackStatsResponse>('/api/v1/stats');
-export const fetchDevices = () => deduplicatedGet<DeviceSummary[]>('/api/v1/devices');
-// ADR 0008: multi-VLAN segments grouping the same devices /api/v1/devices
+// Runtime reads name the session they mean. NIAC can run several scenarios at
+// once, so "the current simulation" is ambiguous: without a session ID the
+// answer depends on which scenario happens to be selected, and two tabs looking
+// at different scenarios would silently read each other's state.
+const sessionPath = (sessionId: string, resource: string) =>
+  `/api/v1/sessions/${encodeURIComponent(sessionId)}/${resource}`;
+
+export const fetchSessions = () => deduplicatedGet<SessionSummary[]>('/api/v1/sessions');
+export const fetchStats = (sessionId: string) =>
+  deduplicatedGet<StackStatsResponse>(sessionPath(sessionId, 'stats'));
+export const fetchDevices = (sessionId: string) =>
+  deduplicatedGet<DeviceSummary[]>(sessionPath(sessionId, 'devices'));
+// ADR 0008: multi-VLAN segments grouping the same devices the devices resource
 // reports flat. A flat (non-segmented) config still reports one untagged
 // segment, so the shape is uniform.
-export const fetchSegments = () => deduplicatedGet<SegmentSummary[]>('/api/v1/segments');
+export const fetchSegments = (sessionId: string) =>
+  deduplicatedGet<SegmentSummary[]>(sessionPath(sessionId, 'segments'));
 export const fetchHistory = () => deduplicatedGet<HistoryRecord[]>('/api/v1/history');
-export const fetchNeighbors = () => deduplicatedGet<NeighborRecord[]>('/api/v1/neighbors');
+export const fetchNeighbors = (sessionId: string) =>
+  deduplicatedGet<NeighborRecord[]>(sessionPath(sessionId, 'neighbors'));
 export const fetchConfig = () => deduplicatedGet<ConfigDocument>('/api/v1/config');
 export const updateConfig = (payload: ConfigUpdateRequest) =>
   requestJson<ConfigDocument>('/api/v1/config', payload, { method: 'PUT' });
@@ -153,7 +166,8 @@ export const importConfig = (payload: { format: 'yaml' | 'java-dsl'; content: st
 // =====================================================================
 
 export const fetchVersion = () => deduplicatedGet<VersionInfo>('/api/v1/version');
-export const fetchTopology = () => deduplicatedGet<TopologyGraph>('/api/v1/topology');
+export const fetchTopology = (sessionId: string) =>
+  deduplicatedGet<TopologyGraph>(sessionPath(sessionId, 'topology'));
 
 // Server-side topology export. The daemon renders the running topology as
 // Graphviz DOT or GraphML (for Graphviz / yEd / gephi interop) — richer than

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -31,6 +31,7 @@ export type {
   ReplayState,
   RuntimeStatus,
   SegmentSummary,
+  SessionSummary,
   SimulationRequest,
   SimulationStatus,
   StackStatsResponse,

--- a/ui/src/contexts/AppContext.session.test.tsx
+++ b/ui/src/contexts/AppContext.session.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * AppContext session scoping.
+ *
+ * NIAC can run several scenarios at once. Which one this browser reads is a
+ * client-side choice: a server-side "current" session would mean one tab
+ * switching scenario silently repoints every other tab.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SimulationStatus } from '../api/types';
+import { AppProvider, useAppContext } from './AppContext';
+
+const fetchSimulationStatus = vi.fn<() => Promise<SimulationStatus>>();
+const fetchDevices = vi.fn<(sessionId: string) => Promise<unknown[]>>();
+
+vi.mock('../api/client', () => ({
+  fetchSimulationStatus: () => fetchSimulationStatus(),
+  fetchDevices: (sessionId: string) => fetchDevices(sessionId),
+  fetchStats: () => Promise.resolve({}),
+  fetchNeighbors: () => Promise.resolve([]),
+  fetchHistory: () => Promise.resolve([]),
+  fetchVersion: () => Promise.resolve({}),
+  fetchErrorTypes: () => Promise.resolve({}),
+  fetchInterfaces: () => Promise.resolve({ interfaces: [] }),
+}));
+
+function SessionProbe() {
+  const { sessionId, setSessionId } = useAppContext();
+  return (
+    <div>
+      <span data-testid="session">{sessionId ?? 'none'}</span>
+      <button type="button" onClick={() => setSessionId('warehouse')}>
+        pick warehouse
+      </button>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <AppProvider>
+      <SessionProbe />
+    </AppProvider>,
+  );
+}
+
+describe('AppContext session scoping', () => {
+  beforeEach(() => {
+    fetchSimulationStatus.mockReset();
+    fetchDevices.mockReset().mockResolvedValue([]);
+  });
+
+  it('reads no session while nothing is running', async () => {
+    fetchSimulationStatus.mockResolvedValue({ running: false } as SimulationStatus);
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('session')).toHaveTextContent('none'));
+    // Requesting a session that does not exist would 404 on every poll.
+    expect(fetchDevices).not.toHaveBeenCalled();
+  });
+
+  it('adopts the running session and scopes runtime reads to it', async () => {
+    fetchSimulationStatus.mockResolvedValue({
+      running: true,
+      sessionId: 'hospital',
+      sessions: [{ running: true, sessionId: 'hospital', deviceCount: 2, uptimeSeconds: 1 }],
+    } as SimulationStatus);
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('session')).toHaveTextContent('hospital'));
+    await waitFor(() => expect(fetchDevices).toHaveBeenCalledWith('hospital'));
+  });
+
+  it('keeps this browser on the session it picked', async () => {
+    // The daemon reports hospital as its own selection; this browser chose
+    // warehouse and must stay there.
+    fetchSimulationStatus.mockResolvedValue({
+      running: true,
+      sessionId: 'hospital',
+      sessions: [
+        { running: true, sessionId: 'hospital', deviceCount: 2, uptimeSeconds: 1 },
+        { running: true, sessionId: 'warehouse', deviceCount: 1, uptimeSeconds: 1 },
+      ],
+    } as SimulationStatus);
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('session')).toHaveTextContent('hospital'));
+    screen.getByRole('button', { name: /pick warehouse/i }).click();
+
+    await waitFor(() => expect(screen.getByTestId('session')).toHaveTextContent('warehouse'));
+    // Switching scenario refetches rather than leaving the previous one's devices on screen.
+    await waitFor(() => expect(fetchDevices).toHaveBeenCalledWith('warehouse'));
+  });
+
+  it('falls back when the picked session stops running', async () => {
+    fetchSimulationStatus.mockResolvedValue({
+      running: true,
+      sessionId: 'hospital',
+      sessions: [{ running: true, sessionId: 'hospital', deviceCount: 2, uptimeSeconds: 1 }],
+    } as SimulationStatus);
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('session')).toHaveTextContent('hospital'));
+    // warehouse is not in the running set, so the pin is ignored rather than
+    // leaving every read 404ing against a stopped session.
+    screen.getByRole('button', { name: /pick warehouse/i }).click();
+
+    await waitFor(() => expect(screen.getByTestId('session')).toHaveTextContent('hospital'));
+  });
+});

--- a/ui/src/contexts/AppContext.tsx
+++ b/ui/src/contexts/AppContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useMemo } from 'react';
+import { createContext, type ReactNode, useContext, useMemo, useState } from 'react';
 import {
   fetchDevices,
   fetchErrorTypes,
@@ -45,39 +45,63 @@ interface AppContextValue {
   errorTypes: ApiResourceResult<ErrorInjectionInfo>;
   interfaces: ApiResourceResult<InterfacesResponse>;
   simStatus: ApiResourceResult<SimulationStatus>;
+  /**
+   * Which scenario this browser is looking at. Selection lives here rather
+   * than on the daemon: with several scenarios running, a server-side
+   * "current" session means one tab switching scenario silently repoints
+   * every other tab. Null until a scenario is running.
+   */
+  sessionId: string | null;
+  setSessionId: (sessionId: string | null) => void;
   pollIntervals: typeof POLL_INTERVALS;
 }
 
 const AppContext = createContext<AppContextValue | null>(null);
 
 export function AppProvider({ children }: { children: ReactNode }) {
-  // Fetch shared data at the top level
-  const stats = useApiResource(fetchStats, [], {
-    intervalMs: POLL_INTERVALS.medium,
+  // Which scenario this browser is reading. Adopts whichever session the
+  // daemon reports until the operator picks one, then this browser keeps its
+  // own choice regardless of what other tabs do.
+  const [pinnedSessionId, setPinnedSessionId] = useState<string | null>(null);
+
+  const simStatus = useApiResource(fetchSimulationStatus, [], {
+    intervalMs: POLL_INTERVALS.fast,
   });
-  const devices = useApiResource(fetchDevices, [], {
+  const runningSessionIds = useMemo(
+    () => (simStatus.data?.sessions ?? []).map((session) => session.sessionId).filter(Boolean),
+    [simStatus.data],
+  );
+  // Drop a pin that no longer names a running scenario, so a stopped session
+  // does not leave every read 404ing.
+  const sessionId =
+    pinnedSessionId && runningSessionIds.includes(pinnedSessionId)
+      ? pinnedSessionId
+      : (simStatus.data?.sessionId ?? null);
+
+  // Runtime reads take the session as a dependency: switching scenario has to
+  // refetch, not keep showing the previous one's devices. With no scenario
+  // running there is nothing to read, so these resolve empty rather than
+  // requesting a session that does not exist.
+  const stats = useApiResource(() => fetchStats(sessionId ?? ''), [sessionId], {
+    intervalMs: POLL_INTERVALS.medium,
+    enabled: sessionId !== null,
+  });
+  const devices = useApiResource(() => fetchDevices(sessionId ?? ''), [sessionId], {
     intervalMs: POLL_INTERVALS.slow,
+    enabled: sessionId !== null,
   });
   const history = useApiResource(fetchHistory, [], {
     intervalMs: POLL_INTERVALS.slow,
   });
-  const neighbors = useApiResource(fetchNeighbors, [], {
+  const neighbors = useApiResource(() => fetchNeighbors(sessionId ?? ''), [sessionId], {
     intervalMs: POLL_INTERVALS.medium,
+    enabled: sessionId !== null,
   });
   const version = useApiResource(fetchVersion, [], {
     intervalMs: POLL_INTERVALS.verySlow,
   });
   const errorTypes = useApiResource(fetchErrorTypes, []);
   const interfaces = useApiResource(fetchInterfaces, []);
-  // Single poller for simulation run/stop state, shared by HeaderBar (status
-  // chip), DashboardPage (status banner + stat cards), RuntimeControlPage
-  // (start/stop controls), and PacketInspectorPage (active-interface
-  // detection) via the useSimulationStatus() hook — see hooks/useSimulationStatus.ts.
-  // Previously each of those pages ran its own independent
-  // useApiResource(fetchSimulationStatus, …) poll against the same endpoint.
-  const simStatus = useApiResource(fetchSimulationStatus, [], {
-    intervalMs: POLL_INTERVALS.fast,
-  });
 
   // Memoize context value to prevent unnecessary re-renders
   const value = useMemo(
@@ -90,9 +114,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
       errorTypes,
       interfaces,
       simStatus,
+      sessionId,
+      setSessionId: setPinnedSessionId,
       pollIntervals: POLL_INTERVALS,
     }),
-    [stats, devices, history, neighbors, version, errorTypes, interfaces, simStatus],
+    [stats, devices, history, neighbors, version, errorTypes, interfaces, simStatus, sessionId],
   );
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/ui/src/hooks/useApiResource.ts
+++ b/ui/src/hooks/useApiResource.ts
@@ -18,6 +18,14 @@ interface Options<T> {
    * message.
    */
   errorToast?: boolean | { title?: string };
+  /**
+   * Skip fetching entirely while false, leaving `data` null and `loading`
+   * false. For a resource that needs something the caller does not have yet —
+   * a session-scoped read before any scenario is running. Requesting anyway
+   * would ask for a session that does not exist, and substituting a
+   * placeholder would report numbers that were never measured.
+   */
+  enabled?: boolean;
 }
 
 export function useApiResource<T>(
@@ -25,7 +33,7 @@ export function useApiResource<T>(
   deps: unknown[] = [],
   options: Options<T> = {},
 ) {
-  const { intervalMs, transform, errorToast } = options;
+  const { intervalMs, transform, errorToast, enabled = true } = options;
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -74,6 +82,12 @@ export function useApiResource<T>(
   );
 
   useEffect(() => {
+    if (!enabled) {
+      // Nothing to fetch yet. Leave data null rather than showing a stale or
+      // invented value, and stop reporting a load that will never happen.
+      setLoading(false);
+      return;
+    }
     // FIX #179: AbortController for cleanup on unmount/dependency change
     const controller = new AbortController();
 
@@ -92,7 +106,7 @@ export function useApiResource<T>(
         timerRef.current = null;
       }
     };
-  }, [...deps, intervalMs, run]);
+  }, [...deps, intervalMs, run, enabled]);
 
   const refetch = useCallback(() => run(), [run]);
 

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { fetchAlerts, fetchStats, updateAlerts } from '../api/client';
 import type { AlertConfig } from '../api/types';
 import { iconSizes } from '../constants/sizes';
+import { useAppContext } from '../contexts/AppContext';
 import { useApiResource } from '../hooks/useApiResource';
 import { useErrorToast } from '../hooks/useErrorToast';
 import { Button } from '../ui/Button';
@@ -16,7 +17,10 @@ import { H2, P, SmallText } from '../ui/Typography';
  * immediately; no daemon restart required.
  */
 export const AutomationPage: FC = () => {
-  const { data: stats } = useApiResource(fetchStats, []);
+  const { sessionId } = useAppContext();
+  const { data: stats } = useApiResource(() => fetchStats(sessionId ?? ''), [sessionId], {
+    enabled: sessionId !== null,
+  });
   const errorCount = stats?.stack.errors ?? 0;
 
   return (

--- a/ui/src/pages/DashboardPage.test.tsx
+++ b/ui/src/pages/DashboardPage.test.tsx
@@ -107,6 +107,9 @@ describe('DashboardPage', () => {
     fetchInterfaces.mockReset().mockResolvedValue({ interfaces: [] });
     fetchSimulationStatus.mockReset().mockResolvedValue({
       running: true,
+      // Runtime reads are session-scoped, so the dashboard needs a session to
+      // read stats from — a running simulation always reports one.
+      sessionId: 'default',
       deviceCount: 5,
       uptimeSeconds: 120,
     });

--- a/ui/src/pages/DevicesPage.configEditor.test.tsx
+++ b/ui/src/pages/DevicesPage.configEditor.test.tsx
@@ -21,6 +21,12 @@ import { DevicesPage } from './DevicesPage';
 
 const updateConfig = vi.fn();
 
+// Runtime reads name their session, so a page rendered on its own has to say
+// which scenario it is looking at.
+vi.mock('../contexts/AppContext', () => ({
+  useAppContext: () => ({ sessionId: 'test-session', setSessionId: vi.fn() }),
+}));
+
 vi.mock('../api/client', () => ({
   fetchDevices: () => Promise.resolve([]),
   fetchConfig: () =>

--- a/ui/src/pages/DevicesPage.test.tsx
+++ b/ui/src/pages/DevicesPage.test.tsx
@@ -14,6 +14,12 @@ import { describe, expect, it, vi } from 'vitest';
 import '../i18n';
 import { DevicesPage } from './DevicesPage';
 
+// Runtime reads name their session, so a page rendered on its own has to say
+// which scenario it is looking at.
+vi.mock('../contexts/AppContext', () => ({
+  useAppContext: () => ({ sessionId: 'test-session', setSessionId: vi.fn() }),
+}));
+
 vi.mock('../api/client', () => ({
   fetchDevices: () => Promise.resolve([]),
   fetchConfig: () =>

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -10,6 +10,7 @@ import { YamlEditor } from '../components/config/YamlEditor';
 import { DeviceTable } from '../components/DeviceTable';
 import { POLL_INTERVALS } from '../constants/polling';
 import { iconSizes } from '../constants/sizes';
+import { useAppContext } from '../contexts/AppContext';
 import { useApiResource } from '../hooks/useApiResource';
 import { BaseCard } from '../ui/BaseCard';
 import { Button } from '../ui/Button';
@@ -35,11 +36,15 @@ export const DevicesPage: FC = () => (
  */
 const DeviceListCard: FC = () => {
   const { t } = useTranslation('pages');
+  const { sessionId } = useAppContext();
   const {
     data: devices,
     loading,
     error,
-  } = useApiResource(fetchDevices, [], { intervalMs: POLL_INTERVALS.slow });
+  } = useApiResource(() => fetchDevices(sessionId ?? ''), [sessionId], {
+    intervalMs: POLL_INTERVALS.slow,
+    enabled: sessionId !== null,
+  });
 
   return (
     <BaseCard<DeviceSummary[]>

--- a/ui/src/pages/SegmentsPage.test.tsx
+++ b/ui/src/pages/SegmentsPage.test.tsx
@@ -18,6 +18,12 @@ vi.mock('../api/client', () => ({
   fetchSegments: () => fetchSegments(),
 }));
 
+// Runtime reads name their session, so a page rendered on its own has to say
+// which scenario it is looking at.
+vi.mock('../contexts/AppContext', () => ({
+  useAppContext: () => ({ sessionId: 'test-session', setSessionId: vi.fn() }),
+}));
+
 const taggedSegments: SegmentSummary[] = [
   {
     vlanTag: 200,

--- a/ui/src/pages/SegmentsPage.tsx
+++ b/ui/src/pages/SegmentsPage.tsx
@@ -6,6 +6,7 @@ import type { SegmentSummary } from '../api/types';
 import { DeviceTable } from '../components/DeviceTable';
 import { POLL_INTERVALS } from '../constants/polling';
 import { iconSizes } from '../constants/sizes';
+import { useAppContext } from '../contexts/AppContext';
 import { useApiResource } from '../hooks/useApiResource';
 import { BaseCard } from '../ui/BaseCard';
 import { Tag } from '../ui/Tag';
@@ -32,11 +33,15 @@ export const SegmentsPage: FC = () => (
  */
 const SegmentsListCard: FC = () => {
   const { t } = useTranslation('pages');
+  const { sessionId } = useAppContext();
   const {
     data: segments,
     loading,
     error,
-  } = useApiResource(fetchSegments, [], { intervalMs: POLL_INTERVALS.slow });
+  } = useApiResource(() => fetchSegments(sessionId ?? ''), [sessionId], {
+    intervalMs: POLL_INTERVALS.slow,
+    enabled: sessionId !== null,
+  });
 
   return (
     <BaseCard<SegmentSummary[]>

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -75,46 +75,36 @@ export const TopologyPage: FC = () => {
   const navigate = useNavigate();
   const { sessionId } = useAppContext();
 
-  // Fetch topology data from the API with periodic polling
+  // Runtime reads name their session; nothing to read before one runs.
+  const poll = { intervalMs: 15000, enabled: sessionId !== null };
+  const session = sessionId ?? '';
   const {
     data: topology,
     loading: topologyLoading,
     refetch: refetchTopology,
-  } = useApiResource(() => fetchTopology(sessionId ?? ''), [sessionId], {
-    intervalMs: 15000,
-    enabled: sessionId !== null,
-  });
+  } = useApiResource(() => fetchTopology(session), [sessionId], poll);
   const {
     data: devices,
     loading: devicesLoading,
     refetch: refetchDevices,
-  } = useApiResource(() => fetchDevices(sessionId ?? ''), [sessionId], {
-    intervalMs: 15000,
-    enabled: sessionId !== null,
-  });
+  } = useApiResource(() => fetchDevices(session), [sessionId], poll);
   const { data: neighbors, refetch: refetchNeighbors } = useApiResource(
-    () => fetchNeighbors(sessionId ?? ''),
+    () => fetchNeighbors(session),
     [sessionId],
-    { intervalMs: 15000, enabled: sessionId !== null },
+    poll,
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState<DeviceNodeType>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<LinkEdge>([]);
   const [selectedDevice, setSelectedDevice] = useState<DeviceSummary | null>(null);
   const [showLegend, setShowLegend] = useState(true);
-  // Minimap removed in this version — it was always toggle-off by
-  // default and operators didn't use it; the ReactFlow Controls
-  // (fit-view + zoom buttons) already cover navigation on big graphs.
-  // showLabels controls whether TrunkEdge renders its per-side
-  // interface labels + the middle VLAN/speed label. On by default
-  // for clarity; toggle off via the header to see clean lines only.
+  // showLabels controls whether TrunkEdge renders its per-side interface
+  // labels + the middle VLAN/speed label. On by default for clarity.
   const [showLabels, setShowLabels] = useState(true);
   const [view, setView] = useState<'graph' | 'neighbors'>('graph');
-  // Search query in the header — filters which devices show up + their
-  // edges. Matched on name (case-insensitive substring).
+  // Filters devices + their edges by name, case-insensitive substring.
   const [search, setSearch] = useState('');
-  // Type-filter chips — empty Set means "show everything". When the
-  // user toggles a type on, only that type renders.
+  // Empty Set means "show everything"; toggling a type renders only it.
   const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set());
   // Node click selects its neighbourhood: the clicked node + every
   // node connected to it by an edge get full opacity; everything else

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -19,6 +19,7 @@ import '@xyflow/react/dist/style.css';
 import { Network, Radar, RefreshCw } from 'lucide-react';
 import { exportTopology, fetchDevices, fetchNeighbors, fetchTopology } from '../api/client';
 import type { DeviceSummary } from '../api/types';
+import { useAppContext } from '../contexts/AppContext';
 import { useApiResource } from '../hooks/useApiResource';
 import { useTopologyLayoutPersistence } from '../hooks/useTopologyLayoutPersistence';
 import { Button } from '../ui/Button';
@@ -72,21 +73,30 @@ export const TopologyPage: FC = () => {
   const { t } = useTranslation('pages');
   const { t: tCommon } = useTranslation('common');
   const navigate = useNavigate();
+  const { sessionId } = useAppContext();
 
   // Fetch topology data from the API with periodic polling
   const {
     data: topology,
     loading: topologyLoading,
     refetch: refetchTopology,
-  } = useApiResource(fetchTopology, [], { intervalMs: 15000 });
+  } = useApiResource(() => fetchTopology(sessionId ?? ''), [sessionId], {
+    intervalMs: 15000,
+    enabled: sessionId !== null,
+  });
   const {
     data: devices,
     loading: devicesLoading,
     refetch: refetchDevices,
-  } = useApiResource(fetchDevices, [], { intervalMs: 15000 });
-  const { data: neighbors, refetch: refetchNeighbors } = useApiResource(fetchNeighbors, [], {
+  } = useApiResource(() => fetchDevices(sessionId ?? ''), [sessionId], {
     intervalMs: 15000,
+    enabled: sessionId !== null,
   });
+  const { data: neighbors, refetch: refetchNeighbors } = useApiResource(
+    () => fetchNeighbors(sessionId ?? ''),
+    [sessionId],
+    { intervalMs: 15000, enabled: sessionId !== null },
+  );
 
   const [nodes, setNodes, onNodesChange] = useNodesState<DeviceNodeType>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<LinkEdge>([]);

--- a/ui/src/pages/topology/NeighborsView.tsx
+++ b/ui/src/pages/topology/NeighborsView.tsx
@@ -1,6 +1,7 @@
 import { type FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { fetchNeighbors } from '../../api/client';
+import { useAppContext } from '../../contexts/AppContext';
 import { useApiResource } from '../../hooks/useApiResource';
 import type { TFunction } from '../../i18n';
 import { Card, CardContent } from '../../ui/Card';
@@ -38,11 +39,15 @@ const formatRelative = (iso: string, tCommon: TFunction<'common'>): string => {
 export const NeighborsView: FC = () => {
   const { t } = useTranslation('pages');
   const { t: tCommon } = useTranslation('common');
+  const { sessionId } = useAppContext();
   const {
     data: neighbors,
     loading,
     error,
-  } = useApiResource(() => fetchNeighbors(), [], { intervalMs: NEIGHBOR_POLL_MS });
+  } = useApiResource(() => fetchNeighbors(sessionId ?? ''), [sessionId], {
+    intervalMs: NEIGHBOR_POLL_MS,
+    enabled: sessionId !== null,
+  });
 
   const [protocolFilter, setProtocolFilter] = useState<ProtocolFilter>('all');
   const [search, setSearch] = useState('');

--- a/ui/src/utils/prefetch.ts
+++ b/ui/src/utils/prefetch.ts
@@ -9,14 +9,20 @@ import {
 } from '../api/client';
 
 type PrefetchFn = () => Promise<unknown>;
+/** Runtime reads need a session, so they can only be warmed once one is running. */
+type SessionPrefetchFn = (sessionId: string) => Promise<unknown>;
 
 const ROUTE_PREFETCH_MAP: Record<string, PrefetchFn[]> = {
-  '/': [fetchStats],
   '/runtime': [fetchRuntimeStatus],
-  '/devices': [fetchDevices],
-  '/device-config': [fetchDevices, fetchConfig],
-  '/topology': [fetchTopology, fetchNeighbors],
+  '/device-config': [fetchConfig],
   '/analysis': [fetchReplayStatus],
+};
+
+const SESSION_PREFETCH_MAP: Record<string, SessionPrefetchFn[]> = {
+  '/': [fetchStats],
+  '/devices': [fetchDevices],
+  '/device-config': [fetchDevices],
+  '/topology': [fetchTopology, fetchNeighbors],
 };
 
 const prefetched = new Set<string>();
@@ -25,17 +31,23 @@ const prefetched = new Set<string>();
  * Prefetch API data for a route during browser idle time.
  * Each route is only prefetched once per session to avoid redundant requests.
  */
-export function prefetchRoute(path: string): void {
+export function prefetchRoute(path: string, sessionId?: string | null): void {
   if (prefetched.has(path)) return;
 
-  const fetchers = ROUTE_PREFETCH_MAP[path];
-  if (!fetchers) return;
+  const fetchers = ROUTE_PREFETCH_MAP[path] ?? [];
+  const sessionFetchers = sessionId ? (SESSION_PREFETCH_MAP[path] ?? []) : [];
+  if (fetchers.length === 0 && sessionFetchers.length === 0) return;
 
   prefetched.add(path);
 
   const run = () => {
     for (const fn of fetchers) {
       fn().catch(() => {
+        // Silently ignore prefetch failures
+      });
+    }
+    for (const fn of sessionFetchers) {
+      fn(sessionId as string).catch(() => {
         // Silently ignore prefetch failures
       });
     }


### PR DESCRIPTION
## Summary

Second half of **M1-2/M1-3**: the UI now reads runtime state from a named session, and starting a scenario no longer repoints the clients watching another one.

### The bug this fixes

`Daemon.publishSimulation` called `SelectSimulation` **unconditionally on every start**. Launching a second scenario silently moved the unscoped runtime surface onto it. In practice: start the warehouse demo, and the hospital demo's device list, topology and counters change underneath whoever was watching it. Nothing errored; the readings just quietly became a different network's.

A session is now adopted as the default only when nothing already holds that place, or when the start replaces the session already in it. Explicit selection still works — this is a default, not a lock.

The existing concurrent-session test asserted `SessionID == "warehouse"` after starting hospital then warehouse. It was pinning the bug in place, so it now asserts the opposite.

### UI

Selection moves into the browser. `AppContext` holds the session this tab is reading and passes it on every runtime request — devices, stats, neighbors, segments, topology. A tab adopts whichever session the daemon reports until the operator picks one, then keeps its own choice regardless of what other tabs do. A pin that no longer names a running scenario is dropped rather than left 404ing against a stopped session.

`useApiResource` gains `enabled`, so a session-scoped read simply does not fetch before a scenario is running. The alternatives were requesting a session that does not exist on every poll tick, or substituting a placeholder and reporting numbers nobody measured.

Route prefetch splits accordingly: session-independent routes warm as before, runtime ones only once there is a session to warm them for.

### Still deliberately not done

`Server.selectedSimulation` and the unscoped runtime routes still exist, serving the default session. They are what CLI and `curl` users hit, and removing them is a separate change with its own blast radius — including the `replaceConfig` write-back, which today lands edits in `s.simulations[selectedSimulation]` and would silently lose device edits if the key disappeared without a replacement lookup.

## Linked Issue

Related to #882

## Testing Evidence

```
go test ./...                     green
go test -race ./internal/daemon/ ./internal/api/   green
golangci-lint run (v2.12.2)       0 issues
gofmt -l internal/ cmd/           clean
vitest                            80 files, 389 tests passed
tsgo --build --noEmit             clean
biome check .                     407 files clean
make schema                       NO DRIFT
i18n:check + validate.sh          clean
check-file-size / -route-policy / -json-casing / -output-escaping / -filename-policy   PASS
```

Five new tests:

- **daemon**: starting a second session does not take the default from the first; restarting the session that holds it keeps it; explicit select still wins
- **UI**: no session read while nothing runs (and no request is made); the running session is adopted and scopes reads to it; a browser keeps the session it picked even while the daemon reports a different one; a pin that stops running falls back instead of 404ing

Four existing page tests needed a session supplied — a page rendered with no session now correctly shows nothing, which is the point.

## Security and Release Checklist

- No new routes; no CSRF/scope change. `check-route-policy.sh` passes.
- Failure mode is fail-quiet-and-empty rather than fail-into-someone-else's-data: an unknown session 404s, and a missing session fetches nothing.
- No secrets, no default credentials, no phone-home.
- `check-file-size.sh` passes without raising the reviewed baseline — TopologyPage was trimmed back under it by removing a comment describing a feature that no longer exists, not by widening the limit.

Release: no version bump; release-please owns tagging.
