### PR TITLE
feat(snmp): answer SNMP queries over IPv6

### DIFF
--- a/internal/protocols/snmp.go
+++ b/internal/protocols/snmp.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"slices"
 
+	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/gosnmp/gosnmp"
 
@@ -35,7 +36,49 @@ func NewSNMPHandler(stack *Stack) *SNMPHandler {
 }
 
 // HandlePacket processes an SNMP request delivered over IPv4/UDP.
-func (h *SNMPHandler) HandlePacket(pkt *Packet, ip *layers.IPv4, udp *layers.UDP, devices []*config.Device) {
+func (h *SNMPHandler) HandlePacket(
+	pkt *Packet,
+	ip *layers.IPv4,
+	udp *layers.UDP,
+	devices []*config.Device,
+) {
+	h.handleDatagram(pkt, snmpPeer{src: ip.SrcIP, dst: ip.DstIP}, udp, devices)
+}
+
+// HandlePacketV6 serves the same request arriving over IPv6.
+//
+// Everything below this point is version-agnostic - the MIB, the PDU codec and
+// the USM engine never see an IP layer - so the two entry points differ only in
+// how the peer addresses are read and how the reply is framed.
+func (h *SNMPHandler) HandlePacketV6(
+	pkt *Packet,
+	ip *layers.IPv6,
+	udp *layers.UDP,
+	devices []*config.Device,
+) {
+	h.handleDatagram(pkt, snmpPeer{src: ip.SrcIP, dst: ip.DstIP, v6: true}, udp, devices)
+}
+
+const (
+	snmpIPv6Version  = 6
+	snmpIPv6HopLimit = 64
+)
+
+// snmpPeer is the pair of addresses a request arrived between, and which IP
+// version carried it. Keeping the handler on this rather than on a layer type
+// is what stops the v4 and v6 paths becoming two implementations that drift.
+type snmpPeer struct {
+	src net.IP
+	dst net.IP
+	v6  bool
+}
+
+func (h *SNMPHandler) handleDatagram(
+	pkt *Packet,
+	peer snmpPeer,
+	udp *layers.UDP,
+	devices []*config.Device,
+) {
 	if h == nil || h.stack == nil || h.stack.udpHandler == nil {
 		return
 	}
@@ -47,7 +90,7 @@ func (h *SNMPHandler) HandlePacket(pkt *Packet, ip *layers.IPv4, udp *layers.UDP
 	// SNMPv3 is handled from the raw datagram (USM engine discovery + auth +
 	// privacy); v1/v2c continue through the community-keyed agent path below.
 	if ver, ok := snmpPeekVersion(udp.Payload); ok && ver == gosnmp.Version3 {
-		h.handleV3(pkt, ip, udp, devices)
+		h.handleV3(pkt, peer, udp, devices)
 		return
 	}
 	if ver, ok := snmpPeekVersion(udp.Payload); ok && ver != gosnmp.Version1 && ver != gosnmp.Version2c {
@@ -59,26 +102,26 @@ func (h *SNMPHandler) HandlePacket(pkt *Packet, ip *layers.IPv4, udp *layers.UDP
 	if err != nil {
 		h.recordForDevices(devices, func(agent *snmp.Agent) { agent.RecordASNParseError() })
 		if h.stack.GetProtocolDebugLevel(logging.ProtocolSNMP) >= DebugLevelInfo {
-			_, _ = fmt.Fprintf(os.Stdout, "SNMP: decode failed for %s sn=%d err=%v\n", ip.DstIP, pkt.SerialNumber, err)
+			_, _ = fmt.Fprintf(os.Stdout, "SNMP: decode failed for %s sn=%d err=%v\n", peer.dst, pkt.SerialNumber, err)
 		}
 
 		return
 	}
 
 	for _, device := range devices {
-		h.processDeviceRequest(pkt, ip, udp, device, request)
+		h.processDeviceRequest(pkt, peer, udp, device, request)
 	}
 }
 
 // processDeviceRequest handles SNMP request for a single device.
 func (h *SNMPHandler) processDeviceRequest(
 	pkt *Packet,
-	ip *layers.IPv4,
+	peer snmpPeer,
 	udp *layers.UDP,
 	device *config.Device,
 	request *gosnmp.SnmpPacket,
 ) {
-	agent := h.findAgent(device, ip.SrcIP, request.Community)
+	agent := h.findAgent(device, peer.src, request.Community)
 	if agent == nil {
 		return
 	}
@@ -100,7 +143,7 @@ func (h *SNMPHandler) processDeviceRequest(
 	h.stack.stats.SNMPQueries++
 	h.stack.stats.mu.Unlock()
 
-	if h.sendResponse(pkt, ip, udp, device, payload) {
+	if h.sendResponse(pkt, peer, udp, device, payload) {
 		agent.RecordResponse(status)
 	}
 }
@@ -160,22 +203,28 @@ func (h *SNMPHandler) buildResponse(
 // sendResponse sends the SNMP response packet.
 func (h *SNMPHandler) sendResponse(
 	pkt *Packet,
-	ip *layers.IPv4,
+	peer snmpPeer,
 	udp *layers.UDP,
 	device *config.Device,
 	payload []byte,
 ) bool {
-	srcIP := ip.DstIP.To4()
-	dstIP := ip.SrcIP.To4()
-
-	if srcIP == nil || dstIP == nil {
-		return false
-	}
-
 	srcMAC := h.sourceMAC(device, pkt)
 	dstMAC := pkt.GetSourceMAC()
 
 	if len(dstMAC) == 0 || len(srcMAC) == 0 {
+		return false
+	}
+	// The reply leaves from the address the manager asked, not from whichever
+	// address the device happens to prefer: a manager only accepts an answer
+	// from the address it queried, which is what makes this load-bearing for a
+	// link-local one.
+	if peer.v6 {
+		return h.sendResponseV6(pkt, peer, udp, device.Name, srcMAC, dstMAC, payload)
+	}
+
+	srcIP := peer.dst.To4()
+	dstIP := peer.src.To4()
+	if srcIP == nil || dstIP == nil {
 		return false
 	}
 
@@ -192,6 +241,48 @@ func (h *SNMPHandler) sendResponse(
 			device.Name, pkt.SerialNumber, err)
 	}
 	return err == nil
+}
+
+// sendResponseV6 frames the reply as Ethernet/IPv6/UDP. IPv6 makes the UDP
+// checksum mandatory, unlike IPv4 where it may be zero, so the checksum is
+// computed rather than left off.
+func (h *SNMPHandler) sendResponseV6(
+	pkt *Packet,
+	peer snmpPeer,
+	udp *layers.UDP,
+	deviceName string,
+	srcMAC, dstMAC net.HardwareAddr,
+	payload []byte,
+) bool {
+	reply := &layers.UDP{SrcPort: udp.DstPort, DstPort: udp.SrcPort}
+	ip := &layers.IPv6{
+		Version:    snmpIPv6Version,
+		NextHeader: layers.IPProtocolUDP,
+		HopLimit:   snmpIPv6HopLimit,
+		SrcIP:      peer.dst,
+		DstIP:      peer.src,
+	}
+	eth := &layers.Ethernet{
+		SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv6,
+	}
+	_ = reply.SetNetworkLayerForChecksum(ip)
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	if err := gopacket.SerializeLayers(
+		buf, opts, eth, ip, reply, gopacket.Payload(payload),
+	); err != nil {
+		if h.stack.GetProtocolDebugLevel(logging.ProtocolSNMP) >= 1 {
+			_, _ = fmt.Fprintf(os.Stdout,
+				"SNMP: failed to serialize IPv6 response for device %s sn=%d err=%v\n",
+				deviceName, pkt.SerialNumber, err)
+		}
+
+		return false
+	}
+
+	// Reply on the VLAN the query arrived on (0 = untagged).
+	return h.stack.SendRawPacketVLAN(buf.Bytes(), pkt.VLAN) == nil
 }
 
 func (h *SNMPHandler) recordForDevices(devices []*config.Device, record func(*snmp.Agent)) {
@@ -231,14 +322,14 @@ func (h *SNMPHandler) decodeRequest(payload []byte) (*gosnmp.SnmpPacket, error) 
 
 // handleV3 routes an SNMPv3 datagram to each matching device's USM engine,
 // emitting the engine's discovery Report or authenticated response.
-func (h *SNMPHandler) handleV3(pkt *Packet, ip *layers.IPv4, udp *layers.UDP, devices []*config.Device) {
+func (h *SNMPHandler) handleV3(pkt *Packet, peer snmpPeer, udp *layers.UDP, devices []*config.Device) {
 	for _, device := range devices {
 		group := h.stack.getSNMPAgents(device)
 		if group == nil || group.v3 == nil || group.v3Agent == nil {
 			continue
 		}
 
-		if !snmpAccessAllowed(device, ip.SrcIP) {
+		if !snmpAccessAllowed(device, peer.src) {
 			continue
 		}
 
@@ -256,7 +347,7 @@ func (h *SNMPHandler) handleV3(pkt *Packet, ip *layers.IPv4, udp *layers.UDP, de
 		h.stack.stats.SNMPQueries++
 		h.stack.stats.mu.Unlock()
 
-		if h.sendResponse(pkt, ip, udp, device, resp) {
+		if h.sendResponse(pkt, peer, udp, device, resp) {
 			group.v3Agent.RecordResponse(gosnmp.NoError)
 		}
 	}

--- a/internal/protocols/snmp_v6_test.go
+++ b/internal/protocols/snmp_v6_test.go
@@ -1,0 +1,125 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+// A simulator whose job is answering scanners answered none of them over IPv6:
+// the dispatch logged "not yet implemented" to stdout and dropped the datagram,
+// while the same query over IPv4 was served. The engine underneath never cared
+// which IP version carried it.
+func TestSNMPAnswersOverIPv6(t *testing.T) {
+	stack, device := ipv6SNMPStack(t)
+	deviceIP := net.ParseIP("2001:db8::10")
+
+	reply := querySNMPv6(t, stack, device, net.ParseIP("2001:db8::1"), deviceIP)
+	if reply == nil {
+		t.Fatal("no reply was queued for an IPv6 SNMP query")
+	}
+	if !reply.NetworkLayer().(*layers.IPv6).SrcIP.Equal(deviceIP) {
+		t.Errorf("reply source = %s, want the address that was queried (%s)",
+			reply.NetworkLayer().(*layers.IPv6).SrcIP, deviceIP)
+	}
+}
+
+// A manager only accepts a reply from the address it queried, which is what
+// makes this matter for a link-local address rather than a stylistic choice.
+func TestSNMPAnswersFromTheLinkLocalAddressItWasAsked(t *testing.T) {
+	stack, device := ipv6SNMPStack(t)
+	linkLocal := net.ParseIP("fe80::20")
+
+	reply := querySNMPv6(t, stack, device, net.ParseIP("fe80::1"), linkLocal)
+	if reply == nil {
+		t.Fatal("no reply was queued for a link-local SNMP query")
+	}
+	if got := reply.NetworkLayer().(*layers.IPv6).SrcIP; !got.Equal(linkLocal) {
+		t.Errorf("reply source = %s, want %s", got, linkLocal)
+	}
+}
+
+// The query counter is a protocol counter, not a per-version one.
+func TestIPv6QueriesAreCounted(t *testing.T) {
+	stack, device := ipv6SNMPStack(t)
+
+	querySNMPv6(t, stack, device, net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::10"))
+
+	if got := stack.GetStats().SNMPQueries; got != 1 {
+		t.Errorf("SNMPQueries = %d, want 1", got)
+	}
+}
+
+// ipv6SNMPStack builds a stack with one SNMP device carrying both a global and
+// a link-local address.
+func ipv6SNMPStack(t *testing.T) (*Stack, *config.Device) {
+	t.Helper()
+	mac, err := net.ParseMAC("00:00:0c:33:06:02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Devices: []config.Device{{
+		Name: "MED-ACC-SW02", Type: "switch", MACAddress: mac,
+		IPAddresses: []net.IP{net.ParseIP("2001:db8::10"), net.ParseIP("fe80::20")},
+		SNMPConfig: config.SNMPConfig{
+			Community: "NetAllyDemo", SysName: "MED-ACC-SW02",
+		},
+	}}}
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+	stack.snmpHandler = NewSNMPHandler(stack)
+
+	return stack, &cfg.Devices[0]
+}
+
+// querySNMPv6 hands the handler a v2c GET over IPv6 and returns the reply the
+// stack queued, if any.
+func querySNMPv6(t *testing.T, stack *Stack, device *config.Device, from, to net.IP) gopacket.Packet {
+	t.Helper()
+	request := &gosnmp.SnmpPacket{
+		Version: gosnmp.Version2c, Community: "NetAllyDemo",
+		PDUType: gosnmp.GetRequest, RequestID: 1,
+		Variables: []gosnmp.SnmpPDU{{
+			Name: "1.3.6.1.2.1.1.5.0", Type: gosnmp.Null,
+		}},
+	}
+	payload, err := request.MarshalMsg()
+	if err != nil {
+		t.Fatal(err)
+	}
+	udp := &layers.UDP{SrcPort: 40000, DstPort: 161}
+	udp.Payload = payload
+	ipv6 := &layers.IPv6{
+		Version: snmpIPv6Version, NextHeader: layers.IPProtocolUDP,
+		HopLimit: snmpIPv6HopLimit, SrcIP: from, DstIP: to,
+	}
+	// The handler reads the requester's MAC off the frame, so the packet needs
+	// a real Ethernet header rather than a bare struct.
+	pkt := &Packet{SerialNumber: 1, Buffer: ethernetHeader(
+		net.HardwareAddr{0x02, 0, 0, 0, 0, 1}, net.HardwareAddr{0xaa, 0, 0, 0, 0, 1},
+	)}
+
+	stack.snmpHandler.HandlePacketV6(pkt, ipv6, udp, []*config.Device{device})
+
+	select {
+	case queued := <-stack.sendQueue:
+		return gopacket.NewPacket(queued.Buffer, layers.LayerTypeEthernet, gopacket.Default)
+	default:
+		return nil
+	}
+}
+
+// ethernetHeader builds the 14-byte header the packet helpers read MACs from.
+func ethernetHeader(dst, src net.HardwareAddr) []byte {
+	frame := make([]byte, 14)
+	copy(frame[0:6], dst)
+	copy(frame[6:12], src)
+	frame[12], frame[13] = 0x86, 0xdd
+
+	return frame
+}

--- a/internal/protocols/udp.go
+++ b/internal/protocols/udp.go
@@ -585,8 +585,8 @@ func (h *UDPHandler) HandlePacketV6(pkt *Packet, packet gopacket.Packet, ipv6 *l
 		// DNS query over IPv6
 		h.stack.dnsHandler.HandleQueryV6(pkt, packet, ipv6, udp, devices)
 	case UDPPortSNMP:
-		if h.stack.snmpHandler != nil && h.stack.GetProtocolDebugLevel(logging.ProtocolSNMP) >= 2 {
-			_, _ = fmt.Fprintf(os.Stdout, "SNMP/IPv6 query received (not yet implemented) sn=%d\n", pkt.SerialNumber)
+		if h.stack.snmpHandler != nil {
+			h.stack.snmpHandler.HandlePacketV6(pkt, ipv6, udp, devices)
 		}
 	case UDPPortDHCPv6:
 		// DHCPv6 server port


### PR DESCRIPTION
## Summary

`internal/protocols/udp.go` logged `SNMP/IPv6 query received (not yet implemented)` to stdout and dropped the packet. A scanner probing a device's IPv6 address got silence from a simulator whose entire job is answering scanners. This serves it.

Both hard parts were already solved elsewhere: `getIPv6TargetDevices` already selects devices owning the exact destination address, link-local included, and the SNMP engine under `internal/protocols/snmp/` (MIB, PDU codec, v3 USM) never touches an IP layer. The only IPv4-specific code was `sendResponse`.

So rather than a parallel `processDeviceRequestV6`/`handleV3V6` twin set, the request path now carries a small `snmpPeer{src, dst, v6}` instead of a `*layers.IPv4` — one request path, one send fork at the end.

`sendResponseV6` builds Ethernet/IPv6/UDP with `SetNetworkLayerForChecksum` (IPv6 UDP checksums are mandatory, unlike IPv4) and sends via `SendRawPacketVLAN` so the reply echoes the request's VLAN. The reply's source address is the queried address verbatim: a manager only accepts a reply from the address it asked, which is what makes link-local work at all. `SNMPQueries` increments on this path too — it is a protocol counter, not a version counter.

## Linked Issue

Related to #1151. Program ledger code-debt item: "SNMP over IPv6 not served".

## Type

- [x] Feature

## Risk

Low. The v4 path is unchanged in behaviour — `HandlePacket` now wraps its addresses in `snmpPeer` and calls the shared `handleDatagram`, and the v6 dispatch replaces a log-and-drop stub, so the worst case is that v6 answers stop rather than something regressing.

## Testing Evidence

New white-box tests in `internal/protocols/snmp_v6_test.go` — build a stack, hand `HandlePacketV6` a v2c GET, read the reply off `stack.sendQueue`:

```
$ go test ./internal/protocols/ -run "TestSNMPAnswers|TestIPv6QueriesAreCounted" -v
--- PASS: TestSNMPAnswersOverIPv6 (0.00s)
--- PASS: TestSNMPAnswersFromTheLinkLocalAddressItWasAsked (0.00s)
--- PASS: TestIPv6QueriesAreCounted (0.00s)
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols	0.231s

$ go test ./internal/...
(no failures)

$ golangci-lint run internal/protocols/...
0 issues.
```

Lab proof follows on the 0.94.31 release binary: `snmpget -v2c udp6:[addr]:161` against a hospital device's global and link-local addresses from pvm01, with `tcpdump -i vmbr0 -v ip6 and udp port 161` confirming the reply's source is the address queried and checksums validate, and the IPv4 path answering before and after.

## Security and Release Checklist

- [x] No new secrets, credentials, or tokens
- [x] No new network listener or privilege — this answers on the existing pcap path
- [x] `golangci-lint run` clean, `gosec` clean via pre-commit
- [x] No customer-facing copy changes