### PR TITLE
docs: supersede runtime licensing and drop tier claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,14 @@ no bump (use `Release-As:` footer to force). Tags trigger `release.yml`
 which builds Linux, macOS, and Windows archives and attaches checksums plus
 SLSA provenance to the GitHub release.
 
-## License
+## Limits
 
-Free: up to 10 simulated devices; Pro removes tier soft cap; absolute ceiling 1000.
+NIAC ships as one unrestricted binary — no runtime tier, no activation, no
+phone-home. One configuration may carry up to 1,000 devices, and the daemon
+bounds concurrent sessions and total devices across everything running at once.
+These are technical safety limits, not entitlements.
+
+## License
 
 [Business Source License 1.1](LICENSE) — free for non-commercial use;
 commercial use requires a license. Converts to Apache-2.0 on the change

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -52,8 +52,8 @@ NIAC to run as a service.
 Daemon mode records the active simulation launch intent in
 `<data-root>/state/active-simulation.json`. A graceful service shutdown keeps
 this record, and the next daemon start restores the simulation only after the
-current license grants, attachment policy, host interface, configuration,
-runtime requirements, and routed preflight all pass.
+attachment policy, host interface, configuration, runtime requirements, and
+routed preflight all pass.
 
 An explicit simulation stop removes the record. If recovery fails, NIAC keeps
 the API available, leaves the simulation stopped, and reports an actionable

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -67,9 +67,10 @@ simulators to the same production-facing interface.
 
 ## How many devices can I simulate?
 
-NIAC Free allows up to ten simulated devices across CLI, API, UI, import,
-template, configuration mutation, and runtime-start paths. NIAC Pro removes
-that tier soft cap. Every tier retains the absolute 1,000-device ceiling.
+One configuration may carry up to 1,000 devices, enforced across CLI, API, UI,
+import, template, configuration mutation, and runtime-start paths. The daemon
+additionally bounds concurrent sessions and total devices across everything
+running at once.
 
 Practical capacity depends on enabled protocols, traffic rate, walk size,
 host resources, and the observer polling NIAC.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -14,10 +14,10 @@ from the target lab instead of fixed capacity claims.
 - Keep browser filters narrow when inspecting large packet or device sets.
 - Do not modify internal queue constants as an operator tuning mechanism.
 
-NIAC Free supports ten simulated devices. NIAC Pro removes that tier soft cap,
-but the absolute ceiling remains 1,000 devices. This is an authorization and
-safety contract, not a promise that every 1,000-device scenario will meet the
-same latency target on every host.
+One configuration is capped at 1,000 devices, and the daemon bounds concurrent
+sessions and total devices on top of that. These are safety limits, not a
+promise that every 1,000-device scenario will meet the same latency target on
+every host.
 
 ## Measure the running daemon
 

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -69,7 +69,7 @@ counts and deterministic SHA-256 fingerprints.
 Generation is side-effect free: it does not replace the active configuration,
 start a simulation, or save a draft. The returned `content` can be reviewed and
 then stored through the draft API. The generate route requires a read-write
-token, the `config_templates` entitlement, and a CSRF token.
+token and a CSRF token.
 
 Scenario packs carry only the logical attachment name used by the composer.
 They cannot select a host interface, attachment mode, or access VLAN. Starting
@@ -112,9 +112,8 @@ native VLAN, and FDB-only properties are updated on both endpoints together.
 }
 ```
 
-The route requires a read-write token, CSRF protection, and the normal draft
-entitlement checks. It replaces only the named draft; it does not apply or
-restart the running simulation.
+The route requires a read-write token and CSRF protection. It replaces only the
+named draft; it does not apply or restart the running simulation.
 
 ## Session-scoped runtime
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,8 +9,6 @@ criterion below is complete and verified from a release-built artifact.
   routed discovery, SNMP walks, and Link-Live observation.
 - [x] Make injected interface faults observable through IF-MIB and EtherLike-MIB
   counters while preserving monotonic counter behavior.
-- [x] Verify the Free-tier ten-device runtime limit and keep product, API, UI,
-  and operator documentation aligned with that contract.
 - [x] Remove stale roadmap, compatibility, licensing, and deployment claims from
   active documentation and close superseded tracking issues.
 - [ ] Pass lint, formatting, unit, integration, browser, security, package,
@@ -26,9 +24,10 @@ includes the CLI, embedded web UI, API, topology and scenario configuration,
 packet capture analysis and replay, and the protocol implementations shipped in
 the current binary.
 
-The v1 contract will limit NIAC Free to ten simulated devices across every
-configuration and startup path. NIAC Pro will remove that soft limit and unlock
-the Pro capability set. License validation remains local-only.
+NIAC ships as one unrestricted binary. There is no runtime tier, no activation,
+and no phone-home. Resource ceilings are technical safety limits rather than
+entitlements: 1,000 devices for one configuration, plus daemon-wide budgets
+bounding concurrent sessions and total devices.
 
 ## Release Process
 

--- a/docs/WEBUI.md
+++ b/docs/WEBUI.md
@@ -39,7 +39,7 @@ layout.
 
 ## Primary workflows
 
-- **Dashboard** — build, license, simulation, device, and traffic status.
+- **Dashboard** — build, simulation, device, and traffic status.
 - **Simulation** — choose a configuration and physical attachment, run
   preflight, and start or stop the runtime.
 - **Running Devices** — inspect the authoritative state of the active devices.
@@ -53,7 +53,6 @@ layout.
   live capture is running.
 - **Compare & Merge** — compare or merge configuration documents.
 - **SNMP Walks** — validate, analyze, sanitize, and manage walk files.
-- **License** — view the active local license and feature grants.
 
 The canonical route registry is `ui/src/pageRegistry.tsx`; navigation groups
 are defined in `ui/src/navGroups.ts`.
@@ -66,9 +65,9 @@ streams and fetch authoritative state again rather than treating the last
 event as durable truth.
 
 Device tables use shared filtering, pagination, and virtual scrolling for
-larger result sets. NIAC Free is limited to ten simulated devices. NIAC Pro
-removes that tier soft cap; every path still enforces the absolute
-1,000-device ceiling.
+larger result sets. Every path enforces the absolute 1,000-device ceiling for
+one configuration; the daemon additionally bounds concurrent sessions and
+total devices across everything running at once.
 
 ## Development
 

--- a/docs/adr/0005-ed25519-signed-licenses.md
+++ b/docs/adr/0005-ed25519-signed-licenses.md
@@ -1,6 +1,18 @@
 # ADR 0005: Ed25519-signed license tokens
 
-**Status:** Accepted (2026-06-08)
+**Status:** Superseded (2026-08-07)
+
+> **Superseded.** NIAC no longer performs any runtime license validation. The
+> product ships as one unrestricted binary; revenue attaches to releases,
+> support, and custom modelling rather than a runtime unlock. `internal/license`,
+> the `/api/v1/license` endpoint, the `niac license` commands, and every feature
+> gate were removed (see #1203). Resource ceilings remain as technical safety
+> limits — 1,000 devices for one configuration, plus daemon-wide session and
+> device budgets — not as entitlements.
+>
+> The reasoning below is retained because it explains why the previous rotor
+> cipher was replaced, and it still applies to any signed-artifact work in the
+> fleet. It no longer describes shipped NIAC behaviour.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,7 +10,7 @@ people and the diffs. Format matches the sibling repos (seed/stem).
 | [0002](0002-capability-registry.md) | Capability registry for route policy | Accepted |
 | [0003](0003-dependency-direction-depguard.md) | Dependency direction enforced by depguard | Accepted |
 | [0004](0004-scope-based-auth-posture.md) | Scope-based bearer-token auth + CSRF posture | Accepted |
-| [0005](0005-ed25519-signed-licenses.md) | Ed25519-signed license tokens | Accepted |
+| [0005](0005-ed25519-signed-licenses.md) | Ed25519-signed license tokens | Superseded |
 | [0006](0006-internal-api-sub-package-decomposition.md) | Decompose `internal/api` into isolated sub-packages | Accepted |
 | [0007](0007-json-wire-casing-convention.md) | JSON wire-casing convention (camelCase API, no exceptions) | Accepted |
 | [0008](0008-multi-vlan-segment-playback.md) | Multi-VLAN segment playback (tagged + untagged, per-segment config) | Proposed |


### PR DESCRIPTION
## Summary

The product ships as one unrestricted binary, so documentation describing tiers, entitlements, or license validation no longer matched the code.

**ADR 0005 is marked Superseded, not deleted.** An ADR records why a decision was made — including one later reversed — and its reasoning about the forgeable rotor cipher still applies to signed-artifact work elsewhere in the fleet. A banner states what actually ships now.

Everywhere else, tier language is replaced with the limits that really exist: **1,000 devices for one configuration**, plus daemon-wide session and device budgets.

Touches `README`, `FAQ`, `PERFORMANCE`, `WEBUI`, `ROADMAP`, `DEPLOYMENT`, `REST_API`, and the ADR index.

## Linked Issue

Closes #1203

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [x] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Documentation only.

## Testing Evidence

Two files the original survey missed were caught by grepping after the fact — `docs/FAQ.md` and `docs/PERFORMANCE.md` both still stated the ten-device Free limit.

```text
$ grep -rniE "free.tier|niac (free|pro)|tier soft cap|license (grant|tier|validation)" docs/*.md docs/adr/*.md README.md
(only the Superseded banner in ADR 0005, and one false positive: "NIAC process")

$ grep -rn "/api/v1/license\|niac license" docs/ README.md ui/src/data/help-content.ts
(no matches)
```

## Deliberately untouched

These state the legal terms of the source, which have not changed:

- the BUSL-1.1 section in `README.md` and the `LICENSE` file
- SPDX headers on every Go file
- `license:` metadata in `docs/openapi.yaml` and both goreleaser configs
- `.github/workflows/license-check.yml` and the dependency-compliance make targets

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. No code touched. `REST_API.md` no longer claims an entitlement is required on two routes — matching the code, which still requires a read-write token and CSRF on both.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. This PR is that update.