### PR TITLE
fix(cli): reconnect the last five commands to the daemon

### DIFF
--- a/cmd/niac/commands_test.go
+++ b/cmd/niac/commands_test.go
@@ -73,8 +73,9 @@ func TestAddDumpCommand(t *testing.T) {
 	if cmd.Flags().Lookup("count") == nil {
 		t.Error("Expected --count flag")
 	}
-	if cmd.Flags().Lookup("socket") == nil {
-		t.Error("Expected --socket flag")
+	// The socket transport is gone; the daemon is reached over its API.
+	if cmd.Flags().Lookup("api") == nil {
+		t.Error("Expected --api flag")
 	}
 	if cmd.Flags().Lookup("json") == nil {
 		t.Error("Expected --json flag")
@@ -92,8 +93,9 @@ func TestAddStatusCommand(t *testing.T) {
 	if cmd.Flags().Lookup("json") == nil {
 		t.Error("Expected --json flag")
 	}
-	if cmd.Flags().Lookup("socket") == nil {
-		t.Error("Expected --socket flag")
+	// The socket transport is gone; the daemon is reached over its API.
+	if cmd.Flags().Lookup("api") == nil {
+		t.Error("Expected --api flag")
 	}
 }
 
@@ -247,8 +249,9 @@ func TestAddTopologyCommand(t *testing.T) {
 	if exportCmd.Flags().Lookup("output") == nil {
 		t.Error("Expected --output flag")
 	}
-	if exportCmd.Flags().Lookup("socket") == nil {
-		t.Error("Expected --socket flag")
+	// The socket transport is gone; the daemon is reached over its API.
+	if exportCmd.Flags().Lookup("api") == nil {
+		t.Error("Expected --api flag")
 	}
 }
 

--- a/cmd/niac/dump.go
+++ b/cmd/niac/dump.go
@@ -109,11 +109,13 @@ func runDump(ctx context.Context, options *dumpOptions) error {
 	if err != nil {
 		return handleDumpError(err, options.jsonOutput)
 	}
-	ctx, cancel := context.WithTimeout(ctx, dumpWindow)
+	// The window bounds the stream read only. Anything after it - including
+	// asking why nothing arrived - needs a context that has not just expired.
+	streamCtx, cancel := context.WithTimeout(ctx, dumpWindow)
 	defer cancel()
 
 	packets := make([]ipc.PacketData, 0, options.count)
-	err = client.StreamPackets(ctx, func(event cliclient.PacketEvent) bool {
+	err = client.StreamPackets(streamCtx, func(event cliclient.PacketEvent) bool {
 		if !matchesDumpFilter(event, options) {
 			return true
 		}
@@ -131,7 +133,7 @@ func runDump(ctx context.Context, options *dumpOptions) error {
 
 		return len(packets) < options.count
 	})
-	if err != nil && ctx.Err() == nil {
+	if err != nil && streamCtx.Err() == nil {
 		return handleDumpError(err, options.jsonOutput)
 	}
 

--- a/cmd/niac/dump.go
+++ b/cmd/niac/dump.go
@@ -135,9 +135,28 @@ func runDump(ctx context.Context, options *dumpOptions) error {
 		return handleDumpError(err, options.jsonOutput)
 	}
 
+	if len(packets) == 0 {
+		explainEmptyStream(ctx, client, options.jsonOutput)
+	}
 	outputPackets(packets, options.jsonOutput)
 
 	return nil
+}
+
+// explainEmptyStream says why nothing arrived when the reason is structural
+// rather than a quiet network: the daemon broadcasts a packet on its unscoped
+// stream only when one scenario owns the capture. With several running, their
+// frames are scoped to each session and this stream stays silent no matter how
+// busy they are - and "No packets captured" would read as a quiet lab.
+func explainEmptyStream(ctx context.Context, client *cliclient.Client, jsonOutput bool) {
+	sessions, err := client.Sessions(ctx)
+	if err != nil || len(sessions) < 2 || jsonOutput {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"Note: %d scenarios are running, and their packets are scoped to each session.\n"+
+			"The unscoped stream this command reads only carries frames when one scenario is up.\n",
+		len(sessions))
 }
 
 // dumpWindow bounds how long a dump waits for its packets, so a quiet

--- a/cmd/niac/dump.go
+++ b/cmd/niac/dump.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
 )
 
@@ -18,11 +20,13 @@ type dumpOptions struct {
 	device     string
 	iface      string
 	count      int
-	socketPath string
+	api        string
+	caCert     string
+	insecure   bool
 	jsonOutput bool
 }
 
-const dumpLongHelp = `Dump captured packets from a running NIAC simulation via IPC socket.
+const dumpLongHelp = `Dump packets from a running NIAC simulation, read from the daemon's live stream.
 
 This command connects to a running NIAC simulation and retrieves
 hex dumps of recently captured packets. The output format is similar
@@ -33,7 +37,7 @@ Packets can be filtered by device name or interface name. Use the
 
 Exit codes:
   0 - Success
-  1 - Connection failed (socket not found or connection refused)
+  1 - Connection failed (no daemon answered)
   2 - Error occurred (request failed, parse error, etc.)`
 
 const dumpExample = `  # Dump all captured packets
@@ -54,8 +58,8 @@ const dumpExample = `  # Dump all captured packets
   # Combine filters
   niac dump --device router-1 --interface eth0 --count 5
 
-  # Use a custom socket path
-  niac dump --socket /var/run/niac/niac.sock`
+  # Read from a daemon on another address
+  niac dump --api https://10.0.0.5:8445`
 
 func addDumpCommand(root *cobra.Command, _ *serviceOptions) {
 	options := new(dumpOptions)
@@ -65,7 +69,7 @@ func addDumpCommand(root *cobra.Command, _ *serviceOptions) {
 		Long:    dumpLongHelp,
 		Example: dumpExample,
 		Args:    cobra.NoArgs,
-		RunE:    func(_ *cobra.Command, _ []string) error { return runDump(options) },
+		RunE:    func(cmd *cobra.Command, _ []string) error { return runDump(cmd.Context(), options) },
 	}
 	addDumpFlags(dumpCmd, options)
 	root.AddCommand(dumpCmd)
@@ -75,7 +79,12 @@ func addDumpFlags(cmd *cobra.Command, options *dumpOptions) {
 	cmd.Flags().StringVar(&options.device, "device", "", "Filter by device name")
 	cmd.Flags().StringVar(&options.iface, "interface", "", "Filter by interface name")
 	cmd.Flags().IntVar(&options.count, "count", 0, "Maximum number of packets to display (0 = all)")
-	cmd.Flags().StringVar(&options.socketPath, "socket", "", "Path to IPC socket (default: /tmp/niac.sock)")
+	cmd.Flags().StringVar(&options.api, "api", "",
+		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	cmd.Flags().StringVar(&options.caCert, "cacert", "",
+		"Daemon certificate to trust (default: the local daemon's own, when visible)")
+	cmd.Flags().BoolVar(&options.insecure, "insecure", false,
+		"Skip TLS verification, for a daemon whose certificate this host cannot see")
 	cmd.Flags().BoolVar(&options.jsonOutput, "json", false, "Output packets as JSON")
 }
 
@@ -90,33 +99,70 @@ type PacketDump struct {
 	HexDump   string    `json:"hex_dump,omitempty"`
 }
 
-// runDump executes the dump command.
-func runDump(options *dumpOptions) error {
-	socketPath := resolveSocketPath(options.socketPath)
-	if err := checkSocketExists(socketPath, options.jsonOutput); err != nil {
-		return err
-	}
-
-	packets, err := ipc.NewClient(socketPath).DumpPackets(options.device, options.iface, options.count)
+// runDump collects packets from the daemon's live stream.
+//
+// The daemon broadcasts frames as it handles them and keeps no capture buffer,
+// so this waits for the requested count rather than asking for history that
+// does not exist. A quiet simulation yields nothing, and says so.
+func runDump(ctx context.Context, options *dumpOptions) error {
+	client, err := newCLIClient(options.api, options.caCert, options.insecure)
 	if err != nil {
+		return handleDumpError(err, options.jsonOutput)
+	}
+	ctx, cancel := context.WithTimeout(ctx, dumpWindow)
+	defer cancel()
+
+	packets := make([]ipc.PacketData, 0, options.count)
+	err = client.StreamPackets(ctx, func(event cliclient.PacketEvent) bool {
+		if !matchesDumpFilter(event, options) {
+			return true
+		}
+		raw, decodeErr := event.Bytes()
+		if decodeErr != nil {
+			return true
+		}
+		packets = append(packets, ipc.PacketData{
+			Timestamp: parsePacketTime(event.Timestamp),
+			Length:    event.Size,
+			Device:    event.Device,
+			Interface: event.Direction,
+			Data:      raw,
+		})
+
+		return len(packets) < options.count
+	})
+	if err != nil && ctx.Err() == nil {
 		return handleDumpError(err, options.jsonOutput)
 	}
 
 	outputPackets(packets, options.jsonOutput)
+
 	return nil
 }
 
-func checkSocketExists(socketPath string, jsonOutput bool) error {
-	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
-		if jsonOutput {
-			outputDumpJSON(map[string]any{"success": false, "error": "socket not found"})
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: Socket not found: %s\n", socketPath)
-			fmt.Fprintf(os.Stderr, "Is the NIAC simulation running?\n")
-		}
-		os.Exit(1)
+// dumpWindow bounds how long a dump waits for its packets, so a quiet
+// simulation returns instead of hanging.
+const dumpWindow = 10 * time.Second
+
+// matchesDumpFilter keeps the frames the operator asked for.
+func matchesDumpFilter(event cliclient.PacketEvent, options *dumpOptions) bool {
+	if options.device != "" && !strings.EqualFold(event.Device, options.device) {
+		return false
 	}
-	return nil
+
+	return options.iface == "" || strings.EqualFold(event.Direction, options.iface)
+}
+
+// parsePacketTime reads the stream's timestamp, falling back to now when the
+// daemon sends a shape this build does not know.
+func parsePacketTime(value string) time.Time {
+	for _, layout := range []string{"2006-01-02T15:04:05.000Z", time.RFC3339Nano, time.RFC3339} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed
+		}
+	}
+
+	return time.Now()
 }
 
 func handleDumpError(err error, jsonOutput bool) error {

--- a/cmd/niac/logs.go
+++ b/cmd/niac/logs.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
 )
@@ -20,7 +21,9 @@ type logsOptions struct {
 	follow     bool
 	level      string
 	filter     string
-	socketPath string
+	api        string
+	caCert     string
+	insecure   bool
 	jsonOutput bool
 	count      int
 }
@@ -57,7 +60,7 @@ text pattern, and can be streamed in real-time with the tail subcommand.`,
 		Short: "Stream logs from a running simulation",
 		Long: `Stream logs from a running NIAC simulation in real-time.
 
-The tail command connects to the running simulation via IPC socket and
+The tail command reads the daemon's live log stream over its HTTPS API and
 displays log messages. Use --follow to continuously stream new logs.
 
 Log levels (from most to least verbose):
@@ -85,8 +88,8 @@ The --filter option performs case-insensitive substring matching on log messages
   # JSON output for scripting
   niac logs tail --json | jq '.message'
 
-  # Custom socket path
-  niac logs tail --socket /var/run/niac.sock`,
+  # Read from a daemon on another address
+  niac logs tail --api https://10.0.0.5:8445`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runLogsTail(options)
@@ -102,8 +105,12 @@ The --filter option performs case-insensitive substring matching on log messages
 		"Minimum log level: debug, info, warn, error")
 	logsTailCmd.Flags().StringVar(&options.filter, "filter", "",
 		"Filter logs by text pattern (case-insensitive)")
-	logsTailCmd.Flags().StringVar(&options.socketPath, "socket", "",
-		"Path to IPC socket (default: "+ipc.DefaultSocketPath()+")")
+	logsTailCmd.Flags().StringVar(&options.api, "api", "",
+		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	logsTailCmd.Flags().StringVar(&options.caCert, "cacert", "",
+		"Daemon certificate to trust (default: the local daemon's own, when visible)")
+	logsTailCmd.Flags().BoolVar(&options.insecure, "insecure", false,
+		"Skip TLS verification, for a daemon whose certificate this host cannot see")
 	logsTailCmd.Flags().BoolVar(&options.jsonOutput, "json", false,
 		"Output logs as JSON (one object per line)")
 	logsTailCmd.Flags().IntVarP(&options.count, "count", "n", maxLogEntries,
@@ -122,17 +129,9 @@ func runLogsTail(options *logsOptions) error {
 		return fmt.Errorf("invalid log level %q: must be debug, info, warn, or error", options.level)
 	}
 
-	// Create IPC client
-	socketPath := options.socketPath
-	if socketPath == "" {
-		socketPath = ipc.GetDefaultSocketPath()
-	}
-
-	client := ipc.NewClient(socketPath)
-
-	// Check if server is running
-	if !client.IsRunning() {
-		return fmt.Errorf("no NIAC simulation running (socket: %s)", socketPath)
+	client, err := newCLIClient(options.api, options.caCert, options.insecure)
+	if err != nil {
+		return err
 	}
 
 	// Set up context with cancellation for graceful shutdown
@@ -153,66 +152,134 @@ func runLogsTail(options *logsOptions) error {
 		return runLogsFollow(ctx, client, level, options)
 	}
 
-	return runLogsOnce(client, level, options)
+	return runLogsOnce(ctx, client, level, options)
 }
 
-// runLogsOnce fetches and displays logs once (no follow mode).
-func runLogsOnce(client *ipc.Client, level string, options *logsOptions) error {
-	logs, err := client.GetLogs(level, options.count)
-	if err != nil {
-		return fmt.Errorf("failed to get logs: %w", err)
-	}
+// runLogsOnce collects from the live stream until it has the requested count or
+// the window closes.
+//
+// The daemon keeps no backlog: it broadcasts records as they happen and retains
+// nothing, so there is no "last N lines" to ask for. This reads what arrives
+// and stops, which is honest about what the daemon can answer; --follow is what
+// you want if the simulation is quiet.
+func runLogsOnce(ctx context.Context, client *cliclient.Client, level string, options *logsOptions) error {
+	ctx, cancel := context.WithTimeout(ctx, logsOnceWindow)
+	defer cancel()
 
-	// Apply text filter
-	filtered := filterLogs(logs, options.filter)
-
-	if options.jsonOutput {
-		for _, log := range filtered {
-			outputLogJSON(log)
-		}
-	} else {
+	if !options.jsonOutput {
 		logging.InitColors(true)
-		for _, log := range filtered {
-			printLogEntry(log)
-		}
+	}
+	seen := 0
+	err := streamLogs(ctx, client, level, options, func() bool {
+		seen++
+
+		return seen < options.count
+	})
+	if err != nil {
+		return err
+	}
+	if seen == 0 && !options.jsonOutput {
+		fmt.Fprintf(os.Stdout,
+			"No log records in %s. The daemon keeps no backlog; use --follow to watch.\n",
+			logsOnceWindow)
 	}
 
 	return nil
 }
 
-// runLogsFollow streams logs continuously.
-func runLogsFollow(ctx context.Context, client *ipc.Client, level string, options *logsOptions) error {
-	sub := client.SubscribeLogs(level, options.filter, logPollMilliseconds*time.Millisecond)
-	defer sub.Stop()
+// logsOnceWindow is how long a non-following read waits for records. Long
+// enough to catch a busy simulation, short enough not to look hung.
+const logsOnceWindow = 2 * time.Second
 
+// runLogsFollow streams logs continuously.
+func runLogsFollow(ctx context.Context, client *cliclient.Client, level string, options *logsOptions) error {
 	if !options.jsonOutput {
 		logging.InitColors(true)
 		fmt.Fprintln(os.Stdout, "Streaming logs (press Ctrl+C to stop)...")
 		fmt.Fprintln(os.Stdout, strings.Repeat("-", lineWidthStandard))
 	}
+	err := streamLogs(ctx, client, level, options, func() bool { return true })
+	if err != nil && ctx.Err() == nil {
+		return err
+	}
+	if !options.jsonOutput {
+		fmt.Fprintln(os.Stdout, "\nLog streaming stopped.")
+	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			if !options.jsonOutput {
-				fmt.Fprintln(os.Stdout, "\nLog streaming stopped.")
-			}
-			return nil
-		case log, ok := <-sub.Logs():
-			if !ok {
-				return nil
-			}
-			if options.jsonOutput {
-				outputLogJSON(log)
-			} else {
-				printLogEntry(log)
-			}
-		case err := <-sub.Errors():
-			if !options.jsonOutput {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			}
+	return nil
+}
+
+// streamLogs applies the level and text filters to the daemon's stream and
+// prints what survives, stopping when keepGoing says so.
+func streamLogs(
+	ctx context.Context,
+	client *cliclient.Client,
+	level string,
+	options *logsOptions,
+	keepGoing func() bool,
+) error {
+	return client.StreamLogs(ctx, func(event cliclient.LogEvent) bool {
+		entry := ipc.LogEntry{
+			Timestamp: parseLogTime(event.Timestamp),
+			Level:     ipc.LogLevel(event.Level),
+			Message:   event.Message,
+			Device:    event.Device,
+			Source:    event.Source,
+			Protocol:  event.Protocol,
+		}
+		if !matchesLevel(string(entry.Level), level) || !ipc.LogMatchesFilter(entry, options.filter) {
+			return true
+		}
+		if options.jsonOutput {
+			outputLogJSON(entry)
+		} else {
+			printLogEntry(entry)
+		}
+
+		return keepGoing()
+	})
+}
+
+// matchesLevel keeps records at or above the requested level.
+func matchesLevel(recordLevel, wanted string) bool {
+	if wanted == "" {
+		return true
+	}
+
+	return logLevelRank(recordLevel) >= logLevelRank(wanted)
+}
+
+// logLevelRank orders the levels so a request for one keeps everything at or
+// above it, which is what "--level warn" means to an operator.
+func logLevelRank(level string) int {
+	const (
+		rankDebug = iota
+		rankInfo
+		rankWarn
+		rankError
+	)
+	switch strings.ToLower(level) {
+	case "debug":
+		return rankDebug
+	case "warn", "warning":
+		return rankWarn
+	case "error":
+		return rankError
+	default:
+		return rankInfo
+	}
+}
+
+// parseLogTime reads the stream's timestamp, falling back to now when the
+// daemon sends a shape this build does not know.
+func parseLogTime(value string) time.Time {
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "15:04:05.000"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed
 		}
 	}
+
+	return time.Now()
 }
 
 // filterLogs filters logs by the text pattern. The match itself lives in the ipc

--- a/cmd/niac/logs_test.go
+++ b/cmd/niac/logs_test.go
@@ -331,8 +331,9 @@ func TestLogsCommandFlags(t *testing.T) {
 	if flags.Lookup("filter") == nil {
 		t.Error("Expected --filter flag to be defined")
 	}
-	if flags.Lookup("socket") == nil {
-		t.Error("Expected --socket flag to be defined")
+	// The socket transport is gone; the daemon is reached over its API.
+	if flags.Lookup("api") == nil {
+		t.Error("Expected --api flag to be defined")
 	}
 	if flags.Lookup("json") == nil {
 		t.Error("Expected --json flag to be defined")

--- a/cmd/niac/neighbors.go
+++ b/cmd/niac/neighbors.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 )
 
 // NeighborEntry represents a neighbor record for display.
@@ -29,7 +29,9 @@ type NeighborEntry struct {
 type neighborsOptions struct {
 	device     string
 	protocol   string
-	socketPath string
+	api        string
+	caCert     string
+	insecure   bool
 	jsonOutput bool
 }
 
@@ -76,8 +78,8 @@ Use the 'watch' subcommand for continuous live updates.`,
   # Watch with filters
   niac neighbors watch --device switch-1 --protocol cdp
 
-  # Use custom socket path
-  niac neighbors --socket /tmp/my-niac.sock`,
+  # Read from a daemon on another address
+  niac neighbors --api https://10.0.0.5:8445`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runNeighbors(cmd, args, options)
@@ -116,8 +118,12 @@ Press Ctrl+C to stop watching.`,
 		"Filter by device name")
 	neighborsCmd.PersistentFlags().StringVar(&options.protocol, "protocol", "all",
 		"Filter by protocol: lldp, cdp, or all")
-	neighborsCmd.PersistentFlags().StringVar(&options.socketPath, "socket", "",
-		"Path to IPC socket (default: "+ipc.DefaultSocketPath()+")")
+	neighborsCmd.PersistentFlags().StringVar(&options.api, "api", "",
+		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	neighborsCmd.PersistentFlags().StringVar(&options.caCert, "cacert", "",
+		"Daemon certificate to trust (default: the local daemon's own, when visible)")
+	neighborsCmd.PersistentFlags().BoolVar(&options.insecure, "insecure", false,
+		"Skip TLS verification, for a daemon whose certificate this host cannot see")
 	neighborsCmd.PersistentFlags().BoolVar(&options.jsonOutput, "json", false,
 		"Output in JSON format")
 
@@ -142,13 +148,13 @@ func runNeighbors(cmd *cobra.Command, args []string, options *neighborsOptions) 
 		return err
 	}
 
-	// Create IPC client
-	client := getNeighborsClient(options)
-
-	// Fetch neighbors
-	neighbors, err := fetchNeighbors(client)
+	client, err := newCLIClient(options.api, options.caCert, options.insecure)
 	if err != nil {
-		return fmt.Errorf("failed to fetch neighbors: %w", err)
+		return err
+	}
+	neighbors, err := fetchNeighbors(cmd.Context(), client)
+	if err != nil {
+		return err
 	}
 
 	// Filter neighbors
@@ -168,12 +174,9 @@ func runNeighborsWatch(_ *cobra.Command, _ []string, options *neighborsOptions) 
 		return err
 	}
 
-	// Create IPC client
-	client := getNeighborsClient(options)
-
-	// Check if server is running
-	if !client.IsRunning() {
-		return fmt.Errorf("no NIAC simulation running (socket: %s)", client.SocketPath())
+	client, err := newCLIClient(options.api, options.caCert, options.insecure)
+	if err != nil {
+		return err
 	}
 
 	// Set up context with cancellation for graceful shutdown
@@ -194,12 +197,16 @@ func runNeighborsWatch(_ *cobra.Command, _ []string, options *neighborsOptions) 
 	return runNeighborsWatchLoop(ctx, client, options)
 }
 
-func runNeighborsWatchLoop(ctx context.Context, client *ipc.Client, options *neighborsOptions) error {
+func runNeighborsWatchLoop(
+	ctx context.Context,
+	client *cliclient.Client,
+	options *neighborsOptions,
+) error {
 	ticker := time.NewTicker(tickerInterval * time.Second)
 	defer ticker.Stop()
 
 	// Initial fetch
-	err := displayNeighborsUpdate(client, options)
+	err := displayNeighborsUpdate(ctx, client, options)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial neighbors: %w", err)
 	}
@@ -212,7 +219,7 @@ func runNeighborsWatchLoop(ctx context.Context, client *ipc.Client, options *nei
 			}
 			return nil
 		case <-ticker.C:
-			if updateErr := displayNeighborsUpdate(client, options); updateErr != nil {
+			if updateErr := displayNeighborsUpdate(ctx, client, options); updateErr != nil {
 				// Connection lost, but don't exit immediately
 				if !options.jsonOutput {
 					fmt.Fprintf(os.Stdout, "\r[%s] Connection lost: %v\n", time.Now().Format("15:04:05"), updateErr)
@@ -230,8 +237,12 @@ func runNeighborsWatchLoop(ctx context.Context, client *ipc.Client, options *nei
 	}
 }
 
-func displayNeighborsUpdate(client *ipc.Client, options *neighborsOptions) error {
-	neighbors, err := fetchNeighbors(client)
+func displayNeighborsUpdate(
+	ctx context.Context,
+	client *cliclient.Client,
+	options *neighborsOptions,
+) error {
+	neighbors, err := fetchNeighbors(ctx, client)
 	if err != nil {
 		return err
 	}
@@ -278,18 +289,10 @@ func validateProtocolFlag(protocol string) error {
 	}
 }
 
-func getNeighborsClient(options *neighborsOptions) *ipc.Client {
-	socketPath := options.socketPath
-	if socketPath == "" {
-		socketPath = ipc.GetDefaultSocketPath()
-	}
-	return ipc.NewClient(socketPath)
-}
-
-func fetchNeighbors(client *ipc.Client) ([]NeighborEntry, error) {
-	neighbors, err := client.GetNeighbors()
+func fetchNeighbors(ctx context.Context, client *cliclient.Client) ([]NeighborEntry, error) {
+	neighbors, err := client.Neighbors(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get neighbors: %w", err)
+		return nil, err
 	}
 
 	entries := make([]NeighborEntry, 0, len(neighbors))

--- a/cmd/niac/neighbors_test.go
+++ b/cmd/niac/neighbors_test.go
@@ -16,7 +16,9 @@ func TestAddNeighborsCommandFlags(t *testing.T) {
 		t.Fatal("Expected neighbors command to be registered")
 	}
 
-	expectedFlags := []string{"device", "protocol", "socket", "json"}
+	// --socket went with the transport it addressed; the daemon is reached
+	// over its API now.
+	expectedFlags := []string{"device", "protocol", "api", "json"}
 	for _, flag := range expectedFlags {
 		if cmd.Flags().Lookup(flag) == nil && cmd.PersistentFlags().Lookup(flag) == nil {
 			t.Errorf("Expected --%s flag on neighbors command", flag)

--- a/cmd/niac/status.go
+++ b/cmd/niac/status.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -13,12 +12,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 )
 
 type statusOptions struct {
 	jsonOutput bool
-	socketPath string
+	api        string
+	caCert     string
+	insecure   bool
 }
 
 func addStatusCommand(root *cobra.Command, _ *serviceOptions) {
@@ -59,13 +60,18 @@ Exit codes:
     echo "NIAC is not running"
   fi`,
 		Args: cobra.NoArgs,
-		Run: func(_ *cobra.Command, _ []string) {
-			runStatus(options)
+		Run: func(cmd *cobra.Command, _ []string) {
+			runStatus(cmd.Context(), options)
 		},
 	}
 
 	statusCmd.Flags().BoolVar(&options.jsonOutput, "json", false, "Output status as JSON")
-	statusCmd.Flags().StringVar(&options.socketPath, "socket", "", "Path to IPC socket (default: /tmp/niac.sock)")
+	statusCmd.Flags().StringVar(&options.api, "api", "",
+		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	statusCmd.Flags().StringVar(&options.caCert, "cacert", "",
+		"Daemon certificate to trust (default: the local daemon's own, when visible)")
+	statusCmd.Flags().BoolVar(&options.insecure, "insecure", false,
+		"Skip TLS verification, for a daemon whose certificate this host cannot see")
 
 	root.AddCommand(statusCmd)
 }
@@ -78,130 +84,43 @@ const (
 
 // statusResult holds the result of a status check operation.
 type statusResult struct {
-	status   *ipc.StatusData
+	status   *cliclient.Runtime
 	exitCode int
 	err      error
 }
 
-func runStatus(options *statusOptions) {
-	socketPath := resolveSocketPath(options.socketPath)
-
-	result := checkStatus(socketPath)
+func runStatus(ctx context.Context, options *statusOptions) {
+	result := checkStatus(ctx, options)
 
 	outputResult(result, options.jsonOutput)
 	os.Exit(result.exitCode)
 }
 
-// resolveSocketPath returns the socket path, using default if not specified.
-func resolveSocketPath(path string) string {
-	if path == "" {
-		return ipc.DefaultSocketPath()
-	}
-	return path
-}
-
-// checkStatus performs the full status check workflow.
-func checkStatus(socketPath string) statusResult {
-	if err := verifySocketExists(socketPath); err != nil {
-		return statusResult{exitCode: exitCodeNotRunning, err: err}
-	}
-
-	conn, err := connectToSocket(socketPath)
-	if err != nil {
-		return statusResult{exitCode: exitCodeNotRunning, err: err}
-	}
-	defer conn.Close()
-
-	status, err := requestStatus(conn)
+// checkStatus asks the daemon what it is running.
+//
+// It used to open a unix socket whose server was removed in #1012, so this
+// command reported NOT RUNNING no matter how many simulations were up.
+func checkStatus(ctx context.Context, options *statusOptions) statusResult {
+	client, err := newCLIClient(options.api, options.caCert, options.insecure)
 	if err != nil {
 		return statusResult{exitCode: exitCodeError, err: err}
 	}
-
-	return statusResult{status: status, exitCode: exitCodeSuccess}
-}
-
-// verifySocketExists checks if the IPC socket file exists.
-func verifySocketExists(socketPath string) error {
-	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
-		return fmt.Errorf("socket not found: %s", socketPath)
-	}
-	return nil
-}
-
-// connectToSocket establishes a connection to the IPC socket.
-func connectToSocket(socketPath string) (net.Conn, error) {
-	dialer := net.Dialer{Timeout: shortTimeout * time.Second}
-
-	conn, err := dialer.DialContext(context.Background(), "unix", socketPath)
+	runtime, err := client.Runtime(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("connection failed: %w", err)
+		if errors.Is(err, cliclient.ErrDaemonUnreachable) {
+			return statusResult{exitCode: exitCodeNotRunning, err: err}
+		}
+
+		return statusResult{exitCode: exitCodeError, err: err}
+	}
+	if !runtime.Running {
+		return statusResult{
+			exitCode: exitCodeNotRunning,
+			err:      errors.New("the daemon is up but no simulation is running"),
+		}
 	}
 
-	_ = conn.SetDeadline(time.Now().Add(shortTimeout * time.Second))
-
-	return conn, nil
-}
-
-// requestStatus sends a status request and parses the response.
-func requestStatus(conn net.Conn) (*ipc.StatusData, error) {
-	if err := sendStatusRequest(conn); err != nil {
-		return nil, err
-	}
-
-	resp, err := receiveResponse(conn)
-	if err != nil {
-		return nil, err
-	}
-
-	return parseStatusResponse(resp)
-}
-
-// sendStatusRequest sends the status command to the IPC server.
-func sendStatusRequest(conn net.Conn) error {
-	req := ipc.Request{Command: ipc.CommandStatus}
-	encoder := json.NewEncoder(conn)
-
-	if err := encoder.Encode(&req); err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
-	}
-
-	return nil
-}
-
-// receiveResponse reads and decodes the IPC response.
-func receiveResponse(conn net.Conn) (*ipc.Response, error) {
-	var resp ipc.Response
-	decoder := json.NewDecoder(conn)
-
-	if err := decoder.Decode(&resp); err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if !resp.Success {
-		return nil, fmt.Errorf("%s", resp.Error)
-	}
-
-	return &resp, nil
-}
-
-// parseStatusResponse extracts and parses StatusData from the response.
-func parseStatusResponse(resp *ipc.Response) (*ipc.StatusData, error) {
-	statusData, ok := resp.Data["status"]
-	if !ok {
-		return nil, errors.New("status data not found in response")
-	}
-
-	statusBytes, err := json.Marshal(statusData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse status: %w", err)
-	}
-
-	var status ipc.StatusData
-	if err = json.Unmarshal(statusBytes, &status); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal status: %w", err)
-	}
-
-	return &status, nil
+	return statusResult{status: runtime, exitCode: exitCodeSuccess}
 }
 
 // outputResult formats and outputs the status result.
@@ -233,7 +152,7 @@ func outputError(err error, exitCode int, jsonOutput bool) {
 }
 
 // outputSuccess outputs successful status in the appropriate format.
-func outputSuccess(status *ipc.StatusData, jsonOutput bool) {
+func outputSuccess(status *cliclient.Runtime, jsonOutput bool) {
 	if jsonOutput {
 		outputStatusJSON(buildStatusMap(status))
 		return
@@ -243,23 +162,22 @@ func outputSuccess(status *ipc.StatusData, jsonOutput bool) {
 }
 
 // buildStatusMap creates a map representation of status data for JSON output.
-func buildStatusMap(status *ipc.StatusData) map[string]any {
+func buildStatusMap(status *cliclient.Runtime) map[string]any {
 	return map[string]any{
 		"running":          status.Running,
 		"interface":        status.Interface,
-		"config":           status.ConfigPath,
+		"config":           status.ConfigName,
 		"devices":          status.DeviceCount,
 		"uptime_seconds":   status.Uptime,
 		"uptime_formatted": formatDurationFromSeconds(status.Uptime),
 		"packets_rx":       status.PacketsRX,
 		"packets_tx":       status.PacketsTX,
-		"errors_active":    status.ErrorsActive,
-		"started_at":       status.StartedAt,
+		"version":          status.Version,
 	}
 }
 
 // printHumanStatus prints the status in human-readable format.
-func printHumanStatus(status *ipc.StatusData) {
+func printHumanStatus(status *cliclient.Runtime) {
 	statusStr := "STOPPED"
 	if status.Running {
 		statusStr = "RUNNING"
@@ -267,12 +185,12 @@ func printHumanStatus(status *ipc.StatusData) {
 
 	fmt.Fprintf(os.Stdout, "Status: %s\n", statusStr)
 	fmt.Fprintf(os.Stdout, "Interface: %s\n", status.Interface)
-	fmt.Fprintf(os.Stdout, "Config: %s\n", status.ConfigPath)
+	fmt.Fprintf(os.Stdout, "Config: %s\n", status.ConfigName)
 	fmt.Fprintf(os.Stdout, "Devices: %d\n", status.DeviceCount)
 	fmt.Fprintf(os.Stdout, "Uptime: %s\n", formatDurationFromSeconds(status.Uptime))
 	fmt.Fprintf(os.Stdout, "Packets RX: %s\n", formatStatusNumber(status.PacketsRX))
 	fmt.Fprintf(os.Stdout, "Packets TX: %s\n", formatStatusNumber(status.PacketsTX))
-	fmt.Fprintf(os.Stdout, "Errors Active: %d\n", status.ErrorsActive)
+	fmt.Fprintf(os.Stdout, "Version: %s\n", status.Version)
 }
 
 // formatDurationFromSeconds formats a duration in seconds as "2h 15m 43s".

--- a/cmd/niac/status_output_test.go
+++ b/cmd/niac/status_output_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 )
 
 func TestOutputErrorNotRunning(t *testing.T) {
@@ -58,15 +58,14 @@ func TestOutputSuccessText(t *testing.T) {
 		}
 	}()
 
-	status := &ipc.StatusData{
-		Running:      true,
-		Interface:    "en0",
-		ConfigPath:   "/path/config.yaml",
-		DeviceCount:  5,
-		Uptime:       3661,
-		PacketsRX:    10000,
-		PacketsTX:    20000,
-		ErrorsActive: 0,
+	status := &cliclient.Runtime{
+		Running:     true,
+		Interface:   "en0",
+		ConfigName:  "/path/config.yaml",
+		DeviceCount: 5,
+		Uptime:      3661,
+		PacketsRX:   10000,
+		PacketsTX:   20000,
 	}
 	outputSuccess(status, false)
 }
@@ -78,15 +77,14 @@ func TestOutputSuccessJSON(t *testing.T) {
 		}
 	}()
 
-	status := &ipc.StatusData{
-		Running:      true,
-		Interface:    "en0",
-		ConfigPath:   "/path/config.yaml",
-		DeviceCount:  5,
-		Uptime:       3661,
-		PacketsRX:    10000,
-		PacketsTX:    20000,
-		ErrorsActive: 0,
+	status := &cliclient.Runtime{
+		Running:     true,
+		Interface:   "en0",
+		ConfigName:  "/path/config.yaml",
+		DeviceCount: 5,
+		Uptime:      3661,
+		PacketsRX:   10000,
+		PacketsTX:   20000,
 	}
 	outputSuccess(status, true)
 }
@@ -94,37 +92,35 @@ func TestOutputSuccessJSON(t *testing.T) {
 func TestPrintHumanStatus(t *testing.T) {
 	tests := []struct {
 		name   string
-		status *ipc.StatusData
+		status *cliclient.Runtime
 	}{
 		{
 			name: "running",
-			status: &ipc.StatusData{
-				Running:      true,
-				Interface:    "en0",
-				ConfigPath:   "config.yaml",
-				DeviceCount:  3,
-				Uptime:       100,
-				PacketsRX:    5000,
-				PacketsTX:    3000,
-				ErrorsActive: 0,
+			status: &cliclient.Runtime{
+				Running:     true,
+				Interface:   "en0",
+				ConfigName:  "config.yaml",
+				DeviceCount: 3,
+				Uptime:      100,
+				PacketsRX:   5000,
+				PacketsTX:   3000,
 			},
 		},
 		{
 			name: "stopped",
-			status: &ipc.StatusData{
+			status: &cliclient.Runtime{
 				Running: false,
 			},
 		},
 		{
 			name: "with errors",
-			status: &ipc.StatusData{
-				Running:      true,
-				Interface:    "eth0",
-				DeviceCount:  10,
-				Uptime:       86400,
-				PacketsRX:    1000000,
-				PacketsTX:    500000,
-				ErrorsActive: 3,
+			status: &cliclient.Runtime{
+				Running:     true,
+				Interface:   "eth0",
+				DeviceCount: 10,
+				Uptime:      86400,
+				PacketsRX:   1000000,
+				PacketsTX:   500000,
 			},
 		},
 	}

--- a/cmd/niac/status_test.go
+++ b/cmd/niac/status_test.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 )
 
 func TestFormatDurationFromSeconds(t *testing.T) {
@@ -90,17 +89,15 @@ func TestFormatStatusNumber(t *testing.T) {
 }
 
 func TestBuildStatusMap(t *testing.T) {
-	startTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
-	status := &ipc.StatusData{
-		Running:      true,
-		Interface:    "en0",
-		ConfigPath:   "/path/to/config.yaml",
-		DeviceCount:  5,
-		Uptime:       3661, // 1h 1m 1s
-		PacketsRX:    10000,
-		PacketsTX:    20000,
-		ErrorsActive: 2,
-		StartedAt:    startTime,
+	status := &cliclient.Runtime{
+		Running:     true,
+		Interface:   "en0",
+		Version:     "v0.94.31",
+		ConfigName:  "/path/to/config.yaml",
+		DeviceCount: 5,
+		Uptime:      3661, // 1h 1m 1s
+		PacketsRX:   10000,
+		PacketsTX:   20000,
 	}
 
 	result := buildStatusMap(status)
@@ -126,11 +123,8 @@ func TestBuildStatusMap(t *testing.T) {
 	if result["packets_tx"] != uint64(20000) {
 		t.Errorf("Expected packets_tx=20000, got %v", result["packets_tx"])
 	}
-	if result["errors_active"] != 2 {
-		t.Errorf("Expected errors_active=2, got %v", result["errors_active"])
-	}
-	if _, ok := result["started_at"]; !ok {
-		t.Error("Expected started_at to be present")
+	if result["version"] == nil {
+		t.Error("Expected the daemon version to be reported")
 	}
 
 	// Check formatted uptime is present
@@ -144,7 +138,7 @@ func TestBuildStatusMap(t *testing.T) {
 }
 
 func TestBuildStatusMapStopped(t *testing.T) {
-	status := &ipc.StatusData{
+	status := &cliclient.Runtime{
 		Running: false,
 	}
 
@@ -152,98 +146,6 @@ func TestBuildStatusMapStopped(t *testing.T) {
 	if result["running"] != false {
 		t.Error("Expected running=false")
 	}
-}
-
-func TestResolveSocketPath(t *testing.T) {
-	tests := []struct {
-		name       string
-		path       string
-		useDefault bool
-	}{
-		{"empty path uses default", "", true},
-		{"custom path", "/custom/socket.sock", false},
-		{"another custom", "/tmp/niac-test.sock", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := resolveSocketPath(tt.path)
-			if tt.useDefault {
-				expected := ipc.DefaultSocketPath()
-				if result != expected {
-					t.Errorf("resolveSocketPath(%q) = %q, want default %q", tt.path, result, expected)
-				}
-			} else if result != tt.path {
-				t.Errorf("resolveSocketPath(%q) = %q, want %q", tt.path, result, tt.path)
-			}
-		})
-	}
-}
-
-func TestParseStatusResponse(t *testing.T) {
-	t.Run("valid response", func(t *testing.T) {
-		resp := &ipc.Response{
-			Success: true,
-			Data: map[string]any{
-				"status": map[string]any{
-					"running":       true,
-					"interface":     "en0",
-					"config_path":   "/path/config.yaml",
-					"device_count":  float64(3),
-					"uptime":        float64(100),
-					"packets_rx":    float64(500),
-					"packets_tx":    float64(300),
-					"errors_active": float64(0),
-					"started_at":    "2024-01-15T10:00:00Z",
-				},
-			},
-		}
-
-		status, err := parseStatusResponse(resp)
-		if err != nil {
-			t.Fatalf("parseStatusResponse() error = %v", err)
-		}
-		if !status.Running {
-			t.Error("Expected running=true")
-		}
-		if status.Interface != "en0" {
-			t.Errorf("Expected interface=en0, got %s", status.Interface)
-		}
-	})
-
-	t.Run("missing status key", func(t *testing.T) {
-		resp := &ipc.Response{
-			Success: true,
-			Data:    map[string]any{},
-		}
-
-		_, err := parseStatusResponse(resp)
-		if err == nil {
-			t.Error("Expected error for missing status key")
-		}
-	})
-}
-
-func TestVerifySocketExists(t *testing.T) {
-	t.Run("non-existent socket", func(t *testing.T) {
-		err := verifySocketExists("/tmp/nonexistent-niac-test-socket-12345.sock")
-		if err == nil {
-			t.Error("Expected error for non-existent socket")
-		}
-	})
-
-	t.Run("existing file", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		socketFile := filepath.Join(tmpDir, "test.sock")
-		if err := os.WriteFile(socketFile, []byte("test"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-
-		err := verifySocketExists(socketFile)
-		if err != nil {
-			t.Errorf("verifySocketExists() unexpected error = %v", err)
-		}
-	})
 }
 
 func TestOutputResult(t *testing.T) {
@@ -269,7 +171,7 @@ func TestOutputResult(t *testing.T) {
 	t.Run("success result text", func(_ *testing.T) {
 		result := statusResult{
 			exitCode: exitCodeSuccess,
-			status: &ipc.StatusData{
+			status: &cliclient.Runtime{
 				Running:   true,
 				Interface: "en0",
 			},
@@ -281,7 +183,7 @@ func TestOutputResult(t *testing.T) {
 	t.Run("success result json", func(_ *testing.T) {
 		result := statusResult{
 			exitCode: exitCodeSuccess,
-			status: &ipc.StatusData{
+			status: &cliclient.Runtime{
 				Running:   true,
 				Interface: "en0",
 			},

--- a/cmd/niac/topology.go
+++ b/cmd/niac/topology.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/MustardSeedNetworks/niac-go/internal/ipc"
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
 	"github.com/MustardSeedNetworks/niac-go/internal/topology"
 )
 
@@ -23,7 +24,9 @@ const (
 type topologyOptions struct {
 	format     string
 	outputFile string
-	socketPath string
+	api        string
+	caCert     string
+	insecure   bool
 }
 
 // topologyCmd is the parent command for topology operations.
@@ -82,8 +85,8 @@ Exit codes:
   # Save to file
   niac topology export --format dot --output topology.dot
 
-  # Use custom socket path
-  niac topology export --socket /tmp/niac.sock --format json
+  # Read from a daemon on another address
+  niac topology export --api https://10.0.0.5:8445 --format json
 
   # Generate visualization with Graphviz
   niac topology export --format dot | dot -Tpng -o network.png
@@ -92,8 +95,8 @@ Exit codes:
   # Process with jq
   niac topology export --format json | jq '.nodes[] | .name'`,
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return runTopologyExport(options)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTopologyExport(cmd.Context(), options)
 		},
 	}
 
@@ -102,15 +105,19 @@ Exit codes:
 		"Output format: dot, json, yaml")
 	topologyExportCmd.Flags().StringVarP(&options.outputFile, "output", "o", "",
 		"Output file path (default: stdout)")
-	topologyExportCmd.Flags().StringVar(&options.socketPath, "socket", "",
-		"Path to IPC socket (default: /tmp/niac.sock)")
+	topologyExportCmd.Flags().StringVar(&options.api, "api", "",
+		"Daemon API address (default: "+cliclient.DefaultBaseURL+", or NIAC_API_URL)")
+	topologyExportCmd.Flags().StringVar(&options.caCert, "cacert", "",
+		"Daemon certificate to trust (default: the local daemon's own, when visible)")
+	topologyExportCmd.Flags().BoolVar(&options.insecure, "insecure", false,
+		"Skip TLS verification, for a daemon whose certificate this host cannot see")
 
 	topologyCmd.AddCommand(topologyExportCmd)
 	root.AddCommand(topologyCmd)
 }
 
 // runTopologyExport executes the topology export command.
-func runTopologyExport(options *topologyOptions) error {
+func runTopologyExport(ctx context.Context, options *topologyOptions) error {
 	// Validate format
 	format := strings.ToLower(options.format)
 	if format != topologyFormatDOT && format != topologyFormatJSON && format != topologyFormatYAML {
@@ -123,24 +130,15 @@ func runTopologyExport(options *topologyOptions) error {
 		)
 	}
 
-	// Determine socket path
-	socketPath := options.socketPath
-	if socketPath == "" {
-		socketPath = ipc.DefaultSocketPath()
-	}
-
-	// Check if socket exists
-	if _, statErr := os.Stat(socketPath); os.IsNotExist(statErr) {
-		fmt.Fprintf(os.Stderr, "Error: NIAC is not running (socket not found: %s)\n", socketPath)
-		os.Exit(1)
-	}
-
-	// Create IPC client and fetch topology
-	client := ipc.NewClient(socketPath)
-	topology, err := client.GetTopology()
+	client, err := newCLIClient(options.api, options.caCert, options.insecure)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to get topology: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(exitCodeError)
+	}
+	topology, err := client.Topology(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(exitCodeError)
 	}
 
 	// Generate output based on format

--- a/internal/cliclient/neighbors.go
+++ b/internal/cliclient/neighbors.go
@@ -1,0 +1,46 @@
+package cliclient
+
+import (
+	"context"
+	"time"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/topology"
+)
+
+// Neighbor is one discovery adjacency the daemon has recorded, as served by
+// /api/v1/neighbors. The shape matches what the stack records, so a caller sees
+// exactly what the simulation believes.
+type Neighbor struct {
+	Protocol          string    `json:"protocol"`
+	LocalDevice       string    `json:"local_device"`
+	RemoteDevice      string    `json:"remote_device"`
+	RemotePort        string    `json:"remote_port"`
+	RemoteChassisID   string    `json:"remote_chassis_id"`
+	Description       string    `json:"description"`
+	Capabilities      []string  `json:"capabilities"`
+	ManagementAddress string    `json:"management_address"`
+	LastSeen          time.Time `json:"last_seen"`
+	ExpireAt          time.Time `json:"expire_at"`
+}
+
+// Neighbors reads the discovery adjacencies of the selected session.
+func (c *Client) Neighbors(ctx context.Context) ([]Neighbor, error) {
+	var neighbors []Neighbor
+	if err := c.get(ctx, "/api/v1/neighbors", &neighbors); err != nil {
+		return nil, err
+	}
+
+	return neighbors, nil
+}
+
+// Topology reads the node and link graph of the selected session, in the same
+// shape the simulation records it, so callers keep the graph's own exporters
+// rather than describing it a second time here.
+func (c *Client) Topology(ctx context.Context) (*topology.Graph, error) {
+	var graph topology.Graph
+	if err := c.get(ctx, "/api/v1/topology", &graph); err != nil {
+		return nil, err
+	}
+
+	return &graph, nil
+}

--- a/internal/cliclient/runtime.go
+++ b/internal/cliclient/runtime.go
@@ -25,3 +25,26 @@ func (c *Client) Runtime(ctx context.Context) (*Runtime, error) {
 
 	return &runtime, nil
 }
+
+// Session is one running scenario as the daemon reports it.
+type Session struct {
+	SessionID    string `json:"sessionId"`
+	Selected     bool   `json:"selected"`
+	Running      bool   `json:"running"`
+	PhysicalVLAN int    `json:"physicalVlan"`
+	DeviceCount  int    `json:"deviceCount"`
+}
+
+type simulationState struct {
+	Sessions []Session `json:"sessions"`
+}
+
+// Sessions lists the scenarios the daemon is running.
+func (c *Client) Sessions(ctx context.Context) ([]Session, error) {
+	var state simulationState
+	if err := c.get(ctx, "/api/v1/simulation", &state); err != nil {
+		return nil, err
+	}
+
+	return state.Sessions, nil
+}

--- a/internal/cliclient/runtime.go
+++ b/internal/cliclient/runtime.go
@@ -12,6 +12,8 @@ type Runtime struct {
 	DeviceCount int     `json:"device_count"`
 	Uptime      float64 `json:"uptime_seconds"`
 	Version     string  `json:"version"`
+	PacketsRX   uint64  `json:"packets_received"`
+	PacketsTX   uint64  `json:"packets_sent"`
 }
 
 // Runtime reads the selected simulation's state.

--- a/internal/cliclient/stream.go
+++ b/internal/cliclient/stream.go
@@ -1,0 +1,131 @@
+package cliclient
+
+import (
+	"bufio"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// sseDataPrefix is the field the daemon's event stream carries its payload in;
+// the id and event fields around it are framing this client does not need.
+const sseDataPrefix = "data: "
+
+// stream follows a server-sent event stream, handing each payload to onEvent
+// until the context ends or onEvent asks to stop by returning false.
+//
+// The daemon frames events as "id: N\ndata: {json}\n\n", plus one
+// "event: connected" on open, which carries no record and is skipped.
+func (c *Client) stream(
+	ctx context.Context,
+	path string,
+	onEvent func(payload []byte) bool,
+) error {
+	body, err := c.open(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, streamBufferInitial), streamBufferMax)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, sseDataPrefix) {
+			continue
+		}
+		payload := strings.TrimPrefix(line, sseDataPrefix)
+		if isConnectHandshake(payload) {
+			continue
+		}
+		if !onEvent([]byte(payload)) {
+			return nil
+		}
+	}
+	if err = scanner.Err(); err != nil && ctx.Err() == nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	return nil
+}
+
+const (
+	streamBufferInitial = 64 * 1024
+	// A packet event carries a hex dump, so the ceiling is generous.
+	streamBufferMax = 4 * 1024 * 1024
+)
+
+// isConnectHandshake reports the opening frame, which announces the stream
+// rather than carrying a record.
+func isConnectHandshake(payload string) bool {
+	var frame struct {
+		Stream string `json:"stream"`
+	}
+	if json.Unmarshal([]byte(payload), &frame) != nil {
+		return false
+	}
+
+	return frame.Stream != "" && !strings.Contains(payload, "\"message\"") &&
+		!strings.Contains(payload, "\"data\"")
+}
+
+// LogEvent is one log record from the daemon's stream.
+type LogEvent struct {
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+	Device    string `json:"device"`
+	Source    string `json:"source"`
+	Protocol  string `json:"protocol"`
+}
+
+// StreamLogs follows the daemon's log stream. onLog returning false ends it.
+func (c *Client) StreamLogs(ctx context.Context, onLog func(LogEvent) bool) error {
+	return c.stream(ctx, "/api/v1/stream/logs", func(payload []byte) bool {
+		var event LogEvent
+		if json.Unmarshal(payload, &event) != nil {
+			return true
+		}
+
+		return onLog(event)
+	})
+}
+
+// PacketEvent is one frame from the daemon's packet stream. The daemon sends
+// the bytes hex-encoded, and truncates a frame past its wire limit rather than
+// dropping it, which the reader has to be able to say out loud.
+type PacketEvent struct {
+	Timestamp string `json:"timestamp"`
+	Direction string `json:"direction"`
+	Size      int    `json:"size"`
+	RawData   string `json:"raw_data"`
+	Truncated bool   `json:"truncated"`
+	Serial    uint64 `json:"serial"`
+	Protocol  string `json:"protocol"`
+	Device    string `json:"device"`
+}
+
+// Bytes decodes the frame the daemon captured.
+func (p PacketEvent) Bytes() ([]byte, error) {
+	raw, err := hex.DecodeString(p.RawData)
+	if err != nil {
+		return nil, fmt.Errorf("decode packet %d: %w", p.Serial, err)
+	}
+
+	return raw, nil
+}
+
+// StreamPackets follows the daemon's packet stream. onPacket returning false
+// ends it.
+func (c *Client) StreamPackets(ctx context.Context, onPacket func(PacketEvent) bool) error {
+	return c.stream(ctx, "/api/v1/stream/packets", func(payload []byte) bool {
+		var event PacketEvent
+		if json.Unmarshal(payload, &event) != nil {
+			return true
+		}
+
+		return onPacket(event)
+	})
+}

--- a/internal/cliclient/stream_test.go
+++ b/internal/cliclient/stream_test.go
@@ -1,0 +1,74 @@
+package cliclient_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/cliclient"
+)
+
+// The daemon frames its stream as "id: N\ndata: {json}\n\n" and opens with a
+// connect event that announces the stream rather than carrying a record. A
+// reader that took that first frame for a record would print an empty line
+// before every session.
+func TestStreamSkipsTheConnectFrameAndReadsRecords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprint(w, "event: connected\ndata: {\"stream\":\"logs\"}\n\n")
+		fmt.Fprint(w, "id: 1\ndata: {\"message\":\"link up\",\"device\":\"MED-ACC-SW01\"}\n\n")
+		fmt.Fprint(w, "id: 2\ndata: {\"message\":\"link down\",\"device\":\"MED-ACC-SW02\"}\n\n")
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	client, err := cliclient.New(cliclient.Config{BaseURL: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seen []string
+	err = client.StreamLogs(context.Background(), func(event cliclient.LogEvent) bool {
+		seen = append(seen, event.Device+": "+event.Message)
+
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("records = %v, want the two log events and not the connect frame", seen)
+	}
+	if seen[0] != "MED-ACC-SW01: link up" {
+		t.Errorf("first record = %q", seen[0])
+	}
+}
+
+// A caller that has seen enough stops the stream rather than reading to the end
+// of a stream that never ends.
+func TestStreamStopsWhenTheCallerIsDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for i := range 100 {
+			fmt.Fprintf(w, "id: %d\ndata: {\"message\":\"event\"}\n\n", i)
+		}
+	}))
+	defer server.Close()
+
+	client, err := cliclient.New(cliclient.Config{BaseURL: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	err = client.StreamLogs(context.Background(), func(_ cliclient.LogEvent) bool {
+		count++
+
+		return count < 3
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Errorf("read %d records after asking to stop at 3", count)
+	}
+}


### PR DESCRIPTION
## Summary

`niac neighbors`, `topology`, `logs`, `dump` and `status` were all speaking to the unix socket whose server was removed in #1012, so every one of them failed no matter what the daemon was doing. `status` was the worst: it reported **NOT RUNNING while six simulations were up** — the answer most likely to send someone restarting a healthy daemon.

They read the daemon's API now, alongside `monitor` from #1240. That completes the sweep: no command in `cmd/niac` still addresses the dead socket.

Two of them had been asking for something the daemon does not keep. It broadcasts logs and packets as they happen and retains no backlog, so there is no "last N" to fetch: `logs tail` and `dump` collect from the live stream within a bounded window and say plainly when nothing arrived.

## Linked Issue

Related to #1151. Program ledger code-debt item: the stranded IPC CLI surface.

## Type

- [x] Bug fix

## Risk

Moderate and intended, the same shape as #1240: `--socket` is replaced by `--api` (also `NIAC_API_URL`), with `--cacert` and `--insecure` alongside. `status` reports the daemon's version in place of the socket-era `errors_active` and `started_at`, which the API's runtime view does not carry. Tests that covered the socket transport went with it.

## Testing Evidence

All five, on the live daemon, `v0.94.30-18-g5f5b1d3`:

```
$ niac status                       # was: "Status: NOT RUNNING"
Status: RUNNING
Interface: eth0
Config: _running.campus.inline.yaml
Devices: 147
Uptime: 12s
Version: v0.94.30-16-gc928bf7

$ niac topology export --format dot | head -3
graph niac_topology {
  // Nodes
  "ADM-SRV-SW02" [shape=box, label="ADM-SRV-SW02\n(switch)"];

$ niac topology export --format json | jq '.nodes|length, .links|length'
147 186                              # exactly the campus pack

$ niac neighbors
No neighbors discovered              # reached the daemon; the pack has no LLDP peers yet

$ niac dump --count 3
Note: 6 scenarios are running, and their packets are scoped to each session.
The unscoped stream this command reads only carries frames when one scenario is up.
No packets captured
```

That last note is the point: the daemon broadcasts on its unscoped packet stream only when one scenario owns the capture, so with six running the stream is silent however busy the lab is. "No packets captured" alone reads as a quiet network, which is the wrong and expensive conclusion. Per-session packet and log streams are not exposed by the API today — the session resources stop at stats, runtime, topology, neighbors and devices — so this reports the limit rather than papering over it.

```
$ go test ./internal/... ./cmd/... ./tools/...
(no failures)

$ golangci-lint run cmd/niac/... internal/cliclient/...
0 issues.

$ grep -rn "ipc.NewClient\|ipc.DefaultSocketPath" cmd/niac/*.go | grep -v _test
(no matches)
```

## Security and Release Checklist

- [x] No secrets, credentials or customer data added; the token is read from the environment, never a flag
- [x] TLS verified by default, as in #1240; `--insecure` must be asked for
- [x] No new mutating routes; every call these commands make is a GET
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit