### PR TITLE
refactor(api): drop the template upload and delete surface

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -305,13 +305,13 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 			methods: []string{http.MethodGet},
 			rl:      rlFile,
 		},
-		// Templates: POST (upload), DELETE, and "use" mutate — write + CSRF.
+		// Templates ship with the product and are read-only; only "use" mutates,
+		// so only it carries write rate limit + CSRF.
 		{
 			path:    "/api/v1/templates",
 			handler: s.handleTemplates,
-			methods: []string{http.MethodGet, http.MethodPost},
-			rl:      rlWrite,
-			csrf:    true,
+			methods: []string{http.MethodGet},
+			rl:      rlFile,
 		},
 		{
 			path:    "/api/v1/templates/use",
@@ -324,9 +324,8 @@ func (s *Server) registerReadOnlyRoutes(mux *http.ServeMux) {
 		{
 			path:    "/api/v1/templates/",
 			handler: s.handleTemplateByName,
-			methods: []string{http.MethodGet, http.MethodDelete},
-			rl:      rlWrite,
-			csrf:    true,
+			methods: []string{http.MethodGet},
+			rl:      rlFile,
 		},
 		// Per-device actions. synthesize-walk (#546 p2) mutates the library +
 		// running config YAML, so this path carries write rate limit + CSRF;

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -613,10 +613,14 @@ func generateTestToken() string {
 // TestCSRFWiring_TemplatesAndLibraryNetworks is the #740 regression test
 // (extended for #897 L4's library-networks unification): it drives
 // requests through the real mux (registerAPIRoutes) to prove the
-// templates + library-networks mutating endpoints actually have
-// csrfProtect in their middleware chain. A POST without the
-// X-Csrf-Token header must be rejected with 403 — if someone removes
-// csrfProtect from routes.go, this fails.
+// library-networks mutating endpoints actually have csrfProtect in their
+// middleware chain. A POST without the X-Csrf-Token header must be
+// rejected with 403 — if someone removes csrfProtect from routes.go, this
+// fails.
+//
+// /api/v1/templates is no longer in this list: templates ship with the
+// product and are read-only, so the path exposes no mutating method. See
+// TestTemplateRoutesRejectMutation.
 func TestCSRFWiring_TemplatesAndLibraryNetworks(t *testing.T) {
 	server, _, token := newTestServerWithAuth(t)
 	lib, err := library.Open(t.TempDir())
@@ -624,14 +628,14 @@ func TestCSRFWiring_TemplatesAndLibraryNetworks(t *testing.T) {
 		t.Fatalf("open library: %v", err)
 	}
 	server.library = lib
-	// The templates/library routes chain through writeRateLimit, whose
-	// limiter newTestServerWithAuth doesn't initialize — set it so the
-	// full mux chain doesn't nil-panic before reaching csrfProtect.
+	// The library routes chain through writeRateLimit, whose limiter
+	// newTestServerWithAuth doesn't initialize — set it so the full mux
+	// chain doesn't nil-panic before reaching csrfProtect.
 	server.writeLimiter = ratelimit.NewRateLimiter(WriteRateLimit, WriteBurst)
 	mux := http.NewServeMux()
 	server.registerAPIRoutes(mux)
 
-	for _, path := range []string{"/api/v1/templates", "/api/v1/library/networks"} {
+	for _, path := range []string{"/api/v1/library/networks"} {
 		t.Run("POST "+path+" without CSRF -> 403", func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, path,
 				bytes.NewReader([]byte(`{"name":"x","content":"y"}`)))
@@ -660,6 +664,41 @@ func TestCSRFWiring_TemplatesAndLibraryNetworks(t *testing.T) {
 			// validation) — only that CSRF did not block it.
 			if rec.Code == http.StatusForbidden {
 				t.Errorf("%s with valid CSRF still 403: %s", path, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestTemplateRoutesRejectMutation locks in that the template paths expose no
+// mutating method. Upload and delete previously existed as registered routes
+// that only ever returned 501 — CSRF-protected, rate-limited surface that
+// could not succeed. They were removed rather than implemented: templates ship
+// with the product and are read-only. If someone re-adds a mutating method
+// here it needs csrfProtect, so this test fails loudly first.
+func TestTemplateRoutesRejectMutation(t *testing.T) {
+	server, _, token := newTestServerWithAuth(t)
+	server.fileLimiter = ratelimit.NewRateLimiter(FileRateLimit, FileBurst)
+	mux := http.NewServeMux()
+	server.registerAPIRoutes(mux)
+
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/templates"},
+		{http.MethodDelete, "/api/v1/templates/example.yaml"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader([]byte(`{}`)))
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s %s: status = %d, want 405 (no mutating template surface)",
+					tc.method, tc.path, rec.Code)
 			}
 		})
 	}

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -26,35 +26,19 @@ type UseTemplateResponse struct {
 	ConfigPath string `json:"configPath"`
 }
 
-// handleTemplates handles GET /api/v1/templates (list) and POST (upload).
+// handleTemplates handles GET /api/v1/templates (list).
 func (s *Server) handleTemplates(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		s.handleTemplatesList(w, r)
-	case http.MethodPost:
-		s.handleTemplateUpload(w, r)
-	default:
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-	}
+	s.handleTemplatesList(w, r)
 }
 
-// handleTemplateByName handles GET /api/v1/templates/{name} and DELETE.
+// handleTemplateByName handles GET /api/v1/templates/{name}.
 func (s *Server) handleTemplateByName(w http.ResponseWriter, r *http.Request) {
-	// Extract template name from path: /api/v1/templates/{name}
 	name := strings.TrimPrefix(r.URL.Path, "/api/v1/templates/")
 	if name == "" {
 		writeError(w, r, http.StatusBadRequest, "invalid_request", "Template name required", nil)
 		return
 	}
-
-	switch r.Method {
-	case http.MethodGet:
-		s.handleTemplateContent(w, r, name)
-	case http.MethodDelete:
-		s.handleTemplateDelete(w, r, name)
-	default:
-		writeError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", nil)
-	}
+	s.handleTemplateContent(w, r, name)
 }
 
 // handleTemplatesList returns a list of available templates.
@@ -155,16 +139,4 @@ func parseUseTemplateRequest(r *http.Request) (*UseTemplateRequest, error) {
 	}
 
 	return &req, nil
-}
-
-// handleTemplateUpload handles POST /api/v1/templates (upload new template).
-func (s *Server) handleTemplateUpload(w http.ResponseWriter, r *http.Request) {
-	// For now, return not implemented
-	writeError(w, r, http.StatusNotImplemented, "not_implemented", "Template upload not yet implemented", nil)
-}
-
-// handleTemplateDelete handles DELETE /api/v1/templates/{name}.
-func (s *Server) handleTemplateDelete(w http.ResponseWriter, r *http.Request, _ string) {
-	// For now, return not implemented (don't want to delete built-in templates)
-	writeError(w, r, http.StatusNotImplemented, "not_implemented", "Template deletion not yet implemented", nil)
 }


### PR DESCRIPTION
## Summary

`POST /api/v1/templates` and `DELETE /api/v1/templates/{name}` were registered routes whose handlers only ever returned **501**. They carried CSRF protection and a write rate limit for an operation that could not succeed, and nothing ever called them — the UI only uses `/api/v1/templates/use`.

The delete stub's own comment explained why it would never be implemented: *"don't want to delete built-in templates"*. Rather than build an upload path nobody asked for, both are removed. The remaining template paths are read-only, so they move from the write rate limit to the file one, and CSRF comes off routes that no longer expose a mutating method.

Net effect: two fewer mutating routes registered, and no endpoint that answers a request with "not yet implemented".

## Linked Issue

Related to #1053

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Removes only unreachable behavior. No caller existed; both methods previously returned 501.

## Testing Evidence

```text
$ go test ./internal/api/... -count=1
ok  	internal/api                6.590s
ok  	internal/api/auth           0.149s
ok  	internal/api/capture        0.148s
ok  	internal/api/ratelimit      0.252s
ok  	internal/api/sse            0.499s
ok  	internal/api/templates      0.231s
ok  	internal/api/tokenstore     0.155s

$ golangci-lint run internal/api/...
0 issues.

$ make schema        # no drift
Wrote docs/schemas/niac.schema.json (1490 lines)
```

New `TestTemplateRoutesRejectMutation` asserts `POST /api/v1/templates` and `DELETE /api/v1/templates/{name}` both return **405**, so re-adding a mutating method without CSRF fails loudly first.

`/api/v1/templates` is dropped from `TestCSRFWiring_TemplatesAndLibraryNetworks` because its premise — that the path mutates — no longer holds. `/api/v1/library/networks` keeps the original #740 assertion unchanged.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. Two mutating routes removed; the surviving `use` route keeps CSRF + write limit + feature gate. Remaining template reads are GET-only.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. No OpenAPI or schema references existed for the removed methods; `make schema` reports no drift.