### PR TITLE
fix(snmp): refuse a SET to an object the agent serves read-only

### DIFF
--- a/docs/design/2026-08-linklive-acceptance-runbook.md
+++ b/docs/design/2026-08-linklive-acceptance-runbook.md
@@ -54,6 +54,20 @@ for v in 200 201 202 203 204 205 299; do
   bridge vlan add dev nic0  vid $v
 done
 
+**Make the bridge membership persistent, or it is gone on the next reboot.**
+`bridge-vids` in `/etc/network/interfaces` programs the bridge *ports*, not the
+bridge itself, and the lab terminates its VLAN sub-interfaces on the bridge. A
+reboot on 2026-08-09 wiped every `self` entry and the packs went silent in a way
+that reads exactly like a NIAC fault — SNMP timing out on every VLAN while the
+daemon was healthy and the sessions were running. Add to the `vmbr0` stanza:
+
+```
+post-up for v in 200 201 202 203 204 205 299; do bridge vlan add dev vmbr0 vid $v self; done
+```
+
+Check it with `bridge vlan show dev vmbr0`: if only VLAN 1 is listed, this is
+why nothing answers.
+
 # A live `bridge vlan add` on the veth is not enough — reboot reapplies
 # the trunk list to veth304i0 cleanly.
 pct reboot 304

--- a/docs/design/2026-08-linklive-acceptance-runbook.md
+++ b/docs/design/2026-08-linklive-acceptance-runbook.md
@@ -54,6 +54,11 @@ for v in 200 201 202 203 204 205 299; do
   bridge vlan add dev nic0  vid $v
 done
 
+# A live `bridge vlan add` on the veth is not enough — reboot reapplies
+# the trunk list to veth304i0 cleanly.
+pct reboot 304
+```
+
 **Make the bridge membership persistent, or it is gone on the next reboot.**
 `bridge-vids` in `/etc/network/interfaces` programs the bridge *ports*, not the
 bridge itself, and the lab terminates its VLAN sub-interfaces on the bridge. A
@@ -65,13 +70,8 @@ daemon was healthy and the sessions were running. Add to the `vmbr0` stanza:
 post-up for v in 200 201 202 203 204 205 299; do bridge vlan add dev vmbr0 vid $v self; done
 ```
 
-Check it with `bridge vlan show dev vmbr0`: if only VLAN 1 is listed, this is
-why nothing answers.
-
-# A live `bridge vlan add` on the veth is not enough — reboot reapplies
-# the trunk list to veth304i0 cleanly.
-pct reboot 304
-```
+Check it with `bridge vlan show dev vmbr0`: if only VLAN 1 is listed, that is why
+nothing answers.
 
 Daemon side — one capture owner per interface, allowlisted tags:
 

--- a/internal/protocols/snmp/agent.go
+++ b/internal/protocols/snmp/agent.go
@@ -2,6 +2,7 @@
 package snmp
 
 import (
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"log/slog"
@@ -544,32 +545,56 @@ func estimateVarbindSize(oid string, value *OIDValue) int {
 	return size
 }
 
-// SetOID sets an OID value (for SNMP SET operations).
+// SetOID publishes a value into this agent's MIB. It is the simulation's own
+// authoring path and is deliberately unrestricted: NIAC decides what a device
+// reports. A manager on the wire goes through writeOID instead.
 func (a *Agent) SetOID(oid string, value *OIDValue) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	oid = strings.TrimPrefix(oid, ".")
-	if oid == snmpGroup+".30.0" {
-		enabled, ok := snmpInteger(value.Value)
-		if !ok || (enabled != authenticationTrapsOn && enabled != authenticationTrapsOff) {
-			return fmt.Errorf(
-				"%w: snmpEnableAuthenTraps must be enabled(1) or disabled(2)",
-				ErrInvalidValue,
-			)
-		}
-		a.stats.enableAuthenTraps.Store(uint32(enabled))
-		return nil
+	if oid == enableAuthenTrapsOID {
+		return a.setEnableAuthenTraps(value)
 	}
-
-	// Check if OID is writable
-	// For now, allow setting any OID
-	// In a full implementation, you'd check write permissions
-
 	a.mib.Set(oid, value)
 
 	if a.debugLevel >= debugLevelVerbose {
 		a.logger.Debug("SNMP SET", "oid", oid, "value", value.Value, "device", a.device.Name)
 	}
+
+	return nil
+}
+
+// writeOID applies a SET that arrived over the network. Everything this agent
+// serves is read-only unless it implements the object as writable, which is
+// what the device being imitated would answer: accepting every write tells a
+// scanner asking "can I write to this device?" the wrong thing, and lets a
+// stray SET put the simulation out of step with its authored truth.
+func (a *Agent) writeOID(oid string, value *OIDValue) error {
+	trimmed := strings.TrimPrefix(oid, ".")
+	if trimmed != enableAuthenTrapsOID {
+		if a.debugLevel >= debugLevelVerbose {
+			a.logger.Debug("SNMP SET refused", "oid", trimmed, "device", a.device.Name)
+		}
+
+		return fmt.Errorf("%w: %s", ErrNotWritable, trimmed)
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.setEnableAuthenTraps(value)
+}
+
+// setEnableAuthenTraps applies the one object this agent implements as
+// writable. The caller holds the lock.
+func (a *Agent) setEnableAuthenTraps(value *OIDValue) error {
+	enabled, ok := snmpInteger(value.Value)
+	if !ok || (enabled != authenticationTrapsOn && enabled != authenticationTrapsOff) {
+		return fmt.Errorf(
+			"%w: snmpEnableAuthenTraps must be enabled(1) or disabled(2)",
+			ErrInvalidValue,
+		)
+	}
+	a.stats.enableAuthenTraps.Store(uint32(enabled))
 
 	return nil
 }
@@ -659,7 +684,9 @@ func (a *Agent) ProcessPDU(
 
 		return a.processGetBulk(vars, nonRepeaters, reps)
 	case gosnmp.SetRequest:
-		return a.processSetRequest(vars)
+		response, _, _ := a.processSetRequest(vars)
+
+		return response
 	case gosnmp.Sequence,
 		gosnmp.GetResponse,
 		gosnmp.Trap,
@@ -697,13 +724,16 @@ func (a *Agent) ProcessPDU(
 func (a *Agent) ProcessRequest(
 	request *gosnmp.SnmpPacket,
 ) ([]gosnmp.SnmpPDU, gosnmp.SNMPError, uint8) {
+	if request.PDUType == gosnmp.SetRequest {
+		a.recordInboundPDU(request.PDUType, len(request.Variables))
+		variables, status, index := a.processSetRequest(request.Variables)
+
+		return variables, setErrorForVersion(status, request.Version), index
+	}
 	variables := a.ProcessPDU(
 		request.PDUType, request.Variables, int(request.NonRepeaters), request.MaxRepetitions,
 	)
 	for i, variable := range variables {
-		if request.PDUType == gosnmp.SetRequest && variable.Type == gosnmp.NoSuchObject {
-			return variables, gosnmp.BadValue, uint8(i + 1)
-		}
 		if request.Version == gosnmp.Version1 &&
 			(variable.Type == gosnmp.NoSuchObject || variable.Type == gosnmp.EndOfMibView) {
 			return request.Variables, gosnmp.NoSuchName, uint8(i + 1)
@@ -712,17 +742,25 @@ func (a *Agent) ProcessRequest(
 	return variables, gosnmp.NoError, 0
 }
 
-func (a *Agent) processSetRequest(vars []gosnmp.SnmpPDU) []gosnmp.SnmpPDU {
+func (a *Agent) processSetRequest(
+	vars []gosnmp.SnmpPDU,
+) ([]gosnmp.SnmpPDU, gosnmp.SNMPError, uint8) {
 	response := make([]gosnmp.SnmpPDU, len(vars))
+	status, index := gosnmp.NoError, uint8(0)
 	for i, variable := range vars {
 		value := &OIDValue{Type: variable.Type, Value: variable.Value}
-		if err := a.SetOID(variable.Name, value); err != nil {
-			response[i] = gosnmp.SnmpPDU{Name: variable.Name, Type: gosnmp.NoSuchObject}
+		err := a.writeOID(variable.Name, value)
+		response[i] = variable
+		if err == nil || status != gosnmp.NoError {
 			continue
 		}
-		response[i] = variable
+		status, index = gosnmp.BadValue, uint8(i+1)
+		if errors.Is(err, ErrNotWritable) {
+			status = gosnmp.NotWritable
+		}
 	}
-	return response
+
+	return response, status, index
 }
 
 // processGetRequest processes GET request variables.
@@ -904,4 +942,16 @@ func ParseOID(oid string) ([]int, error) {
 	}
 
 	return result, nil
+}
+
+// setErrorForVersion answers the way the device being imitated would. notWritable
+// is an SNMPv2c error status and has no SNMPv1 equivalent, so a version 1
+// manager is told noSuchName - which is what a real agent returns when it will
+// not write an object.
+func setErrorForVersion(status gosnmp.SNMPError, version gosnmp.SnmpVersion) gosnmp.SNMPError {
+	if status == gosnmp.NotWritable && version == gosnmp.Version1 {
+		return gosnmp.NoSuchName
+	}
+
+	return status
 }

--- a/internal/protocols/snmp/agent_write_permission_test.go
+++ b/internal/protocols/snmp/agent_write_permission_test.go
@@ -1,0 +1,103 @@
+package snmp
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A real agent refuses to write a read-only object. Accepting every SET is not
+// just permissive - it gives a scanner the wrong answer: a compliance check that
+// asks "can I write to this device?" is told yes, when the device it is
+// imitating would have said no. It also lets a stray SET rename a device and
+// silently put the simulation out of step with its authored truth.
+func TestSetRequestRefusesReadOnlyObjects(t *testing.T) {
+	agent := NewAgent(createTestDevice(), 0)
+	const sysName = "1.3.6.1.2.1.1.5.0"
+	before := agent.mib.Get(sysName)
+
+	_, status, index := agent.ProcessRequest(&gosnmp.SnmpPacket{
+		Version: gosnmp.Version2c, PDUType: gosnmp.SetRequest,
+		Variables: []gosnmp.SnmpPDU{
+			{Name: sysName, Type: gosnmp.OctetString, Value: "attacker-renamed-me"},
+		},
+	})
+
+	if status != gosnmp.NotWritable {
+		t.Errorf("error-status = %v, want NotWritable", status)
+	}
+	if index != 1 {
+		t.Errorf("error-index = %d, want 1", index)
+	}
+	after := agent.mib.Get(sysName)
+	if before != nil && after != nil && after.Value != before.Value {
+		t.Errorf("sysName changed to %v", after.Value)
+	}
+}
+
+// The one object this agent genuinely implements as writable stays writable.
+func TestSetRequestAcceptsTheWritableObject(t *testing.T) {
+	agent := NewAgent(createTestDevice(), 0)
+
+	_, status, _ := agent.ProcessRequest(&gosnmp.SnmpPacket{
+		Version: gosnmp.Version2c, PDUType: gosnmp.SetRequest,
+		Variables: []gosnmp.SnmpPDU{
+			{Name: "1.3.6.1.2.1.11.30.0", Type: gosnmp.Integer, Value: 2},
+		},
+	})
+
+	if status != gosnmp.NoError {
+		t.Errorf("error-status = %v, want NoError", status)
+	}
+}
+
+// A writable object still rejects a value outside its range, and says so as
+// wrongValue rather than as a permission problem.
+func TestSetRequestRejectsABadValueOnAWritableObject(t *testing.T) {
+	agent := NewAgent(createTestDevice(), 0)
+
+	_, status, _ := agent.ProcessRequest(&gosnmp.SnmpPacket{
+		Version: gosnmp.Version2c, PDUType: gosnmp.SetRequest,
+		Variables: []gosnmp.SnmpPDU{
+			{Name: "1.3.6.1.2.1.11.30.0", Type: gosnmp.Integer, Value: 7},
+		},
+	})
+
+	if status != gosnmp.BadValue {
+		t.Errorf("error-status = %v, want BadValue", status)
+	}
+}
+
+// The simulation still publishes its own MIB freely: the restriction is on what
+// a manager may write over the wire, not on what NIAC authors.
+func TestTheSimulationStillPublishesItsOwnValues(t *testing.T) {
+	agent := NewAgent(createTestDevice(), 0)
+	const ifDescr = "1.3.6.1.2.1.2.2.1.2.1"
+
+	if err := agent.SetOID(ifDescr, &OIDValue{
+		Type: gosnmp.OctetString, Value: "GigabitEthernet0/1",
+	}); err != nil {
+		t.Fatalf("SetOID: %v", err)
+	}
+	value := agent.mib.Get(ifDescr)
+	if value == nil || value.Value != "GigabitEthernet0/1" {
+		t.Errorf("authored value = %v", value)
+	}
+}
+
+// notWritable is an SNMPv2c status with no version 1 equivalent, so a version 1
+// manager has to be told something it understands.
+func TestVersionOneIsToldNoSuchName(t *testing.T) {
+	agent := NewAgent(createTestDevice(), 0)
+
+	_, status, _ := agent.ProcessRequest(&gosnmp.SnmpPacket{
+		Version: gosnmp.Version1, PDUType: gosnmp.SetRequest,
+		Variables: []gosnmp.SnmpPDU{
+			{Name: "1.3.6.1.2.1.1.5.0", Type: gosnmp.OctetString, Value: "nope"},
+		},
+	})
+
+	if status != gosnmp.NoSuchName {
+		t.Errorf("SNMPv1 error-status = %v, want NoSuchName", status)
+	}
+}

--- a/internal/protocols/snmp/errors.go
+++ b/internal/protocols/snmp/errors.go
@@ -11,6 +11,10 @@ var (
 	ErrEmptyOID            = errors.New("empty OID")
 	ErrInvalidOIDComponent = errors.New("invalid OID component")
 	ErrInvalidValue        = errors.New("invalid value")
+	// ErrNotWritable reports a manager trying to write an object this agent
+	// serves read-only, which is what a real device answers for almost all of
+	// its MIB.
+	ErrNotWritable = errors.New("object is not writable")
 )
 
 // Sentinel errors for addmib operations.

--- a/internal/protocols/snmp/mib_snmp.go
+++ b/internal/protocols/snmp/mib_snmp.go
@@ -8,7 +8,10 @@ import (
 )
 
 const (
-	snmpGroup              = "1.3.6.1.2.1.11"
+	snmpGroup = "1.3.6.1.2.1.11"
+	// enableAuthenTrapsOID is snmpEnableAuthenTraps, the one object this agent
+	// implements read-write. Everything else it serves is read-only.
+	enableAuthenTrapsOID   = snmpGroup + ".30.0"
 	authenticationTrapsOn  = 1
 	authenticationTrapsOff = 2
 )

--- a/internal/protocols/snmp/mib_snmp_test.go
+++ b/internal/protocols/snmp/mib_snmp_test.go
@@ -50,9 +50,11 @@ func TestSNMPGroupRejectsInvalidAuthTrapControl(t *testing.T) {
 	request := &gosnmp.SnmpPacket{Version: gosnmp.Version2c, PDUType: gosnmp.SetRequest, Variables: []gosnmp.SnmpPDU{{
 		Name: snmpGroup + ".30.0", Type: gosnmp.Integer, Value: 3,
 	}}}
+	// A failed SET echoes the request varbinds and reports the failure in
+	// error-status, which is what the protocol says and what a manager parses.
 	response, status, _ := agent.ProcessRequest(request)
-	if response[0].Type != gosnmp.NoSuchObject {
-		t.Fatalf("invalid SET response type = %v", response[0].Type)
+	if response[0].Name != snmpGroup+".30.0" {
+		t.Fatalf("invalid SET response varbind = %v", response[0].Name)
 	}
 	if status != gosnmp.BadValue {
 		t.Fatalf("invalid SET status = %v, want badValue", status)


### PR DESCRIPTION
## Summary

The agent accepted every SET. A comment said so — *"for now, allow setting any OID"* — and the consequence is worse than permissiveness: a scanner asking "can I write to this device?" was told **yes**, when the device being imitated would have said no. A single SET could rename a device or rewrite its counters, silently putting the simulation out of step with the authored truth every capture is compared against.

The flaw was one method serving two callers. `SetOID` is how the simulation publishes its own MIB and stays unrestricted — NIAC decides what a device reports. Writes arriving over the wire now go through `writeOID`, which refuses anything the agent does not implement as writable. Today that is exactly one object, `snmpEnableAuthenTraps`, which keeps working.

## Linked Issue

Related to #1223. Program ledger code-debt item: SNMP SET write-permission (`agent.go:564`), flagged security.

## Type

- [x] Bug fix

## Risk

Moderate and deliberate — this changes what the simulated agent answers. A manager that previously got a silent success on any object now gets `notWritable` (v2c) or `noSuchName` (v1), which is what a real agent answers. A failed SET also echoes its request varbinds and reports the failure in error-status rather than marking the varbind `NoSuchObject`; that marker was internal and the protocol puts the error in the status. Internal MIB authoring is untouched, so no pack, walk or capture changes.

## Testing Evidence

**The vulnerability, on the live lab before the fix** — the simulated switch renamed itself and reported success:

```
sysName before:  "MED-ACC-SW01"
snmpset -v2c -c NetAllyDemo 10.51.200.21 1.3.6.1.2.1.1.5.0 s ATTACKER
  -> iso.3.6.1.2.1.1.5.0 = STRING: "ATTACKER"
sysName after:   "ATTACKER"
```

**After the fix**, same host, `v0.94.30-10-g38722d8` on CT304:

```
sysName before:  "MED-ACC-SW01"
SET sysName (v2c): Error in packet. Reason: notWritable (That object does not support modification)
SET sysName (v1):  Error in packet. Reason: (noSuchName) There is no such variable name in this MIB.
sysName after:   "MED-ACC-SW01"
SET snmpEnableAuthenTraps = 2: iso.3.6.1.2.1.11.30.0 = INTEGER: 2
```

Unit tests, the first failing before the change:

```
$ go test ./internal/protocols/snmp/ -run "SetRequest|Publishes|VersionOne"
--- FAIL: TestSetRequestRefusesReadOnlyObjects
    error-status = NoError, want NotWritable
    sysName changed to attacker-renamed-me

$ go test ./internal/protocols/snmp/
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols/snmp  6.646s

$ go test ./internal/...
(no failures)

$ golangci-lint run internal/protocols/snmp/...
0 issues.
```

The docs commit records a lab fix found while verifying this: pvm01 rebooted on 2026-08-09 and lost every `bridge vlan add … self` entry, which makes every VLAN look dead exactly like a NIAC fault. The runbook now carries the persistent `post-up` line and the one-command check.

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes; this *removes* an unintended write surface
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit