### PR TITLE
feat(scenario): give the hospital demo something to find

### DIFF
--- a/internal/scenario/congestion_test.go
+++ b/internal/scenario/congestion_test.go
@@ -1,0 +1,75 @@
+package scenario_test
+
+import (
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+// The hospital pack is the guided demo, and a demo that is uniformly healthy
+// gives an engineer nothing to find. Its imaging closet runs deliberately hot,
+// on both ends of both uplinks, above the 80% line where Link-Live raises an
+// interface Warning (measured: clean to 78.7%, warned from 81.8%).
+func TestHospitalImagingUplinksRunHot(t *testing.T) {
+	cfg := generatePack(t, "hospital")
+	hot := map[string]string{
+		"MED-ACC-SW02":  "HundredGigabitEthernet1/0/49",
+		"MED-DIST-SW01": "HundredGigabitEthernet1/0/4",
+	}
+
+	for device, name := range hot {
+		iface := interfaceOf(t, cfg, device, name)
+		if iface.InUtilization <= 80 {
+			t.Errorf("%s %s in-utilization = %.1f, want above the 80%% warning line",
+				device, name, iface.InUtilization)
+		}
+	}
+}
+
+// Every other interface stays under the line: an amber map everywhere teaches
+// nothing either, and the story only reads as a story if it is the exception.
+func TestOnlyTheStoryRunsHot(t *testing.T) {
+	cfg := generatePack(t, "hospital")
+	hot := 0
+	for index := range cfg.Devices {
+		for _, iface := range cfg.Devices[index].Interfaces {
+			if iface.InUtilization > 80 || iface.OutUtilization > 80 {
+				hot++
+			}
+		}
+	}
+	if hot != 4 {
+		t.Errorf("interfaces above the warning line = %d, want the 4 authored ones", hot)
+	}
+}
+
+// A congested link that names an interface the pack does not generate is a typo,
+// and a typo that silently generates a healthy map is the worst outcome.
+func TestCongestionMustNameARealInterface(t *testing.T) {
+	request := packRequest(t, "hospital")
+	request.Congestion = append(request.Congestion, scenario.CongestedLink{
+		Device: "MED-ACC-SW02", Interface: "HundredGigabitEthernet9/9/9",
+		InUtilization: 90, OutUtilization: 90,
+	})
+
+	if _, err := scenario.Generate(request); err == nil {
+		t.Error("congestion on an interface that does not exist generated a fleet")
+	}
+}
+
+func interfaceOf(t *testing.T, cfg *config.Config, device, name string) config.Interface {
+	t.Helper()
+	found := findDevice(cfg, device)
+	if found == nil {
+		t.Fatalf("no device %q", device)
+	}
+	for _, iface := range found.Interfaces {
+		if iface.Name == name {
+			return iface
+		}
+	}
+	t.Fatalf("%s has no interface %q", device, name)
+
+	return config.Interface{}
+}

--- a/internal/scenario/generator.go
+++ b/internal/scenario/generator.go
@@ -56,6 +56,9 @@ func Generate(request Request) (Result, error) {
 		}},
 		Devices: buildDevices(request, links),
 	}
+	if err := applyCongestion(&authored, request.Congestion); err != nil {
+		return Result{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
 	if err := converter.ValidateConfig(&authored); err != nil {
 		return Result{}, fmt.Errorf("generated authoring config: %w", err)
 	}
@@ -196,4 +199,36 @@ func transit(site Site, kind string, siteIndex int) (string, string, int) {
 	base += transitBlockSize * siteIndex
 	return strings.ToLower(site.Code) + "-" + kind + "-transit",
 		fmt.Sprintf("203.0.113.%d/29", base), base
+}
+
+// applyCongestion replaces the generated band on the interfaces a pack calls
+// out as its trouble spots. An interface that does not exist is a typo, and a
+// typo that quietly leaves the map healthy is the one outcome worth failing on:
+// the whole point of the story is that an engineer finds it.
+func applyCongestion(authored *converter.Config, links []CongestedLink) error {
+	for _, link := range links {
+		iface := findAuthoredInterface(authored, link.Device, link.Interface)
+		if iface == nil {
+			return fmt.Errorf("congested link %s %s does not exist", link.Device, link.Interface)
+		}
+		iface.InUtilization = link.InUtilization
+		iface.OutUtilization = link.OutUtilization
+	}
+
+	return nil
+}
+
+func findAuthoredInterface(authored *converter.Config, device, name string) *converter.Interface {
+	for deviceIndex := range authored.Devices {
+		if authored.Devices[deviceIndex].Name != device {
+			continue
+		}
+		for index := range authored.Devices[deviceIndex].Interfaces {
+			if authored.Devices[deviceIndex].Interfaces[index].Name == name {
+				return &authored.Devices[deviceIndex].Interfaces[index]
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/scenario/packs.go
+++ b/internal/scenario/packs.go
@@ -69,28 +69,7 @@ func scenarioPackDefinitions() []Pack {
 
 func customerScenarioPacks() []Pack {
 	return []Pack{
-		newScenarioPack(
-			"hospital",
-			"Hospital network",
-			"Single-site medical center with resilient wired access, 30 Wi-Fi 7 APs, clinical clients, and local services.",
-			MapPurposePresentation,
-			"care.example",
-			packSites(hospitalSiteOctet,
-				packSite{code: "MED", location: "Regional Medical Center"},
-			),
-			packCounts(
-				hospitalAccessSwitches,
-				hospitalAccessPointsPerAccess,
-				hospitalWorkstationsPerAccess,
-			),
-			Manifest{
-				DeviceCount: hospitalDeviceCount, NetworkCount: singleSiteNetworkCount,
-				LinkCount:         hospitalLinkCount,
-				DeviceNamesSHA256: "a026920162b3dcc95656a4d3d69a0aeed84482e7724b018d5a49488383609030",
-				NetworksSHA256:    "af29ba1bf3ae3a58f46809ba0e126fa436ea4e78193842f8ce12b9d276686b30",
-				LinksSHA256:       "99be6cdbe704f4e4d661a27be11b6294e62e8b52ca83e2c6198b4ba9fe8836b2",
-			},
-		),
+		hospitalScenarioPack(),
 		newScenarioPack(
 			"warehouse",
 			"Warehouse network",
@@ -143,6 +122,64 @@ func packSites(firstOctet int, definitions ...packSite) []Site {
 		}
 	}
 	return sites
+}
+
+// hospitalScenarioPack is the guided demo, so it is the one pack that carries a
+// story: the imaging closet saturates both of its uplinks, and both ends of
+// both links report it. Everything else stays healthy, because a finding only
+// reads as a finding when it is the exception on the map.
+func hospitalScenarioPack() Pack {
+	pack := newScenarioPack(
+		"hospital",
+		"Hospital network",
+		"Single-site medical center with resilient wired access, 30 Wi-Fi 7 APs, clinical clients, and local services.",
+		MapPurposePresentation,
+		"care.example",
+		packSites(hospitalSiteOctet,
+			packSite{code: "MED", location: "Regional Medical Center"},
+		),
+		packCounts(
+			hospitalAccessSwitches,
+			hospitalAccessPointsPerAccess,
+			hospitalWorkstationsPerAccess,
+		),
+		Manifest{
+			DeviceCount: hospitalDeviceCount, NetworkCount: singleSiteNetworkCount,
+			LinkCount:         hospitalLinkCount,
+			DeviceNamesSHA256: "a026920162b3dcc95656a4d3d69a0aeed84482e7724b018d5a49488383609030",
+			NetworksSHA256:    "af29ba1bf3ae3a58f46809ba0e126fa436ea4e78193842f8ce12b9d276686b30",
+			LinksSHA256:       "99be6cdbe704f4e4d661a27be11b6294e62e8b52ca83e2c6198b4ba9fe8836b2",
+		},
+	)
+	pack.Request.Congestion = imagingCongestion()
+
+	return pack
+}
+
+func imagingCongestion() []CongestedLink {
+	const (
+		saturated = 88.0
+		busy      = 84.0
+	)
+
+	return []CongestedLink{
+		{
+			Device: "MED-ACC-SW02", Interface: "HundredGigabitEthernet1/0/49",
+			InUtilization: saturated, OutUtilization: busy,
+		},
+		{
+			Device: "MED-ACC-SW02", Interface: "HundredGigabitEthernet1/0/50",
+			InUtilization: busy, OutUtilization: saturated,
+		},
+		{
+			Device: "MED-DIST-SW01", Interface: "HundredGigabitEthernet1/0/4",
+			InUtilization: busy, OutUtilization: saturated,
+		},
+		{
+			Device: "MED-DIST-SW02", Interface: "HundredGigabitEthernet1/0/4",
+			InUtilization: saturated, OutUtilization: busy,
+		},
+	}
 }
 
 func campusScenarioPack() Pack {

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -142,15 +142,26 @@ const (
 	AccessLayerChain AccessLayer = "chain"
 )
 
+// CongestedLink is one authored trouble spot: a link the guided demo is meant
+// to find. It replaces the generated utilization band on one interface, which is
+// how a pack tells a story rather than rendering uniformly healthy.
+type CongestedLink struct {
+	Device         string  `json:"device"`
+	Interface      string  `json:"interface"`
+	InUtilization  float64 `json:"inUtilization"`
+	OutUtilization float64 `json:"outUtilization"`
+}
+
 // Request is the complete deterministic fleet-generation contract.
 type Request struct {
-	Sites           []Site      `json:"sites"`
-	Counts          Counts      `json:"counts"`
-	Domain          string      `json:"domain"`
-	SNMPCommunity   string      `json:"snmpCommunity"`
-	AttachmentName  string      `json:"attachmentName"`
-	EndpointProfile string      `json:"endpointProfile,omitempty"`
-	AccessLayer     AccessLayer `json:"accessLayer,omitempty"`
+	Sites           []Site          `json:"sites"`
+	Counts          Counts          `json:"counts"`
+	Domain          string          `json:"domain"`
+	SNMPCommunity   string          `json:"snmpCommunity"`
+	AttachmentName  string          `json:"attachmentName"`
+	EndpointProfile string          `json:"endpointProfile,omitempty"`
+	AccessLayer     AccessLayer     `json:"accessLayer,omitempty"`
+	Congestion      []CongestedLink `json:"congestion,omitempty"`
 }
 
 // Manifest summarizes authored identity and topology for parity checks.

--- a/internal/scenario/utilization_truth_test.go
+++ b/internal/scenario/utilization_truth_test.go
@@ -15,8 +15,9 @@ const (
 
 	// Link-Live raises an interface Warning above 80% utilization. Measured
 	// against a live discovery: interfaces up to 78.7% stayed clean, 81.8% and
-	// above were flagged. Authored peaks must stay below that line so a demo
-	// map reads healthy instead of amber.
+	// above were flagged. The generated band must stay below that line so a demo
+	// map reads healthy instead of amber; the only interfaces above it are the
+	// ones a pack deliberately calls out as its story.
 	utilizationWarningFloor = 80
 )
 
@@ -47,12 +48,17 @@ func packUtilizationBands(t *testing.T, pack scenario.Pack) (int, int) {
 	if err != nil {
 		t.Fatalf("load %s: %v", pack.ID, err)
 	}
+	authored := make(map[string]bool, len(pack.Request.Congestion))
+	for _, link := range pack.Request.Congestion {
+		authored[link.Device+"|"+link.Interface] = true
+	}
 	for index := range cfg.Devices {
 		device := &cfg.Devices[index]
 		for _, iface := range device.Interfaces {
+			story := authored[device.Name+"|"+iface.Name]
 			for _, value := range []float64{iface.InUtilization, iface.OutUtilization} {
 				total++
-				if value >= utilizationWarningFloor {
+				if value >= utilizationWarningFloor && !story {
 					t.Errorf("%s %s %s utilization %.0f%% would trip the Link-Live warning at %d%%",
 						pack.ID, device.Name, iface.Name, value, utilizationWarningFloor)
 				}


### PR DESCRIPTION
## Summary

The hospital pack is the guided demo and it rendered uniformly healthy, which gives an engineer nothing to do. Its imaging closet now saturates both uplinks — 88% and 84%, on both ends of both links — deliberately above the 80% line where Link-Live raises an interface Warning (measured: clean to 78.7%, warned from 81.8%).

Congestion is authored data on the portable request rather than a special case in the generator, so any pack can carry a story and the comparator still checks it: it compares the authored value, so a story that fails to appear on the map is a finding like any other.

## Linked Issue

Related to #1223. Program ledger M4-2.

## Type

- [x] Feature

## Risk

Low. Device names, networks and links are untouched, so hospital's frozen manifest and its 75/88 authored truth stand — only four interface utilization values change. A congested link naming an interface the pack does not generate now fails generation rather than quietly leaving the map healthy.

## Testing Evidence

Three tests, each failing before the change:

```
$ go test ./internal/scenario/ -run "Hot|Congestion"
--- FAIL: TestHospitalImagingUplinksRunHot
    MED-ACC-SW02 HundredGigabitEthernet1/0/49 in-utilization = 70.0, want above the 80% warning line
--- FAIL: TestOnlyTheStoryRunsHot
    interfaces above the warning line = 0, want the 4 authored ones
--- FAIL: TestCongestionMustNameARealInterface
    congestion on an interface that does not exist generated a fleet

$ go test ./internal/scenario/...
ok  github.com/MustardSeedNetworks/niac-go/internal/scenario  13.782s

$ golangci-lint run internal/scenario/...
0 issues.
```

The existing rule that forbade any interface at or above 80% now exempts exactly the interfaces a pack declares, so the story cannot spread by accident — `TestOnlyTheStoryRunsHot` pins the count at four.

Not run yet: the live capture proving Link-Live renders these four as Warnings. That is the M4-2 acceptance evidence and follows on the lab.

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes, so no CSRF or role-gate surface changed
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit