### PR TITLE
fix(scenario): keep authored utilization below the Link-Live warning line

### DIFF
--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -185,6 +185,10 @@ func interfaceSpeed(name string) int {
 // network under load sits mostly in the 50-70% band, peaks higher on a minority
 // of links, and leaves a few quiet. Keying it off the interface name keeps every
 // run reproducible, which the Link-Live comparator depends on.
+//
+// Peaks stop below utilizationWarningFloor: Link-Live raises an interface
+// Warning above 80% (measured — clean up to 78.7%, warned from 81.8%), and a
+// demo map should read healthy rather than scattered with amber icons.
 func utilization(name string) (float64, float64) {
 	const outSeedFactor = 7
 	sum := 0
@@ -201,7 +205,8 @@ func utilizationBand(seed int) float64 {
 		steadyFloor   = 50
 		peakFloor     = 70
 		quietFloor    = 25
-		bandSpread    = 21 // inclusive width of the steady and peak bands
+		steadySpread  = 21 // inclusive width of the steady band: 50-70
+		peakSpread    = 9  // inclusive width of the peak band: 70-78
 		quietSpread   = 25
 		bandSelector  = 100
 		mixMultiplier = 31 // odd multiplier and shift decorrelate band from value
@@ -212,9 +217,9 @@ func utilizationBand(seed int) float64 {
 	mixed := seed*mixMultiplier + seed/mixShift
 	switch band := mixed % bandSelector; {
 	case band < steadyShare:
-		return float64(steadyFloor + seed%bandSpread)
+		return float64(steadyFloor + seed%steadySpread)
 	case band < peakShare:
-		return float64(peakFloor + seed%bandSpread)
+		return float64(peakFloor + seed%peakSpread)
 	default:
 		return float64(quietFloor + seed%quietSpread)
 	}

--- a/internal/scenario/utilization_truth_test.go
+++ b/internal/scenario/utilization_truth_test.go
@@ -8,16 +8,20 @@ import (
 )
 
 const (
-	steadyFloor        = 50
-	peakFloor          = 70
-	utilizationCeiling = 90
-	wantSteadyPercent  = 50
+	steadyFloor       = 50
+	peakFloor         = 70
+	wantSteadyPercent = 50
+
+	// Link-Live raises an interface Warning above 80% utilization. Measured
+	// against a live discovery: interfaces up to 78.7% stayed clean, 81.8% and
+	// above were flagged. Authored peaks must stay below that line so a demo
+	// map reads healthy instead of amber.
+	utilizationWarningFloor = 80
 )
 
 // A demo network has to look busy. Authored utilization sits mostly in the
 // 50-70% band, peaks higher on a minority of interfaces, and leaves a few quiet
-// — never above 90%, which would read as a saturated link rather than a healthy
-// one.
+// — always below the Link-Live warning threshold.
 func TestAuthoredUtilizationLooksBusy(t *testing.T) {
 	for _, pack := range scenario.Packs() {
 		steady, total := packUtilizationBands(t, pack)
@@ -47,9 +51,9 @@ func packUtilizationBands(t *testing.T, pack scenario.Pack) (int, int) {
 		for _, iface := range device.Interfaces {
 			for _, value := range []float64{iface.InUtilization, iface.OutUtilization} {
 				total++
-				if value > utilizationCeiling {
-					t.Errorf("%s %s %s utilization %.0f%% exceeds %d%%",
-						pack.ID, device.Name, iface.Name, value, utilizationCeiling)
+				if value >= utilizationWarningFloor {
+					t.Errorf("%s %s %s utilization %.0f%% would trip the Link-Live warning at %d%%",
+						pack.ID, device.Name, iface.Name, value, utilizationWarningFloor)
 				}
 				if value >= steadyFloor && value < peakFloor {
 					steady++


### PR DESCRIPTION
## Summary

Authored peaks reached 90%. A live Link-Live discovery showed the platform raises an interface **Warning above 80%**, so three switch interfaces on the hospital map went amber — reading as a fault rather than a healthy network under load. Peaks now stop at **78%**; the steady 50-70% band is unchanged, so the map still looks busy without tripping the threshold.

## Linked Issue

Related to #1198

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Generator-only change to authored values.

## Testing Evidence

Threshold measured empirically against live discovery `6a75485741d3767f8ec8cb7b` (314 interfaces reporting utilization):

```text
clean   : n=311  range 0.0 - 78.7
warned  : n=3    range 81.8 - 83.8
=> Link-Live interface Warning threshold is 80%

After the cap, hospital pack (664 interface samples):
  min=27%  p25=50%  median=57%  p75=64%  max=77%

$ go test ./internal/scenario/... -count=1
ok  	github.com/MustardSeedNetworks/niac-go/internal/scenario	5.598s

$ golangci-lint run internal/scenario/...
0 issues.
```

`TestAuthoredUtilizationLooksBusy` now asserts against `utilizationWarningFloor = 80` and records the measured evidence in a comment, so the reason for the cap survives.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (None touched.)
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Rationale captured in code comment and commit.)