### PR TITLE
feat(scenario): distinct warehouse and manufacturing shapes, and the AP utilization rule

### DIFF
--- a/docs/design/2026-08-linklive-acceptance-runbook.md
+++ b/docs/design/2026-08-linklive-acceptance-runbook.md
@@ -141,7 +141,25 @@ snmpget -v2c -c NetAllyDemo 10.51.200.21  1.3.6.1.2.1.1.5.0   # an access switch
 ```
 
 If those answer, the simulation is fine. Discovery Settings → SNMP will still
-show the communities configured; the stall is unit-side. Retry the capture.
+show the communities configured; the stall is unit-side.
+
+**The cure: re-select the AutoTest profile, then clear and rerun.** Drawer →
+**AutoTest** (the row, not the chevron) opens the profile list; tap **EZ Wired
+Profile** and **START**, then tap **Wired Profile VLAN 200** and **START**
+again. Discovery walks the pack on the next clear-and-rerun. This worked twice
+on 2026-08-08, each time after the same stall, and nothing else did — SNMP
+settings, credentials and Feature Access were all correct throughout.
+
+What a stalled unit is actually doing is worth knowing, because it is the
+fastest way to place the blame: it emits **no SNMP at all**. `tcpdump -i vmbr0
+'vlan and udp port 161'` on pvm01 captured zero packets across a full
+clear-and-rerun; the same filter after the profile bounce showed GetRequests to
+`10.254.200.1` within seconds. The stalled unit also loses its VLAN-200 address
+— it appears in its own Discovery list under the management IP rather than a
+`10.254.200.x` one.
+
+Remove any `vmbr0.<vlan>` sub-interface you added to prove the simulation
+before capturing, or it is discovered too and files as an unexpected device.
 
 ## Link-Live API
 
@@ -246,7 +264,7 @@ Every finding kind the comparator can emit, and where to look first.
 | `interface-speed-conflict` | authored speed disagrees with the walk's `ifSpeed` | walk-backed speed wins on the wire; fix the authored value |
 | `interface-duplex-conflict` | duplex compared on an interface that has no duplex | logical and `ieee80211` interfaces are exempt; a hit means an ethernet interface really differs |
 | `interface-mtu-conflict` | authored MTU differs from IF-MIB | jumbo-frame mismatch on uplinks is the common one |
-| `interface-utilization-conflict` | first poll, or behavior-driven traffic | utilization is only compared once the device has produced a sample; behavior-driven interfaces are expected to move. Only **switch and router** ports are compared: Link-Live takes no utilization sample from a leaf node — endpoint, server, wireless controller — even though ours all serve `ifHCInOctets` (measured: `MED-DNS01`, `MED-WLC01`, `MED-PUMP-B01-F01-02` all return Counter64 and Link-Live still reports none). |
+| `interface-utilization-conflict` | first poll, or behavior-driven traffic | utilization is only compared once the device has produced a sample; behavior-driven interfaces are expected to move. Only **switch and router** ports are compared: Link-Live takes no utilization sample from a leaf node — endpoint, server, wireless controller, **access point** — even though ours all serve `ifHCInOctets` (measured: `MED-DNS01`, `MED-WLC01`, `MED-PUMP-B01-F01-02` all return Counter64 and Link-Live still reports none; on the 2026-08-08 hospital capture all five interfaces of all 30 APs came back `util 0`, wired uplink included, while the switch port facing that uplink read 71.57%). |
 | `interface-error-conflict` / `interface-discard-conflict` | fault injection running during the scan, or counters not authored | whether a behavior timeline was mid-phase |
 | `interface-problem-conflict` | tester flagged an interface problem not authored | usually real |
 

--- a/docs/design/2026-08-niac-program-execution-ledger.md
+++ b/docs/design/2026-08-niac-program-execution-ledger.md
@@ -77,14 +77,22 @@ a validated 6-node ring spike for manufacturing are parked on
 rather than re-deriving them. Hospital's 75-device / 88-link shape is already
 Link-Live-validated and should stay unchanged if at all possible.
 
-The one thing that cannot be answered from code: whether Link-Live's layout
-renders a ring as a visible loop or flattens it into a star. Run the parked spike
-config through one discovery before committing to ring generator work; if it
-flattens, take the cheaper "fewer, larger cells" shape for manufacturing instead.
+**Settled 2026-08-08: Link-Live keeps the ring.** A hand-closed 6-node access
+ring (`PLT-ACC-SW01..06`, east and west on `Te1/0/47` and `Te1/0/48`) was
+discovered by the CyberScope on analysis `6a774b2f9dc61ad4327b182a`, and
+Link-Live reported all six adjacencies including the closing `SW06 - SW01` edge,
+each with its own utilization sample. Its topology model carries the cycle rather
+than reducing it to a tree, so ring generator work is worth doing and the cheaper
+"fewer, larger cells" fallback is not needed. That spike config was hand-edited
+from a generated one, which makes it a spike and never an acceptance artifact.
+
+What the generator still needs is the ability to close a loop. `addEdge` already
+expresses an arbitrary adjacency; `addSiteLAN` only ever walks tiers downward, so
+nothing today emits an edge between two peers within one tier.
 
 | ID | Work item | Hours | Depends on | Acceptance evidence |
 | --- | --- | ---: | --- | --- |
-| M4-1 | Freeze authored-truth manifest and comparator rules | 5-8 | M3 | **Done 2026-08-08** (v0.94.29). Hospital pack: 158 findings -> 1. See below. |
+| M4-1 | Freeze authored-truth manifest and comparator rules | 5-8 | M3 | **Done and signed off 2026-08-08** (v0.94.30). Hospital pack: 158 -> 1, then a confirming capture on the release binary at 152 -> 2 once APs joined the leaf rule. Both remaining findings are the bare-IP discovery-timing artifact, each wire-confirmed by an NBSTAT probe. Analysis `6a7740009dc61ad43270d928`. |
 | M4-2 | Finalize hospital guided baseline and fault story | 6-10 | M4-1 | EtherScope/CyberScope/Link-Live evidence |
 | M4-3 | Finalize warehouse and manufacturing stories, including distinct per-vertical topology shape | 8-14 | M4-2 | Two clean comparisons, and two maps that do not look alike |
 | M4-4 | Finalize campus, retail, and service-provider stories | 12-20 | M4-2 | Three clean comparisons |

--- a/internal/acceptance/linklive/compare_leaf_rules_test.go
+++ b/internal/acceptance/linklive/compare_leaf_rules_test.go
@@ -51,7 +51,7 @@ func TestHostWithoutSNMPFiledAsAgentIsAConflict(t *testing.T) {
 // Expecting a sample from them failed every run for something the simulation
 // gets right.
 func TestLeafDevicesAreNotExpectedToReportUtilization(t *testing.T) {
-	for _, deviceType := range []string{"iot", "server", "host", "printer"} {
+	for _, deviceType := range []string{"iot", "server", "host", "printer", "access-point"} {
 		authored := leafSnapshot(t, deviceType, true)
 
 		findings := linklive.Compare(authored, leafObservedUnsampled())

--- a/internal/acceptance/linklive/compare_values.go
+++ b/internal/acceptance/linklive/compare_values.go
@@ -79,11 +79,14 @@ func isEndpointType(deviceType string) bool {
 }
 
 // isLeafType reports whether the device hangs off the network rather than
-// forming it. Servers and wireless controllers are not endpoints - they are
-// managed infrastructure - but they still sit on one port, which is what
-// decides whether Link-Live measures them.
+// forming it. Servers, wireless controllers and access points are not endpoints
+// - they are managed infrastructure - but they still sit on one port, which is
+// what decides whether Link-Live measures them. Access points are the same
+// reading: on the hospital capture Link-Live returned util 0 for all five
+// interfaces of every one of the 30 APs, wired uplink included, while the
+// switch port facing that same uplink reported 71.57%.
 func isLeafType(deviceType string) bool {
-	return isEndpointType(deviceType) || deviceType == "server"
+	return isEndpointType(deviceType) || deviceType == "server" || deviceType == "access-point"
 }
 
 func parseSpeedMbps(value string) int {

--- a/internal/scenario/access_layer_test.go
+++ b/internal/scenario/access_layer_test.go
@@ -1,0 +1,127 @@
+package scenario_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+// A plant runs its cells off a fibre ring rather than dual-homing every closet
+// to a distribution pair, and Link-Live draws that ring as a ring: a hand-closed
+// six-node ring was discovered intact on analysis 6a774b2f9dc61ad4327b182a,
+// closing edge included. Manufacturing is the pack that reads as a plant, so it
+// is the one that gets the shape.
+func TestManufacturingAccessLayerIsARing(t *testing.T) {
+	cfg := generatePack(t, "manufacturing")
+	access := []string{
+		"PLT-ACC-SW01", "PLT-ACC-SW02", "PLT-ACC-SW03",
+		"PLT-ACC-SW04", "PLT-ACC-SW05", "PLT-ACC-SW06",
+	}
+
+	for index, name := range access {
+		next := access[(index+1)%len(access)]
+		if !adjacent(cfg, name, next) {
+			t.Errorf("%s is not linked to its ring neighbour %s", name, next)
+		}
+	}
+}
+
+// The ring is only a ring if it hangs off the distribution tier at a couple of
+// points. Dual-homing every node as well would leave the same star underneath.
+func TestManufacturingRingJoinsDistributionTwice(t *testing.T) {
+	cfg := generatePack(t, "manufacturing")
+
+	if uplinks := countUplinks(cfg, "PLT-ACC-SW", "PLT-DIST-SW"); uplinks != 2 {
+		t.Errorf("access-to-distribution uplinks = %d, want 2", uplinks)
+	}
+}
+
+// Hospital's shape is the one already validated against Link-Live, so every
+// access switch there still dual-homes into the distribution pair.
+func TestHospitalAccessLayerStaysDualHomed(t *testing.T) {
+	cfg := generatePack(t, "hospital")
+
+	if uplinks := countUplinks(cfg, "MED-ACC-SW", "MED-DIST-SW"); uplinks != 12 {
+		t.Errorf("access-to-distribution uplinks = %d, want 12", uplinks)
+	}
+	if adjacent(cfg, "MED-ACC-SW01", "MED-ACC-SW02") {
+		t.Error("hospital access switches are linked to each other")
+	}
+}
+
+func generatePack(t *testing.T, id string) *config.Config {
+	t.Helper()
+	for _, pack := range scenario.Packs() {
+		if pack.ID == id {
+			return packDevices(t, pack)
+		}
+	}
+	t.Fatalf("no pack %q", id)
+
+	return nil
+}
+
+func adjacent(cfg *config.Config, name, peer string) bool {
+	device := findDevice(cfg, name)
+	if device == nil {
+		return false
+	}
+	for _, port := range device.TrunkPorts {
+		if port.RemoteDevice == peer {
+			return true
+		}
+	}
+
+	return false
+}
+
+func countUplinks(cfg *config.Config, accessPrefix, distributionPrefix string) int {
+	total := 0
+	for index := range cfg.Devices {
+		device := &cfg.Devices[index]
+		if !strings.HasPrefix(device.Name, accessPrefix) {
+			continue
+		}
+		for _, port := range device.TrunkPorts {
+			if strings.HasPrefix(port.RemoteDevice, distributionPrefix) {
+				total++
+			}
+		}
+	}
+
+	return total
+}
+
+// A shape the generator cannot build has to be refused, not silently turned
+// into the default one — that is indistinguishable from a typo in the request.
+func TestUnknownAccessLayerIsRejected(t *testing.T) {
+	request := packRequest(t, "manufacturing")
+	request.AccessLayer = "mesh"
+
+	if _, err := scenario.Generate(request); err == nil {
+		t.Error("an unknown access layer generated a fleet")
+	}
+}
+
+func TestRingNeedsEnoughNodes(t *testing.T) {
+	request := packRequest(t, "manufacturing")
+	request.Counts.AccessSwitches = 2
+
+	if _, err := scenario.Generate(request); err == nil {
+		t.Error("a two-node ring generated a fleet")
+	}
+}
+
+func packRequest(t *testing.T, id string) scenario.Request {
+	t.Helper()
+	for _, pack := range scenario.Packs() {
+		if pack.ID == id {
+			return pack.Request
+		}
+	}
+	t.Fatalf("no pack %q", id)
+
+	return scenario.Request{}
+}

--- a/internal/scenario/packs.go
+++ b/internal/scenario/packs.go
@@ -10,7 +10,7 @@ const (
 	serviceProviderSiteOctet    = 101
 	hospitalDeviceCount         = 75
 	warehouseDeviceCount        = 57
-	compactVerticalDeviceCount  = 69
+	manufacturingDeviceCount    = 69
 	campusDeviceCount           = 155
 	enterpriseScaleDeviceCount  = 531
 	retailDeviceCount           = 95
@@ -21,7 +21,7 @@ const (
 	fourSiteNetworkCount        = 39
 	hospitalLinkCount           = 88
 	warehouseLinkCount          = 67
-	compactVerticalLinkCount    = 82
+	manufacturingLinkCount      = 78
 	campusLinkCount             = 202
 	enterpriseScaleLinkCount    = 634
 	retailLinkCount             = 118

--- a/internal/scenario/packs.go
+++ b/internal/scenario/packs.go
@@ -9,6 +9,7 @@ const (
 	industrialSiteOctet         = 91
 	serviceProviderSiteOctet    = 101
 	hospitalDeviceCount         = 75
+	warehouseDeviceCount        = 57
 	compactVerticalDeviceCount  = 69
 	campusDeviceCount           = 155
 	enterpriseScaleDeviceCount  = 531
@@ -19,6 +20,7 @@ const (
 	threeSiteNetworkCount       = 30
 	fourSiteNetworkCount        = 39
 	hospitalLinkCount           = 88
+	warehouseLinkCount          = 67
 	compactVerticalLinkCount    = 82
 	campusLinkCount             = 202
 	enterpriseScaleLinkCount    = 634
@@ -104,11 +106,11 @@ func customerScenarioPacks() []Pack {
 				warehouseWorkstationsPerAccess,
 			),
 			Manifest{
-				DeviceCount: compactVerticalDeviceCount, NetworkCount: singleSiteNetworkCount,
-				LinkCount:         compactVerticalLinkCount,
-				DeviceNamesSHA256: "5e58dc80d18034ef8e07091a98bd2acda6c3507b1c2c12d3671b9d08aaac5044",
+				DeviceCount: warehouseDeviceCount, NetworkCount: singleSiteNetworkCount,
+				LinkCount:         warehouseLinkCount,
+				DeviceNamesSHA256: "f622b9683718ece6b665f88c858df863b6b7d54d8a4371efdc9b20cd79255b01",
 				NetworksSHA256:    "4b45bbf256fb1440d30d2149f3691664404012f192d5f98f788bcc0c413e90b5",
-				LinksSHA256:       "b7e277f9b64855164d8b0dd7f2e02acc7d6db091da8b5f23fb95378aa801a729",
+				LinksSHA256:       "a495dcb76177b01348573b330b54640318d21c34f7c71e596de2aba0bb8c9939",
 			},
 		),
 		newScenarioPack(

--- a/internal/scenario/packs_counts.go
+++ b/internal/scenario/packs_counts.go
@@ -1,11 +1,16 @@
 package scenario
 
 const (
-	hospitalAccessSwitches             = 6
-	hospitalAccessPointsPerAccess      = 5
-	hospitalWorkstationsPerAccess      = 3
-	warehouseAccessSwitches            = 6
-	warehouseAccessPointsPerAccess     = 5
+	hospitalAccessSwitches        = 6
+	hospitalAccessPointsPerAccess = 5
+	hospitalWorkstationsPerAccess = 3
+	// A warehouse covers a large open floor from a few wiring closets, so it
+	// has far fewer access switches than a hospital or a plant and fans a
+	// dense set of long-range radios off each one. Its endpoints are mostly
+	// wireless handhelds rather than wired. This is what makes its map read
+	// differently from the other single-site verticals.
+	warehouseAccessSwitches            = 3
+	warehouseAccessPointsPerAccess     = maxAccessPointsPerAccess
 	warehouseWorkstationsPerAccess     = 2
 	campusAccessSwitches               = 4
 	campusAccessPointsPerAccess        = 2

--- a/internal/scenario/packs_vertical.go
+++ b/internal/scenario/packs_vertical.go
@@ -27,7 +27,7 @@ func verticalScenarioPacks() []Pack {
 }
 
 func manufacturingScenarioPack() Pack {
-	return newScenarioPack(
+	pack := newScenarioPack(
 		"manufacturing", "Manufacturing plant",
 		"Single production plant with resilient switching, 30 Wi-Fi 7 APs, wired stations, and local services.",
 		MapPurposePresentation, "industrial.example",
@@ -35,13 +35,17 @@ func manufacturingScenarioPack() Pack {
 		packCounts(manufacturingAccessSwitches, manufacturingAccessPointsPerAccess,
 			manufacturingWorkstationsPerAccess),
 		Manifest{
-			DeviceCount: compactVerticalDeviceCount, NetworkCount: singleSiteNetworkCount,
-			LinkCount:         compactVerticalLinkCount,
+			DeviceCount: manufacturingDeviceCount, NetworkCount: singleSiteNetworkCount,
+			LinkCount:         manufacturingLinkCount,
 			DeviceNamesSHA256: "4bae5bd1de01cf8a6918eadf3e1c88754c680258ed0a6b9cffc543ab789f25f1",
 			NetworksSHA256:    "cc9ba550031f67fef5933891d5ff0dbd2aada452ba380493a2b52c830f25d0f8",
-			LinksSHA256:       "7a9980db15625aca3326a658c391d4a26edb066c45ea44bbb21f29e7feee7d90",
+			LinksSHA256:       "f7f48d392ce924ab868a8b0116eee50a6e3eeee24bd0586a3ac31cca802243bb",
 		},
 	)
+	// A plant runs its cells off a fiber ring, not a home run per closet.
+	pack.Request.AccessLayer = AccessLayerRing
+
+	return pack
 }
 
 func serviceProviderScenarioPack() Pack {

--- a/internal/scenario/topology.go
+++ b/internal/scenario/topology.go
@@ -29,7 +29,7 @@ func buildLinks(request Request) linkMap {
 		endpoint{"WAN-R2", "HundredGigabitEthernet0/0/1"}, []int{})
 	for siteIndex, site := range request.Sites {
 		addSiteBackbone(links, site, siteIndex, request.Counts)
-		addSiteLAN(links, site, request.Counts)
+		addSiteLAN(links, site, request)
 		addSiteEndpoints(links, site, request)
 	}
 	return links
@@ -91,7 +91,8 @@ func addSiteBackbone(links linkMap, site Site, siteIndex int, counts Counts) {
 	addMesh(links, firewalls, cores, "HundredGigabitEthernet0/2/", []int{})
 }
 
-func addSiteLAN(links linkMap, site Site, counts Counts) {
+func addSiteLAN(links linkMap, site Site, request Request) {
+	counts := request.Counts
 	cores := numberedNames(site.Code+"-CORE-SW", counts.CoreSwitches)
 	for distribution := 1; distribution <= counts.DistributionSwitches; distribution++ {
 		distName := numberedName(site.Code+"-DIST-SW", distribution)
@@ -100,6 +101,13 @@ func addSiteLAN(links linkMap, site Site, counts Counts) {
 				endpoint{coreName, fmt.Sprintf("HundredGigabitEthernet1/0/%d", distribution)},
 				endpoint{distName, fmt.Sprintf("HundredGigabitEthernet1/0/%d", coreIndex+1)}, nil)
 		}
+	}
+
+	if request.AccessLayer == AccessLayerRing {
+		addAccessRing(links, site, counts)
+		addServerSwitches(links, site, counts)
+
+		return
 	}
 
 	distributionPairs := counts.DistributionSwitches / maxRedundantPeers
@@ -125,6 +133,11 @@ func addSiteLAN(links linkMap, site Site, counts Counts) {
 		}
 	}
 
+	addServerSwitches(links, site, counts)
+}
+
+func addServerSwitches(links linkMap, site Site, counts Counts) {
+	cores := numberedNames(site.Code+"-CORE-SW", counts.CoreSwitches)
 	for serverSwitch := 1; serverSwitch <= counts.ServerSwitches; serverSwitch++ {
 		name := numberedName(site.Code+"-SRV-SW", serverSwitch)
 		for coreIndex, coreName := range cores {
@@ -132,6 +145,32 @@ func addSiteLAN(links linkMap, site Site, counts Counts) {
 				endpoint{coreName, fmt.Sprintf("HundredGigabitEthernet1/0/%d", serverSwitch+coreServerPortOffset)},
 				endpoint{name, fmt.Sprintf("HundredGigabitEthernet1/0/%d", coreIndex+1)}, nil)
 		}
+	}
+}
+
+// addAccessRing closes the access tier into one ring and joins it to the
+// distribution tier at two opposite points, so a break anywhere on the ring
+// still leaves every cell a path out. Link-Live renders this as the loop it is
+// rather than reducing it to a tree, which is what makes it worth generating.
+func addAccessRing(links linkMap, site Site, counts Counts) {
+	for index := 1; index <= counts.AccessSwitches; index++ {
+		next := index%counts.AccessSwitches + 1
+		addEdge(links,
+			endpoint{accessName(site, index), ringEastPort},
+			endpoint{accessName(site, next), ringWestPort}, nil)
+	}
+	for join := range maxRedundantPeers {
+		accessIndex := join*counts.AccessSwitches/maxRedundantPeers + 1
+		addEdge(links,
+			endpoint{
+				numberedName(site.Code+"-DIST-SW", join+1),
+				fmt.Sprintf("HundredGigabitEthernet1/0/%d", firstDistributionAccessPort),
+			},
+			endpoint{
+				accessName(site, accessIndex),
+				fmt.Sprintf("HundredGigabitEthernet1/0/%d", accessUplinkPortStart),
+			},
+			nil)
 	}
 }
 

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -46,29 +46,35 @@ const (
 	serviceHostOffset            = 9
 	controllerHostOffset         = 19
 	accessUplinkPortStart        = 49
-	coreServerPortOffset         = 8
-	workstationPortOffset        = 9
-	serverPortOffset             = 11
-	primaryCoreGatewayHost       = 2
-	dnsServerHost                = 10
-	dhcpServerHost               = 11
-	dhcpPoolStartHost            = 100
-	dhcpPoolEndHost              = 199
-	managedDeviceTTL             = 255
-	windowsTTL                   = 128
-	windowsTCPWindowSize         = 64240
-	windowsMSS                   = 1460
-	dnsRecordTTL                 = 300
-	performanceTestPort          = 5201
-	performanceBandwidthMbps     = 10000
-	performanceLatencyMillis     = 2
-	performanceJitterMillis      = 1
-	performancePacketLoss        = 0.01
-	wanIdentityOffset            = 10
-	transitBlockSize             = 8
-	firstDistributionAccessPort  = 3
-	macHighByteShift             = 16
-	macMiddleByteShift           = 8
+	// Fewer than three nodes is a pair of parallel links, not a ring.
+	minimumRingNodes = 3
+	// The ring ports sit above the access-point range and below the uplinks, so
+	// a ring switch keeps the same port plan as a dual-homed one.
+	ringEastPort                = "TenGigabitEthernet1/0/47"
+	ringWestPort                = "TenGigabitEthernet1/0/48"
+	coreServerPortOffset        = 8
+	workstationPortOffset       = 9
+	serverPortOffset            = 11
+	primaryCoreGatewayHost      = 2
+	dnsServerHost               = 10
+	dhcpServerHost              = 11
+	dhcpPoolStartHost           = 100
+	dhcpPoolEndHost             = 199
+	managedDeviceTTL            = 255
+	windowsTTL                  = 128
+	windowsTCPWindowSize        = 64240
+	windowsMSS                  = 1460
+	dnsRecordTTL                = 300
+	performanceTestPort         = 5201
+	performanceBandwidthMbps    = 10000
+	performanceLatencyMillis    = 2
+	performanceJitterMillis     = 1
+	performancePacketLoss       = 0.01
+	wanIdentityOffset           = 10
+	transitBlockSize            = 8
+	firstDistributionAccessPort = 3
+	macHighByteShift            = 16
+	macMiddleByteShift          = 8
 
 	enterpriseCOSOctet              = 240
 	enterpriseEVTOctet              = 241
@@ -113,14 +119,30 @@ type Counts struct {
 	WirelessControllers   int `json:"wirelessControllers"`
 }
 
+// AccessLayer is how a site organizes its access tier. It is shape rather than
+// a count, and it is what makes one vertical's map read differently from
+// another's at a glance.
+type AccessLayer string
+
+const (
+	// AccessLayerDualHomed hangs every access switch off both distribution
+	// switches. It is the default, and the hospital's Link-Live-validated shape.
+	AccessLayerDualHomed AccessLayer = ""
+	// AccessLayerRing chains the access switches into one closed ring that meets
+	// the distribution tier at two opposite points, the way a plant runs its
+	// cells off a fiber ring rather than home-running every closet.
+	AccessLayerRing AccessLayer = "ring"
+)
+
 // Request is the complete deterministic fleet-generation contract.
 type Request struct {
-	Sites           []Site `json:"sites"`
-	Counts          Counts `json:"counts"`
-	Domain          string `json:"domain"`
-	SNMPCommunity   string `json:"snmpCommunity"`
-	AttachmentName  string `json:"attachmentName"`
-	EndpointProfile string `json:"endpointProfile,omitempty"`
+	Sites           []Site      `json:"sites"`
+	Counts          Counts      `json:"counts"`
+	Domain          string      `json:"domain"`
+	SNMPCommunity   string      `json:"snmpCommunity"`
+	AttachmentName  string      `json:"attachmentName"`
+	EndpointProfile string      `json:"endpointProfile,omitempty"`
+	AccessLayer     AccessLayer `json:"accessLayer,omitempty"`
 }
 
 // Manifest summarizes authored identity and topology for parity checks.

--- a/internal/scenario/validation.go
+++ b/internal/scenario/validation.go
@@ -38,7 +38,30 @@ func validateRequest(request Request) error {
 			"endpoint profile must be enterprise, hospital, warehouse, manufacturing, retail, or service-provider",
 		)
 	}
+	if err := validateAccessLayer(request); err != nil {
+		return err
+	}
+
 	return validateCounts(request.Counts)
+}
+
+// validateAccessLayer refuses a shape that cannot be built rather than quietly
+// generating the default one, which would be indistinguishable from a typo.
+func validateAccessLayer(request Request) error {
+	switch request.AccessLayer {
+	case AccessLayerDualHomed:
+		return nil
+	case AccessLayerRing:
+		if request.Counts.AccessSwitches < minimumRingNodes {
+			return fmt.Errorf(
+				"a ring access layer needs at least %d access switches", minimumRingNodes,
+			)
+		}
+
+		return nil
+	default:
+		return errors.New("access layer must be empty or ring")
+	}
 }
 
 func validEndpointProfile(profile string) bool {

--- a/ui/src/api/scenario-client.ts
+++ b/ui/src/api/scenario-client.ts
@@ -31,6 +31,10 @@ export interface ScenarioGenerateRequest {
     | 'manufacturing'
     | 'retail'
     | 'service-provider';
+  /** How the access tier is organized. Absent means every access switch
+   * dual-homes into the distribution pair; 'ring' closes them into one ring
+   * that meets distribution at two points. */
+  accessLayer?: 'ring';
 }
 
 export interface ScenarioManifest {


### PR DESCRIPTION
## Summary

Two of the seven packs stop being clones of each other, plus the comparator fix and the lab facts that came out of one session against the real CyberScope and Link-Live.

- **Warehouse gets a warehouse shape.** Warehouse and manufacturing declared identical constants and generated the same 69-device, 82-link map. A warehouse covers a large open floor from a few wiring closets: 3 access switches fanning 9 radios each, wireless-dominant — 57 devices / 67 links.
- **Manufacturing runs its access layer as a cell ring.** A plant does not home-run every closet; it runs its cells off a fiber ring that meets distribution at two points. Access-layer *shape* is now part of the portable pack request rather than a count, and `addSiteLAN` can finally emit an edge between two peers in one tier. 69 devices unchanged, links 82 → 78.
- **Access points join the comparator's leaf rule.** Link-Live returns `util 0` for every AP interface — wired uplink included — while the switch port facing that uplink reads 71.57%. An AP sits on one port, so it is a leaf exactly as #1219 established for servers, controllers and appliances.
- **Docs:** the discovery-stall cure, and the ring question is settled.

Hospital's Link-Live-validated 75/88 shape is deliberately untouched, and a test now holds it to its twelve dual-homed uplinks.

## Linked Issue

Related to #1223. Program ledger M4-1 (sign-off) and M4-3 in `docs/design/2026-08-niac-program-execution-ledger.md`.

## Type

- [x] Bug fix
- [x] Feature
- [x] Documentation

## Risk

Low. The comparator is test-only tooling and cannot affect a shipped binary. Warehouse and manufacturing each change their generated topology and their frozen manifest together; hospital, campus, retail, service-provider and enterprise-scale are byte-identical. An unknown or too-small access-layer shape is refused at validation rather than silently generating the default.

## Testing Evidence

Hospital on the v0.94.30 release binary, CT304 VLAN 200, analysis `6a7740009dc61ad43270d928`:

```
before: 152 findings (150 interface-utilization-conflict across 30 APs, 2 name-conflict)
after:    2 findings
{"kind":"name-conflict","device":"MED-NURSE-1203","expected":"MED-NURSE-1203","observed":"10.51.210.26"}
{"kind":"name-conflict","device":"MED-NURSE-1402","expected":"MED-NURSE-1402","observed":"10.51.210.31"}
```

Both remaining findings are the bare-IP discovery-timing artifact, not defects — each host answers an NBSTAT node-status probe bound to source port 137 with its full name:

```
10.51.210.26 -> [('MED-NURSE-1203', 0)]
10.51.210.31 -> [('MED-NURSE-1402', 0)]
```

The ring spike, analysis `6a774b2f9dc61ad4327b182a` — Link-Live keeps the cycle, closing edge included:

```
ACCESS-TO-ACCESS EDGES OBSERVED:
[('PLT-ACC-SW01','PLT-ACC-SW02'), ('PLT-ACC-SW01','PLT-ACC-SW06'),
 ('PLT-ACC-SW02','PLT-ACC-SW03'), ('PLT-ACC-SW03','PLT-ACC-SW04'),
 ('PLT-ACC-SW04','PLT-ACC-SW05'), ('PLT-ACC-SW05','PLT-ACC-SW06')]
```

Unit tests — the AP case and both ring cases failed before their fixes:

```
$ go test ./internal/scenario/... ./internal/acceptance/...
ok  github.com/MustardSeedNetworks/niac-go/internal/scenario          12.446s
ok  github.com/MustardSeedNetworks/niac-go/internal/acceptance/linklive 0.213s
```

The **generated** ring, served by a binary built from this branch on CT304 (v0.94.30-4-g8695a20), VLAN 202 — LLDP on the wire shows the ring and its two distribution joins:

```
PLT-ACC-SW01 -> PLT-ACC-SW02, PLT-ACC-SW06, PLT-DIST-SW01, 5x WAP
PLT-ACC-SW02 -> PLT-ACC-SW01, PLT-ACC-SW03, 5x WAP
PLT-ACC-SW06 -> PLT-ACC-SW05, PLT-ACC-SW01, 5x WAP
```

Still outstanding: manufacturing has not had its own Link-Live comparison since the shape changed. The discovery that answered the layout question ran against a hand-edited config, and the runbook is explicit that a hand-edited config is an oracle and never the product. That comparison is the rest of M4-3.

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes, so no CSRF or role-gate surface changed
- [x] No dependency changes
- [x] `golangci-lint`, `gosec`, Biome, tsgo and the full Go and frontend test suites pass in pre-commit
