### PR TITLE
fix(netbios): answer the port the query came from

### DIFF
--- a/internal/protocols/netbios.go
+++ b/internal/protocols/netbios.go
@@ -153,7 +153,7 @@ func (h *NetBIOSHandler) HandleNameService(
 
 	// Handle queries
 	if opcode == NBNSOpQuery && qdCount > 0 {
-		h.handleNameQuery(pkt, packet, transactionID, flags, payload[12:], devices)
+		h.handleNameQuery(pkt, packet, transactionID, uint16(udp.SrcPort), payload[12:], devices)
 	} else if h.debugLevel >= DebugLevelInfo {
 		_, _ = fmt.Fprintf(os.Stdout, "NetBIOS NS: Unhandled opcode %d sn=%d\n", opcode, pkt.SerialNumber)
 	}
@@ -163,14 +163,13 @@ func (h *NetBIOSHandler) HandleNameService(
 func (h *NetBIOSHandler) handleNameQuery(
 	pkt *Packet,
 	packet gopacket.Packet,
-	transactionID uint16,
-	_ uint16,
+	transactionID, replyPort uint16,
 	data []byte,
 	devices []*config.Device,
 ) {
 	name, nameType, _ := h.decodeNetBIOSName(data)
 	if queryRecordType(data) == nbnsRecordTypeNBSTAT {
-		h.handleNodeStatus(pkt, packet, transactionID, name, nameType)
+		h.handleNodeStatus(pkt, packet, transactionID, replyPort, name, nameType)
 
 		return
 	}
@@ -209,7 +208,7 @@ func (h *NetBIOSHandler) handleNameQuery(
 		return
 	}
 
-	h.sendNameQueryResponse(pkt, transactionID, name, nameType, matchedGroup,
+	h.sendNameQueryResponse(pkt, transactionID, replyPort, name, nameType, matchedGroup,
 		deviceIPv4, ipv4.SrcIP, matchedDevice.MACAddress, eth.SrcMAC)
 
 	if h.debugLevel >= DebugLevelInfo {
@@ -270,7 +269,7 @@ func getFirstIPv4(ips []net.IP) net.IP {
 // sendNameQueryResponse sends a NetBIOS name query response.
 func (h *NetBIOSHandler) sendNameQueryResponse(
 	reqPkt *Packet,
-	transactionID uint16,
+	transactionID, replyPort uint16,
 	name string,
 	nameType byte,
 	isGroup bool,
@@ -343,7 +342,7 @@ func (h *NetBIOSHandler) sendNameQueryResponse(
 		deviceIP.To4(),
 		dstIP.To4(),
 		NetBIOSNameServicePort,
-		NetBIOSNameServicePort,
+		replyPort,
 		buf.Bytes(),
 		srcMAC,
 		dstMAC,
@@ -625,7 +624,7 @@ func queryRecordType(data []byte) uint16 {
 func (h *NetBIOSHandler) handleNodeStatus(
 	pkt *Packet,
 	packet gopacket.Packet,
-	transactionID uint16,
+	transactionID, replyPort uint16,
 	name string,
 	nameType byte,
 ) {
@@ -649,7 +648,7 @@ func (h *NetBIOSHandler) handleNodeStatus(
 		return
 	}
 
-	h.sendNodeStatusResponse(pkt, transactionID, name, nameType, names,
+	h.sendNodeStatusResponse(pkt, transactionID, replyPort, name, nameType, names,
 		deviceIPv4, ipv4.SrcIP, device.MACAddress, eth.SrcMAC)
 
 	if h.debugLevel >= DebugLevelInfo {
@@ -674,7 +673,7 @@ func firstNetBIOSDevice(devices []*config.Device) *config.Device {
 // sendNodeStatusResponse writes an NBSTAT answer listing the device's names.
 func (h *NetBIOSHandler) sendNodeStatusResponse(
 	reqPkt *Packet,
-	transactionID uint16,
+	transactionID, replyPort uint16,
 	name string,
 	nameType byte,
 	names []netbiosNameEntry,
@@ -737,7 +736,7 @@ func (h *NetBIOSHandler) sendNodeStatusResponse(
 
 	_ = h.stack.udpHandler.SendUDP(
 		deviceIP.To4(), dstIP.To4(),
-		NetBIOSNameServicePort, NetBIOSNameServicePort,
+		NetBIOSNameServicePort, replyPort,
 		buf.Bytes(), srcMAC, dstMAC, reqPkt.VLAN,
 	)
 }

--- a/internal/protocols/netbios_nbstat_test.go
+++ b/internal/protocols/netbios_nbstat_test.go
@@ -93,6 +93,17 @@ func nodeStatusQuery(transactionID uint16) []byte {
 
 func netbiosRequestPacket(t *testing.T, srcIP, dstIP string, payload []byte) (gopacket.Packet, *layers.UDP) {
 	t.Helper()
+
+	return netbiosRequestFromPort(t, srcIP, dstIP, NetBIOSNameServicePort, payload)
+}
+
+func netbiosRequestFromPort(
+	t *testing.T,
+	srcIP, dstIP string,
+	srcPort int,
+	payload []byte,
+) (gopacket.Packet, *layers.UDP) {
+	t.Helper()
 	eth := &layers.Ethernet{
 		SrcMAC:       net.HardwareAddr{0xaa, 0xbb, 0xcc, 0x00, 0x00, 0x01},
 		DstMAC:       net.HardwareAddr{0x02, 0x00, 0x33, 0x00, 0x00, 0x21},
@@ -103,7 +114,7 @@ func netbiosRequestPacket(t *testing.T, srcIP, dstIP string, payload []byte) (go
 		SrcIP: net.ParseIP(srcIP).To4(), DstIP: net.ParseIP(dstIP).To4(),
 	}
 	udp := &layers.UDP{
-		SrcPort: layers.UDPPort(NetBIOSNameServicePort),
+		SrcPort: layers.UDPPort(srcPort),
 		DstPort: layers.UDPPort(NetBIOSNameServicePort),
 	}
 	if err := udp.SetNetworkLayerForChecksum(ip); err != nil {
@@ -166,4 +177,51 @@ func decodeNodeStatusNames(t *testing.T, frame []byte) []string {
 	}
 
 	return names
+}
+
+// A conformant client may ask from an ephemeral port. Answering a hard-wired
+// 137 reaches Windows and nbtscan, which both bind 137, and nothing else — the
+// reply has to go back to the port the query came from.
+func TestNodeStatusAnswersTheQueriersPort(t *testing.T) {
+	const ephemeral = 51234
+
+	stack := newTestStackInternal(t)
+	handler := NewNetBIOSHandler(stack, 0)
+	device := netbiosTestDevice()
+	table := stack.devicesFor(0)
+	table.AddByIP(device.IPAddresses[0], device)
+	table.AddByMAC(device.MACAddress, device)
+
+	packet, udp := netbiosRequestFromPort(t, "10.254.200.100", "10.51.210.21",
+		ephemeral, nodeStatusQuery(0x4243))
+	handler.HandleNameService(&Packet{}, packet, udp, []*config.Device{device})
+
+	select {
+	case sent := <-stack.sendQueue:
+		reply := gopacket.NewPacket(sent.Buffer[:sent.Length], layers.LayerTypeEthernet, gopacket.Default)
+		replyUDP, ok := reply.Layer(layers.LayerTypeUDP).(*layers.UDP)
+		if !ok {
+			t.Fatal("reply has no UDP layer")
+		}
+		if replyUDP.DstPort != ephemeral {
+			t.Errorf("reply sent to port %d, want %d — the querier never sees it",
+				replyUDP.DstPort, ephemeral)
+		}
+	default:
+		t.Fatal("no node status reply")
+	}
+}
+
+func netbiosTestDevice() *config.Device {
+	const deviceName = "MED-NURSE-1101"
+
+	return &config.Device{
+		Name:        deviceName,
+		MACAddress:  net.HardwareAddr{0x02, 0x00, 0x33, 0x00, 0x00, 0x21},
+		IPAddresses: []net.IP{net.ParseIP("10.51.210.21")},
+		NetBIOSConfig: &config.NetBIOSConfig{
+			Enabled: true, Name: deviceName, Workgroup: "DEMO",
+			NodeType: "H", Services: []string{"workstation"},
+		},
+	}
 }


### PR DESCRIPTION
## Summary

Both NetBIOS name-query and node-status replies were addressed to port 137 regardless of where the request originated. That reaches Windows and `nbtscan`, which bind 137 in both directions, and nothing else — a client asking from an ephemeral port never sees the answer, which is what RFC 1002 says it should get.

Found while proving NBSTAT on the wire against the live hospital simulation: a probe from an ephemeral port saw nothing even though the responder logged a reply for the right device.

## Linked Issue

Related to #1151

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Strictly wider: a query sourced from 137 still gets its answer on 137, unchanged. Only queries from other ports change behaviour, and today they get nothing.

## Testing Evidence

On the wire, against the running simulation. Same query, only the client's source port differs:

```text
unbound (ephemeral source port)  -> NO ANSWER (timed out)
bound to 137                     -> 1 name(s), first = 'MED-NURSE-1101'
```

The responder logged a reply in both cases, which is what made it look like it was working:

```text
NetBIOS NS: TID=0x4242 Op=0 QD=1 AN=0 Response=false sn=289
NetBIOS NS: Node status for 10.51.210.21 -> 1 name(s) sn=289
```

New `TestNodeStatusAnswersTheQueriersPort` sends from port 51234 and parses the reply's destination port off the wire. Reverting the fix in place:

```text
--- FAIL: TestNodeStatusAnswersTheQueriersPort
    reply sent to port 137, want 51234 — the querier never sees it
```

Full gates:

```text
$ go test ./...
(all packages ok, no FAIL)

$ golangci-lint run ./...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. No API surface touched. The reply still goes only to the address and port that sent the query.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Behaviour change is a protocol correctness fix covered by the new test.
