### PR TITLE
feat(scenario): give campus, retail, and the provider POPs their own shape

### DIFF
--- a/internal/scenario/access_layer_test.go
+++ b/internal/scenario/access_layer_test.go
@@ -1,6 +1,7 @@
 package scenario_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -124,4 +125,59 @@ func packRequest(t *testing.T, id string) scenario.Request {
 	t.Fatalf("no pack %q", id)
 
 	return scenario.Request{}
+}
+
+// A campus is wide and shallow: closets land straight on a collapsed core, with
+// no distribution tier between them. That is what makes its map read as a campus
+// rather than a smaller copy of the hospital.
+func TestCampusCollapsesTheCore(t *testing.T) {
+	cfg := generatePack(t, "campus")
+
+	if findDevice(cfg, "NTH-DIST-SW01") != nil {
+		t.Error("campus still generates a distribution tier")
+	}
+	if uplinks := countUplinks(cfg, "NTH-ACC-SW", "NTH-CORE-SW"); uplinks != 8 {
+		t.Errorf("access-to-core uplinks = %d, want 8", uplinks)
+	}
+}
+
+// A store runs its lanes off one another rather than home-running each till to
+// the back office, so the access tier is a chain with a single uplink.
+func TestRetailStoreChainsItsLanes(t *testing.T) {
+	cfg := generatePack(t, "retail")
+
+	for index := 1; index < 4; index++ {
+		name := numbered("STR-ACC-SW", index)
+		next := numbered("STR-ACC-SW", index+1)
+		if !adjacent(cfg, name, next) {
+			t.Errorf("%s is not chained to %s", name, next)
+		}
+	}
+	if adjacent(cfg, "STR-ACC-SW04", "STR-ACC-SW01") {
+		t.Error("the lane chain closes into a ring")
+	}
+	if uplinks := countUplinks(cfg, "STR-ACC-SW", "STR-DIST-SW"); uplinks != 2 {
+		t.Errorf("chain uplinks = %d, want 2", uplinks)
+	}
+}
+
+// A metro POP hands its access nodes off a ring, and every pack keeps the full
+// spine including radios and a controller pair - service provider was the one
+// pack generating neither.
+func TestServiceProviderRingsItsPOPAndKeepsTheSpine(t *testing.T) {
+	cfg := generatePack(t, "service-provider")
+
+	for index := 1; index <= 4; index++ {
+		next := index%4 + 1
+		if !adjacent(cfg, numbered("NYC-ACC-SW", index), numbered("NYC-ACC-SW", next)) {
+			t.Errorf("NYC-ACC-SW%02d is not linked to its ring neighbour", index)
+		}
+	}
+	if findDevice(cfg, "NYC-WLC01") == nil || findDevice(cfg, "NYC-WAP-B01-F01-01") == nil {
+		t.Error("service provider still generates no radios and no controller")
+	}
+}
+
+func numbered(prefix string, index int) string {
+	return fmt.Sprintf("%s%02d", prefix, index)
 }

--- a/internal/scenario/packs.go
+++ b/internal/scenario/packs.go
@@ -11,10 +11,10 @@ const (
 	hospitalDeviceCount         = 75
 	warehouseDeviceCount        = 57
 	manufacturingDeviceCount    = 69
-	campusDeviceCount           = 155
+	campusDeviceCount           = 147
 	enterpriseScaleDeviceCount  = 531
 	retailDeviceCount           = 95
-	serviceProviderDeviceCount  = 87
+	serviceProviderDeviceCount  = 117
 	singleSiteNetworkCount      = 12
 	twoSiteNetworkCount         = 21
 	threeSiteNetworkCount       = 30
@@ -22,10 +22,10 @@ const (
 	hospitalLinkCount           = 88
 	warehouseLinkCount          = 67
 	manufacturingLinkCount      = 78
-	campusLinkCount             = 202
+	campusLinkCount             = 186
 	enterpriseScaleLinkCount    = 634
-	retailLinkCount             = 118
-	serviceProviderLinkCount    = 122
+	retailLinkCount             = 112
+	serviceProviderLinkCount    = 146
 )
 
 type packSite struct {
@@ -113,31 +113,7 @@ func customerScenarioPacks() []Pack {
 				LinksSHA256:       "a495dcb76177b01348573b330b54640318d21c34f7c71e596de2aba0bb8c9939",
 			},
 		),
-		newScenarioPack(
-			"campus",
-			"Enterprise campus",
-			"Four readable sites with core, distribution, access, Wi-Fi 7, workstation, and service layers.",
-			MapPurposePresentation,
-			"campus.example",
-			packSites(campusSiteOctet,
-				packSite{code: "NTH", location: "North Campus"},
-				packSite{code: "STH", location: "South Campus"},
-				packSite{code: "ENG", location: "Engineering Campus"},
-				packSite{code: "ADM", location: "Administration Campus"},
-			),
-			packCounts(
-				campusAccessSwitches,
-				campusAccessPointsPerAccess,
-				campusWorkstationsPerAccess,
-			),
-			Manifest{
-				DeviceCount: campusDeviceCount, NetworkCount: fourSiteNetworkCount,
-				LinkCount:         campusLinkCount,
-				DeviceNamesSHA256: "17ed0a70d1f95060126e399c19b0a9fc4fa2ad5779be8ac8763debd34f97b72f",
-				NetworksSHA256:    "7262a118fbb0f2d4977d02895b839d0cbce5fd1161201b0f27a5b37fc3eb72ce",
-				LinksSHA256:       "b171d72805e3ea4524118adcf58a99c8e52112c8d32f43f25816b90b3ea2e3e8",
-			},
-		),
+		campusScenarioPack(),
 		newScenarioPack(
 			"enterprise-scale",
 			"Enterprise scale reference",
@@ -167,6 +143,34 @@ func packSites(firstOctet int, definitions ...packSite) []Site {
 		}
 	}
 	return sites
+}
+
+func campusScenarioPack() Pack {
+	pack := newScenarioPack(
+		"campus",
+		"Enterprise campus",
+		"Four readable sites, each wide and shallow: closets land straight on a collapsed core, with Wi-Fi 7, workstation, and service layers.",
+		MapPurposePresentation,
+		"campus.example",
+		packSites(campusSiteOctet,
+			packSite{code: "NTH", location: "North Campus"},
+			packSite{code: "STH", location: "South Campus"},
+			packSite{code: "ENG", location: "Engineering Campus"},
+			packSite{code: "ADM", location: "Administration Campus"},
+		),
+		campusCounts(),
+		Manifest{
+			DeviceCount: campusDeviceCount, NetworkCount: fourSiteNetworkCount,
+			LinkCount:         campusLinkCount,
+			DeviceNamesSHA256: "c15f6f9ddff32dc30e5751858c3ea2650dd2aa1b2900abf89b5f9b23692236f7",
+			NetworksSHA256:    "7262a118fbb0f2d4977d02895b839d0cbce5fd1161201b0f27a5b37fc3eb72ce",
+			LinksSHA256:       "faa6df268e4654e542f89b707ee9bc05744de70b6edc9419f990e77da478410d",
+		},
+	)
+	// A campus is wide and shallow; its closets land on the core directly.
+	pack.Request.AccessLayer = AccessLayerCollapsedCore
+
+	return pack
 }
 
 func newScenarioPack(

--- a/internal/scenario/packs_counts.go
+++ b/internal/scenario/packs_counts.go
@@ -22,7 +22,7 @@ const (
 	manufacturingAccessPointsPerAccess = 5
 	manufacturingWorkstationsPerAccess = 2
 	providerAccessSwitches             = 4
-	providerAccessPointsPerAccess      = 0
+	providerAccessPointsPerAccess      = 2
 	providerWorkstationsPerAccess      = 2
 )
 
@@ -35,5 +35,15 @@ func packCounts(access, accessPoints, workstations int) Counts {
 	if accessPoints > 0 {
 		counts.WirelessControllers = maxRedundantPeers
 	}
+	return counts
+}
+
+// campusCounts drops the distribution tier: a wide, shallow campus lands its
+// closets straight on a collapsed core, so generating distribution switches
+// would put a tier on the map that nobody deployed.
+func campusCounts() Counts {
+	counts := packCounts(campusAccessSwitches, campusAccessPointsPerAccess, campusWorkstationsPerAccess)
+	counts.DistributionSwitches = 0
+
 	return counts
 }

--- a/internal/scenario/packs_test.go
+++ b/internal/scenario/packs_test.go
@@ -66,10 +66,18 @@ func TestVerticalDemoPacksAreSingleSite(t *testing.T) {
 	}
 }
 
-func TestWiredOnlyScenarioPacksOmitWirelessControllers(t *testing.T) {
+// Every presentation pack keeps the full layered spine, radios and controllers
+// included. Service provider used to be the one pack generating neither, which
+// left its map missing a tier every real POP has.
+func TestEveryPresentationPackKeepsTheWirelessTier(t *testing.T) {
 	for _, pack := range scenario.Packs() {
-		if pack.ID == "service-provider" && pack.Request.Counts.WirelessControllers != 0 {
-			t.Errorf("service-provider wireless controllers = %d, want zero",
+		if pack.MapPurpose != scenario.MapPurposePresentation {
+			continue
+		}
+		if pack.Request.Counts.AccessPointsPerAccess < 1 ||
+			pack.Request.Counts.WirelessControllers < 1 {
+			t.Errorf("%s generates %d radios per access switch and %d controllers",
+				pack.ID, pack.Request.Counts.AccessPointsPerAccess,
 				pack.Request.Counts.WirelessControllers)
 		}
 	}

--- a/internal/scenario/packs_vertical.go
+++ b/internal/scenario/packs_vertical.go
@@ -2,28 +2,37 @@ package scenario
 
 func verticalScenarioPacks() []Pack {
 	return []Pack{
-		newScenarioPack(
-			"retail", "Retail network",
-			"Two retail sites with wireless point-of-sale coverage and local business services.",
-			MapPurposePresentation,
-			"retail.example", packSites(retailSiteOctet,
-				packSite{code: "HQ", location: "Retail Headquarters"},
-				packSite{code: "STR", location: "Regional Flagship Store"},
-			), packCounts(
-				retailAccessSwitches,
-				retailAccessPointsPerAccess,
-				retailWorkstationsPerAccess,
-			), Manifest{
-				DeviceCount: retailDeviceCount, NetworkCount: twoSiteNetworkCount,
-				LinkCount:         retailLinkCount,
-				DeviceNamesSHA256: "e5944f8f0f8795d3f054f6ce082c3c8c2c1dde8eab5839992487cebd554215a8",
-				NetworksSHA256:    "88cdfbd6e21a58552873afe83c93dac96b7fae0a28166ecb319475dbcc38d25b",
-				LinksSHA256:       "c57237bbe4a9c00de9506bd06c2da4d0a32acf93e930ebf287f4f83da83d18b3",
-			},
-		),
+		retailScenarioPack(),
 		manufacturingScenarioPack(),
 		serviceProviderScenarioPack(),
 	}
+}
+
+func retailScenarioPack() Pack {
+	pack := newScenarioPack(
+		"retail", "Retail network",
+		"Two retail sites: a back office, and a store whose lanes chain off one another "+
+			"with wireless point-of-sale coverage and local business services.",
+		MapPurposePresentation,
+		"retail.example", packSites(retailSiteOctet,
+			packSite{code: "HQ", location: "Retail Headquarters"},
+			packSite{code: "STR", location: "Regional Flagship Store"},
+		), packCounts(
+			retailAccessSwitches,
+			retailAccessPointsPerAccess,
+			retailWorkstationsPerAccess,
+		), Manifest{
+			DeviceCount: retailDeviceCount, NetworkCount: twoSiteNetworkCount,
+			LinkCount:         retailLinkCount,
+			DeviceNamesSHA256: "e5944f8f0f8795d3f054f6ce082c3c8c2c1dde8eab5839992487cebd554215a8",
+			NetworksSHA256:    "88cdfbd6e21a58552873afe83c93dac96b7fae0a28166ecb319475dbcc38d25b",
+			LinksSHA256:       "e1c65c18481d92c20c743d920c2f7086d9e849350e13a89197d4856523179761",
+		},
+	)
+	// A store runs its lanes off one another rather than home-running each till.
+	pack.Request.AccessLayer = AccessLayerChain
+
+	return pack
 }
 
 func manufacturingScenarioPack() Pack {
@@ -49,9 +58,10 @@ func manufacturingScenarioPack() Pack {
 }
 
 func serviceProviderScenarioPack() Pack {
-	return newScenarioPack(
+	pack := newScenarioPack(
 		"service-provider", "Service provider network",
-		"Three metro points of presence with distribution, access, service, and wired-client layers.",
+		"Three metro points of presence, each handing its access nodes off a ring, "+
+			"with service, wireless, and wired-client layers.",
 		MapPurposePresentation, "provider.example",
 		packSites(serviceProviderSiteOctet,
 			packSite{code: "NYC", location: "New York Metro POP"},
@@ -62,9 +72,13 @@ func serviceProviderScenarioPack() Pack {
 		Manifest{
 			DeviceCount: serviceProviderDeviceCount, NetworkCount: threeSiteNetworkCount,
 			LinkCount:         serviceProviderLinkCount,
-			DeviceNamesSHA256: "279b172d5ce92a4652ff5015da8325297a8d7217211b19ac020cec462d1a711f",
+			DeviceNamesSHA256: "00e2aa73f52847020ae7b8b2afe86329e93087efae74adecfd3835e8685e0ea3",
 			NetworksSHA256:    "79fcb26f2a9f506a24540a583ae570b5c25e1dcf8a63ccfa21946b4912fc7720",
-			LinksSHA256:       "e64dc64a8796d5327205367f70b8934fd02c2cefd3a9d79b9a667b74f7031c9d",
+			LinksSHA256:       "e4e6e35ca4eb6c8ebf70f02f8617b1932b02d74bc6728d7646f3f00e0805daf1",
 		},
 	)
+	// A metro POP hands its access nodes off a ring.
+	pack.Request.AccessLayer = AccessLayerRing
+
+	return pack
 }

--- a/internal/scenario/topology.go
+++ b/internal/scenario/topology.go
@@ -103,11 +103,23 @@ func addSiteLAN(links linkMap, site Site, request Request) {
 		}
 	}
 
-	if request.AccessLayer == AccessLayerRing {
+	switch request.AccessLayer {
+	case AccessLayerRing:
 		addAccessRing(links, site, counts)
 		addServerSwitches(links, site, counts)
 
 		return
+	case AccessLayerCollapsedCore:
+		addAccessToCore(links, site, counts)
+		addServerSwitches(links, site, counts)
+
+		return
+	case AccessLayerChain:
+		addAccessChain(links, site, counts)
+		addServerSwitches(links, site, counts)
+
+		return
+	case AccessLayerDualHomed:
 	}
 
 	distributionPairs := counts.DistributionSwitches / maxRedundantPeers
@@ -145,6 +157,49 @@ func addServerSwitches(links linkMap, site Site, counts Counts) {
 				endpoint{coreName, fmt.Sprintf("HundredGigabitEthernet1/0/%d", serverSwitch+coreServerPortOffset)},
 				endpoint{name, fmt.Sprintf("HundredGigabitEthernet1/0/%d", coreIndex+1)}, nil)
 		}
+	}
+}
+
+// addAccessToCore lands every access switch on both core switches. With no
+// distribution tier the core is what the closets hang off, which is the whole
+// point of collapsing it.
+func addAccessToCore(links linkMap, site Site, counts Counts) {
+	cores := numberedNames(site.Code+"-CORE-SW", counts.CoreSwitches)
+	for accessIndex := 1; accessIndex <= counts.AccessSwitches; accessIndex++ {
+		for coreIndex, coreName := range cores {
+			addEdge(links,
+				endpoint{
+					coreName,
+					fmt.Sprintf("HundredGigabitEthernet1/0/%d", accessIndex),
+				},
+				endpoint{
+					accessName(site, accessIndex),
+					fmt.Sprintf("HundredGigabitEthernet1/0/%d", coreIndex+accessUplinkPortStart),
+				},
+				nil)
+		}
+	}
+}
+
+// addAccessChain daisy-chains the access switches and uplinks only the head of
+// the chain, which is how a store gets from the back office out along its lanes.
+func addAccessChain(links linkMap, site Site, counts Counts) {
+	for index := 1; index < counts.AccessSwitches; index++ {
+		addEdge(links,
+			endpoint{accessName(site, index), ringEastPort},
+			endpoint{accessName(site, index+1), ringWestPort}, nil)
+	}
+	for distribution := 1; distribution <= maxRedundantPeers; distribution++ {
+		addEdge(links,
+			endpoint{
+				numberedName(site.Code+"-DIST-SW", distribution),
+				fmt.Sprintf("HundredGigabitEthernet1/0/%d", firstDistributionAccessPort),
+			},
+			endpoint{
+				accessName(site, 1),
+				fmt.Sprintf("HundredGigabitEthernet1/0/%d", distribution+accessUplinkPortStart-1),
+			},
+			nil)
 	}
 }
 

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -132,6 +132,14 @@ const (
 	// the distribution tier at two opposite points, the way a plant runs its
 	// cells off a fiber ring rather than home-running every closet.
 	AccessLayerRing AccessLayer = "ring"
+	// AccessLayerCollapsedCore lands every access switch straight on the core
+	// pair. A campus that is wide and shallow does not earn a distribution tier,
+	// and generating one it does not use would be a tier nobody deployed.
+	AccessLayerCollapsedCore AccessLayer = "collapsed-core"
+	// AccessLayerChain daisy-chains the access switches, with only the first
+	// uplinked. A store runs its lanes off one another rather than home-running
+	// every till to the back office.
+	AccessLayerChain AccessLayer = "chain"
 )
 
 // Request is the complete deterministic fleet-generation contract.

--- a/internal/scenario/validation.go
+++ b/internal/scenario/validation.go
@@ -42,7 +42,7 @@ func validateRequest(request Request) error {
 		return err
 	}
 
-	return validateCounts(request.Counts)
+	return validateCounts(request.Counts, request.AccessLayer)
 }
 
 // validateAccessLayer refuses a shape that cannot be built rather than quietly
@@ -50,6 +50,8 @@ func validateRequest(request Request) error {
 func validateAccessLayer(request Request) error {
 	switch request.AccessLayer {
 	case AccessLayerDualHomed:
+		return nil
+	case AccessLayerCollapsedCore, AccessLayerChain:
 		return nil
 	case AccessLayerRing:
 		if request.Counts.AccessSwitches < minimumRingNodes {
@@ -60,7 +62,7 @@ func validateAccessLayer(request Request) error {
 
 		return nil
 	default:
-		return errors.New("access layer must be empty or ring")
+		return errors.New("access layer must be empty, ring, collapsed-core, or chain")
 	}
 }
 
@@ -101,19 +103,35 @@ func validateSites(sites []Site) error {
 	return nil
 }
 
-func validateCounts(c Counts) error {
+// validateDistributionTier enforces the redundant pair every shape needs except
+// a collapsed core, which by definition has no distribution tier to size.
+func validateDistributionTier(switches int, accessLayer AccessLayer) error {
+	if accessLayer == AccessLayerCollapsedCore {
+		if switches != 0 {
+			return errors.New("a collapsed core must not declare distribution switches")
+		}
+
+		return nil
+	}
+	if switches < maxRedundantPeers || switches > maxDistributionSwitches {
+		return errors.New("distribution switch count must be between 2 and 8")
+	}
+	if switches%maxRedundantPeers != 0 {
+		return errors.New("distribution switch count must be even")
+	}
+
+	return nil
+}
+
+func validateCounts(c Counts, accessLayer AccessLayer) error {
 	if c.SiteWANRouters != c.Firewalls || c.SiteWANRouters != c.CoreSwitches {
 		return errors.New("WAN, firewall, and core counts must match")
 	}
 	if c.SiteWANRouters < 1 || c.SiteWANRouters > maxRedundantPeers {
 		return errors.New("WAN, firewall, and core counts must be 1 or 2")
 	}
-	if c.DistributionSwitches < maxRedundantPeers ||
-		c.DistributionSwitches > maxDistributionSwitches {
-		return errors.New("distribution switch count must be between 2 and 8")
-	}
-	if c.DistributionSwitches%maxRedundantPeers != 0 {
-		return errors.New("distribution switch count must be even")
+	if err := validateDistributionTier(c.DistributionSwitches, accessLayer); err != nil {
+		return err
 	}
 	if c.AccessSwitches < 1 || c.AccessSwitches > maxAccessSwitches {
 		return errors.New("access switch count must be between 1 and 20")

--- a/ui/src/api/scenario-client.ts
+++ b/ui/src/api/scenario-client.ts
@@ -33,8 +33,9 @@ export interface ScenarioGenerateRequest {
     | 'service-provider';
   /** How the access tier is organized. Absent means every access switch
    * dual-homes into the distribution pair; 'ring' closes them into one ring
-   * that meets distribution at two points. */
-  accessLayer?: 'ring';
+   * that meets distribution at two points; 'collapsed-core' lands them on the
+   * core with no distribution tier; 'chain' daisy-chains them off one uplink. */
+  accessLayer?: 'ring' | 'collapsed-core' | 'chain';
 }
 
 export interface ScenarioManifest {


### PR DESCRIPTION
## Summary

The last three packs still generated the hospital's skeleton, so six verticals rendered as one map with different labels. Each now gets the shape the agreed vertical-realism design calls for, through the same `AccessLayer` field the manufacturing ring introduced.

- **campus — collapsed core.** Wide and shallow: closets land on the core pair directly and the distribution tier is gone rather than drawn and unused. 155 devices → 147.
- **retail — lane chain.** The store chains its lanes off one another behind a single uplink into the back office instead of home-running every till.
- **service-provider — POP ring**, and it stops being the one pack generating no radios and no controller, which left its map missing a tier every real POP has. 87 devices → 117.

## Linked Issue

Related to #1223 (M4-4).

## Type

- [x] Feature

## Risk

Low-to-moderate: three packs change shape and their frozen manifests move with them (campus 155/202 → 147/186, retail links 118 → 112, service provider 87/122 → 117/146). Hospital, warehouse, manufacturing and the scale workload are byte-identical. An unbuildable shape is refused at validation — a collapsed core that still declares distribution switches is an error, not a silent fallback.

## Testing Evidence

Each shape has a test that failed before its implementation:

```
$ go test ./internal/scenario/ -run "Campus|Retail|ServiceProvider"
--- FAIL: TestCampusCollapsesTheCore
    campus still generates a distribution tier
    access-to-core uplinks = 0, want 8
--- FAIL: TestRetailStoreChainsItsLanes
    STR-ACC-SW01 is not chained to STR-ACC-SW02
    chain uplinks = 8, want 2
--- FAIL: TestServiceProviderRingsItsPOPAndKeepsTheSpine
    NYC-ACC-SW01 is not linked to its ring neighbour
    service provider still generates no radios and no controller

$ go test ./internal/scenario/...
ok  github.com/MustardSeedNetworks/niac-go/internal/scenario  13.465s

$ golangci-lint run internal/scenario/...
0 issues.
```

The two shapes that already shipped are live-validated on the CyberScope against Link-Live, on configs generated through the product API, both **zero findings**:

```
manufacturing  analysis 6a77a37d9dc61ad432d7a746   69 devices  78 links  0 findings  passed
warehouse      analysis 6a77af229dc61ad432e2528a   57 devices  67 links  0 findings  passed
```

Not run: campus, retail and service-provider have not yet had their own Link-Live comparison on these new shapes. Those three captures are the rest of M4-4.

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes, so no CSRF or role-gate surface changed
- [x] No dependency changes
- [x] `golangci-lint`, `gosec`, Biome, tsgo and the full Go and frontend suites pass in pre-commit