### PR TITLE
feat(scenario): split endpoints by device class so hosts are not managed gear

### DIFF
--- a/internal/acceptance/linklive/compare_test.go
+++ b/internal/acceptance/linklive/compare_test.go
@@ -115,18 +115,18 @@ func TestFromConfigIncludesFDBLearnedEndpointLink(t *testing.T) {
 			},
 			TrunkPorts: []config.TrunkPort{
 				{
-					Interface: "GigabitEthernet1/0/10", RemoteDevice: "COS-WS-B01-F01-01",
+					Interface: "GigabitEthernet1/0/10", RemoteDevice: "COS-WS-1101",
 					RemoteInterface: "eth0", NativeVLAN: 210, FDBOnly: true,
 				},
 			},
 		},
-		{Name: "COS-WS-B01-F01-01", Type: "host", MACAddress: hostMAC},
+		{Name: "COS-WS-1101", Type: "host", MACAddress: hostMAC},
 	}})
 
 	if len(snapshot.Links) != 1 {
 		t.Fatalf("links = %+v, want one FDB-learned endpoint link", snapshot.Links)
 	}
-	if got := snapshot.Links[0]; got.Target != "COS-WS-B01-F01-01" || got.NativeVLAN != 210 {
+	if got := snapshot.Links[0]; got.Target != "COS-WS-1101" || got.NativeVLAN != 210 {
 		t.Fatalf("link = %+v", got)
 	}
 }

--- a/internal/protocols/stack_snmp_topology_test.go
+++ b/internal/protocols/stack_snmp_topology_test.go
@@ -80,7 +80,7 @@ func TestSNMPTopologyPublishesRouterARPForConnectedHost(t *testing.T) {
 			SNMPConfig: config.SNMPConfig{Community: "NetAllyDemo"},
 		},
 		{
-			Name: "COS-WS-B01-F01-01", Type: "host", MACAddress: hostMAC,
+			Name: "COS-WS-1101", Type: "host", MACAddress: hostMAC,
 			Interfaces: []config.Interface{{
 				Name: "eth0", Address: "10.240.210.21/24",
 			}},

--- a/internal/scenario/devices_base.go
+++ b/internal/scenario/devices_base.go
@@ -96,17 +96,22 @@ func endpointDevice(
 	kind := wiredEndpointKind(request, accessIndex, slot)
 	profile := profileByRole(kind.role)
 	name := wiredEndpointName(request, site, accessIndex, slot)
+	access := newInterface(
+		"eth0",
+		siteNetworkName(site, "data"),
+		address+"/24",
+		speedOneGigabit,
+		"Wired client access",
+	)
+	// Every endpoint's port is eth0, so seeding load off the interface name
+	// alone hands the whole fleet one identical number. Switch and router ports
+	// vary because their names do.
+	access.InUtilization, access.OutUtilization = utilization(name + "/eth0")
 	device := converter.Device{
 		Name: name, Type: profile.DeviceType, Vendor: profile.Vendor,
 		MACSuffix: identitySuffix(&site, kind.role, index), IPs: []string{address}, VLAN: vlanData,
-		Interfaces: []converter.Interface{newInterface(
-			"eth0",
-			siteNetworkName(site, "data"),
-			address+"/24",
-			speedOneGigabit,
-			"Wired client access",
-		)},
-		Icmp: &converter.IcmpConfig{Enabled: true, TTL: kind.ttl},
+		Interfaces: []converter.Interface{access},
+		Icmp:       &converter.IcmpConfig{Enabled: true, TTL: kind.ttl},
 		OSFingerprint: &converter.OSFingerprintConfig{
 			OSType: kind.osType, TTL: kind.ttl, WindowSize: kind.windowSize,
 			MSS: windowsMSS, DontFragment: true,
@@ -115,13 +120,16 @@ func endpointDevice(
 			"role": kind.role, "site": site.Code, "model": profile.Model,
 			"platform": profile.Platform, "software": profile.Software,
 		},
-		// Endpoints answer SNMP for their own identity. A discovery tool names a
-		// host from sysName first and only falls back to a reverse lookup, which
-		// it resolves through its own resolver rather than the simulated one —
-		// so without an agent here these devices render as bare IP addresses on
-		// the map. Managed endpoints (infusion pumps, imaging, patient monitors,
-		// clinical workstations) carry an agent in the real world too.
-		SnmpAgent: &converter.SnmpAgent{
+	}
+	if !kind.personalComputer {
+		// Appliances answer SNMP for their own identity. A discovery tool names
+		// a host from sysName first and only falls back to a reverse lookup,
+		// which it resolves through its own resolver rather than the simulated
+		// one — so without an agent here these render as bare IP addresses on
+		// the map. Infusion pumps, imaging, patient monitors, PLCs and label
+		// printers carry an agent in the real world too, and a discovery tool
+		// is meant to file them as managed rather than as ordinary hosts.
+		device.SnmpAgent = &converter.SnmpAgent{
 			Community: request.SNMPCommunity, SysName: name,
 			// Platform and software already read the way a real agent reports
 			// itself ("Siemens Healthineers MR imaging system, Embedded clinical
@@ -129,7 +137,7 @@ func endpointDevice(
 			// renders as "siemens MAGNETOM Vida" on a discovery map.
 			SysDescr:    profile.Platform + ", " + profile.Software,
 			SysLocation: site.Location, SysContact: "netops@" + request.Domain,
-		},
+		}
 	}
 	if kind.osType == "windows" {
 		device.Netbios = &converter.NetbiosConfig{

--- a/internal/scenario/endpoint_class_test.go
+++ b/internal/scenario/endpoint_class_test.go
@@ -1,0 +1,126 @@
+package scenario_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+// personalComputerRoles are the machines someone sits in front of. They ship
+// without an SNMP agent so a discovery tool files them as hosts; every other
+// endpoint is an appliance that is SNMP-managed in the real world and is meant
+// to appear that way.
+func personalComputerRoles() map[string]bool {
+	return map[string]bool{
+		"nurse-station": true, "point-of-sale": true, "noc-workstation": true,
+		"workstation": true, "windows-laptop": true, "macbook": true,
+	}
+}
+
+// Getting this split backwards files every laptop as managed infrastructure,
+// or leaves the clinical and industrial gear looking like ordinary desktops.
+func TestPersonalComputersAnswerNoSNMP(t *testing.T) {
+	personal := personalComputerRoles()
+
+	forEachPackDevice(t, func(pack string, device *config.Device) {
+		role := device.Properties["role"]
+		if role == "" {
+			return
+		}
+		switch hasAgent := device.SNMPConfig.SysName != ""; {
+		case personal[role] && hasAgent:
+			t.Errorf("%s %s (%s): personal computer answers SNMP", pack, device.Name, role)
+		case !personal[role] && !hasAgent:
+			t.Errorf("%s %s (%s): managed device answers no SNMP", pack, device.Name, role)
+		}
+	})
+}
+
+// Every endpoint's port is eth0, so seeding interface load off the interface
+// name alone handed the whole fleet one identical number.
+func TestEndpointUtilizationVariesAcrossDevices(t *testing.T) {
+	values := map[float64]bool{}
+	count := 0
+
+	forEachPackDevice(t, func(_ string, device *config.Device) {
+		if device.Properties["role"] != "nurse-station" {
+			return
+		}
+		for _, iface := range device.Interfaces {
+			values[iface.InUtilization] = true
+			count++
+		}
+	})
+
+	if count == 0 {
+		t.Fatal("no endpoint interfaces to measure")
+	}
+	if len(values) < 2 {
+		t.Errorf("all %d endpoint interfaces report the same load, %v", count, values)
+	}
+}
+
+// Names have to stay unique fleet-wide. The compact personal computer form
+// drops separators to fit inside the NetBIOS cap, so it is worth proving it did
+// not also drop the distinction between two machines.
+func TestGeneratedDeviceNamesAreUnique(t *testing.T) {
+	for _, pack := range scenario.Packs() {
+		cfg := packDevices(t, pack)
+		seen := map[string]bool{}
+		for index := range cfg.Devices {
+			name := cfg.Devices[index].Name
+			if seen[name] {
+				t.Errorf("%s: %q is used by two devices", pack.ID, name)
+			}
+			seen[name] = true
+		}
+	}
+}
+
+// The compact form still has to lead with site and role so an engineer can find
+// the machine; only the building/floor/slot tail is packed.
+func TestCompactNameShape(t *testing.T) {
+	var found string
+	forEachPackDevice(t, func(pack string, device *config.Device) {
+		if pack == "enterprise-scale" && device.Properties["role"] == "workstation" && found == "" {
+			found = device.Name
+		}
+	})
+
+	if found == "" {
+		t.Fatal("the enterprise pack generated no workstation")
+	}
+	role, tail, split := strings.Cut(strings.TrimPrefix(found, "COS-"), "-")
+	if !split || role != "WS" {
+		t.Fatalf("name = %q, want the COS-WS-<location> shape", found)
+	}
+	if len(tail) < 4 {
+		t.Errorf("location tail = %q, want building, floor and a two-digit slot", tail)
+	}
+}
+
+func packDevices(t *testing.T, pack scenario.Pack) *config.Config {
+	t.Helper()
+	result, err := scenario.Generate(pack.Request)
+	if err != nil {
+		t.Fatalf("generate %s: %v", pack.ID, err)
+	}
+	cfg, err := config.LoadYAMLBytes(result.YAML)
+	if err != nil {
+		t.Fatalf("load %s: %v", pack.ID, err)
+	}
+
+	return cfg
+}
+
+func forEachPackDevice(t *testing.T, visit func(pack string, device *config.Device)) {
+	t.Helper()
+	for _, pack := range scenario.Packs() {
+		cfg := packDevices(t, pack)
+		for index := range cfg.Devices {
+			visit(pack.ID, &cfg.Devices[index])
+		}
+	}
+}

--- a/internal/scenario/endpoint_profiles.go
+++ b/internal/scenario/endpoint_profiles.go
@@ -8,21 +8,31 @@ const (
 )
 
 type endpointKind struct {
-	role       string
-	prefix     string
-	osType     string
-	ttl        uint8
-	windowSize uint16
+	role   string
+	prefix string
+	osType string
+	ttl    uint8
+	// personalComputer marks a machine someone sits in front of. Those ship
+	// without an SNMP agent, so a discovery tool files them as hosts; the
+	// clinical, industrial and retail appliances alongside them are
+	// SNMP-managed in the real world and are meant to appear that way.
+	personalComputer bool
+	windowSize       uint16
 }
 
 func endpointKinds(profile string) []endpointKind {
-	windows := func(role, prefix string) endpointKind {
-		return endpointKind{
-			role: role, prefix: prefix, osType: "windows", ttl: windowsTTL,
-			windowSize: windowsTCPWindowSize,
+	pc := func(role, prefix, osType string) endpointKind {
+		kind := endpointKind{
+			role: role, prefix: prefix, osType: osType, personalComputer: true,
+			ttl: unixTTL, windowSize: unixTCPWindowSize,
 		}
+		if osType == "windows" {
+			kind.ttl, kind.windowSize = windowsTTL, windowsTCPWindowSize
+		}
+
+		return kind
 	}
-	embedded := func(role, prefix string) endpointKind {
+	appliance := func(role, prefix string) endpointKind {
 		return endpointKind{
 			role: role, prefix: prefix, osType: "linux", ttl: unixTTL,
 			windowSize: unixTCPWindowSize,
@@ -32,45 +42,39 @@ func endpointKinds(profile string) []endpointKind {
 	switch profile {
 	case "hospital":
 		return []endpointKind{
-			windows("nurse-station", "NURSE"),
-			embedded("infusion-pump", "PUMP"),
-			embedded("mr-system", "MRI"),
-			embedded("philips-patient-monitor", "PHMX850"),
-			embedded("ge-patient-monitor", "GEB850"),
+			pc("nurse-station", "NURSE", "windows"),
+			appliance("infusion-pump", "PUMP"),
+			appliance("mr-system", "MRI"),
+			appliance("philips-patient-monitor", "PHMX850"),
+			appliance("ge-patient-monitor", "GEB850"),
 		}
 	case "warehouse":
 		return []endpointKind{
-			embedded("rugged-handheld", "SCAN"),
-			embedded("barcode-printer", "LABEL"),
+			appliance("rugged-handheld", "SCAN"),
+			appliance("barcode-printer", "LABEL"),
 		}
 	case "manufacturing":
 		return []endpointKind{
-			embedded("plc", "PLC"),
-			embedded("hmi", "HMI"),
-			embedded("robot-controller", "ROBOT"),
+			appliance("plc", "PLC"),
+			appliance("hmi", "HMI"),
+			appliance("robot-controller", "ROBOT"),
 		}
 	case "retail":
 		return []endpointKind{
-			windows("point-of-sale", "POS"),
-			embedded("receipt-printer", "RCPT"),
-			embedded("digital-signage", "SIGN"),
+			pc("point-of-sale", "POS", "windows"),
+			appliance("receipt-printer", "RCPT"),
+			appliance("digital-signage", "SIGN"),
 		}
 	case "service-provider":
-		return []endpointKind{windows("noc-workstation", "NOC")}
+		return []endpointKind{pc("noc-workstation", "NOC", "windows")}
 	case "enterprise":
 		return []endpointKind{
-			windows("workstation", "WS"),
-			windows("windows-laptop", "LAP"),
-			{
-				role:       "macbook",
-				prefix:     "MBP",
-				osType:     "darwin",
-				ttl:        unixTTL,
-				windowSize: unixTCPWindowSize,
-			},
+			pc("workstation", "WS", "windows"),
+			pc("windows-laptop", "LAP", "windows"),
+			pc("macbook", "MBP", "darwin"),
 		}
 	default:
-		return []endpointKind{windows("workstation", "WS")}
+		return []endpointKind{pc("workstation", "WS", "windows")}
 	}
 }
 
@@ -80,9 +84,24 @@ func wiredEndpointKind(request Request, accessIndex, slot int) endpointKind {
 	return kinds[index]
 }
 
+// wiredEndpointName labels one endpoint.
+//
+// Appliances get the readable asset form. Personal computers get a compact one,
+// because a NetBIOS name is capped at 15 characters and - now that they carry no
+// SNMP agent - NetBIOS is where a discovery tool reads a Windows machine's name
+// from. A longer name would arrive truncated and disagree with authored truth.
+// Real fleets name Windows hosts tersely for exactly this reason.
+//
+// The compact tail packs building, floor and slot with no separators. Read it
+// from the right: two digits of slot, one of floor (always 1-4, see location),
+// and whatever precedes them is the building.
 func wiredEndpointName(request Request, site Site, accessIndex, slot int) string {
 	kind := wiredEndpointKind(request, accessIndex, slot)
 	building, floor := location(accessIndex)
+	if kind.personalComputer {
+		return fmt.Sprintf("%s-%s-%d%d%02d", site.Code, kind.prefix, building, floor, slot)
+	}
+
 	return fmt.Sprintf("%s-%s-B%02d-F%02d-%02d", site.Code, kind.prefix, building, floor, slot)
 }
 

--- a/internal/scenario/generator_test.go
+++ b/internal/scenario/generator_test.go
@@ -28,10 +28,10 @@ func TestGenerateEnterpriseReferenceMatchesAcceptedTopology(t *testing.T) {
 		DeviceCount:       531,
 		NetworkCount:      39,
 		LinkCount:         634,
-		DeviceNamesSHA256: "1286a7b93d0c7185189db240c88d6d400d4deb7dbcc361f1384c4a176bcfce0d",
+		DeviceNamesSHA256: "6da20f0044fb2f696efc3d886c209eb47c07b5fa1e64222f93d58f6dc00f1979",
 		NetworksSHA256:    "e879b7ba38e40f925809edc3bf98d2044959df5d2f76d492e6f2019cbcba5555",
 		// Routed WAN edges carry no VLAN metadata; switched links retain their trunks.
-		LinksSHA256: "ac59d25316d4c1e422199e0dc8d4a1f14b8ca220f09992583ea860bf074dc85f",
+		LinksSHA256: "4c1acbf07eccc6464a4a86d8a53f867fdaa1cc7374d18b881bf30487a98713e6",
 	}
 	if first.Manifest != want {
 		t.Fatalf("manifest = %#v, want %#v", first.Manifest, want)

--- a/internal/scenario/identity_truth_test.go
+++ b/internal/scenario/identity_truth_test.go
@@ -78,7 +78,7 @@ func assertServiceDNS(t *testing.T, cfg *config.Config) {
 		if got, want := resolved, dhcp.IPAddresses[0].String(); got != want {
 			t.Errorf("%s resolves to %s, want DHCP address %s", name, got, want)
 		}
-		workstation := findDevice(cfg, site+"-WS-B01-F01-01")
+		workstation := findDevice(cfg, site+"-WS-1101")
 		if workstation == nil || len(workstation.IPAddresses) == 0 {
 			t.Fatalf("%s workstation DNS prerequisite is missing", site)
 		}

--- a/internal/scenario/packs.go
+++ b/internal/scenario/packs.go
@@ -84,9 +84,9 @@ func customerScenarioPacks() []Pack {
 			Manifest{
 				DeviceCount: hospitalDeviceCount, NetworkCount: singleSiteNetworkCount,
 				LinkCount:         hospitalLinkCount,
-				DeviceNamesSHA256: "b808be4a818b9a3e3dffbaa57448f12d9939e50f2c0b297e49a96dc8f6fb33b3",
+				DeviceNamesSHA256: "a026920162b3dcc95656a4d3d69a0aeed84482e7724b018d5a49488383609030",
 				NetworksSHA256:    "af29ba1bf3ae3a58f46809ba0e126fa436ea4e78193842f8ce12b9d276686b30",
-				LinksSHA256:       "30459dc94c17785cbc4c9394af16ed2820d2b089d84bf244fb95dd8fd01e8a9c",
+				LinksSHA256:       "99be6cdbe704f4e4d661a27be11b6294e62e8b52ca83e2c6198b4ba9fe8836b2",
 			},
 		),
 		newScenarioPack(
@@ -131,9 +131,9 @@ func customerScenarioPacks() []Pack {
 			Manifest{
 				DeviceCount: campusDeviceCount, NetworkCount: fourSiteNetworkCount,
 				LinkCount:         campusLinkCount,
-				DeviceNamesSHA256: "a6c7bf51ab462c09992b8f40d3c9cf7d6580d487bd3c67d4b65157b22c35781c",
+				DeviceNamesSHA256: "17ed0a70d1f95060126e399c19b0a9fc4fa2ad5779be8ac8763debd34f97b72f",
 				NetworksSHA256:    "7262a118fbb0f2d4977d02895b839d0cbce5fd1161201b0f27a5b37fc3eb72ce",
-				LinksSHA256:       "1393d2beae5a030ae96b8b1a295a8b5001417bc5bea114408cc7945902fe7a6f",
+				LinksSHA256:       "b171d72805e3ea4524118adcf58a99c8e52112c8d32f43f25816b90b3ea2e3e8",
 			},
 		),
 		newScenarioPack(
@@ -147,9 +147,9 @@ func customerScenarioPacks() []Pack {
 			Manifest{
 				DeviceCount: enterpriseScaleDeviceCount, NetworkCount: fourSiteNetworkCount,
 				LinkCount:         enterpriseScaleLinkCount,
-				DeviceNamesSHA256: "1286a7b93d0c7185189db240c88d6d400d4deb7dbcc361f1384c4a176bcfce0d",
+				DeviceNamesSHA256: "6da20f0044fb2f696efc3d886c209eb47c07b5fa1e64222f93d58f6dc00f1979",
 				NetworksSHA256:    "e879b7ba38e40f925809edc3bf98d2044959df5d2f76d492e6f2019cbcba5555",
-				LinksSHA256:       "ac59d25316d4c1e422199e0dc8d4a1f14b8ca220f09992583ea860bf074dc85f",
+				LinksSHA256:       "4c1acbf07eccc6464a4a86d8a53f867fdaa1cc7374d18b881bf30487a98713e6",
 			},
 		),
 	}

--- a/internal/scenario/packs_vertical.go
+++ b/internal/scenario/packs_vertical.go
@@ -16,9 +16,9 @@ func verticalScenarioPacks() []Pack {
 			), Manifest{
 				DeviceCount: retailDeviceCount, NetworkCount: twoSiteNetworkCount,
 				LinkCount:         retailLinkCount,
-				DeviceNamesSHA256: "fe35fa8827a70340c3990747010279b97f770e8c6658dfbfb5579b3d4f6ceb73",
+				DeviceNamesSHA256: "e5944f8f0f8795d3f054f6ce082c3c8c2c1dde8eab5839992487cebd554215a8",
 				NetworksSHA256:    "88cdfbd6e21a58552873afe83c93dac96b7fae0a28166ecb319475dbcc38d25b",
-				LinksSHA256:       "da53c82f48efbd25d23b21dc11e32fc8ea7c00043c7b39dc095d57ad6d340100",
+				LinksSHA256:       "c57237bbe4a9c00de9506bd06c2da4d0a32acf93e930ebf287f4f83da83d18b3",
 			},
 		),
 		manufacturingScenarioPack(),
@@ -58,9 +58,9 @@ func serviceProviderScenarioPack() Pack {
 		Manifest{
 			DeviceCount: serviceProviderDeviceCount, NetworkCount: threeSiteNetworkCount,
 			LinkCount:         serviceProviderLinkCount,
-			DeviceNamesSHA256: "fc492e5fe3db7aa366a1c2662fdc4512849350c5046c170f108063fee437d1ab",
+			DeviceNamesSHA256: "279b172d5ce92a4652ff5015da8325297a8d7217211b19ac020cec462d1a711f",
 			NetworksSHA256:    "79fcb26f2a9f506a24540a583ae570b5c25e1dcf8a63ccfa21946b4912fc7720",
-			LinksSHA256:       "b77376f0f247fa026ea07ac903999fd52027545d20296984c256a888f8b1bed7",
+			LinksSHA256:       "e64dc64a8796d5327205367f70b8934fd02c2cefd3a9d79b9a667b74f7031c9d",
 		},
 	)
 }

--- a/internal/scenario/utilization_truth_test.go
+++ b/internal/scenario/utilization_truth_test.go
@@ -1,6 +1,7 @@
 package scenario_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
@@ -64,12 +65,17 @@ func packUtilizationBands(t *testing.T, pack scenario.Pack) (int, int) {
 	return steady, total
 }
 
-// Every device must answer SNMP with its own name. A discovery tool names a
-// host from sysName first and only falls back to a reverse lookup, which it
-// resolves through its own resolver rather than the simulated one. Endpoints
-// without an agent therefore rendered as bare IP addresses on a Link-Live map
-// even though the simulation served correct PTR records.
-func TestEveryDeviceAnswersSNMPWithItsName(t *testing.T) {
+// Every device must announce its own name by some means, or it renders as a
+// bare IP address on a Link-Live map. A discovery tool reads sysName first and
+// only falls back to a reverse lookup, which it resolves through its own
+// resolver rather than the simulated one — so correct PTR records are not
+// enough on their own.
+//
+// Which means depends on what the device is. Infrastructure and appliances
+// answer SNMP; personal computers deliberately do not, so that a discovery tool
+// files them as hosts rather than as managed infrastructure, and they announce
+// over NetBIOS or multicast DNS instead.
+func TestEveryDeviceAnnouncesItsName(t *testing.T) {
 	for _, pack := range scenario.Packs() {
 		result, err := scenario.Generate(pack.Request)
 		if err != nil {
@@ -81,10 +87,33 @@ func TestEveryDeviceAnswersSNMPWithItsName(t *testing.T) {
 		}
 		for index := range cfg.Devices {
 			device := &cfg.Devices[index]
-			if got := device.SNMPConfig.SysName; got != device.Name {
-				t.Errorf("%s %s sysName = %q, want %q — a device without its own sysName renders as a bare IP",
-					pack.ID, device.Name, got, device.Name)
+			switch {
+			case device.SNMPConfig.SysName != "":
+				if got := device.SNMPConfig.SysName; got != device.Name {
+					t.Errorf("%s %s sysName = %q, want %q", pack.ID, device.Name, got, device.Name)
+				}
+			case device.NetBIOSConfig != nil && device.NetBIOSConfig.Enabled:
+				assertAnnouncedName(t, pack.ID, device.Name, device.NetBIOSConfig.Name, netbiosNameLimit)
+			case device.MDNSConfig != nil && device.MDNSConfig.Enabled:
+				assertAnnouncedName(t, pack.ID, device.Name, device.MDNSConfig.Hostname, 0)
+			default:
+				t.Errorf("%s %s announces no name at all — it renders as a bare IP", pack.ID, device.Name)
 			}
 		}
+	}
+}
+
+// netbiosNameLimit is the wire cap on a NetBIOS name. A longer name reaches a
+// discovery tool truncated and disagrees with authored truth.
+const netbiosNameLimit = 15
+
+func assertAnnouncedName(t *testing.T, pack, deviceName, announced string, limit int) {
+	t.Helper()
+	if !strings.EqualFold(announced, deviceName) {
+		t.Errorf("%s %s announces %q, want its own name", pack, deviceName, announced)
+	}
+	if limit > 0 && len(announced) > limit {
+		t.Errorf("%s %s announces %d characters, truncated above %d",
+			pack, deviceName, len(announced), limit)
 	}
 }


### PR DESCRIPTION
## Summary

Giving every endpoint an SNMP agent fixed the bare-IP problem but overshot: a discovery tool then files a nurse's desktop and a laptop as managed infrastructure alongside the infusion pumps. Real fleets do not look like that. Clinical, industrial and retail appliances are SNMP-managed; the machine someone sits in front of is not.

Personal computers now ship without an agent, so they classify as hosts, and announce over **NetBIOS** (#1214) or **multicast DNS** (#1215) instead — both of which now work on the wire. Appliances keep the agent and keep classifying as managed.

That moves the name source for Windows machines to NetBIOS, which caps a name at **15 characters**. A 20-character name would arrive truncated and disagree with authored truth, so personal computers now get a compact name — `MED-NURSE-1101` rather than `MED-NURSE-B01-F01-01`. Real fleets name Windows hosts tersely for exactly this reason. Appliances, named through `sysName`, keep the readable asset form.

Also fixes interface load on endpoints: it was seeded off the interface name, and every endpoint's port is `eth0`, so the entire fleet reported one identical number while switch and router ports varied.

Stacked on #1215.

## Linked Issue

Related to #1151

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

Endpoint hostnames change for personal computers, so any saved capture or comparator baseline naming them needs regenerating. That is deliberate, and lands before the M4-1 manifest freeze so the freeze happens once. Device counts, network counts and link counts are unchanged.

## Testing Evidence

Generated result across two packs — the split is visible per role:

```text
pack              role                     name                     snmp  netbios  mdns
hospital          nurse-station            MED-NURSE-1101           -     netbios  -
hospital          infusion-pump            MED-PUMP-B01-F01-02      SNMP  -        mdns
hospital          mr-system                MED-MRI-B01-F01-03       SNMP  -        mdns
hospital          philips-patient-monitor  MED-PHMX850-B01-F02-01   SNMP  -        mdns
enterprise-scale  workstation              COS-WS-1101              -     netbios  -
enterprise-scale  windows-laptop           COS-LAP-1102             -     netbios  -
enterprise-scale  macbook                  COS-MBP-1103             -     -        mdns
enterprise-scale  core                     COS-CORE-SW01            SNMP  -        -
```

New tests assert the split in **both** directions, name uniqueness, the NetBIOS length cap, and that endpoint load varies. The existing "every device answers SNMP with its name" test is widened to the real invariant — every device announces its name by *some* means — which still catches the bare-IP regression it was written for.

Discrimination check, reverting the split in place:

```text
$ sed -i 's/if !kind.personalComputer {/if true {/' internal/scenario/devices_base.go
$ go test ./internal/scenario/... -run TestPersonalComputersAnswerNoSNMP
324 failures: "personal computer answers SNMP"

$ (restored)
ok  	github.com/MustardSeedNetworks/niac-go/internal/scenario	1.705s
```

Full gates:

```text
$ go test ./...
(all packages ok, no FAIL)

$ golangci-lint run ./...
0 issues.
```

Pack manifests are re-pinned; only the `DeviceNamesSHA256` and `LinksSHA256` values move, and only for the four packs that contain personal computers. `warehouse` and `manufacturing` hash identically, which is the expected result since neither has one.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. No API surface touched; this changes generated scenario content only.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. The naming rule and its 15-character reason are documented at `wiredEndpointName`, and the class split at `endpointKind.personalComputer`.
