### PR TITLE
fix(lab): name the logical attachment when starting a pack

### DIFF
--- a/docs/design/2026-08-linklive-acceptance-runbook.md
+++ b/docs/design/2026-08-linklive-acceptance-runbook.md
@@ -90,6 +90,21 @@ under test. If the capture VLAN cannot reach Link-Live, finish and queue
 Discovery first, then switch to an outbound profile to flush — switching
 profiles resets the test port, so never do it mid-scan.
 
+## Start-up failures
+
+Before a discovery is worth running, the session has to actually start. Two
+failures seen in the lab:
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `preflight` returns `safe: false` with `unknown_attachment` | The generated config declares a logical attachment (`cyberscope` connected to `lab-transit`) and the start request did not name one. A config that declares attachments requires the binding to pick one. | Pass `attachment` in the start request; `acceptance.sh` reads it from the pack's `attachmentName`. |
+| `POST /api/v1/simulation` returns a bare `500 simulation_start_failed` | Deliberate: the error may contain config-derived secrets, so neither the response nor the log carries detail. | Run `preflight` with the same payload — it reports the real diagnostic. |
+
+`niac-demo-lab.service` requests attachment mode `access` on the same interface
+the presentation packs hold as `trunk`. Mixing modes on one interface is
+rejected by design, so that unit fails whenever the trunk sessions are up. It
+predates the concurrent-VLAN model and should be disabled rather than debugged.
+
 ## Findings triage
 
 Every finding kind the comparator can emit, and where to look first.

--- a/scripts/lab/acceptance.sh
+++ b/scripts/lab/acceptance.sh
@@ -72,16 +72,21 @@ print(json.dumps(doc['manifest']))
 
 start_session() {
 	local pack="$1" vlan="$2" out="$3"
+	# The generated config declares a logical attachment; the start request has
+	# to name it. Omitting it fails preflight with unknown_attachment, because
+	# a config that declares attachments requires the binding to pick one.
 	python3 -c "
 import json,sys
+request = json.load(open(sys.argv[5]))
 print(json.dumps({
   'sessionId': sys.argv[1],
   'attachmentMode': 'trunk',
   'accessVlan': int(sys.argv[2]),
   'interface': sys.argv[3],
+  'attachment': request.get('attachmentName', 'cyberscope'),
   'configData': open(sys.argv[4]).read(),
 }))
-" "$pack" "$vlan" "${LAB_IFACE:-eth0}" "${out}/${pack}.yaml" >"${out}/${pack}.start.json"
+" "$pack" "$vlan" "${LAB_IFACE:-eth0}" "${out}/${pack}.yaml" "${out}/${pack}.request.json" >"${out}/${pack}.start.json"
 
 	"${CURL[@]}" -X POST "${NIAC_URL}/api/v1/simulation/preflight" \
 		-H 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary

Found by running the acceptance loop against CT304 for real: **the script could not start any pack.**

A generated config declares a logical attachment (`cyberscope` connected to `lab-transit`). A config that declares attachments requires the start request to name one. The script omitted it, so:

- `POST /api/v1/simulation/preflight` returned `safe: false` with `unknown_attachment` — "logical attachment does not exist"
- `POST /api/v1/simulation` returned a bare `500 simulation_start_failed`

The attachment name now comes from the pack's own `attachmentName` rather than a hardcoded constant, so a pack naming a different attachment still starts.

### Why this took real diagnosis

The 500 carries no detail **by design** — the error may include config-derived secrets, so neither the response body nor the daemon log records it. That makes `preflight` the only thing that reports the actual cause. The runbook now says so explicitly, alongside both start-up failures seen in the lab.

Also documented: `niac-demo-lab.service` requests attachment mode `access` on the same interface the presentation packs hold as `trunk`. Mixing modes on one interface is rejected by design, so that unit fails whenever the trunk sessions are up. It predates the concurrent-VLAN model and should be disabled rather than debugged — it has been failing on CT304 since 2026-08-04.

## Linked Issue

Related to #882

## Testing Evidence

Verified against the live lab (CT304, niac v0.94.26-dirty, 7 concurrent trunk sessions):

```
bash -n scripts/lab/acceptance.sh      syntax OK
shellcheck scripts/lab/acceptance.sh   clean
markdownlint runbook                   0 errors

# with the attachment named, against the running daemon:
preflight: 200 safe: True diagnostics: null
start:     201 session=hospital vlan=200 devices=75

# and confirmed on the wire from a VLAN 200 tester:
ping 10.254.200.1        2/2 received, 0% loss
snmpget sysName.0        "LAB-EDGE-R1"
snmpget sysDescr.0       "Cisco Catalyst 8500L isolated lab edge"
snmpwalk lldpRemSysName  "WAN-R1", "WAN-R2"
snmpwalk cdpCacheDeviceId "WAN-R1", "WAN-R2"
```

The hospital pack was **not running** on CT304 before this — it had failed to start on 2026-08-04 and stayed down, while the other six packs ran. Recovery reported "7 active simulation sessions restored" but only 6 came back. It is running now.

## Security and Release Checklist

- Operator script only; no product code change.
- No credential handling changed; the script still sends `Authorization` only when `NIAC_API_TOKEN` is set.
- The opaque 500 is left opaque — this documents how to diagnose around it rather than weakening it to leak config-derived detail.
- No secrets, no default credentials, no phone-home.

Release: no version bump; release-please owns tagging.