### PR TITLE
fix(deps): move the nanoid pin to 3.3.18 to clear GHSA-2v37-7h3g-55p8 again

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7331,9 +7331,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     "@codemirror/lang-yaml": "6.1.3",
     "@codemirror/language": "6.12.4",
     "@codemirror/state": "6.7.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "@codemirror/view": "6.43.7",
     "@fontsource-variable/inter": "5.3.0",
     "@fontsource-variable/jetbrains-mono": "5.3.0",
@@ -93,7 +93,7 @@
   "packageManager": "npm@12.0.1",
   "overrides": {
     "@codemirror/state": "6.7.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "esbuild": "0.28.1"
   }
 }


### PR DESCRIPTION
## Summary

The same advisory has been re-issued with a higher fixed version — nanoid below **3.3.18** now, where the August pin of 3.3.17 cleared it before. It reaches us through postcss, which asks for `^3.3.16`, so the resolution still needs the override to move.

`npm audit` is a hard CI gate, so this is failing every open pull request rather than anything in those changes.

## Linked Issue

Related to #1216, which pinned the previous fixed version of the same advisory.

## Type

- [x] Bug fix

## Risk

Low, and the same shape as #1216: a patch bump within nanoid 3.x, applied through the existing override so postcss's `^3.3.16` range resolves to it.

## Testing Evidence

```
$ npm audit
found 0 vulnerabilities

$ npm ls nanoid
niac-ui@0.94.30
+-- nanoid@3.3.18 overridden
`-- postcss@8.5.25

$ npx vitest run
Test Files  78 passed (78)
     Tests  377 passed (377)

$ npx tsgo --build --noEmit
(clean)
```

The lockfile entry was edited to the published 3.3.18 tarball and integrity hash (`npm view nanoid@3.3.18 dist.integrity`) rather than regenerated, because this environment blocks fetching one dependency's remote tarball type and a full `npm install` cannot complete here. CI's `npm ci` installs from that lockfile, so it is the real check that the resolution is consistent.

## Security and Release Checklist

- [x] Clears a high-severity advisory rather than suppressing it — no audit exceptions added
- [x] No secrets, credentials or customer data added
- [x] No new mutating routes, so no CSRF or role-gate surface changed
- [x] Dependency change is the point: nanoid 3.3.17 → 3.3.18, integrity hash taken from the registry
- [x] Pre-commit gates pass