### PR TITLE
fix(lab): stop the isolation check reporting a leak that is not there

### DIFF
--- a/scripts/lab/isolation.sh
+++ b/scripts/lab/isolation.sh
@@ -22,6 +22,13 @@ declare -A ROUTE=(
 
 sysname() { snmpget -v2c -c NetAllyDemo -t 2 -r 0 -Ovq "$1" 1.3.6.1.2.1.1.5.0 2>/dev/null; }
 
+# A sub-interface left over from an earlier probe keeps its own route to a pack's
+# space, so every VLAN under test reaches that pack through the stale link and
+# the check reports a leak that is not there. Start from a clean slate.
+for stale in $(ip -br link show | awk '$1 ~ /^vmbr0\./ {sub(/@.*/, "", $1); print $1}'); do
+	ip link del "$stale"
+done
+
 failures=0
 for pack in "${!VLAN[@]}"; do
 	vlan=${VLAN[$pack]}


### PR DESCRIPTION
## Summary

A sub-interface left over from an earlier probe keeps its own route into a pack's address space, so every VLAN under test reaches that pack through the stale link and the check calls it a leak. It did exactly that today: three VLANs "answered from hospital space" because a `vmbr0.200` from an unrelated SNMP test was still up.

A false failure is as bad as a false pass — it teaches the operator to ignore the check.

## Linked Issue

Related to #1223. Program ledger M4-7.

## Type

- [x] Bug fix

## Risk

None to the product — lab tooling. The script now deletes `vmbr0.<vlan>` links before probing, which is the state it already left behind after a clean run.

## Testing Evidence

The false failure, with a stale `vmbr0.200` present:

```
vlan 201  warehouse         own device answers as "FUL-ACC-SW01"
FAIL vlan 201: warehouse answered from hospital space as "MED-ACC-SW01"
FAIL vlan 204: retail answered from hospital space as "MED-ACC-SW01"
FAIL vlan 205: service-provider answered from hospital space as "MED-ACC-SW01"

isolation failures: 4
```

After the fix, all six packs up on `v0.94.30-10-g38722d8`:

```
vlan 200  hospital          own device answers as "MED-ACC-SW01"
vlan 201  warehouse         own device answers as "FUL-ACC-SW01"
vlan 202  manufacturing     own device answers as "PLT-ACC-SW01"
vlan 203  campus            own device answers as "NTH-ACC-SW01"
vlan 204  retail            own device answers as "HQ-ACC-SW01"
vlan 205  service-provider  own device answers as "NYC-ACC-SW01"

isolation failures: 0
```

```
$ bash -n scripts/lab/isolation.sh
(clean)
```

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No product code changed, so no route, CSRF or role-gate surface touched
- [x] No dependency changes
- [x] Pre-commit gates pass