### PR TITLE
fix(config): refuse a second capture playback instead of deleting it

### DIFF
--- a/internal/converter/capture_playback_single_test.go
+++ b/internal/converter/capture_playback_single_test.go
@@ -1,0 +1,56 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+)
+
+// The runtime has always played back exactly one capture: the config carries a
+// single CapturePlayback, the replay controller builds one engine. The YAML
+// schema nonetheless accepted a list, kept the first entry and dropped the rest
+// - and worse, a load followed by a save wrote the survivor back out as a
+// one-element list, so a round trip deleted the others from disk.
+//
+// Nothing ships more than one, so this is refused at the schema rather than
+// answered with multi-playback support nobody asked for.
+func TestMoreThanOneCapturePlaybackIsRefused(t *testing.T) {
+	cfg := &Config{
+		CapturePlaybacks: []CapturePlayback{
+			{FileName: "first.pcap"},
+			{FileName: "second.pcap"},
+		},
+		Devices: []Device{validPlaybackDevice()},
+	}
+
+	err := ValidateConfig(cfg)
+	if err == nil {
+		t.Fatal("a config declaring two capture playbacks was accepted")
+	}
+	if !strings.Contains(err.Error(), "capture_playbacks") {
+		t.Errorf("error = %v, want it to name the offending field", err)
+	}
+	// An operator reads this, so it has to say what is wrong rather than name
+	// the rule that caught it.
+	if !strings.Contains(err.Error(), "at most 1") {
+		t.Errorf("error = %v, want it to state the limit", err)
+	}
+}
+
+// One playback is what the runtime plays, and it stays valid.
+func TestOneCapturePlaybackIsAccepted(t *testing.T) {
+	cfg := &Config{
+		CapturePlaybacks: []CapturePlayback{{FileName: "only.pcap"}},
+		Devices:          []Device{validPlaybackDevice()},
+	}
+
+	if err := ValidateConfig(cfg); err != nil {
+		t.Errorf("ValidateConfig: %v", err)
+	}
+}
+
+func validPlaybackDevice() Device {
+	return Device{
+		Name: "SW01", Type: "switch",
+		MAC: "00:11:22:33:44:55", IPs: []string{"10.0.0.1"},
+	}
+}

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -49,8 +49,12 @@ const (
 
 // Config represents the YAML configuration structure.
 type Config struct {
-	IncludePath        string              `yaml:"include_path,omitempty"`
-	CapturePlaybacks   []CapturePlayback   `yaml:"capture_playbacks,omitempty"   validate:"omitempty,dive"`
+	IncludePath string `yaml:"include_path,omitempty"`
+	// One playback, not a list of them: the runtime plays exactly one capture
+	// (config.Config.CapturePlayback, one engine in the replay controller). The
+	// schema kept the shape of a list, so extra entries were dropped on load and
+	// deleted from disk on the next save. Refuse them instead.
+	CapturePlaybacks   []CapturePlayback   `yaml:"capture_playbacks,omitempty"   validate:"omitempty,max=1,dive"`
 	BehaviorTimelines  []BehaviorTimeline  `yaml:"behavior_timelines,omitempty"  validate:"omitempty,max=64,dive"`
 	DiscoveryProtocols *DiscoveryProtocols `yaml:"discovery_protocols,omitempty"`
 	Devices            []Device            `yaml:"devices"                       validate:"omitempty,dive"`

--- a/internal/converter/validate.go
+++ b/internal/converter/validate.go
@@ -68,7 +68,32 @@ func formatFieldError(fe validator.FieldError) string {
 		return fmt.Sprintf("%s: %q is not one of [%s]", fe.Namespace(), fe.Value(), fe.Param())
 	case "gte", "lte", "gt", "lt":
 		return fmt.Sprintf("%s: %v fails rule %s=%s", fe.Namespace(), fe.Value(), fe.Tag(), fe.Param())
+	case "max", "min":
+		// A list cap is something an operator can act on, so say the limit and
+		// what they supplied rather than naming the rule that caught it.
+		return fmt.Sprintf("%s: %s %s entries, got %d",
+			fe.Namespace(), boundWord(fe.Tag()), fe.Param(), lengthOf(fe.Value()))
 	default:
 		return fmt.Sprintf("%s: failed rule %q", fe.Namespace(), fe.Tag())
 	}
+}
+
+func boundWord(tag string) string {
+	if tag == "min" {
+		return "at least"
+	}
+
+	return "at most"
+}
+
+// lengthOf reports the size of the value a length rule rejected, which for the
+// list and string rules this formatter serves is what the operator supplied.
+func lengthOf(value any) int {
+	rv := reflect.ValueOf(value)
+	if kind := rv.Kind(); kind == reflect.Slice || kind == reflect.Array ||
+		kind == reflect.Map || kind == reflect.String {
+		return rv.Len()
+	}
+
+	return 0
 }


### PR DESCRIPTION
## Summary

The runtime has always played exactly one capture — a single `CapturePlayback` on the config, one engine in the replay controller — but the YAML schema accepted a list. Loading kept the first entry and dropped the rest, and saving wrote the survivor back out as a one-element list, so **a load followed by a save deleted the others from disk**.

Nothing ships more than one entry, so this is refused at the schema rather than answered with multi-playback support nobody asked for.

The refusal also had to be readable: a length rule reported itself as `failed rule "max"`, which tells an operator nothing.

## Linked Issue

Related to #1151. Program ledger code-debt item: "`CapturePlaybacks[0]`-only".

## Type

- [x] Bug fix

## Risk

Low, and latent today: no shipped config, template or starter pack declares more than one `capture_playbacks` entry (grep across every YAML in the repo finds none), so nothing that works now begins to fail. The error-message change affects every length rule in the config, including the behavior-timeline cap, which now reads the same way.

## Testing Evidence

Both tests failed before the change — the first is the defect:

```
$ go test ./internal/converter/ -run CapturePlayback
--- FAIL: TestMoreThanOneCapturePlaybackIsRefused
    a config declaring two capture playbacks was accepted
```

After:

```
$ go test ./internal/converter/ -run CapturePlayback -v
--- PASS: TestMoreThanOneCapturePlaybackIsRefused
--- PASS: TestOneCapturePlaybackIsAccepted
--- PASS: TestParse_CapturePlayback           (unchanged, still valid)
```

The refusal now reads:

```
config validation failed:
  - Config.capture_playbacks: at most 1 entries, got 2
```

```
$ go test ./internal/...
(no failures)

$ golangci-lint run internal/converter/...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes, so no CSRF or role-gate surface changed
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit