### PR TITLE
feat(mdns): let devices announce themselves on multicast DNS

### DIFF
--- a/docs/schemas/niac.schema.json
+++ b/docs/schemas/niac.schema.json
@@ -347,6 +347,9 @@
         "netbios": {
           "$ref": "#/$defs/NetbiosConfig"
         },
+        "mdns": {
+          "$ref": "#/$defs/MdnsConfig"
+        },
         "snmpv3": {
           "$ref": "#/$defs/Snmpv3Config"
         },
@@ -992,6 +995,49 @@
       "required": [
         "name",
         "connect"
+      ]
+    },
+    "MdnsConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "services": {
+          "items": {
+            "$ref": "#/$defs/MdnsService"
+          },
+          "type": "array"
+        },
+        "ttl": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MdnsService": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "txt": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "port"
       ]
     },
     "NetbiosConfig": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -301,6 +301,7 @@ type Device struct {
 	HTTPConfig          *HTTPConfig          // HTTP server configuration
 	FTPConfig           *FTPConfig           // FTP server configuration
 	NetBIOSConfig       *NetBIOSConfig       // NetBIOS service configuration
+	MDNSConfig          *MDNSConfig          // multicast DNS (Bonjour/Avahi) advertisement
 	SNMPv3Config        *SNMPv3Config        // SNMPv3 USM users (v0.86.0 — free, safe SNMP variant)
 	ICMPConfig          *ICMPConfig          // ICMP/ICMPv4 configuration
 	ICMPv6Config        *ICMPv6Config        // ICMPv6 configuration
@@ -557,6 +558,22 @@ type FTPUser struct {
 	Username string
 	Password string
 	HomeDir  string // Virtual home directory path
+}
+
+// MDNSConfig publishes a device on multicast DNS, the way Bonjour and Avahi
+// announce a host and its services on the local link.
+type MDNSConfig struct {
+	Enabled  bool
+	Hostname string // published as <Hostname>.local
+	Services []MDNSService
+	TTL      uint32
+}
+
+// MDNSService is one advertised DNS-SD service, such as _ipp._tcp.
+type MDNSService struct {
+	Type string
+	Port uint16
+	TXT  []string
 }
 
 // NetBIOSConfig holds NetBIOS service configuration.

--- a/internal/config/yaml_device.go
+++ b/internal/config/yaml_device.go
@@ -415,6 +415,7 @@ func parseDeviceProtocolConfigs(device *Device, yamlDevice *converter.Device) er
 	device.HTTPConfig = parseHTTPConfig(yamlDevice.HTTP, device.Name)
 	device.FTPConfig = parseFTPConfig(yamlDevice.Ftp, device.Name)
 	device.NetBIOSConfig = parseNetBIOSConfig(yamlDevice.Netbios, device.Name)
+	device.MDNSConfig = parseMDNSConfig(yamlDevice.Mdns, device.Name)
 
 	// Handle manageability protocols (v0.86.0)
 	device.SNMPv3Config = parseSNMPv3Config(yamlDevice.Snmpv3)

--- a/internal/config/yaml_protocols.go
+++ b/internal/config/yaml_protocols.go
@@ -129,6 +129,37 @@ func parseIPerf3Config(yamlIPerf3 *converter.IPerf3Config) *IPerf3Config {
 }
 
 // parseNetBIOSConfig parses NetBIOS configuration from YAML.
+// parseMDNSConfig converts the YAML mdns block. A device that advertises
+// itself on multicast DNS defaults to its own name, which is what Bonjour and
+// Avahi do when no hostname is configured.
+func parseMDNSConfig(yamlMdns *converter.MdnsConfig, deviceName string) *MDNSConfig {
+	if yamlMdns == nil {
+		return nil
+	}
+
+	const defaultMDNSTTL = 120
+
+	cfg := &MDNSConfig{
+		Enabled:  yamlMdns.Enabled,
+		Hostname: yamlMdns.Hostname,
+		TTL:      yamlMdns.TTL,
+	}
+	if cfg.Hostname == "" {
+		cfg.Hostname = deviceName
+	}
+	if cfg.TTL == 0 {
+		cfg.TTL = defaultMDNSTTL
+	}
+
+	for _, svc := range yamlMdns.Services {
+		cfg.Services = append(cfg.Services, MDNSService{
+			Type: svc.Type, Port: svc.Port, TXT: append([]string(nil), svc.TXT...),
+		})
+	}
+
+	return cfg
+}
+
 func parseNetBIOSConfig(yamlNetbios *converter.NetbiosConfig, deviceName string) *NetBIOSConfig {
 	if yamlNetbios == nil {
 		return nil

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -172,6 +172,7 @@ type Device struct {
 	HTTP          *HTTPConfig          `yaml:"http,omitempty"`
 	Ftp           *FtpConfig           `yaml:"ftp,omitempty"`
 	Netbios       *NetbiosConfig       `yaml:"netbios,omitempty"`
+	Mdns          *MdnsConfig          `yaml:"mdns,omitempty"`
 	Snmpv3        *Snmpv3Config        `yaml:"snmpv3,omitempty"` // v0.86.0 — free (safe SNMP variant)
 	Icmp          *IcmpConfig          `yaml:"icmp,omitempty"`
 	Icmpv6        *Icmpv6Config        `yaml:"icmpv6,omitempty"`
@@ -500,6 +501,22 @@ type FtpUser struct {
 	Username string `yaml:"username,omitempty"`
 	Password string `yaml:"password,omitempty"`
 	HomeDir  string `yaml:"home_dir,omitempty"`
+}
+
+// MdnsConfig publishes a device on multicast DNS, the way Bonjour and Avahi
+// announce a host and its services on the local link.
+type MdnsConfig struct {
+	Enabled  bool          `yaml:"enabled,omitempty"`
+	Hostname string        `yaml:"hostname,omitempty"`
+	Services []MdnsService `yaml:"services,omitempty"`
+	TTL      uint32        `yaml:"ttl,omitempty"`
+}
+
+// MdnsService is one advertised DNS-SD service, such as _ipp._tcp.
+type MdnsService struct {
+	Type string   `yaml:"type"`
+	Port uint16   `yaml:"port"`
+	TXT  []string `yaml:"txt,omitempty"`
 }
 
 // NetbiosConfig represents NetBIOS service configuration.

--- a/internal/protocols/mdns.go
+++ b/internal/protocols/mdns.go
@@ -1,0 +1,258 @@
+package protocols
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/safeconv"
+)
+
+const (
+	// MDNSPort carries multicast DNS.
+	MDNSPort = 5353
+	// mdnsDomain suffixes every multicast DNS name.
+	mdnsDomain = ".local"
+	// serviceEnumerationName lists the service types a host offers.
+	serviceEnumerationName = "_services._dns-sd._udp.local"
+	// mdnsCacheFlush marks a record as authoritative, replacing any cached
+	// copy rather than adding to it.
+	mdnsCacheFlush = 0x8000
+)
+
+// MDNSHandler answers multicast DNS queries for simulated devices.
+//
+// Apple hardware, printers and most IoT gear announce themselves this way
+// rather than through NetBIOS, so without it those devices are unnamed on a
+// discovery map even when they answer everything else.
+type MDNSHandler struct {
+	stack      *Stack
+	debugLevel int
+}
+
+// NewMDNSHandler creates a multicast DNS responder.
+func NewMDNSHandler(stack *Stack, debugLevel int) *MDNSHandler {
+	return &MDNSHandler{stack: stack, debugLevel: debugLevel}
+}
+
+// SetDebugLevel adjusts responder logging.
+func (h *MDNSHandler) SetDebugLevel(level int) {
+	h.debugLevel = level
+}
+
+// HandleQuery answers a multicast DNS query.
+//
+// Queries arrive addressed to the multicast group, so the responding device
+// cannot be identified from the destination address the way a unicast service
+// identifies it. Each advertising device is matched against the question
+// instead, and every device holding a matching name answers.
+func (h *MDNSHandler) HandleQuery(
+	pkt *Packet,
+	ipLayer *layers.IPv4,
+	udp *layers.UDP,
+	devices []*config.Device,
+	packet gopacket.Packet,
+) {
+	var query layers.DNS
+	if err := query.DecodeFromBytes(udp.Payload, gopacket.NilDecodeFeedback); err != nil {
+		return
+	}
+	if query.QR || len(query.Questions) == 0 {
+		return
+	}
+
+	eth, _ := packet.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+	if eth == nil {
+		return
+	}
+
+	for _, device := range devices {
+		if device == nil || device.MDNSConfig == nil || !device.MDNSConfig.Enabled {
+			continue
+		}
+		answers := mdnsAnswers(device, query.Questions)
+		if len(answers) == 0 {
+			continue
+		}
+		h.respond(pkt, ipLayer, udp, eth, device, query.ID, answers)
+	}
+}
+
+// respond sends one device's answers back to the asking host.
+//
+// The reply is unicast to the querier rather than multicast: it reaches the
+// tool that asked without every other listener on the segment having to
+// process it, and a querier accepts either.
+func (h *MDNSHandler) respond(
+	pkt *Packet,
+	ipLayer *layers.IPv4,
+	udp *layers.UDP,
+	eth *layers.Ethernet,
+	device *config.Device,
+	id uint16,
+	answers []layers.DNSResourceRecord,
+) {
+	response := &layers.DNS{
+		ID: id, QR: true, AA: true,
+		ANCount: safeconv.Uint16(len(answers)),
+		Answers: answers,
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	if err := response.SerializeTo(buf, gopacket.SerializeOptions{FixLengths: true}); err != nil {
+		return
+	}
+
+	deviceIP := getFirstIPv4(device.IPAddresses)
+	if deviceIP == nil {
+		return
+	}
+
+	err := h.stack.udpHandler.SendUDP(
+		deviceIP.To4(), ipLayer.SrcIP.To4(),
+		MDNSPort, uint16(udp.SrcPort),
+		buf.Bytes(), device.MACAddress, eth.SrcMAC, pkt.VLAN,
+	)
+	if err != nil {
+		return
+	}
+
+	if h.debugLevel >= DebugLevelInfo {
+		_, _ = fmt.Fprintf(os.Stdout, "mDNS: %s answered %d record(s) sn=%d\n",
+			device.Name, len(answers), pkt.SerialNumber)
+	}
+}
+
+// mdnsAnswers builds the records a device owes for the questions asked.
+func mdnsAnswers(device *config.Device, questions []layers.DNSQuestion) []layers.DNSResourceRecord {
+	cfg := device.MDNSConfig
+	host := mdnsHostname(cfg)
+	deviceIP := getFirstIPv4(device.IPAddresses)
+	if host == "" || deviceIP == nil {
+		return nil
+	}
+
+	var answers []layers.DNSResourceRecord
+	for _, question := range questions {
+		name := strings.ToLower(strings.TrimSuffix(string(question.Name), "."))
+		switch {
+		case question.Type == layers.DNSTypeA && name == host:
+			answers = append(answers, mdnsRecord(host, layers.DNSTypeA, cfg.TTL, func(r *layers.DNSResourceRecord) {
+				r.IP = deviceIP.To4()
+			}))
+		case question.Type == layers.DNSTypePTR && name == serviceEnumerationName:
+			answers = append(answers, mdnsServiceEnumeration(cfg)...)
+		case question.Type == layers.DNSTypePTR:
+			answers = append(answers, mdnsServiceInstances(cfg, host, name)...)
+		}
+	}
+
+	return answers
+}
+
+// mdnsServiceEnumeration lists the service types this device offers, the reply
+// to the "what services exist here" question a browser asks first.
+func mdnsServiceEnumeration(cfg *config.MDNSConfig) []layers.DNSResourceRecord {
+	records := make([]layers.DNSResourceRecord, 0, len(cfg.Services))
+	for _, svc := range cfg.Services {
+		serviceType := mdnsServiceType(svc.Type)
+		records = append(records, mdnsRecord(serviceEnumerationName, layers.DNSTypePTR, cfg.TTL,
+			func(r *layers.DNSResourceRecord) { r.PTR = []byte(serviceType) }))
+	}
+
+	return records
+}
+
+// mdnsServiceInstances answers a browse for one service type with this
+// device's instance of it.
+func mdnsServiceInstances(
+	cfg *config.MDNSConfig,
+	host, question string,
+) []layers.DNSResourceRecord {
+	var records []layers.DNSResourceRecord
+	for _, svc := range cfg.Services {
+		serviceType := mdnsServiceType(svc.Type)
+		if question != serviceType {
+			continue
+		}
+		instance := mdnsInstanceName(cfg, serviceType)
+		records = append(records,
+			mdnsRecord(serviceType, layers.DNSTypePTR, cfg.TTL,
+				func(r *layers.DNSResourceRecord) { r.PTR = []byte(instance) }),
+			mdnsRecord(instance, layers.DNSTypeSRV, cfg.TTL,
+				func(r *layers.DNSResourceRecord) {
+					r.SRV = layers.DNSSRV{Port: svc.Port, Name: []byte(host)}
+				}),
+			mdnsRecord(instance, layers.DNSTypeTXT, cfg.TTL,
+				func(r *layers.DNSResourceRecord) { r.TXTs = mdnsTXT(svc.TXT) }),
+		)
+	}
+
+	return records
+}
+
+func mdnsRecord(
+	name string,
+	recordType layers.DNSType,
+	ttl uint32,
+	fill func(*layers.DNSResourceRecord),
+) layers.DNSResourceRecord {
+	record := layers.DNSResourceRecord{
+		Name:  []byte(name),
+		Type:  recordType,
+		Class: layers.DNSClass(mdnsCacheFlush | uint16(layers.DNSClassIN)),
+		TTL:   ttl,
+	}
+	fill(&record)
+
+	return record
+}
+
+func mdnsHostname(cfg *config.MDNSConfig) string {
+	name := strings.ToLower(strings.TrimSpace(cfg.Hostname))
+	if name == "" {
+		return ""
+	}
+	if strings.HasSuffix(name, mdnsDomain) {
+		return name
+	}
+
+	return name + mdnsDomain
+}
+
+// mdnsServiceType normalises "_ipp._tcp" into a fully qualified service name.
+func mdnsServiceType(serviceType string) string {
+	name := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(serviceType), "."))
+	if name == "" {
+		return ""
+	}
+	if strings.HasSuffix(name, mdnsDomain) {
+		return name
+	}
+
+	return name + mdnsDomain
+}
+
+// mdnsInstanceName labels this device's instance of a service, the
+// "<instance>.<service>.local" form a browser displays.
+func mdnsInstanceName(cfg *config.MDNSConfig, serviceType string) string {
+	label := strings.TrimSuffix(strings.ToLower(cfg.Hostname), mdnsDomain)
+
+	return label + "." + serviceType
+}
+
+func mdnsTXT(entries []string) [][]byte {
+	if len(entries) == 0 {
+		return [][]byte{[]byte("")}
+	}
+	txt := make([][]byte, 0, len(entries))
+	for _, entry := range entries {
+		txt = append(txt, []byte(entry))
+	}
+
+	return txt
+}

--- a/internal/protocols/mdns_test.go
+++ b/internal/protocols/mdns_test.go
@@ -1,0 +1,175 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// Apple hardware, printers and most IoT gear announce themselves over multicast
+// DNS rather than NetBIOS. Without a responder they are unnamed on a discovery
+// map even when they answer everything else, so a query for <host>.local has to
+// come back with the device's address.
+func TestMDNSAnswersHostnameQuery(t *testing.T) {
+	const (
+		hostLabel = "med-mri-b01-f01-03"
+		deviceIP  = "10.51.210.23"
+	)
+
+	device := mdnsTestDevice(hostLabel, deviceIP, nil)
+	answers := mdnsAnswers(device, []layers.DNSQuestion{{
+		Name: []byte(hostLabel + ".local"), Type: layers.DNSTypeA, Class: layers.DNSClassIN,
+	}})
+
+	if len(answers) != 1 {
+		t.Fatalf("got %d answers, want 1 — the device is unnamed to a browser", len(answers))
+	}
+	if got := string(answers[0].Name); got != hostLabel+".local" {
+		t.Errorf("answer name = %q, want %q", got, hostLabel+".local")
+	}
+	if got := answers[0].IP.String(); got != deviceIP {
+		t.Errorf("answer address = %s, want %s", got, deviceIP)
+	}
+	// The cache-flush bit marks the record authoritative so a browser replaces
+	// any cached copy instead of accumulating stale entries.
+	if answers[0].Class&mdnsCacheFlush == 0 {
+		t.Error("answer is missing the cache-flush bit")
+	}
+}
+
+// A browser first asks which service types exist, then browses one of them.
+// Both steps have to answer or the device shows up with no services.
+func TestMDNSAnswersServiceDiscovery(t *testing.T) {
+	const (
+		hostLabel   = "med-imaging-printer"
+		deviceIP    = "10.51.210.40"
+		serviceType = "_ipp._tcp"
+	)
+
+	device := mdnsTestDevice(hostLabel, deviceIP, []config.MDNSService{
+		{Type: serviceType, Port: 631, TXT: []string{"rp=ipp/print"}},
+	})
+
+	enumeration := mdnsAnswers(device, []layers.DNSQuestion{{
+		Name: []byte(serviceEnumerationName), Type: layers.DNSTypePTR, Class: layers.DNSClassIN,
+	}})
+	if len(enumeration) != 1 {
+		t.Fatalf("service enumeration returned %d answers, want 1", len(enumeration))
+	}
+	if got := string(enumeration[0].PTR); got != serviceType+".local" {
+		t.Errorf("enumerated service = %q, want %q", got, serviceType+".local")
+	}
+
+	browse := mdnsAnswers(device, []layers.DNSQuestion{{
+		Name: []byte(serviceType + ".local"), Type: layers.DNSTypePTR, Class: layers.DNSClassIN,
+	}})
+	if len(browse) != 3 {
+		t.Fatalf("browse returned %d answers, want PTR+SRV+TXT", len(browse))
+	}
+
+	var srv *layers.DNSResourceRecord
+	for index := range browse {
+		if browse[index].Type == layers.DNSTypeSRV {
+			srv = &browse[index]
+		}
+	}
+	if srv == nil {
+		t.Fatal("browse carried no SRV record, so the port is unknown")
+	}
+	if srv.SRV.Port != 631 {
+		t.Errorf("SRV port = %d, want 631", srv.SRV.Port)
+	}
+	if got := string(srv.SRV.Name); got != hostLabel+".local" {
+		t.Errorf("SRV target = %q, want %q", got, hostLabel+".local")
+	}
+}
+
+// A device that does not advertise must stay silent rather than answering for
+// a name it does not own.
+func TestMDNSIgnoresOtherNames(t *testing.T) {
+	device := mdnsTestDevice("med-mri-b01-f01-03", "10.51.210.23", nil)
+
+	answers := mdnsAnswers(device, []layers.DNSQuestion{{
+		Name: []byte("someone-else.local"), Type: layers.DNSTypeA, Class: layers.DNSClassIN,
+	}})
+	if len(answers) != 0 {
+		t.Errorf("answered for a name it does not own: %d record(s)", len(answers))
+	}
+}
+
+func TestMDNSHandlerSkipsResponses(t *testing.T) {
+	stack := newTestStackInternal(t)
+	handler := NewMDNSHandler(stack, 0)
+	device := mdnsTestDevice("med-mri-b01-f01-03", "10.51.210.23", nil)
+
+	reply := &layers.DNS{ID: 1, QR: true}
+	buf := gopacket.NewSerializeBuffer()
+	if err := reply.SerializeTo(buf, gopacket.SerializeOptions{FixLengths: true}); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	packet, udp, ip := mdnsRequestPacket(t, "10.254.200.100", mdnsGroupIPv4Test, buf.Bytes())
+
+	handler.HandleQuery(&Packet{}, ip, udp, []*config.Device{device}, packet)
+
+	select {
+	case <-stack.sendQueue:
+		t.Error("responded to another responder's reply, which would storm the segment")
+	default:
+	}
+}
+
+const mdnsGroupIPv4Test = "224.0.0.251"
+
+func mdnsTestDevice(hostLabel, ip string, services []config.MDNSService) *config.Device {
+	return &config.Device{
+		Name:        hostLabel,
+		MACAddress:  net.HardwareAddr{0x02, 0x00, 0x33, 0x00, 0x00, 0x23},
+		IPAddresses: []net.IP{net.ParseIP(ip)},
+		MDNSConfig: &config.MDNSConfig{
+			Enabled: true, Hostname: hostLabel, TTL: 120, Services: services,
+		},
+	}
+}
+
+func mdnsRequestPacket(
+	t *testing.T,
+	srcIP, dstIP string,
+	payload []byte,
+) (gopacket.Packet, *layers.UDP, *layers.IPv4) {
+	t.Helper()
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0xaa, 0xbb, 0xcc, 0x00, 0x00, 0x01},
+		DstMAC:       net.HardwareAddr{0x01, 0x00, 0x5e, 0x00, 0x00, 0xfb},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version: 4, TTL: 255, Protocol: layers.IPProtocolUDP,
+		SrcIP: net.ParseIP(srcIP).To4(), DstIP: net.ParseIP(dstIP).To4(),
+	}
+	udp := &layers.UDP{SrcPort: MDNSPort, DstPort: MDNSPort}
+	if err := udp.SetNetworkLayerForChecksum(ip); err != nil {
+		t.Fatalf("checksum layer: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	if err := gopacket.SerializeLayers(buf, opts, eth, ip, udp, gopacket.Payload(payload)); err != nil {
+		t.Fatalf("serialize request: %v", err)
+	}
+
+	parsed := gopacket.NewPacket(buf.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
+	decodedUDP, ok := parsed.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	if !ok {
+		t.Fatal("request has no UDP layer")
+	}
+	decodedIP, ok := parsed.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+	if !ok {
+		t.Fatal("request has no IPv4 layer")
+	}
+
+	return parsed, decodedUDP, decodedIP
+}

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -98,6 +98,7 @@ type Stack struct {
 	httpHandler        *HTTPHandler
 	ftpHandler         *FTPHandler
 	netbiosHandler     *NetBIOSHandler
+	mdnsHandler        *MDNSHandler
 	stpHandler         *STPHandler
 	lldpHandler        *LLDPHandler
 	cdpHandler         *CDPHandler
@@ -249,6 +250,7 @@ func newStack(
 	stack.dhcpv6Handler = NewDHCPv6Handler(stack)
 	stack.httpHandler = NewHTTPHandler(stack)
 	stack.ftpHandler = NewFTPHandler(stack)
+	stack.mdnsHandler = NewMDNSHandler(stack, debugConfig.GetProtocolLevel(logging.ProtocolDNS))
 	stack.netbiosHandler = NewNetBIOSHandler(
 		stack,
 		debugConfig.GetProtocolLevel(logging.ProtocolNetBIOS),

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -142,6 +142,9 @@ func (h *UDPHandler) HandlePacket(pkt *Packet, ipLayer *layers.IPv4, devices []*
 		}
 	case UDPPortSNMP:
 		h.handleSNMP(pkt, ipLayer, udp, devices)
+	case MDNSPort:
+		// Multicast DNS (Bonjour/Avahi)
+		h.stack.mdnsHandler.HandleQuery(pkt, ipLayer, udp, devices, packet)
 	case NetBIOSNameServicePort:
 		// NetBIOS Name Service
 		h.stack.netbiosHandler.HandleNameService(pkt, packet, udp, devices)

--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -135,8 +135,37 @@ func endpointDevice(
 		device.Netbios = &converter.NetbiosConfig{
 			Enabled: true, Name: name, Workgroup: "DEMO", NodeType: "H", Services: []string{"workstation"},
 		}
+	} else {
+		// Windows announces itself over NetBIOS; everything else - Apple
+		// hardware, printers, and the embedded Linux inside clinical and
+		// industrial gear - uses multicast DNS. A device with neither is
+		// unnamed to a browser.
+		device.Mdns = &converter.MdnsConfig{
+			Enabled: true, Hostname: strings.ToLower(name),
+			Services: endpointMDNSServices(profile.DeviceType),
+		}
 	}
 	return device
+}
+
+// endpointMDNSServices advertises the services a device of this class offers.
+// A printer that does not answer a print-service browse is just an unnamed
+// host to anything looking for printers.
+func endpointMDNSServices(deviceType string) []converter.MdnsService {
+	const (
+		ippPort  = 631
+		rawPort  = 9100
+		httpPort = 80
+	)
+
+	if deviceType == "printer" {
+		return []converter.MdnsService{
+			{Type: "_ipp._tcp", Port: ippPort, TXT: []string{"rp=ipp/print"}},
+			{Type: "_pdl-datastream._tcp", Port: rawPort},
+		}
+	}
+
+	return []converter.MdnsService{{Type: "_http._tcp", Port: httpPort}}
 }
 
 func newInterface(


### PR DESCRIPTION
## Summary

Apple hardware, printers and the embedded Linux inside clinical and industrial gear announce themselves over **multicast DNS** rather than NetBIOS. NIAC had no mDNS at all — no responder, no config, nothing listening on 5353 — so those devices were unnamed to anything that browses the local link.

There is no mDNS *server*. Every host answers for itself, which is the whole point of the protocol, so each simulated device is its own responder rather than one central service answering for the fleet. A device that does not own the queried name stays silent; answering for names it does not own would storm the segment.

Answers `A` for `<hostname>.local`, the service enumeration a browser asks first, and `PTR`/`SRV`/`TXT` when it then browses a service type. Replies carry the cache-flush bit so a browser replaces a cached record instead of accumulating stale copies, and go back unicast to the querier rather than to the group.

Endpoints that are not Windows now advertise: Windows keeps NetBIOS, everything else gets mDNS, and printers additionally offer `_ipp._tcp` and `_pdl-datastream._tcp` so a print browse finds them.

Stacked on #1214.

## Linked Issue

Related to #1151

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

New protocol handler on a previously unused port. No existing path changes behaviour; a device without an `mdns:` block is unaffected.

## Testing Evidence

Measured against the live hospital simulation on CT304 (VLAN 200). Before — both timed out:

```text
A med-pump-b01-f01-02.local    -> NO ANSWER (timed out)
_services._dns-sd._udp.local   -> NO ANSWER (timed out)
```

After, same queries against the same running simulation:

```text
A med-pump-b01-f01-02.local    -> 53 byte reply,  1 answer, addr=10.51.210.22
A med-mri-b01-f01-03.local     -> 52 byte reply,  1 answer, addr=10.51.210.23
_services._dns-sd._udp.local   -> 70 byte reply,  1 answer  (service enumeration)
browse _http._tcp.local        -> 208 byte reply, 3 answers (PTR + SRV + TXT)
someone-else.local             -> NO ANSWER               <- correctly silent
```

That last line matters as much as the others: a responder that answers for names it does not own would storm the segment.

Four new unit tests cover the hostname query, the two-step service discovery a browser performs, silence on a foreign name, and ignoring another responder's reply.

```text
$ go test ./...
(all packages ok)

$ golangci-lint run ./...
0 issues.
```

No `//nolint` was added; the length conversions use the repo's own `safeconv.Uint16`. `make schema` was regenerated for the new `mdns` config block.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. No API surface touched. The responder only publishes names and services already declared in the device's own configuration, replies unicast to the querier, and stays silent for any name it does not own.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. The generated JSON schema is regenerated for the new config block.
