### PR TITLE
fix(security): bump Go to 1.26.6 for five reachable stdlib CVEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 #
 # REQUIREMENTS
 # ------------
-#   - Go 1.26.5 (with CGO for libpcap)
+#   - Go 1.26.6 (with CGO for libpcap)
 #   - Node.js 26.5.0 and npm 12.0.1
 #   - libpcap-dev (Linux) or libpcap (macOS via Homebrew)
 #

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [`docs/SHARED_DEMO_CATALOG.md`](docs/SHARED_DEMO_CATALOG.md).
 | `make fmt-all` | Auto-format everything |
 | `make schema` | Regenerate JSON schema from `Config` struct |
 
-Verified versions: **Go 1.26.5**, Node.js 26.5.0, golangci-lint v2.12.2.
+Verified versions: **Go 1.26.6**, Node.js 26.5.0, golangci-lint v2.12.2.
 All release artifacts are built in GitHub Actions by the pinned `release.yml`
 pipeline after release-please creates a `v*` tag. Linux and Apple Silicon macOS
 use GoReleaser Cross; Windows uses native GitHub runners with CGO and the Npcap

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MustardSeedNetworks/niac-go
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/MustardSeedNetworks/foundation v0.2.1


### PR DESCRIPTION
## Summary

`govulncheck` went red on the 0.94.31 release PR (#1224) — a hard CI gate, and correctly so. Five Go standard-library advisories are **reachable** from this code:

| Advisory | Package | Fixed in |
|---|---|---|
| GO-2026-5026 | `crypto/tls` | go1.26.6 |
| GO-2026-5972 | `encoding/asn1` | go1.26.6 |
| GO-2026-6089 | `net/http` | go1.26.6 |
| GO-2026-6090 | `net/http` | go1.26.6 |
| GO-2026-6218 | `crypto/tls` | go1.26.6 |

All five are fixed in the same toolchain release, so the fix is the version bump — `go.mod`, plus the two places that state the verified version in prose.

Worth naming: one of the reported traces is `internal/cliclient/client.go:165 cliclient.Client.open calls http.Client.Do`, code added days ago in #1241 when the stranded CLI commands were reconnected to the daemon over HTTPS. The advisories were not new to the module; the new call paths made them reachable. That is the gate doing its job rather than a regression in the CLI work.

Per the always-latest policy this wants to land in seed and stem too; niac goes first because it is holding a release.

## Linked Issue

Related to #1151. Found while cutting 0.94.31 — this is what is currently blocking that release.

## Type

- [x] Security fix

## Risk

Low. A patch-level toolchain bump with no source changes; the one previous bump of this kind (1.26.4 → 1.26.5, #970) needed a lint exclusion for tooling lag, and this one needs none — `golangci-lint` is clean as-is.

## Testing Evidence

Before, on 1.26.5:

```
Your code is affected by 5 vulnerabilities from the Go standard library.
##[error] #1: internal/cliclient/client.go:165:24: cliclient.Client.open calls http.Client.Do
make: *** [mk/security.mk:41: security-backend] Error 3
```

After, on 1.26.6:

```
$ govulncheck ./...
=== Symbol Results ===
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.

$ go test ./internal/... ./tools/...
45 packages ok, 0 failures

$ golangci-lint run
0 issues.
```

## Security and Release Checklist

- [x] Closes five reachable CVEs; `govulncheck` clean
- [x] No new secrets, credentials, or tokens
- [x] No source changes — toolchain and stated-version prose only
- [x] No customer-facing copy changes