### PR TITLE
fix(scenario): give endpoints an SNMP identity so they stop rendering as IPs

### DIFF
--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -115,6 +115,17 @@ func endpointDevice(
 			"role": kind.role, "site": site.Code, "model": profile.Model,
 			"platform": profile.Platform, "software": profile.Software,
 		},
+		// Endpoints answer SNMP for their own identity. A discovery tool names a
+		// host from sysName first and only falls back to a reverse lookup, which
+		// it resolves through its own resolver rather than the simulated one —
+		// so without an agent here these devices render as bare IP addresses on
+		// the map. Managed endpoints (infusion pumps, imaging, patient monitors,
+		// clinical workstations) carry an agent in the real world too.
+		SnmpAgent: &converter.SnmpAgent{
+			Community: request.SNMPCommunity, SysName: name,
+			SysDescr:    profile.Vendor + " " + profile.Model,
+			SysLocation: site.Location, SysContact: "netops@" + request.Domain,
+		},
 	}
 	if kind.osType == "windows" {
 		device.Netbios = &converter.NetbiosConfig{

--- a/internal/scenario/utilization_truth_test.go
+++ b/internal/scenario/utilization_truth_test.go
@@ -63,3 +63,28 @@ func packUtilizationBands(t *testing.T, pack scenario.Pack) (int, int) {
 	}
 	return steady, total
 }
+
+// Every device must answer SNMP with its own name. A discovery tool names a
+// host from sysName first and only falls back to a reverse lookup, which it
+// resolves through its own resolver rather than the simulated one. Endpoints
+// without an agent therefore rendered as bare IP addresses on a Link-Live map
+// even though the simulation served correct PTR records.
+func TestEveryDeviceAnswersSNMPWithItsName(t *testing.T) {
+	for _, pack := range scenario.Packs() {
+		result, err := scenario.Generate(pack.Request)
+		if err != nil {
+			t.Fatalf("generate %s: %v", pack.ID, err)
+		}
+		cfg, err := config.LoadYAMLBytes(result.YAML)
+		if err != nil {
+			t.Fatalf("load %s: %v", pack.ID, err)
+		}
+		for index := range cfg.Devices {
+			device := &cfg.Devices[index]
+			if got := device.SNMPConfig.SysName; got != device.Name {
+				t.Errorf("%s %s sysName = %q, want %q — a device without its own sysName renders as a bare IP",
+					pack.ID, device.Name, got, device.Name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Eighteen medical endpoints appeared on the Link-Live map as bare addresses — `10.51.210.21` rather than `MED-NURSE-B01-F01-01` — across every capture.

**Fixing the malformed PTR replies (#1200) did not clear it**, and the live check explains why:

```
dig -x 10.51.210.21 @10.254.200.1  →  med-nurse-b01-f01-01.care.example.   ✅
Link-Live still shows              →  10.51.210.21                          ❌
```

A discovery tool names a host from **`sysName` first** and only falls back to a reverse lookup — which it resolves through **its own** resolver, not the simulated one. That resolver knows nothing about `10.51.210.0/24`. Switches were never affected because they already carry an agent.

`endpointDevice` now publishes an SNMP agent with its own `sysName`. Managed endpoints — infusion pumps, imaging, patient monitors, clinical workstations — carry an agent in the real world too, so this is more faithful, not less.

## Linked Issue

Related to #1200

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Generator-only: adds an SNMP agent to devices that previously published none.

## Testing Evidence

New `TestEveryDeviceAnswersSNMPWithItsName` asserts every generated device in every pack answers with its own name.

**Verified the test is meaningful** rather than vacuous — with `sysName` deliberately wrong it reports **378 failures** across the seven packs, and passes with the fix:

```text
$ go test ./internal/scenario/ -run TestEveryDeviceAnswersSNMP -count=1   # sysName broken
378 failures

$ go test ./internal/scenario/... ./internal/config/... -count=1          # with the fix
ok  	internal/scenario   6.340s
ok  	internal/config     0.367s

$ golangci-lint run internal/scenario/...
0 issues.
```

Live evidence from the clean VLAN-200-only capture that motivated this (analysis `6a75ff899dc61ad43207c50e`): **75/75 devices, 88/88 links, zero missing** — but 18 `name-conflict` findings, all of the form `expected=MED-NURSE-B01-F01-01 observed=10.51.210.21`.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included. The community string is the existing per-request value already used by every other simulated device.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. None touched — generator only.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Rationale is captured in the code comment and the test.