### PR TITLE
fix(dns): stop emitting a trailing empty label in PTR replies

### DIFF
--- a/internal/protocols/dns_ptr_wire_test.go
+++ b/internal/protocols/dns_ptr_wire_test.go
@@ -1,0 +1,103 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+// TestPTRAnswerParsesBackOnTheWire guards the wire form of a PTR reply.
+//
+// gopacket appends the root label when it serializes a name, so handing it a
+// name that already ends in "." adds an empty label and a second terminator.
+// The record then declares one more byte of RDATA than the name occupies, and
+// every resolver rejects the reply with "extra input data". That is why
+// simulated endpoints rendered as bare IP addresses in Link-Live instead of
+// their hostnames: the forward lookup worked, the reverse lookup was discarded.
+func TestPTRAnswerParsesBackOnTheWire(t *testing.T) {
+	const (
+		wantName = "med-nurse-b01-f01-01.care.example"
+		query    = "21.210.51.10.in-addr.arpa"
+	)
+
+	handler := NewDNSHandler(newTestStackInternal(t))
+	set := &dnsRecordSet{
+		forward: make(map[string][]dnsRecord),
+		reverse: map[string]dnsPTR{
+			net.ParseIP("10.51.210.21").String(): {name: wantName, ttl: 300},
+		},
+	}
+	ctx := &dnsResolveContext{}
+
+	handler.resolvePTRRecord(layers.DNSQuestion{
+		Name:  []byte(query),
+		Type:  layers.DNSTypePTR,
+		Class: layers.DNSClassIN,
+	}, set, ctx)
+
+	if len(ctx.answers) != 1 {
+		t.Fatalf("resolver produced %d answers, want 1", len(ctx.answers))
+	}
+
+	response := &layers.DNS{
+		ID: 1, QR: true, AA: true,
+		Questions: []layers.DNSQuestion{{
+			Name: []byte(query), Type: layers.DNSTypePTR, Class: layers.DNSClassIN,
+		}},
+		Answers: ctx.answers,
+	}
+	buf := gopacket.NewSerializeBuffer()
+	if err := response.SerializeTo(buf, gopacket.SerializeOptions{FixLengths: true}); err != nil {
+		t.Fatalf("serialize PTR response: %v", err)
+	}
+
+	var decoded layers.DNS
+	if err := decoded.DecodeFromBytes(buf.Bytes(), gopacket.NilDecodeFeedback); err != nil {
+		t.Fatalf("a resolver could not parse our PTR reply: %v", err)
+	}
+	if len(decoded.Answers) != 1 {
+		t.Fatalf("decoded %d answers, want 1", len(decoded.Answers))
+	}
+	if got := string(decoded.Answers[0].PTR); got != wantName {
+		t.Errorf("PTR name = %q, want %q", got, wantName)
+	}
+
+	// gopacket's decoder tolerates trailing slack inside RDATA; dig and BIND do
+	// not, so assert the declared length matches the name exactly. A wire name
+	// costs one length byte per label plus a single root terminator, which for
+	// a dot-separated name is len(name)+2.
+	wantRDLength := len(wantName) + 2
+	if got := rdLengthOfFirstAnswer(t, buf.Bytes()); got != wantRDLength {
+		t.Errorf("PTR RDLENGTH = %d, want %d (extra bytes make resolvers reject the reply)",
+			got, wantRDLength)
+	}
+}
+
+// rdLengthOfFirstAnswer walks the header, question and answer name to read the
+// first answer's declared RDLENGTH straight off the wire.
+func rdLengthOfFirstAnswer(t *testing.T, packet []byte) int {
+	t.Helper()
+	const (
+		headerLen    = 12
+		typeClassLen = 4
+		ttlLen       = 4
+	)
+	offset := headerLen
+	skipName := func() {
+		for offset < len(packet) && packet[offset] != 0 {
+			offset += int(packet[offset]) + 1
+		}
+		offset++ // root terminator
+	}
+	skipName()             // question name
+	offset += typeClassLen // question type + class
+	skipName()             // answer name
+	offset += typeClassLen // answer type + class
+	offset += ttlLen       // answer TTL
+	if offset+1 >= len(packet) {
+		t.Fatalf("packet truncated before RDLENGTH at offset %d of %d", offset, len(packet))
+	}
+	return int(packet[offset])<<8 | int(packet[offset+1])
+}

--- a/internal/protocols/dns_resolver.go
+++ b/internal/protocols/dns_resolver.go
@@ -213,10 +213,11 @@ func (h *DNSHandler) resolvePTRRecord(
 		return
 	}
 
-	ptr := host.name
-	if !strings.HasSuffix(ptr, ".") {
-		ptr += "."
-	}
+	// Hand the name over without a trailing dot: the serializer appends the
+	// root label itself, and a name that already ends in "." adds an empty
+	// label plus a second terminator. RDLENGTH then overstates the name by one
+	// byte and resolvers reject the whole reply as "extra input data".
+	ptr := strings.TrimSuffix(host.name, ".")
 
 	ctx.answers = append(ctx.answers, layers.DNSResourceRecord{
 		Name:  q.Name,


### PR DESCRIPTION
## Summary

Every PTR reply was malformed and rejected by standard resolvers, so reverse DNS against a NIAC simulation did not work at all. `resolvePTRRecord` appended a trailing dot before handing the name to the serializer, which appends the root label itself — producing an empty label plus a second terminator, and an `RDLENGTH` one byte longer than the name. PTR was the only record type doing this.

This is why simulated **endpoints rendered as bare IP addresses in Link-Live**. Managed devices are named from SNMP `sysName`, but wired endpoints carry no SNMP agent and no LLDP, so a working reverse lookup is their only identity source.

## Linked Issue

Fixes #1200

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

One-line change in the PTR answer path; no other record type touched.

## Testing Evidence

Reproduced against a live hospital simulation on VLAN 200 before the fix:

```text
$ dig +short @10.254.200.1 med-nurse-b01-f01-01.care.example
10.51.210.21                          <- forward lookup fine

$ dig +short -x 10.51.210.21 @10.254.200.1
;; Got bad packet: extra input data
116 bytes

wire bytes of the answer:
  RDLENGTH = 0x0024 = 36
  RDATA    = 14 "med-nurse-b01-f01-01" 04 "care" 07 "example" 00 00
                                                            ^^ ^^ name is 35 bytes

New test, RED before the fix:
--- FAIL: TestPTRAnswerParsesBackOnTheWire
    PTR RDLENGTH = 36, want 35 (extra bytes make resolvers reject the reply)

GREEN after:
$ go test ./internal/protocols/... -count=1
ok  	internal/protocols        2.559s
ok  	internal/protocols/snmp   6.443s
ok  	internal/protocols/snmp/synth  0.116s

$ golangci-lint run internal/protocols/...
0 issues.
```

The test asserts `RDLENGTH` matches the name exactly rather than only round-tripping, because gopacket's own decoder tolerates the trailing slack that `dig` and BIND reject — a round-trip-only assertion passes against the bug.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (None touched; this is response encoding for a simulated protocol.)
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (Rationale captured in code comment, test and issue #1200.)