### PR TITLE
feat(scenario): author utilization that looks like a network under load

### DIFF
--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -181,20 +181,43 @@ func interfaceSpeed(name string) int {
 	}
 }
 
+// utilization derives a busy-but-plausible load for one interface. A production
+// network under load sits mostly in the 50-70% band, peaks higher on a minority
+// of links, and leaves a few quiet. Keying it off the interface name keeps every
+// run reproducible, which the Link-Live comparator depends on.
 func utilization(name string) (float64, float64) {
-	const (
-		minimumInUtilization  = 5
-		inUtilizationSpread   = 26
-		minimumOutUtilization = 4
-		outUtilizationFactor  = 7
-		outUtilizationSpread  = 25
-	)
+	const outSeedFactor = 7
 	sum := 0
 	for _, value := range []byte(name) {
 		sum += int(value)
 	}
-	return float64(minimumInUtilization + sum%inUtilizationSpread),
-		float64(minimumOutUtilization + (sum*outUtilizationFactor)%outUtilizationSpread)
+	return utilizationBand(sum), utilizationBand(sum * outSeedFactor)
+}
+
+func utilizationBand(seed int) float64 {
+	const (
+		steadyShare   = 70 // of 100 interfaces, this many sit in the steady band
+		peakShare     = 90 // steadyShare..peakShare peak; the remainder stay quiet
+		steadyFloor   = 50
+		peakFloor     = 70
+		quietFloor    = 25
+		bandSpread    = 21 // inclusive width of the steady and peak bands
+		quietSpread   = 25
+		bandSelector  = 100
+		mixMultiplier = 31 // odd multiplier and shift decorrelate band from value
+		mixShift      = 7
+	)
+	// Mix before selecting so a name's band and its value inside that band are
+	// not derived from the same low bits.
+	mixed := seed*mixMultiplier + seed/mixShift
+	switch band := mixed % bandSelector; {
+	case band < steadyShare:
+		return float64(steadyFloor + seed%bandSpread)
+	case band < peakShare:
+		return float64(peakFloor + seed%bandSpread)
+	default:
+		return float64(quietFloor + seed%quietSpread)
+	}
 }
 
 func authoredTrunkPorts(links []link) []converter.TrunkPort {

--- a/internal/scenario/utilization_truth_test.go
+++ b/internal/scenario/utilization_truth_test.go
@@ -1,0 +1,61 @@
+package scenario_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+const (
+	steadyFloor        = 50
+	peakFloor          = 70
+	utilizationCeiling = 90
+	wantSteadyPercent  = 50
+)
+
+// A demo network has to look busy. Authored utilization sits mostly in the
+// 50-70% band, peaks higher on a minority of interfaces, and leaves a few quiet
+// — never above 90%, which would read as a saturated link rather than a healthy
+// one.
+func TestAuthoredUtilizationLooksBusy(t *testing.T) {
+	for _, pack := range scenario.Packs() {
+		steady, total := packUtilizationBands(t, pack)
+		if total == 0 {
+			t.Fatalf("%s authored no interface utilization", pack.ID)
+		}
+		if got := steady * 100 / total; got < wantSteadyPercent {
+			t.Errorf("%s steady-band utilization = %d%%, want at least %d%%",
+				pack.ID, got, wantSteadyPercent)
+		}
+	}
+}
+
+func packUtilizationBands(t *testing.T, pack scenario.Pack) (int, int) {
+	t.Helper()
+	var steady, total int
+	result, err := scenario.Generate(pack.Request)
+	if err != nil {
+		t.Fatalf("generate %s: %v", pack.ID, err)
+	}
+	cfg, err := config.LoadYAMLBytes(result.YAML)
+	if err != nil {
+		t.Fatalf("load %s: %v", pack.ID, err)
+	}
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		for _, iface := range device.Interfaces {
+			for _, value := range []float64{iface.InUtilization, iface.OutUtilization} {
+				total++
+				if value > utilizationCeiling {
+					t.Errorf("%s %s %s utilization %.0f%% exceeds %d%%",
+						pack.ID, device.Name, iface.Name, value, utilizationCeiling)
+				}
+				if value >= steadyFloor && value < peakFloor {
+					steady++
+				}
+			}
+		}
+	}
+	return steady, total
+}


### PR DESCRIPTION
## Summary

Authored interface utilization sat between 4% and 30%, which reads as an idle lab on a Link-Live topology map rather than a facility under load. Utilization now lands mostly in the 50-70% band, peaks into 70-90% on a minority of interfaces, and leaves a few quiet. Values stay deterministic (derived from the interface name) so the Link-Live acceptance comparator keeps working from reproducible authored truth.

## Linked Issue

Fixes #1198

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Generator-only change to authored values. No protocol, API, or auth surface touched.

## Testing Evidence

New `TestAuthoredUtilizationLooksBusy` asserts for every one of the 7 packs that the steady band dominates and nothing exceeds 90%. Black-box through the public `Generate()` API.

```text
$ go test ./internal/scenario/... -count=1
ok  	github.com/MustardSeedNetworks/niac-go/internal/scenario	5.026s

$ golangci-lint run internal/scenario/...
0 issues.

Measured distribution, hospital pack (664 interface samples):
  min=27%  p25=50%  median=57%  p75=64%  max=84%

  MED-ACC-SW01   HundredGigabitEthernet1/0/49  in=70% out=64%
  MED-ACC-SW01   TenGigabitEthernet1/0/1       in=73% out=27%
  MED-WAP-B01-F01-01  Dot11Radio1              in=83% out=57%
  MED-WAP-B01-F01-01  Dot11Radio2              in=64% out=84%

Band shares across all 7 packs:
  steady 50-70%: 68%   peak >=70%: 22%   quiet <50%: 10%
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (None touched.)
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Behavior change is authored demo data; issue #1198 records the rationale.)