### PR TITLE
fix(library): report bundle-installed content as bundle content

### DIFF
--- a/internal/content/extract.go
+++ b/internal/content/extract.go
@@ -79,6 +79,10 @@ type Manifest struct {
 	// PerKind reports the count of entries dropped under each library
 	// kind directory. Useful for the install summary line.
 	PerKind map[library.Kind]int
+	// Paths lists what was written, relative to the library root. A bundle's
+	// files are indistinguishable from the operator's own once they are on
+	// disk, so this is what lets them keep being reported as bundle content.
+	Paths []string
 }
 
 // Extract reads a gzip-tar bundle from r and writes its contents into
@@ -125,6 +129,12 @@ func Extract(r io.Reader, libRoot string, opts ExtractOptions) (Manifest, error)
 
 		if procErr := processEntry(tr, hdr, root, opts, overwrite, &manifest, &totalBytes); procErr != nil {
 			return manifest, procErr
+		}
+	}
+
+	if !opts.DryRun {
+		if recErr := library.RecordBundleInstall(abs, manifest.Paths); recErr != nil {
+			return manifest, fmt.Errorf("record bundle contents: %w", recErr)
 		}
 	}
 
@@ -188,6 +198,7 @@ func processEntry(
 		manifest.Files++
 		manifest.Bytes += hdr.Size
 		manifest.PerKind[kind]++
+		manifest.Paths = append(manifest.Paths, rel)
 		return nil
 
 	default:

--- a/internal/content/extract_test.go
+++ b/internal/content/extract_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/content"
+	"github.com/MustardSeedNetworks/niac-go/internal/library"
 )
 
 // maxEntrySize mirrors the package-internal cap. Duplicated rather
@@ -269,4 +270,78 @@ func TestBuildTarballYieldsValidGzip(t *testing.T) {
 	if _, readErr := io.ReadAll(gz); readErr != nil {
 		t.Fatalf("read all: %v", readErr)
 	}
+}
+
+// A bundle's files are indistinguishable from the operator's own once they are
+// on disk, so the extractor records what it wrote. Without it the library
+// reports installed content as "user" and the UI's Bundle badge never appears.
+func TestExtractRecordsWhatTheBundleInstalled(t *testing.T) {
+	dir := t.TempDir()
+	bundle := buildBundle(t, map[string]string{
+		"networks/campus.yaml": "devices: []\n",
+		"walks/switch-01.walk": ".1.3.6.1.2.1.1.5.0 = STRING: SW01\n",
+	})
+
+	manifest, err := content.Extract(bytes.NewReader(bundle), dir, content.ExtractOptions{})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(manifest.Paths) != 2 {
+		t.Fatalf("recorded paths = %v, want both entries", manifest.Paths)
+	}
+
+	lib, err := library.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := lib.ListNetworks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name == "campus" && entry.Source != library.SourceBundle {
+			t.Errorf("campus source = %q, want %q", entry.Source, library.SourceBundle)
+		}
+	}
+}
+
+// A dry run writes nothing, so it must not claim anything either.
+func TestADryRunRecordsNothing(t *testing.T) {
+	dir := t.TempDir()
+	bundle := buildBundle(t, map[string]string{"networks/campus.yaml": "devices: []\n"})
+
+	if _, err := content.Extract(
+		bytes.NewReader(bundle), dir, content.ExtractOptions{DryRun: true},
+	); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, library.BundleIndexName)); !os.IsNotExist(err) {
+		t.Error("a dry run left an install record behind")
+	}
+}
+
+// buildBundle writes a gzip-tar the extractor accepts.
+func buildBundle(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, body := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name, Mode: 0o600, Size: int64(len(body)), Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.Bytes()
 }

--- a/internal/library/bundle_index.go
+++ b/internal/library/bundle_index.go
@@ -1,0 +1,84 @@
+package library
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// BundleIndexName is the file recording which library entries arrived in a
+// content bundle.
+//
+// Nothing else can tell: a bundle's files land in the same directories as the
+// operator's own and look identical afterwards, so without this every installed
+// file was reported as "user" and the Bundle badge the UI already draws could
+// never appear.
+//
+// It is a plain list of library-relative paths, one per line, appended as
+// bundles install. A missing or unreadable index means nothing is known to have
+// come from a bundle, which is the pre-existing behaviour.
+const BundleIndexName = ".bundle-installed"
+
+// bundleIndex is the set of paths a bundle installed, read once per library
+// handle. Listing a directory asks for every entry's source in turn, and each
+// answer should not cost a file read.
+type bundleIndex struct {
+	once  sync.Once
+	paths map[string]bool
+}
+
+func (b *bundleIndex) contains(root, relative string) bool {
+	b.once.Do(func() { b.paths = readBundleIndex(root) })
+
+	return b.paths[filepath.ToSlash(relative)]
+}
+
+func readBundleIndex(root string) map[string]bool {
+	paths := map[string]bool{}
+	file, err := os.Open(filepath.Join(root, BundleIndexName))
+	if err != nil {
+		return paths
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if line := strings.TrimSpace(scanner.Text()); line != "" {
+			paths[filepath.ToSlash(line)] = true
+		}
+	}
+
+	return paths
+}
+
+// RecordBundleInstall adds the paths a bundle wrote to the library's index, so
+// they are reported as bundle content rather than as the operator's own.
+//
+// Paths are library-relative, as the extractor resolves them. Appending keeps
+// earlier installs, and duplicates are harmless because the index is read as a
+// set.
+func RecordBundleInstall(root string, relativePaths []string) error {
+	if len(relativePaths) == 0 {
+		return nil
+	}
+	file, err := os.OpenFile(
+		filepath.Join(root, BundleIndexName),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+		0o600,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	writer := bufio.NewWriter(file)
+	for _, path := range relativePaths {
+		if _, err = writer.WriteString(filepath.ToSlash(path) + "\n"); err != nil {
+			return err
+		}
+	}
+
+	return writer.Flush()
+}

--- a/internal/library/bundle_index_internal_test.go
+++ b/internal/library/bundle_index_internal_test.go
@@ -1,0 +1,86 @@
+package library
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A bundle's files land in the same directories as the operator's own and look
+// identical afterwards, so without a record every installed file was reported
+// as "user" - and the Bundle badge the UI already draws could never appear.
+func TestBundleInstalledContentReportsItsSource(t *testing.T) {
+	lib := newLibraryWithFile(t, KindNetworks, "campus.yaml")
+	if err := RecordBundleInstall(lib.root, []string{"networks/campus.yaml"}); err != nil {
+		t.Fatalf("RecordBundleInstall: %v", err)
+	}
+
+	if got := lib.detectSource("campus.yaml"); got != SourceBundle {
+		t.Errorf("source = %q, want %q", got, SourceBundle)
+	}
+}
+
+// Anything the operator wrote is still theirs.
+func TestUnrecordedContentIsStillTheOperatorsOwn(t *testing.T) {
+	lib := newLibraryWithFile(t, KindNetworks, "mine.yaml")
+
+	if got := lib.detectSource("mine.yaml"); got != SourceUser {
+		t.Errorf("source = %q, want %q", got, SourceUser)
+	}
+}
+
+// Walks and pcaps arrive in bundles too, and are asked about by kind.
+func TestBundleInstalledWalksReportTheirSource(t *testing.T) {
+	lib := newLibraryWithFile(t, KindWalks, "switch-01.walk")
+	if err := RecordBundleInstall(lib.root, []string{"walks/switch-01.walk"}); err != nil {
+		t.Fatalf("RecordBundleInstall: %v", err)
+	}
+
+	if got := lib.detectFileSource(KindWalks, "switch-01.walk"); got != SourceBundle {
+		t.Errorf("source = %q, want %q", got, SourceBundle)
+	}
+}
+
+// The starter pack ships inside the binary and outranks the index: a bundle
+// cannot claim a file that reappears on every bootstrap.
+func TestStarterContentOutranksTheIndex(t *testing.T) {
+	lib := newLibraryWithFile(t, KindNetworks, "enterprise.yaml")
+	if err := RecordBundleInstall(lib.root, []string{"networks/enterprise.yaml"}); err != nil {
+		t.Fatalf("RecordBundleInstall: %v", err)
+	}
+	starterName := firstStarterNetwork(t)
+
+	if got := lib.detectSource(starterName); got != SourceStarter {
+		t.Errorf("starter %s reported as %q", starterName, got)
+	}
+}
+
+func newLibraryWithFile(t *testing.T, kind Kind, name string) *Library {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, string(kind))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("devices: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return &Library{root: root}
+}
+
+func firstStarterNetwork(t *testing.T) string {
+	t.Helper()
+	entries, err := starterPack.ReadDir("starter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			return entry.Name()
+		}
+	}
+	t.Fatal("the starter pack ships no network")
+
+	return ""
+}

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -72,6 +72,9 @@ type Library struct {
 	root      string
 	draftRoot *os.Root
 	draftMu   sync.RWMutex
+	// bundles records which entries a content bundle installed, so they are
+	// reported as bundle content instead of as the operator's own.
+	bundles bundleIndex
 }
 
 // DefaultRoot resolves the standard library root following:

--- a/internal/library/list.go
+++ b/internal/library/list.go
@@ -375,17 +375,18 @@ func (l *Library) fileEntry(kind Kind, relPath string, info fs.FileInfo) FileEnt
 	}
 }
 
-// detectFileSource mirrors detectSource for the walks/pcaps kinds:
-// consulting the embedded starterWalks pack is the source of truth for
-// SourceStarter. Only KindWalks has a starter pack today; pcaps have
-// no embedded set, so they're always SourceUser.
+// detectFileSource mirrors detectSource for the walks/pcaps kinds. Only
+// KindWalks has a starter pack today; both kinds can arrive in a bundle.
 func (l *Library) detectFileSource(kind Kind, relPath string) Source {
-	if kind != KindWalks {
-		return SourceUser
+	if kind == KindWalks {
+		if _, err := starterWalks.Open(filepath.Join("starter", "walks", relPath)); err == nil {
+			return SourceStarter
+		}
 	}
-	if _, err := starterWalks.Open(filepath.Join("starter", "walks", relPath)); err == nil {
-		return SourceStarter
+	if l.bundles.contains(l.root, filepath.Join(string(kind), relPath)) {
+		return SourceBundle
 	}
+
 	return SourceUser
 }
 
@@ -417,15 +418,19 @@ func (l *Library) FileEntryByName(kind Kind, relPath string) (FileEntry, error) 
 	return l.fileEntry(kind, leaf, info), nil
 }
 
-// detectSource decides whether a given filename came from the starter
-// pack or from user/bundle install. Starter-pack files are embedded
-// in the binary, so consulting starterPack is the source of truth.
+// detectSource decides whether a given filename came from the starter pack, a
+// content bundle, or the operator. Starter-pack files are embedded in the
+// binary, so consulting starterPack is the source of truth for those; a bundle
+// records what it installed, because afterwards its files are indistinguishable
+// from anything else on disk.
 func (l *Library) detectSource(filename string) Source {
 	if _, err := starterPack.Open(filepath.Join("starter", filename)); err == nil {
 		return SourceStarter
 	}
-	// Bundle vs user split is deferred to PR 2 (the bundle installer
-	// writes a marker file). For now, anything non-starter is "user".
+	if l.bundles.contains(l.root, filepath.Join(string(KindNetworks), filename)) {
+		return SourceBundle
+	}
+
 	return SourceUser
 }
 


### PR DESCRIPTION
## Summary

Installing a content bundle is a shipped feature — `niac content install --bundle` and `POST /api/v1/library/install` — and everything it wrote was then listed as the operator's own work. The UI has drawn a **Bundle** badge since the library page was built, styled and translated, and it could never appear: nothing ever assigned that source.

The reason is that a bundle's files are indistinguishable from anything else once they are on disk: same directories, same names. The extractor now records what it wrote, and the library consults that record.

## Linked Issue

Related to #1151. Program ledger code-debt item: "library bundle/user split".

## Type

- [x] Bug fix

## Risk

Low. Nothing destructive keys off this distinction — `DeleteNetwork` refuses only starter content, and walks and pcaps have no delete endpoint — so this changes a label, not a permission. Content installed before this change stays labelled "user" because there is no record of it; a reinstall labels it correctly.

## Testing Evidence

Four library tests and two extractor tests, the bundle ones failing before the change:

```
$ go test ./internal/library/ -run "Bundle|Starter"
--- FAIL: TestBundleInstalledContentReportsItsSource
    source = "user", want "bundle"
--- FAIL: TestBundleInstalledWalksReportTheirSource
    source = "user", want "bundle"

# after
ok  github.com/MustardSeedNetworks/niac-go/internal/library   1.158s
ok  github.com/MustardSeedNetworks/niac-go/internal/content   0.372s
```

The extractor test installs a two-file bundle and then asks the library what it thinks, which is the path the UI takes. The starter test proves precedence: a bundle claiming a starter file does not win, because that file reappears on every bootstrap regardless.

```
$ go test ./internal/...
(no failures)

$ golangci-lint run internal/library/... internal/content/...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, credentials or customer data added
- [x] No new mutating routes; the record is written by the existing install path, inside the library root it already writes to
- [x] No dependency changes
- [x] `golangci-lint`, `gosec` and the full Go suite pass in pre-commit