### PR TITLE
fix(logs): make --filter mean the same thing with and without --follow

### DIFF
--- a/cmd/niac/logs.go
+++ b/cmd/niac/logs.go
@@ -215,22 +215,20 @@ func runLogsFollow(ctx context.Context, client *ipc.Client, level string, option
 	}
 }
 
-// filterLogs filters logs by the text pattern.
+// filterLogs filters logs by the text pattern. The match itself lives in the ipc
+// package so that this path and the --follow subscription cannot drift apart -
+// they are the same flag and must answer the same way.
 func filterLogs(logs []ipc.LogEntry, filter string) []ipc.LogEntry {
 	if filter == "" {
 		return logs
 	}
-
-	filter = strings.ToLower(filter)
-	filtered := make([]ipc.LogEntry, 0)
+	filtered := make([]ipc.LogEntry, 0, len(logs))
 	for _, log := range logs {
-		if strings.Contains(strings.ToLower(log.Message), filter) ||
-			strings.Contains(strings.ToLower(log.Device), filter) ||
-			strings.Contains(strings.ToLower(log.Source), filter) ||
-			strings.Contains(strings.ToLower(log.Protocol), filter) {
+		if ipc.LogMatchesFilter(log, filter) {
 			filtered = append(filtered, log)
 		}
 	}
+
 	return filtered
 }
 

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/topology"
@@ -42,7 +43,6 @@ const (
 	defaultPollingMs     = 500  // default polling interval
 	logChannelBuffer     = 100  // log channel buffer size
 	maxSeenLogs          = 1000 // max seen logs before map cleanup
-	asciiCaseOffset      = 32   // ASCII case conversion offset (a-A)
 )
 
 // Client is an IPC client for communicating with the NIAC server.
@@ -467,7 +467,7 @@ func (s *LogSubscription) shouldSkipLog(log LogEntry, seenLogs map[string]bool) 
 		return true
 	}
 
-	if s.filter != "" && !matchesFilter(log.Message, s.filter) {
+	if !LogMatchesFilter(log, s.filter) {
 		return true
 	}
 
@@ -493,59 +493,21 @@ func (s *LogSubscription) cleanupSeenLogs(seenLogs map[string]bool) map[string]b
 	return seenLogs
 }
 
-// matchesFilter checks if a message matches the given filter pattern.
-func matchesFilter(message, filter string) bool {
-	// Simple substring match for now
-	return len(filter) == 0 || containsIgnoreCase(message, filter)
-}
-
-// containsIgnoreCase checks if s contains substr (case-insensitive).
-func containsIgnoreCase(s, substr string) bool {
-	sLower := make([]byte, len(s))
-
-	substrLower := make([]byte, len(substr))
-
-	for i := range len(s) {
-		if s[i] >= 'A' && s[i] <= 'Z' {
-			sLower[i] = s[i] + asciiCaseOffset
-		} else {
-			sLower[i] = s[i]
-		}
-	}
-
-	for i := range len(substr) {
-		if substr[i] >= 'A' && substr[i] <= 'Z' {
-			substrLower[i] = substr[i] + asciiCaseOffset
-		} else {
-			substrLower[i] = substr[i]
-		}
-	}
-
-	return bytesContains(sLower, substrLower)
-}
-
-// bytesContains checks if b contains sub.
-func bytesContains(b, sub []byte) bool {
-	if len(sub) == 0 {
+// LogMatchesFilter reports whether a log record matches the operator's text
+// filter. It is the one implementation: `niac logs tail --filter X` and the same
+// command with --follow are the same flag and must answer the same way, so the
+// polling subscription here and the batch path in the CLI both call this.
+//
+// The match is a case-insensitive substring across every field the operator can
+// see in the output - message, device, source and protocol - which is what the
+// CLI help promises and what the log viewer's single text box implies.
+func LogMatchesFilter(log LogEntry, filter string) bool {
+	if filter == "" {
 		return true
 	}
-
-	if len(b) < len(sub) {
-		return false
-	}
-
-	for i := range len(b) - len(sub) + 1 {
-		match := true
-
-		for j := range sub {
-			if b[i+j] != sub[j] {
-				match = false
-
-				break
-			}
-		}
-
-		if match {
+	wanted := strings.ToLower(filter)
+	for _, field := range []string{log.Message, log.Device, log.Source, log.Protocol} {
+		if strings.Contains(strings.ToLower(field), wanted) {
 			return true
 		}
 	}

--- a/internal/ipc/log_filter_test.go
+++ b/internal/ipc/log_filter_test.go
@@ -1,0 +1,42 @@
+package ipc
+
+import "testing"
+
+// `niac logs tail --filter X` and `niac logs tail --follow --filter X` are the
+// same flag and must answer the same way. They did not: the follow path matched
+// only the message, with a hand-rolled ASCII case fold, while the non-follow
+// path also matched device, source and protocol with a proper one.
+func TestFilterMatchesEveryFieldTheUserCanSee(t *testing.T) {
+	entry := LogEntry{
+		Message:  "link state changed",
+		Device:   "MED-ACC-SW02",
+		Source:   "stack",
+		Protocol: "LLDP",
+	}
+
+	for _, filter := range []string{"med-acc-sw02", "STACK", "lldp", "LINK STATE"} {
+		if !LogMatchesFilter(entry, filter) {
+			t.Errorf("filter %q did not match a record the user can see it in", filter)
+		}
+	}
+	if LogMatchesFilter(entry, "nothing-here") {
+		t.Error("filter matched a record containing none of it")
+	}
+}
+
+// An empty filter is not a filter.
+func TestEmptyFilterKeepsEverything(t *testing.T) {
+	if !LogMatchesFilter(LogEntry{Message: "anything"}, "") {
+		t.Error("an empty filter dropped a record")
+	}
+}
+
+// The follow path folded case by hand, over ASCII only, so a non-ASCII filter
+// silently stopped being case-insensitive.
+func TestFilterFoldsCaseBeyondASCII(t *testing.T) {
+	entry := LogEntry{Message: "ÜBERTRAGUNG fehlgeschlagen"}
+
+	if !LogMatchesFilter(entry, "übertragung") {
+		t.Error("a non-ASCII filter did not fold case")
+	}
+}


### PR DESCRIPTION
## Summary

Two implementations of one flag had drifted. The batch path (`cmd/niac/logs.go`) matched message, device, source and protocol with a proper case fold; the follow subscription (`internal/ipc/client.go`) matched **only the message**, with a hand-rolled ASCII-only fold.

So `niac logs tail --filter MED-ACC-SW02` found records that the same command with `--follow` did not, and a non-ASCII filter silently stopped being case-insensitive.

There is now one matcher, called by both. The behaviour kept is the batch path's — substring across the fields the operator can see, which is what the CLI help promises and what the log viewer's single text box implies. The follow path was the one that was wrong.

## Linked Issue

Related to #1151. Program ledger code-debt item: "IPC substring filter".

## Type

- [x] Bug fix

## Risk

Low. `--follow --filter` now returns *more* records than before (it was under-matching), and matching is unchanged for the batch path. This also retires the hand-rolled `containsIgnoreCase` and `bytesContains`, which existed only to serve the old matcher and had no other callers.

## Testing Evidence

Three tests, all failing before the change — `LogMatchesFilter` did not exist, because there was no shared matcher to test:

```
$ go test ./internal/ipc/ -run Filter
internal/ipc/log_filter_test.go:18:7: undefined: LogMatchesFilter
```

After:

```
$ go test ./internal/ipc/ -run Filter -v
--- PASS: TestFilterMatchesEveryFieldTheUserCanSee
--- PASS: TestEmptyFilterKeepsEverything
--- PASS: TestFilterFoldsCaseBeyondASCII

$ go test ./internal/... ./cmd/...
(no failures)

$ golangci-lint run internal/ipc/... cmd/niac/...
0 issues.
```

The non-ASCII case is the one the old fold got wrong: filtering `übertragung` against `ÜBERTRAGUNG fehlgeschlagen` matched in the batch path and not in follow.

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes, so no CSRF or role-gate surface changed
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit