### PR TITLE
fix(acceptance): stop the comparator expecting what Link-Live never reports

### DIFF
--- a/internal/acceptance/linklive/compare.go
+++ b/internal/acceptance/linklive/compare.go
@@ -44,7 +44,7 @@ func compareDevice(expected AuthoredDevice, actual ObservedHost) []Finding {
 		)
 	}
 	wantType := displayedType(expected.Type)
-	if wantType != "" && !displayedTypeMatches(expected.Type, actual.Type) {
+	if wantType != "" && !displayedTypeMatches(expected, actual.Type) {
 		findings = append(
 			findings,
 			conflict(FindingTypeConflict, expected.Name, wantType, actual.Type),

--- a/internal/acceptance/linklive/compare_interfaces.go
+++ b/internal/acceptance/linklive/compare_interfaces.go
@@ -25,7 +25,25 @@ func compareInterfaces(expected AuthoredDevice, actual []ObservedInterface) []Fi
 	return append(findings, compareUnexpectedInterfaces(expected.Name, wanted, actual)...)
 }
 
+// samplesUtilization reports whether Link-Live measures interface utilization
+// for this device at all.
+//
+// It measures switch and router ports. A leaf node - an endpoint, a server, a
+// wireless controller - is never sampled even when its agent serves
+// ifHCInOctets, which every one of ours does: verified against the live
+// simulation, MED-DNS01, MED-WLC01 and MED-PUMP-B01-F01-02 all return Counter64
+// octet counters and Link-Live still reports no utilization for any of them.
+// Expecting a sample there fails every run for something the simulation gets
+// right, and drowns the findings that matter.
+func samplesUtilization(device AuthoredDevice) bool {
+	return !isLeafType(device.Type)
+}
+
 func missingUtilizationFindings(device AuthoredDevice) []Finding {
+	if !samplesUtilization(device) {
+		return nil
+	}
+
 	var findings []Finding
 	for _, iface := range device.Interfaces {
 		if iface.UtilizationPercent <= 0 && !iface.UtilizationDynamic {

--- a/internal/acceptance/linklive/compare_leaf_rules_test.go
+++ b/internal/acceptance/linklive/compare_leaf_rules_test.go
@@ -1,0 +1,124 @@
+package linklive_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/acceptance/linklive"
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// An appliance that answers SNMP is filed by Link-Live as an SNMP Agent rather
+// than a Host/Client, and that is the correct reading of it: a clinical pump or
+// an imaging system is managed gear, not somebody's desktop. Reporting that as a
+// conflict buried the real findings under one per appliance.
+func TestSNMPAppliancesMayBeFiledAsAgents(t *testing.T) {
+	authored := leafSnapshot(t, "iot", true)
+
+	findings := linklive.Compare(authored, leafObservedUnsampled())
+	if hasKind(findings, linklive.FindingTypeConflict) {
+		t.Errorf("SNMP appliance flagged as the wrong type: %+v", findings)
+	}
+}
+
+// The same latitude must not extend to infrastructure. A switch Link-Live
+// failed to recognise as a switch is a real finding.
+func TestSwitchFiledAsAgentIsStillAConflict(t *testing.T) {
+	authored := leafSnapshot(t, "switch", true)
+	observed := leafObserved("SNMP Agent")
+
+	findings := linklive.Compare(authored, observed)
+	if !hasKind(findings, linklive.FindingTypeConflict) {
+		t.Errorf("switch filed as an SNMP Agent went unreported: %+v", findings)
+	}
+}
+
+// A personal computer carries no agent, so being filed as an SNMP Agent would
+// mean the simulation leaked one.
+func TestHostWithoutSNMPFiledAsAgentIsAConflict(t *testing.T) {
+	authored := leafSnapshot(t, "host", false)
+	observed := leafObserved("SNMP Agent")
+
+	findings := linklive.Compare(authored, observed)
+	if !hasKind(findings, linklive.FindingTypeConflict) {
+		t.Errorf("agent-less host filed as an SNMP Agent went unreported: %+v", findings)
+	}
+}
+
+// Link-Live measures switch and router ports, never a leaf node — verified
+// against the live simulation, where servers, controllers and appliances all
+// serve Counter64 octet counters and are still reported with no utilization.
+// Expecting a sample from them failed every run for something the simulation
+// gets right.
+func TestLeafDevicesAreNotExpectedToReportUtilization(t *testing.T) {
+	for _, deviceType := range []string{"iot", "server", "host", "printer"} {
+		authored := leafSnapshot(t, deviceType, true)
+
+		findings := linklive.Compare(authored, leafObservedUnsampled())
+		if hasKind(findings, linklive.FindingInterfaceUtilizationConflict) {
+			t.Errorf("%s: expected a utilization sample Link-Live never takes: %+v",
+				deviceType, findings)
+		}
+	}
+}
+
+// A switch reporting no utilization is still the finding this check exists for.
+func TestInfrastructureStillMustReportUtilization(t *testing.T) {
+	authored := leafSnapshot(t, "switch", true)
+
+	findings := linklive.Compare(authored, leafObservedUnsampled())
+	if !hasKind(findings, linklive.FindingInterfaceUtilizationConflict) {
+		t.Errorf("switch with no utilization went unreported: %+v", findings)
+	}
+}
+
+// leafObservedUnsampled is the device as Link-Live returns it when it took no
+// utilization measurement: the port is there, the sample is not.
+func leafObservedUnsampled() linklive.ObservedSnapshot {
+	observed := leafObserved("SNMP Agent")
+	observed.Hosts[0].Interfaces = []linklive.ObservedInterface{{
+		Interface: linklive.ObservedInterfaceDetails{
+			Name: "eth0", Status: "Up", Speed: "1 Gb", Duplex: "Full", MTU: 1500,
+		},
+	}}
+
+	return observed
+}
+
+func leafSnapshot(t *testing.T, deviceType string, servesSNMP bool) linklive.AuthoredSnapshot {
+	t.Helper()
+	mac, err := net.ParseMAC("00:00:0c:f0:09:01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	device := config.Device{
+		Name: "MED-PUMP-B01-F01-02", Type: deviceType, MACAddress: mac,
+		IPAddresses: []net.IP{net.ParseIP("10.51.210.22")},
+		Interfaces: []config.Interface{{
+			Name: "eth0", Type: "ethernet", MTU: 1500, Speed: 1000,
+			Duplex: "full", OperStatus: "up", InUtilization: 60,
+		}},
+	}
+	if servesSNMP {
+		device.SNMPConfig = config.SNMPConfig{Community: "NetAllyDemo"}
+	}
+
+	return linklive.FromConfig(&config.Config{Devices: []config.Device{device}})
+}
+
+func leafObserved(observedType string) linklive.ObservedSnapshot {
+	return linklive.ObservedSnapshot{Hosts: []linklive.ObservedHost{{
+		Name: "MED-PUMP-B01-F01-02", Type: observedType,
+		MAC: "00000cf00901", IPv4: "10.51.210.22",
+	}}}
+}
+
+func hasKind(findings []linklive.Finding, kind linklive.FindingKind) bool {
+	for _, finding := range findings {
+		if finding.Kind == kind {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/acceptance/linklive/compare_values.go
+++ b/internal/acceptance/linklive/compare_values.go
@@ -46,11 +46,44 @@ func displayedType(deviceType string) string {
 	}
 }
 
-func displayedTypeMatches(deviceType, actual string) bool {
-	if deviceType == "layer3-switch" {
+// displayedTypeMatches reports whether Link-Live filed the device the way the
+// authored role says it should.
+//
+// An endpoint that answers SNMP is filed as an SNMP Agent rather than as a
+// Host/Client, and that is the correct reading of it - a clinical appliance or
+// a managed printer is SNMP-managed gear, not somebody's desktop. Infrastructure
+// keeps its role label, so a switch Link-Live failed to recognise as a switch is
+// still a finding.
+func displayedTypeMatches(expected AuthoredDevice, actual string) bool {
+	if expected.Type == "layer3-switch" {
 		return actual == "Switch" || actual == "Router"
 	}
-	return displayedType(deviceType) == actual
+	if actual == snmpAgentType && expected.ServesSNMP && isEndpointType(expected.Type) {
+		return true
+	}
+
+	return displayedType(expected.Type) == actual
+}
+
+// snmpAgentType is how Link-Live labels a device it identified only by its
+// SNMP agent.
+const snmpAgentType = "SNMP Agent"
+
+func isEndpointType(deviceType string) bool {
+	switch deviceType {
+	case "host", "workstation", "iot", "printer":
+		return true
+	default:
+		return false
+	}
+}
+
+// isLeafType reports whether the device hangs off the network rather than
+// forming it. Servers and wireless controllers are not endpoints - they are
+// managed infrastructure - but they still sit on one port, which is what
+// decides whether Link-Live measures them.
+func isLeafType(deviceType string) bool {
+	return isEndpointType(deviceType) || deviceType == "server"
 }
 
 func parseSpeedMbps(value string) int {

--- a/internal/acceptance/linklive/model.go
+++ b/internal/acceptance/linklive/model.go
@@ -52,6 +52,9 @@ type AuthoredDevice struct {
 	IPv4                       []string
 	Interfaces                 []AuthoredInterface
 	InterfaceInventoryComplete bool
+	// ServesSNMP marks a device that answers SNMP for itself. Link-Live may
+	// file such a device as an SNMP Agent rather than by its role.
+	ServesSNMP bool
 }
 
 // AuthoredInterface contains deterministic interface state exposed through SNMP.

--- a/internal/acceptance/linklive/normalize.go
+++ b/internal/acceptance/linklive/normalize.go
@@ -80,6 +80,7 @@ func authoredDevice(device config.Device, faults map[string]authoredFaultExpecta
 		IPv4: addresses,
 	}
 	if snmpEnabled(device) {
+		authored.ServesSNMP = true
 		authored.InterfaceInventoryComplete = !hasCapturedInterfaceInventory(device.SNMPConfig)
 		authored.Interfaces = authoredInterfaces(device, authored.InterfaceInventoryComplete)
 		for index := range authored.Interfaces {


### PR DESCRIPTION
## Summary

Two comparator expectations were wrong about **Link-Live**, not about the simulation, and between them they produced 36 of 37 findings on a clean hospital capture — drowning the one that was real.

**Utilization.** Link-Live measures interface utilization on switch and router ports and nowhere else. It takes no sample from a leaf node even when that node serves `ifHCInOctets` — and every one of ours does. Verified on the wire against the running simulation:

```text
10.51.240.10  MED-DNS01              ifHCInOctets.1 = Counter64: 2912381763678
10.51.240.20  MED-WLC01              ifHCInOctets.1 = Counter64: 3375723768968
10.51.210.22  MED-PUMP-B01-F01-02    ifHCInOctets.1 = Counter64:  475487836414
```

Link-Live reports no utilization for any of those. The expectation now applies to infrastructure only, so a switch reporting nothing is still the finding this check exists for.

**Type.** An endpoint that answers SNMP is filed as an `SNMP Agent` rather than a `Host/Client`, and that is the correct reading of it — a clinical pump or an imaging system is managed gear, not somebody's desktop. That latitude is deliberately limited to endpoint roles.

## Linked Issue

Related to #1151

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

This narrows what the acceptance comparator reports, so the risk is masking a real regression. Guarded by three tests that pin the boundary: a **switch** filed as an SNMP Agent is still a conflict, an **agent-less host** filed as an SNMP Agent is still a conflict, and a **switch** reporting no utilization is still a conflict.

## Testing Evidence

Against one real CyberScope capture of the hospital pack (analysis `6a767a6f9dc61ad432a4616f`, uploaded from VLAN 200 tonight):

```text
before this PR                 after this PR
  22  interface-utilization-conflict      0
  14  type-conflict                       0
   1  name-conflict                       1
  ---                                   ---
  37  TOTAL                               1
```

For scale, the same pack reported **158** findings before tonight's endpoint work (#1213–#1218).

The one remaining finding is `MED-NURSE-1203` reported as `10.51.210.26`. That is a discovery-timing artifact, not a defect — the host answers an NBSTAT probe with its full name:

```text
10.51.210.26 'MED-NURSE-1203'
10.51.210.21 'MED-NURSE-1101'
```

Unit gates:

```text
$ go test ./...
(all packages ok, no FAIL)

$ golangci-lint run ./...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. Comparator only; no product code and no API surface.
- [x] Dependencies are pinned and justified if changed. (None changed.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Both rules are documented at `samplesUtilization` and `displayedTypeMatches` with the measurement that justifies them.
