### PR TITLE
ci: exempt bot PRs from the human change-PR body template

### DIFF
--- a/.github/workflows/pr-body-lint.yml
+++ b/.github/workflows/pr-body-lint.yml
@@ -14,11 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR body
-        # release-please PRs carry an auto-generated changelog body, not the human
-        # change-PR template (no single linked issue, no code delta to test).
-        # Validating them against it is a category error; their integrity is
-        # ensured by release-please itself + the CI Complete gate. Skip them.
-        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')
+        # Bot PRs carry an auto-generated body -- a release-please changelog, or
+        # dependabot's upstream release notes -- not the human change-PR
+        # template. Neither can name a linked issue or write testing evidence,
+        # so the gate is unsatisfiable for them by construction, and holding a
+        # dependency bump behind it just parks security updates. Their
+        # integrity comes from the CI Complete gate, which still runs.
+        if: >-
+          github.event_name == 'pull_request'
+          && !startsWith(github.head_ref, 'release-please--')
+          && github.event.pull_request.user.login != 'dependabot[bot]'
+          && github.event.pull_request.user.login != 'renovate[bot]'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary

`pr-body-lint.yml` requires a linked-issue heading with a `Fixes #123`-style reference, and a testing-evidence heading containing command output. A dependabot or renovate PR carries the upstream release notes as its body and can produce neither — the gate is **unsatisfiable for them by construction**.

Both currently open dependency PRs (#1238 gopacket 1.7.0→1.7.1, #1239 the gh-actions group) are red on `Lint PR Body` and green on everything else. That means dependency updates — including security ones — can never auto-merge without a human rewriting a bot's body into a template it was never going to fill.

The workflow already exempts release-please for precisely this reason, and its comment states the rationale: an auto-generated body is not the human change-PR template, so validating it against one is a category error. This extends that to `dependabot[bot]` and `renovate[bot]`.

What actually protects the merge is unchanged: the CI Complete gate still runs on these PRs.

## Linked Issue

Related to #1151. Surfaced while clearing the program ledger's code-debt line — the last two open PRs could not merge.

## Type

- [x] Bug fix (CI)

## Risk

Low, and narrow. The exemption keys on the PR author being one of two named bot accounts, so a human PR cannot reach it. Widening the gate is the opposite of what it looks like at a glance — the gate was previously blocking only the PRs it cannot apply to.

## Testing Evidence

The `if:` expression is a folded block, so the risk is malformed YAML silently disabling the step. Parsed to confirm it is one expression:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/pr-body-lint.yml')); print(d['jobs']['lint-pr-body']['steps'][0]['if'])"
github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'
```

The gate also proved itself against this very PR: the first revision failed, because its summary quoted the heading names literally and the checker's section split landed on the wrong slice. That is a real (if minor) sharp edge in the checker, noted rather than silently worked around.

End-to-end proof is this PR plus #1238/#1239: this one is human-authored and must still be checked, carrying the full template, while the two dependency PRs must go green on `Lint PR Body` once this lands.

## Security and Release Checklist

- [x] No new secrets, credentials, or tokens
- [x] No change to what CI verifies about the code — CI Complete still gates every merge
- [x] Action SHAs unchanged
- [x] No customer-facing copy changes