### PR TITLE
fix(cli): make niac monitor work, and report real numbers

### DIFF
--- a/cmd/niac/cli_client.go
+++ b/cmd/niac/cli_client.go
@@ -40,8 +40,12 @@ func findDaemonCert() string {
 		return existingFile(certFile)
 	}
 
+	// Order matters: an installed daemon's certificate beats one left in the
+	// working directory by an earlier run. A stale certificate with the same
+	// subject fails verification in a way that reads like a configuration
+	// error, so the current directory is consulted last.
 	home, _ := os.UserHomeDir()
-	for _, dir := range []string{".", "/var/lib/niac", filepath.Join(home, ".niac")} {
+	for _, dir := range []string{packagedDataDir, filepath.Join(home, ".niac"), "."} {
 		if found := existingFile(filepath.Join(dir, certFile)); found != "" {
 			return found
 		}
@@ -49,6 +53,10 @@ func findDaemonCert() string {
 
 	return ""
 }
+
+// packagedDataDir is where the packaged service keeps its state, and therefore
+// where it resolves its relative certs/ directory.
+const packagedDataDir = "/var/lib/niac"
 
 func existingFile(path string) string {
 	if _, err := os.Stat(path); err != nil {

--- a/cmd/niac/cli_client.go
+++ b/cmd/niac/cli_client.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
+)
+
+// newCLIClient builds the API client the read-only commands share.
+//
+// The daemon self-signs its certificate on first start, so a same-host CLI can
+// verify the connection by trusting that certificate rather than skipping the
+// check. --insecure remains for a daemon whose certificate this host cannot
+// see, and has to be asked for.
+func newCLIClient(apiURL string, insecure bool) (*cliclient.Client, error) {
+	return cliclient.New(cliclient.Config{
+		BaseURL:  apiURL,
+		CertPath: daemonCertPath(),
+		Insecure: insecure,
+	})
+}
+
+// daemonCertPath finds the certificate the local daemon serves, if this host is
+// the one running it. An empty result falls back to the system trust store,
+// which is right for a daemon fronted by a real certificate.
+func daemonCertPath() string {
+	certPath, _ := api.DefaultCertPaths(defaultCertDir())
+	if !filepath.IsAbs(certPath) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		certPath = filepath.Join(home, ".niac", certPath)
+	}
+	if _, err := os.Stat(certPath); err != nil {
+		return ""
+	}
+
+	return certPath
+}

--- a/cmd/niac/cli_client.go
+++ b/cmd/niac/cli_client.go
@@ -10,33 +10,50 @@ import (
 
 // newCLIClient builds the API client the read-only commands share.
 //
-// The daemon self-signs its certificate on first start, so a same-host CLI can
-// verify the connection by trusting that certificate rather than skipping the
-// check. --insecure remains for a daemon whose certificate this host cannot
-// see, and has to be asked for.
-func newCLIClient(apiURL string, insecure bool) (*cliclient.Client, error) {
+// The daemon self-signs its certificate on first start, so a CLI on the same
+// host verifies the connection by trusting that certificate rather than
+// skipping the check. --cacert names it outright; otherwise the usual places
+// are searched. --insecure remains for a daemon whose certificate this host
+// cannot see, and has to be asked for.
+func newCLIClient(apiURL, caCert string, insecure bool) (*cliclient.Client, error) {
+	if caCert == "" {
+		caCert = findDaemonCert()
+	}
+
 	return cliclient.New(cliclient.Config{
 		BaseURL:  apiURL,
-		CertPath: daemonCertPath(),
+		CertPath: caCert,
 		Insecure: insecure,
 	})
 }
 
-// daemonCertPath finds the certificate the local daemon serves, if this host is
-// the one running it. An empty result falls back to the system trust store,
-// which is right for a daemon fronted by a real certificate.
-func daemonCertPath() string {
-	certPath, _ := api.DefaultCertPaths(defaultCertDir())
-	if !filepath.IsAbs(certPath) {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		certPath = filepath.Join(home, ".niac", certPath)
+// findDaemonCert looks where a local daemon keeps its certificate. The daemon
+// resolves the same relative `certs/` directory against its own working
+// directory, which for the packaged service is its data directory - so a CLI
+// run from elsewhere has to check the data directory too.
+//
+// An empty result falls back to the system trust store, which is right for a
+// daemon behind a certificate a real authority issued.
+func findDaemonCert() string {
+	certFile, _ := api.DefaultCertPaths(defaultCertDir())
+	if filepath.IsAbs(certFile) {
+		return existingFile(certFile)
 	}
-	if _, err := os.Stat(certPath); err != nil {
+
+	home, _ := os.UserHomeDir()
+	for _, dir := range []string{".", "/var/lib/niac", filepath.Join(home, ".niac")} {
+		if found := existingFile(filepath.Join(dir, certFile)); found != "" {
+			return found
+		}
+	}
+
+	return ""
+}
+
+func existingFile(path string) string {
+	if _, err := os.Stat(path); err != nil {
 		return ""
 	}
 
-	return certPath
+	return path
 }

--- a/cmd/niac/monitor.go
+++ b/cmd/niac/monitor.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 )
 
@@ -49,7 +49,8 @@ type monitorStats struct {
 type monitorOptions struct {
 	format   string
 	interval string
-	socket   string
+	api      string
+	insecure bool
 }
 
 func addMonitorCommand(root *cobra.Command, _ *serviceOptions) {
@@ -60,8 +61,8 @@ func addMonitorCommand(root *cobra.Command, _ *serviceOptions) {
 		Short: "Stream real-time statistics from a running NIAC simulation",
 		Long: `Monitor a running NIAC simulation in real-time.
 
-This command connects to a running NIAC instance via IPC socket and
-continuously displays statistics, similar to 'top' or 'watch'.
+This command reads statistics from a running NIAC daemon over its HTTPS API
+and displays them continuously, similar to 'top' or 'watch'.
 
 The monitor supports multiple output formats:
   - table: Human-readable table with auto-refresh (default)
@@ -82,8 +83,8 @@ JSON and CSV formats append new lines for pipe-friendly output.`,
   # Monitor with CSV output, redirect to file
   niac monitor --format csv > stats.csv
 
-  # Use a custom socket path
-  niac monitor --socket /tmp/my-niac.sock
+  # Read from a daemon on another address
+  niac monitor --api https://10.0.0.5:8445
 
   # Monitor with fast 500ms updates
   niac monitor --interval 500ms`,
@@ -96,8 +97,10 @@ JSON and CSV formats append new lines for pipe-friendly output.`,
 		"Output format: table, json, or csv")
 	monitorCmd.Flags().StringVar(&options.interval, "interval", "1s",
 		"Update interval (e.g., 1s, 500ms, 2s)")
-	monitorCmd.Flags().StringVar(&options.socket, "socket", "",
-		"IPC socket path (default: "+ipc.DefaultSocketPath()+")")
+	monitorCmd.Flags().StringVar(&options.api, "api", "",
+		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	monitorCmd.Flags().BoolVar(&options.insecure, "insecure", false,
+		"Skip TLS verification, for a daemon whose certificate this host cannot see")
 
 	root.AddCommand(monitorCmd)
 }
@@ -122,17 +125,9 @@ func runMonitor(options *monitorOptions) error {
 		return fmt.Errorf("invalid format %q: must be table, json, or csv", options.format)
 	}
 
-	// Create IPC client
-	socketPath := options.socket
-	if socketPath == "" {
-		socketPath = ipc.GetDefaultSocketPath()
-	}
-
-	client := ipc.NewClient(socketPath)
-
-	// Check if server is running
-	if !client.IsRunning() {
-		return fmt.Errorf("no NIAC simulation running (socket: %s)", socketPath)
+	client, err := newCLIClient(options.api, options.insecure)
+	if err != nil {
+		return err
 	}
 
 	// Set up context with cancellation for graceful shutdown
@@ -163,7 +158,7 @@ func runMonitor(options *monitorOptions) error {
 }
 
 // runTableMonitor displays statistics in a continuously-updated table format.
-func runTableMonitor(ctx context.Context, client *ipc.Client, interval time.Duration) error {
+func runTableMonitor(ctx context.Context, client *cliclient.Client, interval time.Duration) error {
 	var prevStats *monitorStats
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -171,7 +166,7 @@ func runTableMonitor(ctx context.Context, client *ipc.Client, interval time.Dura
 	logging.InitColors(true)
 
 	// Initial fetch
-	stats, err := fetchStats(client, prevStats, interval)
+	stats, err := fetchStats(ctx, client, prevStats, interval)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial stats: %w", err)
 	}
@@ -185,7 +180,7 @@ func runTableMonitor(ctx context.Context, client *ipc.Client, interval time.Dura
 			fmt.Fprintln(os.Stdout, "\nMonitoring stopped.")
 			return nil
 		case <-ticker.C:
-			latestStats, fetchErr := fetchStats(client, prevStats, interval)
+			latestStats, fetchErr := fetchStats(ctx, client, prevStats, interval)
 			if fetchErr != nil {
 				// Connection lost, but don't exit immediately
 				fmt.Fprintf(os.Stdout, "\r[%s] Connection lost: %v\n", time.Now().Format("15:04:05"), fetchErr)
@@ -200,13 +195,13 @@ func runTableMonitor(ctx context.Context, client *ipc.Client, interval time.Dura
 }
 
 // runJSONMonitor outputs statistics as JSON Lines (one JSON object per line).
-func runJSONMonitor(ctx context.Context, client *ipc.Client, interval time.Duration) error {
+func runJSONMonitor(ctx context.Context, client *cliclient.Client, interval time.Duration) error {
 	var prevStats *monitorStats
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	// Initial fetch
-	stats, err := fetchStats(client, prevStats, interval)
+	stats, err := fetchStats(ctx, client, prevStats, interval)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial stats: %w", err)
 	}
@@ -218,7 +213,7 @@ func runJSONMonitor(ctx context.Context, client *ipc.Client, interval time.Durat
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			latestStats, fetchErr := fetchStats(client, prevStats, interval)
+			latestStats, fetchErr := fetchStats(ctx, client, prevStats, interval)
 			if fetchErr != nil {
 				// Output error as JSON
 				errObj := map[string]any{
@@ -236,7 +231,7 @@ func runJSONMonitor(ctx context.Context, client *ipc.Client, interval time.Durat
 }
 
 // runCSVMonitor outputs statistics as CSV.
-func runCSVMonitor(ctx context.Context, client *ipc.Client, interval time.Duration) error {
+func runCSVMonitor(ctx context.Context, client *cliclient.Client, interval time.Duration) error {
 	var prevStats *monitorStats
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -264,7 +259,7 @@ func runCSVMonitor(ctx context.Context, client *ipc.Client, interval time.Durati
 	writer.Flush()
 
 	// Initial fetch
-	stats, err := fetchStats(client, prevStats, interval)
+	stats, err := fetchStats(ctx, client, prevStats, interval)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial stats: %w", err)
 	}
@@ -276,7 +271,7 @@ func runCSVMonitor(ctx context.Context, client *ipc.Client, interval time.Durati
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			latestStats, fetchErr := fetchStats(client, prevStats, interval)
+			latestStats, fetchErr := fetchStats(ctx, client, prevStats, interval)
 			if fetchErr != nil {
 				// Skip this interval on error
 				continue
@@ -287,29 +282,38 @@ func runCSVMonitor(ctx context.Context, client *ipc.Client, interval time.Durati
 	}
 }
 
-// fetchStats fetches current statistics from the IPC server and calculates rates.
-func fetchStats(client *ipc.Client, prev *monitorStats, interval time.Duration) (*monitorStats, error) {
-	status, err := client.GetStatus()
+// fetchStats reads one sample from the daemon and derives the rates.
+//
+// The per-protocol counters were reported as zero for as long as this command
+// read the IPC transport, which carried no protocol breakdown. The daemon has
+// always counted them; /api/v1/stats serves them.
+func fetchStats(
+	ctx context.Context,
+	client *cliclient.Client,
+	prev *monitorStats,
+	interval time.Duration,
+) (*monitorStats, error) {
+	sample, err := client.Stats(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get status: %w", err)
+		return nil, err
+	}
+	runtime, err := client.Runtime(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	// Safe conversion: ErrorsActive is an int from IPC status, bounded by protocol
-	var errorsActive uint64
-	if status.ErrorsActive >= 0 {
-		errorsActive = uint64(status.ErrorsActive)
+	stats := &monitorStats{
+		Time:      time.Now(),
+		PacketsRX: sample.Stack.PacketsReceived,
+		PacketsTX: sample.Stack.PacketsSent,
+		ARP:       sample.Stack.ARP(),
+		ICMP:      sample.Stack.ICMP(),
+		DNS:       sample.Stack.DNSQueries,
+		DHCP:      sample.Stack.DHCPRequests,
+		SNMP:      sample.Stack.SNMPQueries,
+		Errors:    sample.Stack.Errors,
+		Uptime:    runtime.Uptime,
 	}
-
-	stats := new(monitorStats)
-	stats.Time = time.Now()
-	stats.PacketsRX = status.PacketsRX
-	stats.PacketsTX = status.PacketsTX
-	stats.Errors = errorsActive
-	stats.Uptime = status.Uptime
-
-	// Note: The IPC StatusData currently only has PacketsRX, PacketsTX, ErrorsActive
-	// Protocol-specific stats (ARP, ICMP, DNS, etc.) would need to be added to the IPC protocol
-	// For now, we use placeholders that show 0 until the IPC protocol is extended
 
 	// Calculate rates if we have previous stats.
 	if prev == nil {

--- a/cmd/niac/monitor.go
+++ b/cmd/niac/monitor.go
@@ -40,6 +40,9 @@ type monitorStats struct {
 	SNMP      uint64    `json:"snmp"`
 	Errors    uint64    `json:"errors"`
 	Uptime    float64   `json:"uptime_seconds"`
+	// Session names the scenario these counters belong to. Several run at
+	// once, each with its own stack, so a sample without it is ambiguous.
+	Session string `json:"session"`
 
 	// Rates (packets per second)
 	RateRX float64 `json:"rate_rx,omitempty"`
@@ -51,6 +54,7 @@ type monitorOptions struct {
 	interval string
 	api      string
 	caCert   string
+	session  string
 	insecure bool
 }
 
@@ -100,6 +104,8 @@ JSON and CSV formats append new lines for pipe-friendly output.`,
 		"Update interval (e.g., 1s, 500ms, 2s)")
 	monitorCmd.Flags().StringVar(&options.api, "api", "",
 		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	monitorCmd.Flags().StringVar(&options.session, "session", "",
+		"Scenario session to watch (default: whichever the daemon has selected)")
 	monitorCmd.Flags().StringVar(&options.caCert, "cacert", "",
 		"Daemon certificate to trust (default: the local daemon's own, when visible)")
 	monitorCmd.Flags().BoolVar(&options.insecure, "insecure", false,
@@ -150,18 +156,23 @@ func runMonitor(options *monitorOptions) error {
 	// Run the appropriate monitor based on format
 	switch format {
 	case FormatTable:
-		return runTableMonitor(ctx, client, interval)
+		return runTableMonitor(ctx, client, options.session, interval)
 	case FormatJSON:
-		return runJSONMonitor(ctx, client, interval)
+		return runJSONMonitor(ctx, client, options.session, interval)
 	case FormatCSV:
-		return runCSVMonitor(ctx, client, interval)
+		return runCSVMonitor(ctx, client, options.session, interval)
 	}
 
 	return nil
 }
 
 // runTableMonitor displays statistics in a continuously-updated table format.
-func runTableMonitor(ctx context.Context, client *cliclient.Client, interval time.Duration) error {
+func runTableMonitor(
+	ctx context.Context,
+	client *cliclient.Client,
+	session string,
+	interval time.Duration,
+) error {
 	var prevStats *monitorStats
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -169,7 +180,7 @@ func runTableMonitor(ctx context.Context, client *cliclient.Client, interval tim
 	logging.InitColors(true)
 
 	// Initial fetch
-	stats, err := fetchStats(ctx, client, prevStats, interval)
+	stats, err := fetchStats(ctx, client, session, prevStats, interval)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial stats: %w", err)
 	}
@@ -183,7 +194,7 @@ func runTableMonitor(ctx context.Context, client *cliclient.Client, interval tim
 			fmt.Fprintln(os.Stdout, "\nMonitoring stopped.")
 			return nil
 		case <-ticker.C:
-			latestStats, fetchErr := fetchStats(ctx, client, prevStats, interval)
+			latestStats, fetchErr := fetchStats(ctx, client, session, prevStats, interval)
 			if fetchErr != nil {
 				// Connection lost, but don't exit immediately
 				fmt.Fprintf(os.Stdout, "\r[%s] Connection lost: %v\n", time.Now().Format("15:04:05"), fetchErr)
@@ -198,13 +209,18 @@ func runTableMonitor(ctx context.Context, client *cliclient.Client, interval tim
 }
 
 // runJSONMonitor outputs statistics as JSON Lines (one JSON object per line).
-func runJSONMonitor(ctx context.Context, client *cliclient.Client, interval time.Duration) error {
+func runJSONMonitor(
+	ctx context.Context,
+	client *cliclient.Client,
+	session string,
+	interval time.Duration,
+) error {
 	var prevStats *monitorStats
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	// Initial fetch
-	stats, err := fetchStats(ctx, client, prevStats, interval)
+	stats, err := fetchStats(ctx, client, session, prevStats, interval)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial stats: %w", err)
 	}
@@ -216,7 +232,7 @@ func runJSONMonitor(ctx context.Context, client *cliclient.Client, interval time
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			latestStats, fetchErr := fetchStats(ctx, client, prevStats, interval)
+			latestStats, fetchErr := fetchStats(ctx, client, session, prevStats, interval)
 			if fetchErr != nil {
 				// Output error as JSON
 				errObj := map[string]any{
@@ -234,7 +250,12 @@ func runJSONMonitor(ctx context.Context, client *cliclient.Client, interval time
 }
 
 // runCSVMonitor outputs statistics as CSV.
-func runCSVMonitor(ctx context.Context, client *cliclient.Client, interval time.Duration) error {
+func runCSVMonitor(
+	ctx context.Context,
+	client *cliclient.Client,
+	session string,
+	interval time.Duration,
+) error {
 	var prevStats *monitorStats
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -262,7 +283,7 @@ func runCSVMonitor(ctx context.Context, client *cliclient.Client, interval time.
 	writer.Flush()
 
 	// Initial fetch
-	stats, err := fetchStats(ctx, client, prevStats, interval)
+	stats, err := fetchStats(ctx, client, session, prevStats, interval)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial stats: %w", err)
 	}
@@ -274,7 +295,7 @@ func runCSVMonitor(ctx context.Context, client *cliclient.Client, interval time.
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			latestStats, fetchErr := fetchStats(ctx, client, prevStats, interval)
+			latestStats, fetchErr := fetchStats(ctx, client, session, prevStats, interval)
 			if fetchErr != nil {
 				// Skip this interval on error
 				continue
@@ -285,6 +306,20 @@ func runCSVMonitor(ctx context.Context, client *cliclient.Client, interval time.
 	}
 }
 
+// readStats reads the named session's counters, or the selected session's when
+// no name was given.
+func readStats(
+	ctx context.Context,
+	client *cliclient.Client,
+	session string,
+) (*cliclient.Stats, error) {
+	if session == "" {
+		return client.Stats(ctx)
+	}
+
+	return client.SessionStats(ctx, session)
+}
+
 // fetchStats reads one sample from the daemon and derives the rates.
 //
 // The per-protocol counters were reported as zero for as long as this command
@@ -293,14 +328,22 @@ func runCSVMonitor(ctx context.Context, client *cliclient.Client, interval time.
 func fetchStats(
 	ctx context.Context,
 	client *cliclient.Client,
+	session string,
 	prev *monitorStats,
 	interval time.Duration,
 ) (*monitorStats, error) {
-	sample, err := client.Stats(ctx)
+	runtime, err := client.Runtime(ctx)
 	if err != nil {
 		return nil, err
 	}
-	runtime, err := client.Runtime(ctx)
+	// Several scenarios run at once, each with its own counters. Watch the one
+	// named, or the daemon's selected one - and say which, because a sample
+	// that does not name its session reads as though it covered everything.
+	watching := session
+	if watching == "" {
+		watching = runtime.ConfigName
+	}
+	sample, err := readStats(ctx, client, session)
 	if err != nil {
 		return nil, err
 	}
@@ -316,6 +359,7 @@ func fetchStats(
 		SNMP:      sample.Stack.SNMPQueries,
 		Errors:    sample.Stack.Errors,
 		Uptime:    runtime.Uptime,
+		Session:   watching,
 	}
 
 	// Calculate rates if we have previous stats.

--- a/cmd/niac/monitor.go
+++ b/cmd/niac/monitor.go
@@ -50,6 +50,7 @@ type monitorOptions struct {
 	format   string
 	interval string
 	api      string
+	caCert   string
 	insecure bool
 }
 
@@ -99,6 +100,8 @@ JSON and CSV formats append new lines for pipe-friendly output.`,
 		"Update interval (e.g., 1s, 500ms, 2s)")
 	monitorCmd.Flags().StringVar(&options.api, "api", "",
 		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	monitorCmd.Flags().StringVar(&options.caCert, "cacert", "",
+		"Daemon certificate to trust (default: the local daemon's own, when visible)")
 	monitorCmd.Flags().BoolVar(&options.insecure, "insecure", false,
 		"Skip TLS verification, for a daemon whose certificate this host cannot see")
 
@@ -125,7 +128,7 @@ func runMonitor(options *monitorOptions) error {
 		return fmt.Errorf("invalid format %q: must be table, json, or csv", options.format)
 	}
 
-	client, err := newCLIClient(options.api, options.insecure)
+	client, err := newCLIClient(options.api, options.caCert, options.insecure)
 	if err != nil {
 		return err
 	}

--- a/cmd/niac/monitor_test.go
+++ b/cmd/niac/monitor_test.go
@@ -166,8 +166,16 @@ func TestAddMonitorCommandFlags(t *testing.T) {
 	if cmd.Flags().Lookup("interval") == nil {
 		t.Error("Expected --interval flag")
 	}
-	if cmd.Flags().Lookup("socket") == nil {
-		t.Error("Expected --socket flag")
+	// The socket transport is gone: the daemon serves over its API, so the
+	// command points at an address rather than a socket path.
+	if cmd.Flags().Lookup("api") == nil {
+		t.Error("Expected --api flag")
+	}
+	if cmd.Flags().Lookup("insecure") == nil {
+		t.Error("Expected --insecure flag")
+	}
+	if cmd.Flags().Lookup("socket") != nil {
+		t.Error("--socket outlived the transport it addressed")
 	}
 }
 

--- a/internal/api/tls.go
+++ b/internal/api/tls.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -58,9 +59,12 @@ func ensureSelfSignedCert(certPath, keyPath string) (string, string, error) {
 		return "", "", errors.New("cert and key paths must both be set")
 	}
 
-	// Reuse existing cert+key when both are present on disk.
+	// Reuse existing cert+key when both are present and still cover what the
+	// daemon serves. A certificate written before loopback was covered cannot
+	// verify the address the daemon advertises, so it is replaced rather than
+	// served for another year.
 	if _, certErr := os.Stat(certPath); certErr == nil {
-		if _, keyErr := os.Stat(keyPath); keyErr == nil {
+		if _, keyErr := os.Stat(keyPath); keyErr == nil && coversLoopback(certPath) {
 			return certPath, keyPath, nil
 		}
 	}
@@ -91,6 +95,11 @@ func ensureSelfSignedCert(certPath, keyPath string) (string, string, error) {
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 		DNSNames:              []string{"localhost", "niac.local"},
+		// The daemon tells operators it listens on https://127.0.0.1:8445, so
+		// the certificate has to cover that address. Without these a browser
+		// shows a warning nothing can clear, and a client on the same host
+		// cannot verify the daemon even holding its certificate.
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
 	}
 
 	certDER, err := x509.CreateCertificate(
@@ -139,4 +148,24 @@ func DefaultCertPaths(certDir string) (string, string) {
 	}
 	return filepath.Join(certDir, defaultCertFileName),
 		filepath.Join(certDir, defaultKeyFileName)
+}
+
+// coversLoopback reports whether an existing certificate can verify the address
+// the daemon advertises. It is how a certificate generated before loopback was
+// covered gets replaced instead of reused.
+func coversLoopback(certPath string) bool {
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return false
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+
+	return cert.VerifyHostname("127.0.0.1") == nil
 }

--- a/internal/api/tls_loopback_test.go
+++ b/internal/api/tls_loopback_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+// The daemon advertises https://127.0.0.1:8445 as where it listens, and its own
+// help text says so - but the certificate it generated covered only two DNS
+// names, so nothing could verify a connection to that address. A browser saw an
+// unfixable warning and the CLI could not trust the daemon on the same host.
+func TestGeneratedCertificateCoversTheAddressTheDaemonAdvertises(t *testing.T) {
+	certPath, _ := generateIntoTempDir(t)
+	cert := parseCert(t, certPath)
+
+	for _, ip := range []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")} {
+		if err := cert.VerifyHostname(ip.String()); err != nil {
+			t.Errorf("certificate does not cover %s: %v", ip, err)
+		}
+	}
+}
+
+// The names it already carried keep working.
+func TestGeneratedCertificateKeepsItsHostnames(t *testing.T) {
+	certPath, _ := generateIntoTempDir(t)
+	cert := parseCert(t, certPath)
+
+	for _, name := range []string{"localhost", "niac.local"} {
+		if err := cert.VerifyHostname(name); err != nil {
+			t.Errorf("certificate does not cover %s: %v", name, err)
+		}
+	}
+}
+
+// A certificate written before loopback was covered is replaced rather than
+// reused, or the daemon keeps serving one nothing can verify.
+func TestACertificateMissingLoopbackIsReplaced(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := DefaultCertPaths(dir)
+	if _, _, err := EnsureSelfSignedCert(certPath, keyPath); err != nil {
+		t.Fatalf("first generation: %v", err)
+	}
+	// Stand in for the old certificate by stripping its loopback coverage.
+	writeCertWithoutIPs(t, certPath, keyPath)
+
+	if _, _, err := EnsureSelfSignedCert(certPath, keyPath); err != nil {
+		t.Fatalf("regeneration: %v", err)
+	}
+	if err := parseCert(t, certPath).VerifyHostname("127.0.0.1"); err != nil {
+		t.Errorf("stale certificate was reused: %v", err)
+	}
+}
+
+func generateIntoTempDir(t *testing.T) (string, string) {
+	t.Helper()
+	certPath, keyPath := DefaultCertPaths(t.TempDir())
+	gotCert, gotKey, err := EnsureSelfSignedCert(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("EnsureSelfSignedCert: %v", err)
+	}
+
+	return gotCert, gotKey
+}
+
+func parseCert(t *testing.T, path string) *x509.Certificate {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		t.Fatalf("%s holds no PEM block", path)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cert
+}
+
+// writeCertWithoutIPs replaces the certificate with one carrying only the DNS
+// names, which is what every daemon installed before this change is serving.
+func writeCertWithoutIPs(t *testing.T, certPath, keyPath string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"NIAC"}, CommonName: "NIAC Self-Signed"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost", "niac.local"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(
+		&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)},
+	)
+	if err = os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cliclient/client.go
+++ b/internal/cliclient/client.go
@@ -1,0 +1,185 @@
+// Package cliclient talks to a running NIAC daemon over its HTTPS API.
+//
+// The CLI used to reach the daemon through a unix socket. That server was
+// removed in #1012 as a dead subsystem — the daemon serves over internal/api —
+// but the commands built on it were left behind, so `niac monitor`, `logs`,
+// `neighbors`, `dump` and `topology` failed every time with "no NIAC simulation
+// running" even while simulations were running. They speak to the API now,
+// which is the surface the daemon actually serves.
+package cliclient
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is where the daemon listens unless it was told otherwise.
+const DefaultBaseURL = "https://127.0.0.1:8445"
+
+const requestTimeout = 30 * time.Second
+
+var (
+	// ErrDaemonUnreachable reports that no daemon answered. It carries the
+	// address tried, because the usual cause is a daemon on another port.
+	ErrDaemonUnreachable = errors.New("no NIAC daemon is answering")
+	// ErrUnauthorized reports that the daemon wanted a token this client did
+	// not present.
+	ErrUnauthorized = errors.New("the daemon requires an API token")
+	// ErrRequestFailed reports a non-2xx answer that is not an auth failure.
+	ErrRequestFailed = errors.New("daemon request failed")
+)
+
+// Config describes how to reach the daemon.
+type Config struct {
+	// BaseURL defaults to DefaultBaseURL, overridden by NIAC_API_URL.
+	BaseURL string
+	// Token authenticates against a daemon bound to a non-loopback address.
+	// Empty is correct for the default loopback bind. NIAC_API_TOKEN is read
+	// when this is empty.
+	Token string
+	// CertPath is the daemon's self-signed certificate, trusted as a root so
+	// the connection is verified rather than waved through. Empty means the
+	// system trust store.
+	CertPath string
+	// Insecure skips verification. It exists for a daemon whose certificate
+	// this host cannot see, and says so on the command line.
+	Insecure bool
+}
+
+// Client is a read-only view of a running daemon.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// New builds a client, resolving the address, token and trust settings.
+func New(cfg Config) (*Client, error) {
+	base := cfg.BaseURL
+	if base == "" {
+		base = os.Getenv("NIAC_API_URL")
+	}
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	if _, err := url.Parse(base); err != nil {
+		return nil, fmt.Errorf("invalid daemon address %q: %w", base, err)
+	}
+	token := cfg.Token
+	if token == "" {
+		token = os.Getenv("NIAC_API_TOKEN")
+	}
+	transport, err := newTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		baseURL: strings.TrimSuffix(base, "/"),
+		token:   token,
+		http:    &http.Client{Transport: transport},
+	}, nil
+}
+
+// BaseURL is the address this client talks to, for error messages that need to
+// tell an operator where it looked.
+func (c *Client) BaseURL() string { return c.baseURL }
+
+func newTransport(cfg Config) (*http.Transport, error) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	switch {
+	case cfg.Insecure:
+		// Explicitly asked for on the command line: the daemon's certificate is
+		// not visible from this host.
+		tlsConfig.InsecureSkipVerify = true
+	case cfg.CertPath != "":
+		pool, err := poolFromFile(cfg.CertPath)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	return &http.Transport{TLSClientConfig: tlsConfig}, nil
+}
+
+// poolFromFile trusts the daemon's own certificate. The daemon self-signs on
+// first start, so this is how a same-host CLI verifies the connection instead
+// of skipping the check.
+func poolFromFile(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read daemon certificate: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("%w: %s holds no certificate", ErrRequestFailed, path)
+	}
+
+	return pool, nil
+}
+
+// get fetches one JSON document from the daemon into out.
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	// A stream stays open for as long as the caller wants; a plain fetch does
+	// not, and should give up rather than hang a script.
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	body, err := c.open(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	if err = json.NewDecoder(body).Decode(out); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// open starts a request and hands back the body, which the caller closes. A
+// stream endpoint stays open until the context ends.
+func (c *Client) open(ctx context.Context, path string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request for %s: %w", path, err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		var opErr *net.OpError
+		if errors.As(err, &opErr) {
+			return nil, fmt.Errorf("%w at %s: is the daemon running?",
+				ErrDaemonUnreachable, c.baseURL)
+		}
+
+		return nil, fmt.Errorf("request %s: %w", path, err)
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		_ = resp.Body.Close()
+
+		return nil, fmt.Errorf("%w: set NIAC_API_TOKEN", ErrUnauthorized)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_ = resp.Body.Close()
+
+		return nil, fmt.Errorf("%w: %s returned %s", ErrRequestFailed, path, resp.Status)
+	}
+
+	return resp.Body, nil
+}

--- a/internal/cliclient/client.go
+++ b/internal/cliclient/client.go
@@ -59,9 +59,10 @@ type Config struct {
 
 // Client is a read-only view of a running daemon.
 type Client struct {
-	baseURL string
-	token   string
-	http    *http.Client
+	baseURL  string
+	token    string
+	certPath string
+	http     *http.Client
 }
 
 // New builds a client, resolving the address, token and trust settings.
@@ -86,9 +87,10 @@ func New(cfg Config) (*Client, error) {
 	}
 
 	return &Client{
-		baseURL: strings.TrimSuffix(base, "/"),
-		token:   token,
-		http:    &http.Client{Transport: transport},
+		baseURL:  strings.TrimSuffix(base, "/"),
+		token:    token,
+		certPath: cfg.CertPath,
+		http:     &http.Client{Transport: transport},
 	}, nil
 }
 
@@ -166,6 +168,15 @@ func (c *Client) open(ctx context.Context, path string) (io.ReadCloser, error) {
 		if errors.As(err, &opErr) {
 			return nil, fmt.Errorf("%w at %s: is the daemon running?",
 				ErrDaemonUnreachable, c.baseURL)
+		}
+
+		var certErr *tls.CertificateVerificationError
+		if errors.As(err, &certErr) && c.certPath != "" {
+			// Naming the certificate that was tried turns "unknown authority"
+			// into something an operator can act on: it is usually a stale one
+			// left by an earlier run, and --cacert points at the right file.
+			return nil, fmt.Errorf("%w: trusted %s, which the daemon at %s does not match: %w",
+				ErrRequestFailed, c.certPath, c.baseURL, err)
 		}
 
 		return nil, fmt.Errorf("request %s: %w", path, err)

--- a/internal/cliclient/client_test.go
+++ b/internal/cliclient/client_test.go
@@ -1,0 +1,113 @@
+package cliclient_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
+)
+
+// The counters the monitor prints come from the daemon's own stats endpoint,
+// which has always carried them. The CLI reported zeros because it read a
+// transport that carried no protocol breakdown at all.
+func TestStatsCarriesThePerProtocolCounters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/stats" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"interface":"eth0","deviceCount":75,"stack":{
+			"packetsSent":6902,"packetsReceived":25758,
+			"arpRequests":5,"arpReplies":3,"icmpRequests":2,"icmpReplies":1,
+			"dnsQueries":7,"dhcpRequests":4,"snmpQueries":11,"errors":0}}`))
+	}))
+	defer server.Close()
+
+	stats := fetch(t, server.URL)
+	if stats.Stack.SNMPQueries != 11 || stats.Stack.DNSQueries != 7 {
+		t.Errorf("stack = %+v, want the served counters", stats.Stack)
+	}
+	// One column each for ARP and ICMP, so request and reply are summed.
+	if stats.Stack.ARP() != 8 {
+		t.Errorf("ARP() = %d, want 8", stats.Stack.ARP())
+	}
+	if stats.Stack.ICMP() != 3 {
+		t.Errorf("ICMP() = %d, want 3", stats.Stack.ICMP())
+	}
+}
+
+// The old failure told an operator "no NIAC simulation running" while several
+// were running. Say what was actually tried instead.
+func TestUnreachableDaemonNamesTheAddress(t *testing.T) {
+	client, err := cliclient.New(cliclient.Config{BaseURL: "http://127.0.0.1:1", Insecure: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Stats(context.Background())
+	if !errors.Is(err, cliclient.ErrDaemonUnreachable) {
+		t.Fatalf("error = %v, want ErrDaemonUnreachable", err)
+	}
+	if !strings.Contains(err.Error(), "127.0.0.1:1") {
+		t.Errorf("error = %v, want it to name the address tried", err)
+	}
+}
+
+// A daemon on a non-loopback address wants a token, and the operator needs to
+// be told which one.
+func TestTokenRefusalSaysWhatToSet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client, err := cliclient.New(cliclient.Config{BaseURL: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Stats(context.Background())
+	if !errors.Is(err, cliclient.ErrUnauthorized) {
+		t.Fatalf("error = %v, want ErrUnauthorized", err)
+	}
+	if !strings.Contains(err.Error(), "NIAC_API_TOKEN") {
+		t.Errorf("error = %v, want it to name the variable to set", err)
+	}
+}
+
+// A token, when set, has to actually reach the daemon.
+func TestTokenIsSent(t *testing.T) {
+	var seen string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"interface":"eth0"}`))
+	}))
+	defer server.Close()
+
+	client, err := cliclient.New(cliclient.Config{BaseURL: server.URL, Token: "s3cret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = client.Stats(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if seen != "Bearer s3cret" {
+		t.Errorf("Authorization = %q", seen)
+	}
+}
+
+func fetch(t *testing.T, baseURL string) *cliclient.Stats {
+	t.Helper()
+	client, err := cliclient.New(cliclient.Config{BaseURL: baseURL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats, err := client.Stats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return stats
+}

--- a/internal/cliclient/runtime.go
+++ b/internal/cliclient/runtime.go
@@ -1,0 +1,25 @@
+package cliclient
+
+import "context"
+
+// Runtime is the selected simulation's state, as served by /api/v1/runtime.
+// It carries the uptime and config identity that /api/v1/stats does not.
+type Runtime struct {
+	Running     bool    `json:"running"`
+	Interface   string  `json:"interface"`
+	ConfigName  string  `json:"config_name"`
+	ConfigPath  string  `json:"config_path"`
+	DeviceCount int     `json:"device_count"`
+	Uptime      float64 `json:"uptime_seconds"`
+	Version     string  `json:"version"`
+}
+
+// Runtime reads the selected simulation's state.
+func (c *Client) Runtime(ctx context.Context) (*Runtime, error) {
+	var runtime Runtime
+	if err := c.get(ctx, "/api/v1/runtime", &runtime); err != nil {
+		return nil, err
+	}
+
+	return &runtime, nil
+}

--- a/internal/cliclient/stats.go
+++ b/internal/cliclient/stats.go
@@ -1,0 +1,46 @@
+package cliclient
+
+import "context"
+
+// StackStats is the daemon's per-protocol packet accounting, as served by
+// /api/v1/stats. These are the counters `niac monitor` reports; it used to
+// print zeros for all of them because the transport it read from carried no
+// protocol breakdown.
+type StackStats struct {
+	PacketsSent     uint64 `json:"packetsSent"`
+	PacketsReceived uint64 `json:"packetsReceived"`
+	ARPRequests     uint64 `json:"arpRequests"`
+	ARPReplies      uint64 `json:"arpReplies"`
+	ICMPRequests    uint64 `json:"icmpRequests"`
+	ICMPReplies     uint64 `json:"icmpReplies"`
+	DNSQueries      uint64 `json:"dnsQueries"`
+	DHCPRequests    uint64 `json:"dhcpRequests"`
+	SNMPQueries     uint64 `json:"snmpQueries"`
+	Errors          uint64 `json:"errors"`
+}
+
+// Stats is one sample of the daemon's runtime counters.
+type Stats struct {
+	Interface   string     `json:"interface"`
+	Version     string     `json:"version"`
+	DeviceCount int        `json:"deviceCount"`
+	Goroutines  int        `json:"goroutines"`
+	Stack       StackStats `json:"stack"`
+}
+
+// ARP is request and reply traffic together, which is what a single "ARP"
+// column in the monitor output means.
+func (s StackStats) ARP() uint64 { return s.ARPRequests + s.ARPReplies }
+
+// ICMP is request and reply traffic together, for the same reason as ARP.
+func (s StackStats) ICMP() uint64 { return s.ICMPRequests + s.ICMPReplies }
+
+// Stats reads one sample of the daemon's counters.
+func (c *Client) Stats(ctx context.Context) (*Stats, error) {
+	var stats Stats
+	if err := c.get(ctx, "/api/v1/stats", &stats); err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/internal/cliclient/stats.go
+++ b/internal/cliclient/stats.go
@@ -1,6 +1,9 @@
 package cliclient
 
-import "context"
+import (
+	"context"
+	"net/url"
+)
 
 // StackStats is the daemon's per-protocol packet accounting, as served by
 // /api/v1/stats. These are the counters `niac monitor` reports; it used to
@@ -35,10 +38,25 @@ func (s StackStats) ARP() uint64 { return s.ARPRequests + s.ARPReplies }
 // ICMP is request and reply traffic together, for the same reason as ARP.
 func (s StackStats) ICMP() uint64 { return s.ICMPRequests + s.ICMPReplies }
 
-// Stats reads one sample of the daemon's counters.
+// Stats reads one sample of the counters for whichever session is selected.
+//
+// Several scenarios run at once, each with its own stack and its own counters,
+// so "the stats" is ambiguous unless a session is named: a caller watching the
+// selected session sees zeros while another session carries the traffic. Prefer
+// SessionStats.
 func (c *Client) Stats(ctx context.Context) (*Stats, error) {
 	var stats Stats
 	if err := c.get(ctx, "/api/v1/stats", &stats); err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}
+
+// SessionStats reads one sample of a named session's counters.
+func (c *Client) SessionStats(ctx context.Context, session string) (*Stats, error) {
+	var stats Stats
+	if err := c.get(ctx, "/api/v1/sessions/"+url.PathEscape(session)+"/stats", &stats); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

`niac monitor` has never worked in any shipped build. It spoke to a unix socket whose server was deleted in #1012 as a dead subsystem, so it answered **"no NIAC simulation running" while six simulations were running** — and sent the operator looking in the wrong place. Four more commands are stranded the same way and follow in a second PR.

It reads the daemon's HTTPS API now. That also settles the per-protocol counters this command has always printed as zero: the daemon has counted them all along.

Three real defects surfaced while proving it on the lab, each fixed here:

- **The daemon's certificate did not cover its own advertised address.** It tells operators it listens on `https://127.0.0.1:8445` and generated a certificate for `localhost` and `niac.local` only, so *nothing* could verify that URL — the browser warning was unfixable too.
- **The CLI looked for that certificate in the wrong place**, and a stale one left by an earlier run has the same subject, so verification failed with a bare "unknown authority".
- **Stats are per-session.** Six scenarios run at once; the unqualified endpoint reports whichever is *selected*, so the monitor showed zeros while another session carried the traffic.

## Linked Issue

Related to #1151. Program ledger code-debt item: "`monitor.go` zeros".

## Type

- [x] Bug fix
- [x] Feature

## Risk

Moderate and intended. `--socket` is replaced by `--api` (also `NIAC_API_URL`), with `--session`, `--cacert` and `--insecure` added; a token comes from `NIAC_API_TOKEN`, the same variable the daemon takes. Connections are **verified**, not waved through — `--insecure` exists but must be asked for. The certificate change regenerates any certificate that predates loopback coverage, so an existing install gets a new one on next start; that is the point, since the old one cannot be verified by anything.

## Testing Evidence

**Before**, on the live daemon with six simulations running:

```
$ niac monitor --format json
Error: no NIAC simulation running (socket: /tmp/niac.sock)
```

**After**, same host, driving exactly 30 `snmpget`s and 30 pings at the hospital pack while it samples:

```
{"time":"...","packets_rx":4, "packets_tx":2, "arp":0,"icmp":0, "dns":0,"dhcp":0,"snmp":0, "uptime_seconds":14.29,"session":"hospital"}
{"time":"...","packets_rx":65,"packets_tx":62,"arp":0,"icmp":60,"dns":0,"dhcp":0,"snmp":30,"uptime_seconds":17.28,"session":"hospital","rate_rx":20.33,"rate_tx":20}
{"time":"...","packets_rx":69,"packets_tx":65,"arp":2,"icmp":60,"dns":0,"dhcp":0,"snmp":30,"uptime_seconds":23.28,"session":"hospital","rate_rx":0.66,"rate_tx":1}
```

`snmp:30` is the 30 queries; `icmp:60` is 30 pings counted as request and reply. Those columns were previously hard zeros in every sample.

The regenerated certificate, on the same box:

```
$ openssl x509 -in /var/lib/niac/certs/server.crt -noout -ext subjectAltName
    DNS:localhost, DNS:niac.local, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1
```

Unit tests, each failing before its fix:

```
$ go test ./internal/api/ -run Certificate
--- FAIL: TestGeneratedCertificateCoversTheAddressTheDaemonAdvertises
    certificate does not cover 127.0.0.1: x509: ... doesn't contain any IP SANs
--- FAIL: TestACertificateMissingLoopbackIsReplaced
    stale certificate was reused

$ go test ./internal/... ./cmd/...
(no failures)

$ golangci-lint run cmd/niac/... internal/cliclient/... internal/api/...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, credentials or customer data added; the token is read from the environment, never a flag that lands in `ps`
- [x] TLS is verified by default — the daemon's own certificate is trusted when present, and skipping verification requires `--insecure`
- [x] No new mutating routes; every call this client makes is a GET
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit