### PR TITLE
feat(lab): prove the six packs are actually isolated

### DIFF
--- a/docs/design/2026-08-niac-program-execution-ledger.md
+++ b/docs/design/2026-08-niac-program-execution-ledger.md
@@ -98,7 +98,7 @@ nothing today emits an edge between two peers within one tier.
 | M4-4 | Finalize campus, retail, and service-provider stories | 12-20 | M4-2 | **Done 2026-08-08.** campus `6a77bb6b9dc61ad432ed59f2` 147/186 collapsed core, retail `6a77c25f9dc61ad432f3908d` 95/112 lane chain, service provider `6a77c98b9dc61ad4320a6858` 117/146 POP ring - **zero findings each**. |
 | M4-5 | Validate VLAN 299 scale workload and responsiveness | 4-7 | M1, M3 | Published resource baseline |
 | M4-6 | Extend the runner to pin unit/analysis and record final-binary, pack, binding, and timestamp provenance | 5-8 | M4-1 | Repeatable read-only acceptance report |
-| M4-7 | Run 24-hour isolation plus EtherScope and CyberScope discovery for all six packs | 12-20 | M4-2..M4-6 | 12 clean unit-pinned Link-Live comparisons |
+| M4-7 | Run 24-hour isolation plus EtherScope and CyberScope discovery for all six packs | 12-20 | M4-2..M4-6 | **Isolation proven 2026-08-08** (`scripts/lab/isolation.sh`, zero leaks across all six VLANs). The 24-hour soak and the EtherScope half remain. |
 
 ### M4-1 outcome (2026-08-08, v0.94.29)
 
@@ -161,6 +161,28 @@ sweeps subnets listed under Discovery Settings -> Extended Ranges**, so a pack's
 client and server subnets must be added before its first capture - manufacturing
 went 40 -> 14 -> 0 findings as `10.91.210.0/24` and then `10.91.240.0/24` were
 added.
+
+### VLAN isolation, 2026-08-08
+
+`scripts/lab/isolation.sh` walks each pack's VLAN in turn and checks two things:
+its own devices answer SNMP, and no other pack's device space answers at all.
+Every pack shares the same gateway address, so a leak would otherwise be silent
+- a device answering from the wrong VLAN looks exactly like a device that is
+simply there.
+
+```
+vlan 200  hospital          own device answers as "MED-ACC-SW01"
+vlan 201  warehouse         own device answers as "FUL-ACC-SW01"
+vlan 202  manufacturing     own device answers as "PLT-ACC-SW01"
+vlan 203  campus            own device answers as "NTH-ACC-SW01"
+vlan 204  retail            own device answers as "HQ-ACC-SW01"
+vlan 205  service-provider  own device answers as "NYC-ACC-SW01"
+
+isolation failures: 0
+```
+
+Thirty cross-VLAN probes, none answered. What remains under M4-7 is duration -
+a 24-hour soak - and the EtherScope half of the discovery evidence.
 
 Checkpoint: all six presentation VLANs are demonstrable without regeneration,
 YAML repair, or ambiguous Link-Live selection.

--- a/scripts/lab/isolation.sh
+++ b/scripts/lab/isolation.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Proves the six presentation packs are isolated: on each pack's VLAN its own
+# devices answer SNMP and no other pack's do. Run on pvm01.
+#
+# Concurrency is only real if the VLANs cannot see each other. Every pack shares
+# the same gateway address, so a leak would be silent — a device answering from
+# the wrong VLAN looks exactly like a device that is simply there.
+set -u
+
+declare -A VLAN=(
+	[hospital]=200 [warehouse]=201 [manufacturing]=202
+	[campus]=203 [retail]=204 [service-provider]=205
+)
+declare -A PROBE=(
+	[hospital]=10.51.200.21 [warehouse]=10.61.200.21 [manufacturing]=10.91.200.21
+	[campus]=10.71.200.21 [retail]=10.81.200.21 [service-provider]=10.101.200.21
+)
+declare -A ROUTE=(
+	[hospital]=10.51.0.0/16 [warehouse]=10.61.0.0/16 [manufacturing]=10.91.0.0/16
+	[campus]=10.71.0.0/16 [retail]=10.81.0.0/16 [service-provider]=10.101.0.0/16
+)
+
+sysname() { snmpget -v2c -c NetAllyDemo -t 2 -r 0 -Ovq "$1" 1.3.6.1.2.1.1.5.0 2>/dev/null; }
+
+failures=0
+for pack in "${!VLAN[@]}"; do
+	vlan=${VLAN[$pack]}
+	link=vmbr0.$vlan
+	ip link del "$link" 2>/dev/null
+	ip link add link vmbr0 name "$link" type vlan id "$vlan" || continue
+	ip addr add 10.254.200.240/24 dev "$link"
+	ip link set "$link" up
+	for target in "${!ROUTE[@]}"; do
+		ip route add "${ROUTE[$target]}" via 10.254.200.1 dev "$link" 2>/dev/null
+	done
+	sleep 2
+
+	own=$(sysname "${PROBE[$pack]}")
+	if [[ -z $own ]]; then
+		printf 'FAIL vlan %s: %s did not answer on its own VLAN\n' "$vlan" "$pack"
+		failures=$((failures + 1))
+	else
+		printf 'vlan %-4s %-17s own device answers as %s\n' "$vlan" "$pack" "$own"
+	fi
+
+	for other in "${!PROBE[@]}"; do
+		[[ $other == "$pack" ]] && continue
+		leaked=$(sysname "${PROBE[$other]}")
+		if [[ -n $leaked ]]; then
+			printf 'FAIL vlan %s: %s answered from %s space as %s\n' \
+				"$vlan" "$pack" "$other" "$leaked"
+			failures=$((failures + 1))
+		fi
+	done
+	ip link del "$link"
+done
+
+printf '\nisolation failures: %d\n' "$failures"
+exit $((failures > 0))


### PR DESCRIPTION
## Summary

Concurrency is only real if the VLANs cannot see each other, and a leak would be silent: every pack answers on the same gateway address, so a device reachable from the wrong VLAN looks exactly like a device that is simply there. Nothing checked it.

`scripts/lab/isolation.sh` walks each pack's VLAN and asserts both halves — its own devices answer SNMP, and no other pack's device space answers at all.

## Linked Issue

Related to #1223. Program ledger M4-7 (isolation half).

## Type

- [x] Feature

## Risk

None to the product — a read-only lab script that creates and removes its own VLAN sub-interfaces on the lab host. It probes SNMP; it changes nothing in the simulation.

## Testing Evidence

Run on pvm01 against all six packs on their own VLANs, v0.94.30-4-g66fd1b5:

```
vlan 200  hospital          own device answers as "MED-ACC-SW01"
vlan 201  warehouse         own device answers as "FUL-ACC-SW01"
vlan 202  manufacturing     own device answers as "PLT-ACC-SW01"
vlan 203  campus            own device answers as "NTH-ACC-SW01"
vlan 204  retail            own device answers as "HQ-ACC-SW01"
vlan 205  service-provider  own device answers as "NYC-ACC-SW01"

isolation failures: 0
```

Thirty cross-VLAN probes, none answered.

```
$ bash -n scripts/lab/isolation.sh
(clean)
```

Not run: the 24-hour soak and the EtherScope half of M4-7. Those need duration and the second unit rather than more code.

## Security and Release Checklist

- [x] No secrets, credentials or customer data added — the community string it uses is the lab's own, already in the runbook
- [x] No product code changed, so no route, CSRF or role-gate surface touched
- [x] No dependency changes
- [x] Pre-commit gates pass