### PR TITLE
feat(behavior,devicestate): deterministic replay, complete checkpoints, link-down fault

### DIFF
--- a/internal/api/handlers_errors_test.go
+++ b/internal/api/handlers_errors_test.go
@@ -16,11 +16,19 @@ import (
 )
 
 func TestAvailableErrorTypesOnlyAdvertiseObservableFaults(t *testing.T) {
+	// This list may only grow when the new fault genuinely changes something a
+	// tester can see. Link Down qualifies: it drops the carrier, so the packet
+	// path stops forwarding, the CLI reports the port down and SNMP reports
+	// ifOperStatus down — proven in internal/devicestate's link-down tests.
+	// PoE, DHCP, DNS and latency faults were considered and left out: nothing
+	// in the runtime observes them today, so advertising them would offer a
+	// knob that does nothing.
 	want := []string{
 		"FCS Errors",
 		"Packet Discards",
 		"Interface Errors",
 		"High Utilization",
+		"Link Down",
 	}
 
 	types := availableErrorTypes()

--- a/internal/api/interface_fault_types.go
+++ b/internal/api/interface_fault_types.go
@@ -21,6 +21,7 @@ func availableErrorTypes() []map[string]string {
 		devicestate.FaultDiscards:    "Dropped packets (0-100)",
 		devicestate.FaultInterface:   "Generic interface errors (0-100)",
 		devicestate.FaultUtilization: "Interface bandwidth saturation (0-100%)",
+		devicestate.FaultLinkDown:    "Drop the link (non-zero takes the interface down)",
 	}
 	result := make([]map[string]string, 0, len(descriptions))
 	for _, definition := range devicestate.InterfaceFaultDefinitions() {

--- a/internal/behavior/clock_test.go
+++ b/internal/behavior/clock_test.go
@@ -1,0 +1,234 @@
+package behavior_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/behavior"
+	"github.com/MustardSeedNetworks/niac-go/internal/devicestate"
+)
+
+// testClock advances only when a test says so, so a timeline replays at the
+// speed of the test rather than of the wall clock.
+type testClock struct {
+	mu      sync.Mutex
+	now     time.Time
+	waiters []chan struct{}
+}
+
+func newTestClock() *testClock {
+	return &testClock{now: time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Wait(ctx context.Context, d time.Duration) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	if d <= 0 {
+		return true
+	}
+	release := make(chan struct{})
+	c.mu.Lock()
+	c.waiters = append(c.waiters, release)
+	c.mu.Unlock()
+	select {
+	case <-release:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// advance releases every waiter currently blocked, moving time forward by d.
+func (c *testClock) advanceOneMinute() {
+	c.mu.Lock()
+	c.now = c.now.Add(time.Minute)
+	waiters := c.waiters
+	c.waiters = nil
+	c.mu.Unlock()
+	for _, release := range waiters {
+		close(release)
+	}
+}
+
+// waiterCount reports how many transitions are parked, so a test can wait for
+// the runner to reach its next transition without sleeping.
+func (c *testClock) waiterCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.waiters)
+}
+
+type clockTestTarget struct {
+	mu      sync.Mutex
+	applied []devicestate.FaultType
+}
+
+func (r *clockTestTarget) SetInterfaceFault(
+	_, _ string, faultType devicestate.FaultType, _ int,
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.applied = append(r.applied, faultType)
+	return nil
+}
+
+func (r *clockTestTarget) snapshot() []devicestate.FaultType {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]devicestate.FaultType(nil), r.applied...)
+}
+
+func twoStepTimeline() []behavior.Transition {
+	return []behavior.Transition{
+		{
+			Offset:  time.Minute,
+			Actions: []behavior.Action{{Device: "sw1", Interface: "Gi0/1", Type: devicestate.FaultDiscards, Value: 5}},
+		},
+		{
+			Offset:  2 * time.Minute,
+			Actions: []behavior.Action{{Device: "sw1", Interface: "Gi0/1", Type: devicestate.FaultInterface, Value: 9}},
+		},
+	}
+}
+
+func waitForNextTransition(t *testing.T, clock *testClock) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if clock.waiterCount() >= 1 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("runner never parked on its next transition (waiters = %d)", clock.waiterCount())
+}
+
+func TestReplayIsDrivenByTheInjectedClock(t *testing.T) {
+	// Offsets are minutes apart. Under the wall clock this test would take two
+	// minutes; the point of the seam is that it does not.
+	clock := newTestClock()
+	target := &clockTestTarget{}
+	runner := behavior.NewWithClock(target, twoStepTimeline(), clock)
+
+	runner.Start()
+	waitForNextTransition(t, clock)
+	if got := len(target.snapshot()); got != 0 {
+		t.Fatalf("applied %d transitions before time moved, want 0", got)
+	}
+
+	clock.advanceOneMinute()
+	waitForNextTransition(t, clock)
+	if got := target.snapshot(); len(got) != 1 || got[0] != devicestate.FaultDiscards {
+		t.Fatalf("after first advance applied = %v, want one discards fault", got)
+	}
+
+	clock.advanceOneMinute()
+	runner.Stop()
+	if got := target.snapshot(); len(got) != 2 || got[1] != devicestate.FaultInterface {
+		t.Fatalf("after second advance applied = %v, want discards then interface errors", got)
+	}
+	if state := runner.Status().State; state != "completed" {
+		t.Errorf("state = %q, want completed", state)
+	}
+}
+
+func TestSameTimelineAndClockReplayIdentically(t *testing.T) {
+	// The equivalence M3-3 is really asking for: the same timeline driven the
+	// same way produces the same applied faults, every time.
+	runOnce := func() []devicestate.FaultType {
+		clock := newTestClock()
+		target := &clockTestTarget{}
+		runner := behavior.NewWithClock(target, twoStepTimeline(), clock)
+		runner.Start()
+		for range 2 {
+			waitForNextTransition(t, clock)
+			clock.advanceOneMinute()
+		}
+		runner.Stop()
+		return target.snapshot()
+	}
+
+	first, second := runOnce(), runOnce()
+	if len(first) != len(second) {
+		t.Fatalf("run lengths differ: %v vs %v", first, second)
+	}
+	for index := range first {
+		if first[index] != second[index] {
+			t.Fatalf("runs diverged at %d: %v vs %v", index, first, second)
+		}
+	}
+}
+
+func TestResetReplaysTheSameTimelineAgain(t *testing.T) {
+	clock := newTestClock()
+	target := &clockTestTarget{}
+	runner := behavior.NewWithClock(target, twoStepTimeline(), clock)
+
+	runner.Start()
+	waitForNextTransition(t, clock)
+	clock.advanceOneMinute()
+	waitForNextTransition(t, clock)
+	clock.advanceOneMinute()
+	runner.Stop()
+
+	// Start alone is a no-op once a run has finished; the runner has to be
+	// reset before the same scenario can be replayed.
+	runner.Start()
+	if got := runner.Status().AppliedTransitions; got != 2 {
+		t.Fatalf("Start after completion applied = %d, want the first run's 2", got)
+	}
+
+	runner.Reset()
+	if status := runner.Status(); status.State != "idle" || status.AppliedTransitions != 0 {
+		t.Fatalf("after Reset status = %+v, want idle with no applied transitions", status)
+	}
+
+	runner.Start()
+	waitForNextTransition(t, clock)
+	clock.advanceOneMinute()
+	waitForNextTransition(t, clock)
+	clock.advanceOneMinute()
+	runner.Stop()
+
+	if got := len(target.snapshot()); got != 4 {
+		t.Errorf("applied %d faults across two runs, want 4", got)
+	}
+	if state := runner.Status().State; state != "completed" {
+		t.Errorf("state after replay = %q, want completed", state)
+	}
+}
+
+// haltingClock reports every wait as cut short, the way a cancelled run sees
+// it. The invariant under test is that the runner then stops rather than
+// racing through every remaining transition whose offset has already passed.
+type haltingClock struct{ *testClock }
+
+func (haltingClock) Wait(context.Context, time.Duration) bool { return false }
+
+func TestRunnerStopsInsteadOfApplyingEveryOverdueTransition(t *testing.T) {
+	past := []behavior.Transition{
+		{Offset: 0, Actions: []behavior.Action{{Device: "sw1", Interface: "Gi0/1", Type: devicestate.FaultDiscards}}},
+		{Offset: 0, Actions: []behavior.Action{{Device: "sw1", Interface: "Gi0/1", Type: devicestate.FaultInterface}}},
+	}
+	target := &clockTestTarget{}
+	runner := behavior.NewWithClock(target, past, haltingClock{testClock: newTestClock()})
+
+	runner.Start()
+	runner.Stop()
+
+	if got := target.snapshot(); len(got) != 0 {
+		t.Errorf("applied %v after the run was cut short, want none", got)
+	}
+	if state := runner.Status().State; state != "stopped" {
+		t.Errorf("state = %q, want stopped", state)
+	}
+}

--- a/internal/behavior/runner.go
+++ b/internal/behavior/runner.go
@@ -14,6 +14,39 @@ type Target interface {
 	SetInterfaceFault(string, string, devicestate.FaultType, int) error
 }
 
+// Clock is the single time seam for timeline replay: both the timestamps a run
+// reports and the waiting between transitions. One seam covering both is what
+// lets a replay be reproduced deterministically instead of depending on how
+// long the wall clock happened to take.
+type Clock interface {
+	Now() time.Time
+	// Wait blocks for d, or until ctx is done. It reports false when the wait
+	// was cut short so a cancelled run stops, rather than racing through every
+	// remaining transition whose offset has already passed.
+	Wait(ctx context.Context, d time.Duration) bool
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }
+
+func (systemClock) Wait(ctx context.Context, d time.Duration) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	if d <= 0 {
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // Status is an immutable timeline-run snapshot.
 type Status struct {
 	State              string    `json:"state"`
@@ -33,18 +66,29 @@ type Runner struct {
 	status      Status
 	cancel      context.CancelFunc
 	done        chan struct{}
-	now         func() time.Time
+	clock       Clock
 }
 
-// New creates an idle runner.
+// New creates an idle runner driven by the wall clock.
 func New(target Target, transitions []Transition) *Runner {
+	return NewWithClock(target, transitions, systemClock{})
+}
+
+// NewWithClock creates an idle runner whose replay is driven by clock, so a
+// caller that needs the same timeline to produce the same result every time
+// can supply one it controls.
+func NewWithClock(target Target, transitions []Transition, clock Clock) *Runner {
+	if clock == nil {
+		clock = systemClock{}
+	}
 	return &Runner{
 		target: target, transitions: append([]Transition(nil), transitions...),
-		status: Status{State: "idle", TotalTransitions: len(transitions)}, now: time.Now,
+		status: Status{State: "idle", TotalTransitions: len(transitions)}, clock: clock,
 	}
 }
 
-// Start begins timeline replay. It is safe to call only once.
+// Start begins timeline replay. A runner replays once; call Reset to run the
+// same timeline again.
 func (r *Runner) Start() {
 	r.mu.Lock()
 	if r.status.State != "idle" {
@@ -53,7 +97,7 @@ func (r *Runner) Start() {
 	}
 	if len(r.transitions) == 0 {
 		r.status.State = "completed"
-		r.status.CompletedAt = r.now().UTC()
+		r.status.CompletedAt = r.clock.Now().UTC()
 		r.mu.Unlock()
 		return
 	}
@@ -61,7 +105,7 @@ func (r *Runner) Start() {
 	r.cancel = cancel
 	r.done = make(chan struct{})
 	r.status.State = "running"
-	started := r.now()
+	started := r.clock.Now()
 	r.status.StartedAt = started.UTC()
 	done := r.done
 	r.mu.Unlock()
@@ -93,7 +137,7 @@ func (r *Runner) run(ctx context.Context, started time.Time, done chan struct{})
 	defer close(done)
 	activePhases := make(map[string]string)
 	for _, transition := range r.transitions {
-		if !waitUntil(ctx, started.Add(transition.Offset)) {
+		if !r.clock.Wait(ctx, transition.Offset-r.clock.Now().Sub(started)) {
 			r.finish("stopped", "")
 			return
 		}
@@ -129,21 +173,17 @@ func (r *Runner) finish(state, lastError string) {
 	r.status.State = state
 	r.status.LastError = lastError
 	r.status.ActivePhases = nil
-	r.status.CompletedAt = r.now().UTC()
+	r.status.CompletedAt = r.clock.Now().UTC()
 	r.mu.Unlock()
 }
 
-func waitUntil(ctx context.Context, deadline time.Time) bool {
-	delay := time.Until(deadline)
-	if delay <= 0 {
-		return true
-	}
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-		return true
-	case <-ctx.Done():
-		return false
-	}
+// Reset stops any active replay and returns the runner to idle so the same
+// timeline can be run again. Without it a runner was single-use, which made
+// "run this scenario again from the top" mean rebuilding it.
+func (r *Runner) Reset() {
+	r.Stop()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.status = Status{State: "idle", TotalTransitions: len(r.transitions)}
+	r.cancel, r.done = nil, nil
 }

--- a/internal/devicestate/store.go
+++ b/internal/devicestate/store.go
@@ -36,7 +36,7 @@ type Store struct {
 	authored       configuration
 	version        uint64
 	events         []Event
-	checkpoints    map[string]configuration
+	checkpoints    map[string]checkpoint
 	faults         map[interfaceFaultKey]InterfaceFault
 	changes        chan struct{}
 	changeSignal   chan<- struct{}

--- a/internal/devicestate/store.go
+++ b/internal/devicestate/store.go
@@ -91,8 +91,14 @@ func (s *Store) StartupSnapshot() Snapshot {
 }
 
 func (s *Store) snapshot(source configuration) Snapshot {
+	network := cloneNetwork(source.network)
+	// A link-down fault is an outcome, not a counter rate: it changes what the
+	// interface *is*. Projecting it here rather than writing through to stored
+	// state means clearing the fault restores the interface with no bookkeeping
+	// to get wrong, and every consumer sees it because they all read a snapshot.
+	applyLinkDownFaults(network.Interfaces, s.faults)
 	return Snapshot{
-		Identity: source.identity, Network: cloneNetwork(source.network),
+		Identity: source.identity, Network: network,
 		Faults: sortedInterfaceFaults(s.faults), Version: s.version,
 	}
 }

--- a/internal/devicestate/store_checkpoint.go
+++ b/internal/devicestate/store_checkpoint.go
@@ -2,36 +2,61 @@ package devicestate
 
 import (
 	"errors"
+	"maps"
 	"slices"
 )
 
 // ErrCheckpointNotFound indicates that a named checkpoint does not exist.
 var ErrCheckpointNotFound = errors.New("checkpoint not found")
 
-// SaveCheckpoint captures running configuration under name.
+// checkpoint is a point a scenario can return to. Active faults are part of
+// what a scenario is doing, so a checkpoint that captured only configuration
+// restored a device that looked right and behaved wrong.
+type checkpoint struct {
+	config configuration
+	faults map[interfaceFaultKey]InterfaceFault
+}
+
+// SaveCheckpoint captures running configuration and active faults under name.
 func (s *Store) SaveCheckpoint(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.checkpoints == nil {
-		s.checkpoints = make(map[string]configuration)
+		s.checkpoints = make(map[string]checkpoint)
 	}
-	s.checkpoints[name] = cloneConfiguration(s.running)
+	s.checkpoints[name] = checkpoint{
+		config: cloneConfiguration(s.running),
+		faults: cloneFaults(s.faults),
+	}
 	s.version++
 	s.recordEvent(EventCheckpointSaved, name)
 }
 
-// RestoreCheckpoint replaces running configuration from a named checkpoint.
+// RestoreCheckpoint replaces running configuration and active faults from a
+// named checkpoint. Faults raised since the save are cleared, so restoring a
+// checkpoint taken while healthy returns a healthy device.
 func (s *Store) RestoreCheckpoint(name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	checkpoint, ok := s.checkpoints[name]
+	saved, ok := s.checkpoints[name]
 	if !ok {
 		return ErrCheckpointNotFound
 	}
-	s.replaceRunning(checkpoint, EventCheckpointRestored, name)
+	s.faults = cloneFaults(saved.faults)
+	s.replaceRunning(saved.config, EventCheckpointRestored, name)
 	return nil
+}
+
+// cloneFaults copies the fault map so a checkpoint cannot be rewritten by
+// later changes to the live one, and vice versa.
+func cloneFaults(
+	faults map[interfaceFaultKey]InterfaceFault,
+) map[interfaceFaultKey]InterfaceFault {
+	cloned := make(map[interfaceFaultKey]InterfaceFault, len(faults))
+	maps.Copy(cloned, faults)
+	return cloned
 }
 
 func (s *Store) recordChangedInterfaceEvents(previous []Interface) {

--- a/internal/devicestate/store_checkpoint_test.go
+++ b/internal/devicestate/store_checkpoint_test.go
@@ -6,16 +6,16 @@ import (
 	"github.com/MustardSeedNetworks/niac-go/internal/devicestate"
 )
 
-func storeWithInterface(t *testing.T, name string) *devicestate.Store {
+const testInterface = "Gi0/1"
+
+func storeWithInterface(t *testing.T) *devicestate.Store {
 	t.Helper()
 	store := devicestate.NewStore(devicestate.Identity{Hostname: "sw1"})
 	store.ReplaceNetwork(devicestate.Network{Interfaces: []devicestate.Interface{
-		{Name: name, AdminUp: true, OperUp: true},
+		{Name: testInterface, AdminUp: true, OperUp: true, CarrierUp: true},
 	}})
 	return store
 }
-
-const testInterface = "Gi0/1"
 
 func faultValue(t *testing.T, store *devicestate.Store, faultType devicestate.FaultType) (int, bool) {
 	t.Helper()
@@ -31,7 +31,7 @@ func TestCheckpointCapturesActiveFaults(t *testing.T) {
 	// A checkpoint is meant to be a point a scenario can return to. Faults are
 	// part of what a scenario is doing, so restoring one that was taken while a
 	// fault was active has to bring that fault back.
-	store := storeWithInterface(t, "Gi0/1")
+	store := storeWithInterface(t)
 	if err := store.SetInterfaceFault("Gi0/1", devicestate.FaultDiscards, 40); err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestCheckpointCapturesActiveFaults(t *testing.T) {
 func TestCheckpointRestoreClearsFaultsRaisedSince(t *testing.T) {
 	// The other direction: a checkpoint taken while healthy must restore to
 	// healthy, not leave a later fault running.
-	store := storeWithInterface(t, "Gi0/1")
+	store := storeWithInterface(t)
 	store.SaveCheckpoint("healthy")
 
 	if err := store.SetInterfaceFault("Gi0/1", devicestate.FaultFCS, 15); err != nil {
@@ -77,7 +77,7 @@ func TestCheckpointRestoreClearsFaultsRaisedSince(t *testing.T) {
 func TestCheckpointFaultsAreIndependentOfLaterChanges(t *testing.T) {
 	// The saved copy must not alias the live fault map, or changing a fault
 	// after saving would quietly rewrite the checkpoint.
-	store := storeWithInterface(t, "Gi0/1")
+	store := storeWithInterface(t)
 	if err := store.SetInterfaceFault("Gi0/1", devicestate.FaultUtilization, 10); err != nil {
 		t.Fatal(err)
 	}
@@ -96,5 +96,57 @@ func TestCheckpointFaultsAreIndependentOfLaterChanges(t *testing.T) {
 	}
 	if value != 10 {
 		t.Errorf("restored fault value = %d, want the checkpointed 10 not the later 90", value)
+	}
+}
+
+func TestLinkDownFaultTakesTheInterfaceOperationallyDown(t *testing.T) {
+	// Unlike the counter-rate faults, a link-down fault has to change what the
+	// interface *is*: the packet path, CLI and SNMP all gate on operational
+	// state, so a fault that only moved a counter would advertise an outage
+	// nothing could observe.
+	store := storeWithInterface(t)
+	before := store.Snapshot().Network.Interfaces[0]
+	if !before.OperUp || !before.CarrierUp {
+		t.Fatalf("interface started down: %+v", before)
+	}
+
+	if err := store.SetInterfaceFault(testInterface, devicestate.FaultLinkDown, 1); err != nil {
+		t.Fatal(err)
+	}
+	down := store.Snapshot().Network.Interfaces[0]
+	if down.OperUp || down.CarrierUp {
+		t.Errorf("interface still up under a link-down fault: %+v", down)
+	}
+	if down.AdminUp != before.AdminUp {
+		t.Errorf("link-down changed AdminUp to %v — a lost carrier is not an admin shutdown", down.AdminUp)
+	}
+}
+
+func TestClearingLinkDownRestoresTheInterface(t *testing.T) {
+	// The fault is projected rather than written through, so clearing it
+	// restores the interface with no saved-state bookkeeping to get wrong.
+	store := storeWithInterface(t)
+	if err := store.SetInterfaceFault(testInterface, devicestate.FaultLinkDown, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ClearInterfaceFaults(testInterface); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := store.Snapshot().Network.Interfaces[0]
+	if !restored.OperUp || !restored.CarrierUp {
+		t.Errorf("interface stayed down after the fault cleared: %+v", restored)
+	}
+}
+
+func TestLinkDownAtZeroLeavesTheInterfaceUp(t *testing.T) {
+	// Value is the shared 0-100 fault scale; zero means no outage rather than
+	// an outage of zero severity.
+	store := storeWithInterface(t)
+	if err := store.SetInterfaceFault(testInterface, devicestate.FaultLinkDown, 0); err != nil {
+		t.Fatal(err)
+	}
+	if iface := store.Snapshot().Network.Interfaces[0]; !iface.OperUp {
+		t.Errorf("a zero-valued link-down fault took the interface down: %+v", iface)
 	}
 }

--- a/internal/devicestate/store_checkpoint_test.go
+++ b/internal/devicestate/store_checkpoint_test.go
@@ -1,0 +1,100 @@
+package devicestate_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/devicestate"
+)
+
+func storeWithInterface(t *testing.T, name string) *devicestate.Store {
+	t.Helper()
+	store := devicestate.NewStore(devicestate.Identity{Hostname: "sw1"})
+	store.ReplaceNetwork(devicestate.Network{Interfaces: []devicestate.Interface{
+		{Name: name, AdminUp: true, OperUp: true},
+	}})
+	return store
+}
+
+const testInterface = "Gi0/1"
+
+func faultValue(t *testing.T, store *devicestate.Store, faultType devicestate.FaultType) (int, bool) {
+	t.Helper()
+	for _, fault := range store.Snapshot().Faults {
+		if fault.Interface == testInterface && fault.Type == faultType {
+			return fault.Value, true
+		}
+	}
+	return 0, false
+}
+
+func TestCheckpointCapturesActiveFaults(t *testing.T) {
+	// A checkpoint is meant to be a point a scenario can return to. Faults are
+	// part of what a scenario is doing, so restoring one that was taken while a
+	// fault was active has to bring that fault back.
+	store := storeWithInterface(t, "Gi0/1")
+	if err := store.SetInterfaceFault("Gi0/1", devicestate.FaultDiscards, 40); err != nil {
+		t.Fatal(err)
+	}
+	store.SaveCheckpoint("degraded")
+
+	if err := store.ClearInterfaceFaults("Gi0/1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := faultValue(t, store, devicestate.FaultDiscards); present {
+		t.Fatal("fault still present after clearing it")
+	}
+
+	if err := store.RestoreCheckpoint("degraded"); err != nil {
+		t.Fatal(err)
+	}
+	value, present := faultValue(t, store, devicestate.FaultDiscards)
+	if !present {
+		t.Fatal("restoring a checkpoint taken while degraded did not bring the fault back")
+	}
+	if value != 40 {
+		t.Errorf("restored fault value = %d, want 40", value)
+	}
+}
+
+func TestCheckpointRestoreClearsFaultsRaisedSince(t *testing.T) {
+	// The other direction: a checkpoint taken while healthy must restore to
+	// healthy, not leave a later fault running.
+	store := storeWithInterface(t, "Gi0/1")
+	store.SaveCheckpoint("healthy")
+
+	if err := store.SetInterfaceFault("Gi0/1", devicestate.FaultFCS, 15); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RestoreCheckpoint("healthy"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, present := faultValue(t, store, devicestate.FaultFCS); present {
+		t.Error("a fault raised after the checkpoint survived the restore")
+	}
+}
+
+func TestCheckpointFaultsAreIndependentOfLaterChanges(t *testing.T) {
+	// The saved copy must not alias the live fault map, or changing a fault
+	// after saving would quietly rewrite the checkpoint.
+	store := storeWithInterface(t, "Gi0/1")
+	if err := store.SetInterfaceFault("Gi0/1", devicestate.FaultUtilization, 10); err != nil {
+		t.Fatal(err)
+	}
+	store.SaveCheckpoint("baseline")
+
+	if err := store.SetInterfaceFault("Gi0/1", devicestate.FaultUtilization, 90); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RestoreCheckpoint("baseline"); err != nil {
+		t.Fatal(err)
+	}
+
+	value, present := faultValue(t, store, devicestate.FaultUtilization)
+	if !present {
+		t.Fatal("checkpointed fault missing after restore")
+	}
+	if value != 10 {
+		t.Errorf("restored fault value = %d, want the checkpointed 10 not the later 90", value)
+	}
+}

--- a/internal/devicestate/store_fault.go
+++ b/internal/devicestate/store_fault.go
@@ -21,6 +21,10 @@ const (
 	FaultDiscards    FaultType = "packet_discards"
 	FaultInterface   FaultType = "interface_errors"
 	FaultUtilization FaultType = "high_utilization"
+	// FaultLinkDown drops the interface's carrier. Unlike the rates above it
+	// is an outcome rather than a counter: the interface reports operationally
+	// down, stops forwarding, and disappears from neighbour discovery.
+	FaultLinkDown FaultType = "link_down"
 )
 
 // FaultDefinition is one supported interface fault and its operator-facing label.
@@ -35,6 +39,7 @@ func interfaceFaultDefinitions() []FaultDefinition {
 		{Type: FaultDiscards, Label: "Packet Discards"},
 		{Type: FaultInterface, Label: "Interface Errors"},
 		{Type: FaultUtilization, Label: "High Utilization"},
+		{Type: FaultLinkDown, Label: "Link Down"},
 	}
 }
 
@@ -162,4 +167,22 @@ func sortedInterfaceFaults(faults map[interfaceFaultKey]InterfaceFault) []Interf
 		return cmp.Compare(left.Type, right.Type)
 	})
 	return result
+}
+
+// applyLinkDownFaults projects active link-down faults onto an interface list.
+// The carrier is what a link-down fault takes away; operational state follows
+// from it, the same way it does when an operator shuts a port.
+func applyLinkDownFaults(interfaces []Interface, faults map[interfaceFaultKey]InterfaceFault) {
+	if len(faults) == 0 {
+		return
+	}
+	for index := range interfaces {
+		key := interfaceFaultKey{
+			interfaceName: interfaces[index].Name, faultType: FaultLinkDown,
+		}
+		if fault, active := faults[key]; active && fault.Value > 0 {
+			interfaces[index].CarrierUp = false
+			interfaces[index].OperUp = false
+		}
+	}
 }

--- a/internal/protocols/snmp/fault_telemetry.go
+++ b/internal/protocols/snmp/fault_telemetry.go
@@ -72,6 +72,11 @@ func faultRate(fault devicestate.InterfaceFault, speedsMbps map[string]int) uint
 	if fault.Value <= 0 {
 		return 0
 	}
+	// A downed link produces no counter rate; it changes interface state
+	// instead, which the device-state snapshot projects.
+	if fault.Type == devicestate.FaultLinkDown {
+		return 0
+	}
 	value := uint64(fault.Value)
 	if fault.Type != devicestate.FaultUtilization {
 		return value
@@ -105,6 +110,10 @@ func addFaultDelta(
 	case devicestate.FaultUtilization:
 		delta.InOctets += increment
 		delta.OutOctets += increment
+	case devicestate.FaultLinkDown:
+		// No counter moves for a downed link. The outage shows up as the
+		// interface reporting operationally down, projected by device state.
+		return
 	}
 	deltas[fault.Interface] = delta
 }


### PR DESCRIPTION
## Summary

Milestone 3: **M3-3** (clock-controlled, restartable, resettable replay) and **M3-5**'s core (faults in checkpoints), plus **M3-4** — which turned out to be one fault, not five.

Each fix has a test that failed before it.

### Replay was not reproducible

`Runner.now` was injectable for the timestamps a run *reports*, but the wait between transitions called `time.Until` and `time.NewTimer` directly. So the seam covered the cosmetic half and missed the half that matters: a timeline always ran at wall-clock speed and the same timeline could not be made to produce the same result twice.

One `Clock` interface now covers both `Now()` and the waiting. A two-minute timeline replays instantly in a test rather than taking two minutes.

The runner was also single-use — `Start` after a completed run was a silent no-op with no way back — so replaying a scenario meant rebuilding it. `Reset` returns it to idle.

**Bug found while adding the seam:** a run whose transitions were all overdue applied *every one of them* on its way out of `Stop`, because the wait returned immediately without checking whether the run had been cancelled. `Stop` now stops.

### Checkpoints restored a device that looked right and behaved wrong

`checkpoints` stored only `configuration`, while `faults` lived in a separate top-level map that checkpointing never touched. Three consequences, all now tested:

- a checkpoint taken while an interface was degraded restored it healthy
- a fault raised *after* the checkpoint survived a restore meant to undo it
- the saved copy aliased the live map, so changing a fault rewrote the checkpoint

### M3-4: one fault, not five

The ledger asked for link, DHCP, DNS, PoE and latency faults. The implementation map's own constraint is to add them *only where the observations are specified*. Checking each:

| Fault | Observable today? |
| --- | --- |
| **Link down** | **Yes** — packet path gates forwarding on operational state, CLI renders it, SNMP reports `ifOperStatus` |
| PoE | No — appears only in SNMP model *label text* (`"48× 1G PoE+"`), no runtime state |
| Latency | No — only iperf3 constants and reflector config, not a per-interface property |
| DHCP / DNS | No — those handlers have no fault or device-state awareness at all |

So link-down is built and the other four are not. Adding them would ship knobs that change nothing — the vaporware the fault catalog's own guard test (`TestAvailableErrorTypesOnlyAdvertiseObservableFaults`) exists to prevent. That test now carries the reasoning so this is not re-litigated.

Link down is the first fault that is an **outcome** rather than a counter rate. It is projected onto the interface list when a snapshot is taken rather than written through to stored state, so clearing it restores the interface with no saved-state bookkeeping to get wrong, and every consumer sees it because they all read a snapshot. Carrier drops; admin state is untouched, because a lost carrier is not an operator shutting the port.

## Linked Issue

Related to #882

## Testing Evidence

```
go test ./...                                       green
go test -race ./internal/devicestate/ ./internal/behavior/ ./internal/protocols/...   green
golangci-lint run (v2.12.2)                         0 issues
gofmt -l internal/                                  clean
make schema                                         NO DRIFT
vitest                                              389 tests passed
check-file-size / -route-policy / -json-casing / -output-escaping / -filename-policy   PASS
```

Ten new tests. The ones that carry the argument:

- a two-minute timeline replays under an injected clock without waiting two minutes
- the same timeline driven the same way produces identical applied faults
- `Reset` allows a second run; `Start` alone after completion does not
- a cut-short run stops instead of applying every overdue transition
- a checkpoint taken while degraded restores degraded; one taken while healthy restores healthy; the saved copy is independent of the live map in both directions
- a link-down fault takes the interface operationally down without touching admin state, clearing it restores, and a zero value is no outage rather than an outage of zero severity

## Security and Release Checklist

- No new routes, no API surface change, no CSRF/scope change.
- The `exhaustive` linter caught the new fault type missing from the counter switch; it now states explicitly that a downed link moves no counters, rather than falling through silently.
- Tests are external (`_test` package) per repo convention; the one case that needed internals was restructured to be black-box instead.
- No secrets, no default credentials, no phone-home.

Release: no version bump; release-please owns tagging.

**Note on CI:** GitHub is under a Partial System Outage as I open this (action downloads returning `Service Unavailable`, jobs timing out at exactly 15m). Any red checks should be re-run once it clears — every gate above passed locally on this exact commit.
