### PR TITLE
fix(api): stop the device editor throwing away the fields it just showed you

### DIFF
--- a/internal/api/device_yaml_round_trip_test.go
+++ b/internal/api/device_yaml_round_trip_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// The device editor reads a device as YAML and writes it back. Parsing that
+// document with a second, partial reader loses everything it does not know
+// about: an operator who edits one line finds the addresses, agent and
+// interfaces gone, with no error to say so. The read and write paths have to
+// agree, so the write path uses the product's own loader.
+func TestEditingADeviceKeepsWhatWasNotEdited(t *testing.T) {
+	const document = `
+name: MED-ACC-SW02
+type: switch
+mac: "00:00:0c:33:06:02"
+ips:
+  - 10.51.200.22
+snmp_agent:
+  community: NetAllyDemo
+  sysname: MED-ACC-SW02
+  sysdescr: Cisco C9350-48HX MED multigigabit access 2
+interfaces:
+  - name: Vlan200
+    type: l2vlan
+    address: 10.51.200.22/24
+    speed: 100000
+    admin_status: up
+    oper_status: up
+`
+
+	device, err := parseDeviceFromYAML(document, "MED-ACC-SW02")
+	if err != nil {
+		t.Fatalf("parseDeviceFromYAML: %v", err)
+	}
+	if device.Type != "switch" {
+		t.Errorf("type = %q, want switch", device.Type)
+	}
+	if len(device.IPAddresses) != 1 || device.IPAddresses[0].String() != "10.51.200.22" {
+		t.Errorf("addresses = %v, want [10.51.200.22]", device.IPAddresses)
+	}
+	if device.SNMPConfig.Community != "NetAllyDemo" {
+		t.Errorf("SNMP community = %q, want NetAllyDemo", device.SNMPConfig.Community)
+	}
+	if device.SNMPConfig.SysName != "MED-ACC-SW02" {
+		t.Errorf("sysName = %q, want MED-ACC-SW02", device.SNMPConfig.SysName)
+	}
+	if len(device.Interfaces) != 1 || device.Interfaces[0].Name != "Vlan200" {
+		t.Errorf("interfaces = %+v, want one Vlan200", device.Interfaces)
+	}
+}
+
+// The hostname the request names is what the device is called, whatever the
+// document says - that is how a clone or a rename works.
+func TestTheRequestHostnameWins(t *testing.T) {
+	device, err := parseDeviceFromYAML(
+		"name: OLD-NAME\ntype: switch\nmac: \"00:00:0c:33:06:02\"\n", "NEW-NAME")
+	if err != nil {
+		t.Fatalf("parseDeviceFromYAML: %v", err)
+	}
+	if device.Name != "NEW-NAME" {
+		t.Errorf("name = %q, want NEW-NAME", device.Name)
+	}
+}
+
+// A document that is not a device must be refused rather than quietly yielding
+// an empty one.
+func TestAMalformedDeviceIsRefused(t *testing.T) {
+	if _, err := parseDeviceFromYAML("type: [not, a, string]\n", "X"); err == nil {
+		t.Error("a malformed device parsed without error")
+	}
+}
+
+// A device with no MAC cannot be simulated, and the product's loader has always
+// said so. The old reader accepted one and handed back something unusable; the
+// editor now hears about it while the operator is still looking at the document.
+func TestADeviceWithoutAMACIsRefused(t *testing.T) {
+	_, err := parseDeviceFromYAML("name: X\ntype: switch\n", "X")
+	if err == nil {
+		t.Fatal("a device with no MAC parsed without error")
+	}
+	if !strings.Contains(err.Error(), "MAC") {
+		t.Errorf("error = %v, want it to name the missing MAC", err)
+	}
+}
+
+// The reader still refuses what the security checks reject, unchanged.
+func TestValidationStillGuardsTheInput(t *testing.T) {
+	deep := strings.Repeat("a:\n  ", 200) + "  b: c\n"
+	if _, err := parseDeviceFromYAML(deep, "X"); err == nil {
+		t.Error("a deeply nested document parsed without error")
+	}
+}

--- a/internal/api/devices_helpers.go
+++ b/internal/api/devices_helpers.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/converter"
 )
 
 func (s *Server) validateDeviceCreatePreconditions(
@@ -399,40 +400,45 @@ func parseIP(s string) (net.IP, error) {
 	return ip, nil
 }
 
+// parseDeviceFromYAML reads one device document the way the rest of the product
+// reads a config. It used to have its own reader that understood two fields, so
+// an operator who edited one line in the device editor got a device with its
+// addresses, agent and interfaces silently dropped - the read path serializes
+// all of them and the write path threw them away.
 func parseDeviceFromYAML(yamlStr, hostname string) (*config.Device, error) {
 	// SECURITY FIX #153: Validate YAML input before parsing
 	if validateErr := validateYAMLInput(yamlStr); validateErr != nil {
 		return nil, fmt.Errorf("YAML validation failed: %w", validateErr)
 	}
-
-	// This is a simplified parser - in production, use the full config loader
-	// For now, return a basic device
-	dev := &config.Device{
-		Name: hostname,
-	}
-
-	// Parse YAML into map for basic fields
-	var data map[string]any
-	if unmarshalErr := yaml.Unmarshal([]byte(yamlStr), &data); unmarshalErr != nil {
+	var depthCheck map[string]any
+	if unmarshalErr := yaml.Unmarshal([]byte(yamlStr), &depthCheck); unmarshalErr != nil {
 		return nil, fmt.Errorf("invalid YAML: %w", unmarshalErr)
 	}
-
 	// SECURITY FIX #153: Check YAML depth to prevent DoS attacks
-	if depthErr := checkYAMLDepth(data, 0); depthErr != nil {
+	if depthErr := checkYAMLDepth(depthCheck, 0); depthErr != nil {
 		return nil, depthErr
 	}
 
-	if t, ok := data["type"].(string); ok {
-		dev.Type = t
+	var authored converter.Device
+	if unmarshalErr := yaml.Unmarshal([]byte(yamlStr), &authored); unmarshalErr != nil {
+		return nil, fmt.Errorf("invalid device: %w", unmarshalErr)
+	}
+	// The request names the device; that is what a rename and a clone rely on.
+	authored.Name = hostname
+
+	document, marshalErr := yaml.Marshal(converter.Config{Devices: []converter.Device{authored}})
+	if marshalErr != nil {
+		return nil, fmt.Errorf("re-encode device: %w", marshalErr)
+	}
+	loaded, loadErr := config.LoadYAMLBytes(document)
+	if loadErr != nil {
+		return nil, fmt.Errorf("invalid device: %w", loadErr)
+	}
+	if len(loaded.Devices) != 1 {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidDeviceDocument, hostname)
 	}
 
-	if mac, ok := data["mac"].(string); ok {
-		if parsed, parseErr := parseMAC(mac); parseErr == nil {
-			dev.MACAddress = parsed
-		}
-	}
-
-	return dev, nil
+	return &loaded.Devices[0], nil
 }
 
 func cloneDevice(src *config.Device, newHostname, newIP, newMAC string) *config.Device {

--- a/internal/api/devices_validation.go
+++ b/internal/api/devices_validation.go
@@ -13,7 +13,10 @@ import (
 var (
 	ErrInvalidMACAddress = errors.New("invalid MAC address")
 	ErrInvalidIPAddress  = errors.New("invalid IP address")
-	errValidationFailed  = errors.New("validation failed")
+	// ErrInvalidDeviceDocument reports a device document that did not load as
+	// exactly one device.
+	ErrInvalidDeviceDocument = errors.New("device document did not resolve to one device")
+	errValidationFailed      = errors.New("validation failed")
 )
 
 const (


### PR DESCRIPTION
## Summary

The device editor reads a device as YAML — addresses, SNMP agent, interfaces, routes, the lot — and writes the edited document back. The write path parsed it with a *second* reader that understood three fields: `name`, `type` and `mac`. Everything else was dropped on the floor with no error, so editing one line in the editor returned a device stripped of its addresses, its agent and its interfaces.

Two readers for one format is the defect. The write path now uses the product's own loader, so what the editor shows and what it saves are parsed by the same rules.

## Linked Issue

Related to #1151. Program ledger code-debt item: "simplified device YAML parser".

## Type

- [x] Bug fix

## Risk

Moderate and deliberate. The real loader is stricter than the reader it replaces: a device with no MAC, or one claiming both a MAC and a vendor identity, is now refused instead of being accepted and then failing to simulate. Both raw-YAML callers are updates to an existing device and the editor serializes a complete document, so a well-formed edit is unaffected.

## Testing Evidence

Five tests, the round-trip one failing before the change — it is the bug, reproduced:

```
$ go test ./internal/api/ -run "Editing|HostnameWins|Malformed|StillGuards|WithoutAMAC"
--- FAIL: TestEditingADeviceKeepsWhatWasNotEdited
    addresses = [], want [10.51.200.22]
    SNMP community = "", want NetAllyDemo
    sysName = "", want MED-ACC-SW02
    interfaces = [], want one Vlan200

# after the fix
ok  github.com/MustardSeedNetworks/niac-go/internal/api  0.678s

$ go test ./internal/...
(no failures)

$ golangci-lint run internal/api/...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes; the existing YAML security checks (input validation, depth limit) are preserved ahead of the loader
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit