### PR TITLE
fix(scenario): report endpoint sysDescr the way a real agent would

### DIFF
--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -123,7 +123,11 @@ func endpointDevice(
 		// clinical workstations) carry an agent in the real world too.
 		SnmpAgent: &converter.SnmpAgent{
 			Community: request.SNMPCommunity, SysName: name,
-			SysDescr:    profile.Vendor + " " + profile.Model,
+			// Platform and software already read the way a real agent reports
+			// itself ("Siemens Healthineers MR imaging system, Embedded clinical
+			// software"). The raw vendor field is a lowercase lookup key and
+			// renders as "siemens MAGNETOM Vida" on a discovery map.
+			SysDescr:    profile.Platform + ", " + profile.Software,
 			SysLocation: site.Location, SysContact: "netops@" + request.Domain,
 		},
 	}


### PR DESCRIPTION
## Summary

Endpoints described themselves as `"dell OptiPlex 7020 Micro"` and `"siemens MAGNETOM Vida"`. The `Vendor` field is a lowercase lookup key, not display text, so it rendered wrong on every discovery map.

Managed devices already use written descriptions. Endpoints now use the catalogue text they already carry:

```
Clinical nurse station, Windows 11 Enterprise
Baxter infusion pump, Embedded clinical software
Siemens Healthineers MR imaging system, Embedded clinical software
Philips IntelliVue MX850 bedside patient monitor, Embedded clinical software
GE HealthCare CARESCAPE B850 patient monitor, Embedded clinical software
```

Caught on the wire immediately after #1209 landed — the endpoints answered SNMP correctly but described themselves badly.

## Linked Issue

Related to #1151

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

One string expression in the generator.

## Testing Evidence

Observed live on CT304 running v0.94.28 before the fix:

```text
10.51.210.21  sysName="MED-NURSE-B01-F01-01"  sysDescr="dell OptiPlex 7020 Micro"
10.51.210.22  sysName="MED-PUMP-B01-F01-02"   sysDescr="baxter Sigma Spectrum"
10.51.210.23  sysName="MED-MRI-B01-F01-03"    sysDescr="siemens MAGNETOM Vida"
```

Generated output after:

```text
MED-NURSE-B01-F01-01     Clinical nurse station, Windows 11 Enterprise
MED-PUMP-B01-F01-02      Baxter infusion pump, Embedded clinical software
MED-MRI-B01-F01-03       Siemens Healthineers MR imaging system, Embedded clinical software

$ go test ./internal/scenario/... -count=1
ok  	internal/scenario   7.439s

$ golangci-lint run internal/scenario/...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. None touched.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Authored demo data only.