### PR TITLE
fix(netbios): answer node status requests so endpoints are not anonymous

### DIFF
--- a/internal/protocols/netbios.go
+++ b/internal/protocols/netbios.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/gopacket/gopacket/layers"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
 )
 
 // NetBIOS ports.
@@ -74,6 +76,7 @@ const (
 	nbnsMinHeader        = 12     // Minimum NBNS header size
 	nbDGMMinHeader       = 10     // Minimum Datagram header size
 	nbnsRecordTypeNB     = 0x0020 // NB record type
+	nbnsRecordTypeNBSTAT = 0x0021 // NBSTAT (node status) record type
 	nbnsClassIN          = 0x0001 // IN class
 	nbnsDefaultTTL       = 300    // Default TTL in seconds
 	nbnsDefaultNodeFlags = 0x0000 // Default B-node, unique name
@@ -166,6 +169,11 @@ func (h *NetBIOSHandler) handleNameQuery(
 	devices []*config.Device,
 ) {
 	name, nameType, _ := h.decodeNetBIOSName(data)
+	if queryRecordType(data) == nbnsRecordTypeNBSTAT {
+		h.handleNodeStatus(pkt, packet, transactionID, name, nameType)
+
+		return
+	}
 	if name == "" {
 		if h.debugLevel >= DebugLevelInfo {
 			_, _ = fmt.Fprintf(os.Stdout, "NetBIOS NS: Failed to decode name sn=%d\n", pkt.SerialNumber)
@@ -593,4 +601,143 @@ func (h *NetBIOSHandler) RegisterName(name string, device *config.Device) {
 // SetDebugLevel updates the debug level.
 func (h *NetBIOSHandler) SetDebugLevel(level int) {
 	h.debugLevel = level
+}
+
+// queryRecordType reads the QTYPE that follows the encoded name in an NBNS
+// question. The name is always nbnsEncodedNameCap bytes; decodeNetBIOSName's
+// own offset already steps past QTYPE and QCLASS, so it cannot be used here.
+func queryRecordType(data []byte) uint16 {
+	if len(data) < nbnsEncodedNameCap+2 {
+		return 0
+	}
+
+	return binary.BigEndian.Uint16(data[nbnsEncodedNameCap : nbnsEncodedNameCap+2])
+}
+
+// handleNodeStatus answers an NBSTAT (node status) request.
+//
+// A discovery tool that finds an unknown address asks it "what are you called"
+// by sending NBSTAT for the wildcard name "*". That cannot be answered by
+// matching the queried name against a device, the way an ordinary name query
+// is, because "*" matches nothing — the device is identified by the address the
+// request was sent to. Without this, simulated Windows endpoints stayed
+// anonymous on a discovery map even with NetBIOS enabled.
+func (h *NetBIOSHandler) handleNodeStatus(
+	pkt *Packet,
+	packet gopacket.Packet,
+	transactionID uint16,
+	name string,
+	nameType byte,
+) {
+	ipv4, eth := extractNameQueryLayers(packet)
+	if ipv4 == nil || eth == nil {
+		return
+	}
+
+	device := firstNetBIOSDevice(h.stack.devicesFor(pkt.VLAN).GetByIP(ipv4.DstIP))
+	if device == nil {
+		return
+	}
+
+	names := deriveNetBIOSNames(device)
+	if len(names) == 0 {
+		return
+	}
+
+	deviceIPv4 := getFirstIPv4(device.IPAddresses)
+	if deviceIPv4 == nil {
+		return
+	}
+
+	h.sendNodeStatusResponse(pkt, transactionID, name, nameType, names,
+		deviceIPv4, ipv4.SrcIP, device.MACAddress, eth.SrcMAC)
+
+	if h.debugLevel >= DebugLevelInfo {
+		_, _ = fmt.Fprintf(os.Stdout, "NetBIOS NS: Node status for %s -> %d name(s) sn=%d\n",
+			deviceIPv4, len(names), pkt.SerialNumber)
+	}
+}
+
+// firstNetBIOSDevice picks the device at an address that actually serves
+// NetBIOS. One address can map to several devices, and only one of them needs
+// to answer.
+func firstNetBIOSDevice(devices []*config.Device) *config.Device {
+	for _, device := range devices {
+		if device != nil && device.NetBIOSConfig != nil && device.NetBIOSConfig.Enabled {
+			return device
+		}
+	}
+
+	return nil
+}
+
+// sendNodeStatusResponse writes an NBSTAT answer listing the device's names.
+func (h *NetBIOSHandler) sendNodeStatusResponse(
+	reqPkt *Packet,
+	transactionID uint16,
+	name string,
+	nameType byte,
+	names []netbiosNameEntry,
+	deviceIP, dstIP net.IP,
+	srcMAC, dstMAC net.HardwareAddr,
+) {
+	const (
+		nbstatNameLen       = 15 // padded name inside a node-status entry
+		nbstatEntryLen      = 18 // 15 name + 1 suffix + 2 flags
+		nbstatStatisticsLen = 46 // unit ID plus counters, zero-filled after the MAC
+		nbstatGroupFlag     = 0x8000
+		nbstatActiveFlag    = 0x0400
+		macLen              = 6
+	)
+
+	// A node-status reply carries the name count in one byte, so never claim
+	// more names than that field can express.
+	if len(names) > math.MaxUint8 {
+		names = names[:math.MaxUint8]
+	}
+
+	body := new(bytes.Buffer)
+	body.WriteByte(safeconv.Uint8(len(names)))
+
+	for _, entry := range names {
+		padded := entry.Name
+		if len(padded) > nbstatNameLen {
+			padded = padded[:nbstatNameLen]
+		}
+		body.WriteString(padded + strings.Repeat(" ", nbstatNameLen-len(padded)))
+		body.WriteByte(entry.Suffix)
+
+		flags := uint16(nbstatActiveFlag)
+		if entry.Group {
+			flags |= nbstatGroupFlag
+		}
+		_ = binary.Write(body, binary.BigEndian, flags)
+	}
+
+	// Statistics: the adapter's unit ID is its MAC; the counters that follow
+	// are reported as zero because nothing here models adapter statistics.
+	statistics := make([]byte, nbstatStatisticsLen)
+	copy(statistics, srcMAC[:min(len(srcMAC), macLen)])
+	body.Write(statistics)
+
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.BigEndian, transactionID)
+	_ = binary.Write(buf, binary.BigEndian, uint16(NBNSFlagResponse|NBNSFlagAuthAnswer))
+	_ = binary.Write(buf, binary.BigEndian, uint16(0)) // QDCOUNT
+	_ = binary.Write(buf, binary.BigEndian, uint16(1)) // ANCOUNT
+	_ = binary.Write(buf, binary.BigEndian, uint16(0)) // NSCOUNT
+	_ = binary.Write(buf, binary.BigEndian, uint16(0)) // ARCOUNT
+
+	buf.Write(h.encodeNetBIOSName(name, nameType))
+	_ = binary.Write(buf, binary.BigEndian, uint16(nbnsRecordTypeNBSTAT))
+	_ = binary.Write(buf, binary.BigEndian, uint16(nbnsClassIN))
+	_ = binary.Write(buf, binary.BigEndian, uint32(0)) // node status carries no TTL
+	_ = binary.Write(buf, binary.BigEndian, safeconv.Uint16(body.Len()))
+	buf.Write(body.Bytes())
+
+	_ = h.stack.udpHandler.SendUDP(
+		deviceIP.To4(), dstIP.To4(),
+		NetBIOSNameServicePort, NetBIOSNameServicePort,
+		buf.Bytes(), srcMAC, dstMAC, reqPkt.VLAN,
+	)
 }

--- a/internal/protocols/netbios_nbstat_test.go
+++ b/internal/protocols/netbios_nbstat_test.go
@@ -1,0 +1,169 @@
+package protocols
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// A discovery tool that finds an unknown address asks it "what are you called"
+// by sending an NBSTAT node-status request for the wildcard name "*". That
+// cannot be answered by matching the queried name against a device, because "*"
+// matches nothing — the device is identified by the address the request was
+// addressed to. Before this was handled, simulated Windows endpoints stayed
+// anonymous on a discovery map even with NetBIOS enabled and port 137 open.
+func TestNodeStatusRequestNamesTheDevice(t *testing.T) {
+	const (
+		deviceName = "MED-NURSE-B01-F01-01"
+		deviceIP   = "10.51.210.21"
+		clientIP   = "10.254.200.100"
+	)
+
+	stack := newTestStackInternal(t)
+	handler := NewNetBIOSHandler(stack, 0)
+
+	device := &config.Device{
+		Name:        deviceName,
+		MACAddress:  net.HardwareAddr{0x02, 0x00, 0x33, 0x00, 0x00, 0x21},
+		IPAddresses: []net.IP{net.ParseIP(deviceIP)},
+		NetBIOSConfig: &config.NetBIOSConfig{
+			Enabled: true, Name: deviceName, Workgroup: "DEMO",
+			NodeType: "H", Services: []string{"workstation"},
+		},
+	}
+	table := stack.devicesFor(0)
+	table.AddByIP(net.ParseIP(deviceIP), device)
+	table.AddByMAC(device.MACAddress, device)
+
+	query := nodeStatusQuery(0x4242)
+	packet, udp := netbiosRequestPacket(t, clientIP, deviceIP, query)
+
+	handler.HandleNameService(&Packet{}, packet, udp, []*config.Device{device})
+
+	select {
+	case sent := <-stack.sendQueue:
+		names := decodeNodeStatusNames(t, sent.Buffer[:sent.Length])
+		if len(names) == 0 {
+			t.Fatal("node status reply carried no names")
+		}
+		// NetBIOS names are capped at 15 characters, so a longer device name is
+		// reported truncated — the same thing a real Windows host does.
+		const netbiosNameLimit = 15
+		want := deviceName
+		if len(want) > netbiosNameLimit {
+			want = want[:netbiosNameLimit]
+		}
+		if names[0] != want {
+			t.Errorf("first reported name = %q, want %q", names[0], want)
+		}
+	default:
+		t.Fatal("no node status reply — the device stays anonymous to a discovery tool")
+	}
+}
+
+// nodeStatusQuery builds an NBSTAT request for the wildcard name, the form a
+// scanner sends when it knows only the address.
+func nodeStatusQuery(transactionID uint16) []byte {
+	payload := make([]byte, 0, 50)
+	payload = binary.BigEndian.AppendUint16(payload, transactionID)
+	payload = binary.BigEndian.AppendUint16(payload, 0) // query, opcode 0
+	payload = binary.BigEndian.AppendUint16(payload, 1) // QDCOUNT
+	payload = binary.BigEndian.AppendUint16(payload, 0) // ANCOUNT
+	payload = binary.BigEndian.AppendUint16(payload, 0) // NSCOUNT
+	payload = binary.BigEndian.AppendUint16(payload, 0) // ARCOUNT
+
+	name := "*" + strings.Repeat("\x00", 15)
+	payload = append(payload, 32)
+	for _, ch := range []byte(name) {
+		payload = append(payload, 0x41+(ch>>4), 0x41+(ch&0x0F))
+	}
+	payload = append(payload, 0)
+
+	payload = binary.BigEndian.AppendUint16(payload, nbnsRecordTypeNBSTAT)
+	payload = binary.BigEndian.AppendUint16(payload, nbnsClassIN)
+
+	return payload
+}
+
+func netbiosRequestPacket(t *testing.T, srcIP, dstIP string, payload []byte) (gopacket.Packet, *layers.UDP) {
+	t.Helper()
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0xaa, 0xbb, 0xcc, 0x00, 0x00, 0x01},
+		DstMAC:       net.HardwareAddr{0x02, 0x00, 0x33, 0x00, 0x00, 0x21},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version: 4, TTL: 64, Protocol: layers.IPProtocolUDP,
+		SrcIP: net.ParseIP(srcIP).To4(), DstIP: net.ParseIP(dstIP).To4(),
+	}
+	udp := &layers.UDP{
+		SrcPort: layers.UDPPort(NetBIOSNameServicePort),
+		DstPort: layers.UDPPort(NetBIOSNameServicePort),
+	}
+	if err := udp.SetNetworkLayerForChecksum(ip); err != nil {
+		t.Fatalf("checksum layer: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	if err := gopacket.SerializeLayers(buf, opts, eth, ip, udp, gopacket.Payload(payload)); err != nil {
+		t.Fatalf("serialize request: %v", err)
+	}
+
+	parsed := gopacket.NewPacket(buf.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
+	decoded, ok := parsed.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	if !ok {
+		t.Fatal("request has no UDP layer")
+	}
+
+	return parsed, decoded
+}
+
+// decodeNodeStatusNames walks the reply to the name list, so the test asserts
+// the wire form a real client parses rather than trusting our own encoder.
+func decodeNodeStatusNames(t *testing.T, frame []byte) []string {
+	t.Helper()
+	packet := gopacket.NewPacket(frame, layers.LayerTypeEthernet, gopacket.Default)
+	udp, ok := packet.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	if !ok {
+		t.Fatal("reply has no UDP layer")
+	}
+	if udp.SrcPort != layers.UDPPort(NetBIOSNameServicePort) {
+		t.Errorf("reply source port = %d, want %d — a client bound to 137 drops anything else",
+			udp.SrcPort, NetBIOSNameServicePort)
+	}
+
+	const (
+		headerLen  = 12
+		nameLen    = 34 // encoded wildcard name plus terminator
+		rrPrefix   = 8  // type, class, ttl
+		entryLen   = 18
+		nameField  = 15
+		countField = 1
+	)
+	offset := headerLen + nameLen + rrPrefix + 2 // + RDLENGTH
+	if len(udp.Payload) <= offset {
+		t.Fatalf("reply too short: %d bytes", len(udp.Payload))
+	}
+
+	count := int(udp.Payload[offset])
+	offset += countField
+
+	names := make([]string, 0, count)
+	for range count {
+		if offset+entryLen > len(udp.Payload) {
+			break
+		}
+		raw := strings.TrimSpace(string(udp.Payload[offset : offset+nameField]))
+		names = append(names, raw)
+		offset += entryLen
+	}
+
+	return names
+}


### PR DESCRIPTION
## Summary

A discovery tool that finds an unknown address asks it *"what are you called"* by sending an **NBSTAT node-status request for the wildcard name `*`**.

NIAC only answered ordinary name queries — which resolve a *known* name to an address by matching the queried name against a device. `*` matches nothing, so the handler returned silently and **every simulated Windows endpoint stayed anonymous on a discovery map**, with NetBIOS enabled and UDP 137 open, which made it look like it was working.

An NBSTAT responder already existed, but only on the DNS path reachable at port 53, so a request to 137 never reached it.

## Linked Issue

Related to #1151

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

New branch in the NetBIOS name-service handler; the existing name-query path is untouched.

## Testing Evidence

Measured against the live simulation first — port open, no answer:

```text
$ nc -uvz 10.51.210.21 137
med-nurse-b01-f01-01.care.example [10.51.210.21] 137 (netbios-ns) open

$ raw NBSTAT node-status query to 137
  10.51.210.21   NO ANSWER (timed out)
  10.51.210.24   NO ANSWER (timed out)
```

New `TestNodeStatusRequestNamesTheDevice` drives the handler with a real wildcard NBSTAT query and parses the reply **off the wire**, including asserting it is sourced from port 137 — a client bound to 137 drops anything else. RED before the fix ("no node status reply — the device stays anonymous to a discovery tool"), GREEN after.

```text
$ go test ./internal/protocols/... -count=1
ok  	internal/protocols              2.722s
ok  	internal/protocols/snmp         6.559s
ok  	internal/protocols/snmp/synth   0.235s

$ golangci-lint run internal/protocols/
0 issues.
```

**Worth knowing:** NetBIOS names are capped at **15 characters**, so `MED-NURSE-B01-F01-01` is reported as `MED-NURSE-B01-F`. That is what a real Windows host does with a name that long. The test asserts the truncation rather than pretending otherwise — and it means a device-naming scheme longer than 15 characters can never round-trip through NetBIOS.

No `//nolint` was added; the one gosec finding was resolved with the repo's own `safeconv.Uint8`.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. No API surface touched. The responder only reports names already published in the device's own NetBIOS configuration, and replies solely to the address the request was addressed to.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Behaviour is a protocol fix; the 15-character limit is documented in the test.