### PR TITLE
fix(icmpv6): answer neighbor discovery, and answer it on the right VLAN

### DIFF
--- a/internal/protocols/icmpv6.go
+++ b/internal/protocols/icmpv6.go
@@ -243,6 +243,7 @@ func (h *ICMPv6Handler) sendEchoReply(
 	}
 
 	err := h.sendICMPv6PacketWithDevice(
+		pkt.VLAN,
 		ipv6.DstIP,
 		ipv6.SrcIP,
 		device.MACAddress,
@@ -295,29 +296,25 @@ func (h *ICMPv6Handler) handleNeighborSolicitation(pkt *Packet, packet gopacket.
 		return
 	}
 
-	// Parse NS message: Type(1) | Code(1) | Checksum(2) | Reserved(4) | Target Address(16) | Options...
-	appLayer := packet.ApplicationLayer()
-	if appLayer == nil {
-		return
-	}
-	data := appLayer.Payload()
-	if len(data) < icmpv6NSMinSize {
+	// gopacket decodes a solicitation into its own layer, so the message is not
+	// application payload -- reading it as such found nothing and the device
+	// never answered, on any VLAN.
+	ns, ok := packet.Layer(layers.LayerTypeICMPv6NeighborSolicitation).(*layers.ICMPv6NeighborSolicitation)
+	if !ok {
 		if h.debugLevel.Load() >= int32(DebugLevelInfo) {
-			_, _ = fmt.Fprintf(os.Stdout, "ICMPv6: NS too short sn=%d\n", pkt.SerialNumber)
+			_, _ = fmt.Fprintf(os.Stdout, "ICMPv6: NS not decodable sn=%d\n", pkt.SerialNumber)
 		}
 
 		return
 	}
-
-	// Extract target IPv6 address (bytes 4-20)
-	targetIP := net.IP(data[4:20])
+	targetIP := ns.TargetAddress
 
 	if h.debugLevel.Load() >= int32(DebugLevelInfo) {
 		_, _ = fmt.Fprintf(os.Stdout, "ICMPv6: NS for %s from %s sn=%d\n", targetIP, ipv6.SrcIP, pkt.SerialNumber)
 	}
 
 	// Find device with target IPv6
-	devices := h.stack.devices.GetByIPv6(targetIP)
+	devices := h.stack.devicesFor(pkt.VLAN).GetByIPv6(targetIP)
 	if len(devices) == 0 {
 		if h.debugLevel.Load() >= int32(DebugLevelVerbose) {
 			_, _ = fmt.Fprintf(os.Stdout, "ICMPv6: No device for target %s sn=%d\n", targetIP, pkt.SerialNumber)
@@ -328,7 +325,7 @@ func (h *ICMPv6Handler) handleNeighborSolicitation(pkt *Packet, packet gopacket.
 
 	// Send NA for each matching device
 	for _, device := range devices {
-		err := h.sendNeighborAdvertisement(device, ipv6.SrcIP, eth.SrcMAC, targetIP)
+		err := h.sendNeighborAdvertisement(pkt.VLAN, device, ipv6.SrcIP, eth.SrcMAC, targetIP)
 		if err != nil {
 			if h.debugLevel.Load() >= int32(DebugLevelInfo) {
 				_, _ = fmt.Fprintf(os.Stdout, "ICMPv6: Error sending NA sn=%d: %v\n", pkt.SerialNumber, err)
@@ -350,12 +347,14 @@ func (h *ICMPv6Handler) handleNeighborSolicitation(pkt *Packet, packet gopacket.
 }
 
 // sendNeighborAdvertisement sends a Neighbor Advertisement response.
-func (h *ICMPv6Handler) sendNeighborAdvertisement(device *config.Device, dstIP net.IP,
+func (h *ICMPv6Handler) sendNeighborAdvertisement(vlan int, device *config.Device, dstIP net.IP,
 	dstMAC net.HardwareAddr, targetIP net.IP,
 ) error {
-	// Require a source IPv6 and MAC on the device.
-	srcIP := firstIPv6Address(device)
-	if srcIP == nil || len(device.MACAddress) == 0 {
+	// The solicited address is the source: a host discards an advertisement
+	// that names any other, which is what makes link-local resolvable on a
+	// device that also holds a global address.
+	srcIP := targetIP
+	if len(device.MACAddress) == 0 {
 		return ErrDeviceMissingMACOrIP
 	}
 
@@ -401,6 +400,7 @@ func (h *ICMPv6Handler) sendNeighborAdvertisement(device *config.Device, dstIP n
 
 	// Send packet
 	return h.sendICMPv6Packet(
+		vlan,
 		srcIP,
 		dstIP,
 		device.MACAddress,
@@ -428,7 +428,7 @@ func (h *ICMPv6Handler) handleRouterSolicitation(pkt *Packet, packet gopacket.Pa
 		_, _ = fmt.Fprintf(os.Stdout, "ICMPv6: Router Solicitation from %s sn=%d\n", ipv6.SrcIP, pkt.SerialNumber)
 	}
 
-	for _, device := range h.stack.devices.GetAll() {
+	for _, device := range h.stack.devicesFor(pkt.VLAN).GetAll() {
 		if !deviceCanAdvertiseIPv6(device) {
 			continue
 		}
@@ -437,7 +437,7 @@ func (h *ICMPv6Handler) handleRouterSolicitation(pkt *Packet, packet gopacket.Pa
 		if srcIP == nil {
 			continue
 		}
-		err := h.sendRouterAdvertisement(device, srcIP, ipv6.SrcIP, dstMAC)
+		err := h.sendRouterAdvertisement(pkt.VLAN, device, srcIP, ipv6.SrcIP, dstMAC)
 		if err != nil {
 			if h.debugLevel.Load() >= int32(DebugLevelInfo) {
 				_, _ = fmt.Fprintf(
@@ -464,6 +464,7 @@ func (h *ICMPv6Handler) handleRouterSolicitation(pkt *Packet, packet gopacket.Pa
 }
 
 func (h *ICMPv6Handler) sendRouterAdvertisement(
+	vlan int,
 	device *config.Device,
 	srcIP, dstIP net.IP,
 	dstMAC net.HardwareAddr,
@@ -474,6 +475,7 @@ func (h *ICMPv6Handler) sendRouterAdvertisement(
 	}
 
 	return h.sendICMPv6PacketWithDevice(
+		vlan,
 		srcIP,
 		dstIP,
 		device.MACAddress,
@@ -661,14 +663,14 @@ func appendDefaultPrefix(options []byte, srcIP net.IP) []byte {
 }
 
 // sendICMPv6Packet sends an ICMPv6 packet.
-func (h *ICMPv6Handler) sendICMPv6Packet(srcIP, dstIP net.IP, srcMAC, dstMAC net.HardwareAddr,
+func (h *ICMPv6Handler) sendICMPv6Packet(vlan int, srcIP, dstIP net.IP, srcMAC, dstMAC net.HardwareAddr,
 	icmpv6 *layers.ICMPv6, payload []byte,
 ) error {
-	return h.sendICMPv6PacketWithDevice(srcIP, dstIP, srcMAC, dstMAC, icmpv6, payload, nil)
+	return h.sendICMPv6PacketWithDevice(vlan, srcIP, dstIP, srcMAC, dstMAC, icmpv6, payload, nil)
 }
 
 // sendICMPv6PacketWithDevice sends an ICMPv6 packet with device config.
-func (h *ICMPv6Handler) sendICMPv6PacketWithDevice(srcIP, dstIP net.IP, srcMAC, dstMAC net.HardwareAddr,
+func (h *ICMPv6Handler) sendICMPv6PacketWithDevice(vlan int, srcIP, dstIP net.IP, srcMAC, dstMAC net.HardwareAddr,
 	icmpv6 *layers.ICMPv6, payload []byte, device *config.Device,
 ) error {
 	// Determine hop limit based on ICMPv6 type
@@ -713,6 +715,13 @@ func (h *ICMPv6Handler) sendICMPv6PacketWithDevice(srcIP, dstIP net.IP, srcMAC, 
 	// Set ICMPv6 payload
 	icmpv6.Payload = payload
 
+	// An ICMPv6 checksum covers the IPv6 pseudo-header, so serialization fails
+	// outright without this -- every reply this function built was discarded
+	// with "checksum cannot be computed without network layer".
+	if err := icmpv6.SetNetworkLayerForChecksum(ipv6); err != nil {
+		return fmt.Errorf("failed to bind ICMPv6 checksum to IPv6 header: %w", err)
+	}
+
 	// Serialize packet
 	buf := gopacket.NewSerializeBuffer()
 	opts := gopacket.SerializeOptions{
@@ -731,7 +740,7 @@ func (h *ICMPv6Handler) sendICMPv6PacketWithDevice(srcIP, dstIP net.IP, srcMAC, 
 	}
 
 	// Send the packet
-	return h.stack.SendRawPacket(buf.Bytes())
+	return h.stack.SendRawPacketVLAN(buf.Bytes(), vlan)
 }
 
 // getTypeName returns a human-readable name for an ICMPv6 type.

--- a/internal/protocols/icmpv6_vlan_test.go
+++ b/internal/protocols/icmpv6_vlan_test.go
@@ -1,0 +1,169 @@
+package protocols
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+)
+
+// NDP is how a host finds a device before it can send it anything, so a
+// simulation that does not answer Neighbor Solicitation is unreachable over
+// IPv6 no matter which protocols it serves above. These tests cover the two
+// ways that went wrong on a tagged segment: the lookup consulted the flat
+// device table rather than the segment's, and the answer went out untagged.
+
+const ndpTestVLAN = 200
+
+// TestNeighborSolicitationOnATaggedSegmentIsAnswered: with segments configured,
+// devices live in per-tag tables and the flat table is empty, so a lookup that
+// ignores the frame's VLAN finds nothing and the device never answers.
+func TestNeighborSolicitationOnATaggedSegmentIsAnswered(t *testing.T) {
+	stack, device := ndpSegmentStack(t)
+
+	solicit(t, stack, device, net.ParseIP("fd00:6a::21"))
+
+	select {
+	case <-stack.sendQueue:
+	default:
+		t.Fatal("no Neighbor Advertisement queued: the device is unreachable over IPv6 on its own segment")
+	}
+}
+
+// TestNeighborAdvertisementEchoesVLAN: a tester on an 802.1Q trunk drops an
+// untagged reply before it reaches the sender -- the same defect fixed for ARP
+// in #876 and for DNS later.
+func TestNeighborAdvertisementEchoesVLAN(t *testing.T) {
+	stack, device := ndpSegmentStack(t)
+
+	solicit(t, stack, device, net.ParseIP("fd00:6a::21"))
+
+	select {
+	case pkt := <-stack.sendQueue:
+		if pkt.VLAN != ndpTestVLAN {
+			t.Errorf("Neighbor Advertisement VLAN = %d, want %d (must echo the request VLAN)",
+				pkt.VLAN, ndpTestVLAN)
+		}
+	default:
+		t.Fatal("no Neighbor Advertisement queued")
+	}
+}
+
+// TestNeighborAdvertisementAnswersForTheAddressSolicited: a device holds both a
+// global and a link-local address. A host that solicited the link-local rejects
+// an advertisement naming any other address, so answering from whichever
+// address happens to be first leaves link-local unusable.
+func TestNeighborAdvertisementAnswersForTheAddressSolicited(t *testing.T) {
+	stack, device := ndpSegmentStack(t)
+	linkLocal := net.ParseIP("fe80::6a:21")
+
+	solicit(t, stack, device, linkLocal)
+
+	select {
+	case pkt := <-stack.sendQueue:
+		reply := gopacket.NewPacket(pkt.Buffer[:pkt.Length], layers.LayerTypeEthernet, gopacket.Default)
+		ipv6, ok := reply.Layer(layers.LayerTypeIPv6).(*layers.IPv6)
+		if !ok {
+			t.Fatal("advertisement carried no IPv6 layer")
+		}
+		if !ipv6.SrcIP.Equal(linkLocal) {
+			t.Errorf("advertisement source = %s, want %s (the address solicited)", ipv6.SrcIP, linkLocal)
+		}
+	default:
+		t.Fatal("no Neighbor Advertisement queued")
+	}
+}
+
+// ndpSegmentStack builds a stack in segment mode -- the shape every scenario
+// pack runs in -- holding one device with a global and a link-local address.
+func ndpSegmentStack(t *testing.T) (*Stack, *config.Device) {
+	t.Helper()
+
+	device := config.Device{
+		Name:       "v6-probe-sw01",
+		Type:       "switch",
+		MACAddress: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x6a, 0x01},
+		IPAddresses: []net.IP{
+			net.ParseIP("10.66.200.21"),
+			net.ParseIP("fd00:6a::21"),
+			net.ParseIP("fe80::6a:21"),
+		},
+	}
+	cfg := &config.Config{
+		Segments: []config.Segment{{Tag: ndpTestVLAN, Devices: []config.Device{device}}},
+	}
+	stack := NewStack(nil, cfg, logging.NewDebugConfig(0))
+
+	found := stack.devicesFor(ndpTestVLAN).GetByIP(net.ParseIP("fd00:6a::21"))
+	if len(found) != 1 {
+		t.Fatalf("segment table holds %d devices for fd00:6a::21, want 1", len(found))
+	}
+
+	return stack, found[0]
+}
+
+// solicit hands the handler a Neighbor Solicitation for target, tagged onto the
+// segment, exactly as a host on the trunk sends it: to the solicited-node
+// multicast address, not to the device.
+func solicit(t *testing.T, stack *Stack, device *config.Device, target net.IP) {
+	t.Helper()
+
+	from := net.ParseIP("fd00:6a::240")
+	senderMAC := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x6a, 0xf0}
+
+	payload := make([]byte, 24)
+	payload[0] = ICMPv6TypeNeighborSolicitation
+	copy(payload[8:24], target.To16())
+
+	ipv6 := &layers.IPv6{
+		Version: 6, NextHeader: layers.IPProtocolICMPv6, HopLimit: 255,
+		SrcIP: from, DstIP: solicitedNodeAddress(target), Length: uint16(len(payload)),
+	}
+
+	frame := append(ethernetHeader(multicastMACFor(target), senderMAC), encodeIPv6Header(ipv6)...)
+	frame = append(frame, payload...)
+
+	packet := gopacket.NewPacket(frame, layers.LayerTypeEthernet, gopacket.Default)
+	pkt := &Packet{Buffer: frame, Length: len(frame), VLAN: ndpTestVLAN, VLANTagged: true}
+
+	handler := NewICMPv6Handler(stack, 0)
+	handler.handleNeighborSolicitation(pkt, packet, ipv6)
+
+	_ = device
+}
+
+// solicitedNodeAddress is ff02::1:ff00:0/104 with the low 24 bits of target,
+// per RFC 4291.
+func solicitedNodeAddress(target net.IP) net.IP {
+	addr := net.ParseIP("ff02::1:ff00:0").To16()
+	copy(addr[13:16], target.To16()[13:16])
+
+	return addr
+}
+
+// multicastMACFor is 33:33 followed by the low 32 bits of the multicast
+// address, per RFC 2464.
+func multicastMACFor(target net.IP) net.HardwareAddr {
+	solicited := solicitedNodeAddress(target).To16()
+
+	return net.HardwareAddr{0x33, 0x33, solicited[12], solicited[13], solicited[14], solicited[15]}
+}
+
+// encodeIPv6Header serializes just the fixed header; the callers above supply
+// their own payload rather than a full gopacket stack.
+func encodeIPv6Header(ipv6 *layers.IPv6) []byte {
+	header := make([]byte, IPv6HeaderSize)
+	header[0] = 0x60
+	header[4] = byte(ipv6.Length >> 8)
+	header[5] = byte(ipv6.Length)
+	header[6] = byte(ipv6.NextHeader)
+	header[7] = ipv6.HopLimit
+	copy(header[8:24], ipv6.SrcIP.To16())
+	copy(header[24:40], ipv6.DstIP.To16())
+
+	return header
+}


### PR DESCRIPTION
## Summary

**Nothing could reach a simulated device over IPv6.** This surfaced while producing the lab proof promised in #1244: on CT304, the host's Neighbor Solicitation arrived at the container — confirmed with `tcpdump` on `eth0` — and was never answered, so the SNMP query never left the host. NDP is how a host finds a device before it can send it anything, so no protocol above it was reachable over IPv6, regardless of what the simulation served.

Four faults were stacked on top of each other:

1. **The solicitation was never parsed.** `handleNeighborSolicitation` read the message from `packet.ApplicationLayer()`, which is nil — gopacket decodes a solicitation into its own `ICMPv6NeighborSolicitation` layer. The handler returned at its first check every time, on every VLAN, tagged or not.
2. **Every ICMPv6 reply failed to serialize.** An ICMPv6 checksum covers the IPv6 pseudo-header, and `SetNetworkLayerForChecksum` was never called, so `SerializeLayers` returned `checksum cannot be computed without network layer` for advertisements, router advertisements, and echo replies alike. Same requirement the SNMP/IPv6 path handles in #1244.
3. **Lookups ignored the segment.** Solicitation and router-solicitation resolved against the flat device table, while every scenario pack runs in segment mode where devices live in per-tag tables. ARP has resolved VLAN-scoped since #876; NDP never was.
4. **Replies went out untagged.** A tester on an 802.1Q trunk drops them — the #876 defect once more, never applied here. Fixed at the single send choke point, so echo replies and router advertisements get it too.

The advertisement now also answers **from the address solicited** rather than the device's first IPv6 address. A host discards an advertisement naming any other address, so this is what makes link-local resolvable on a device that also holds a global address — the same reasoning as the SNMP reply-source fix.

### Relationship to #1244

#1244 shipped SNMP over IPv6 in 0.94.31 and said a lab proof would follow. That proof is what found this: the SNMP/IPv6 code is correct and unit-tested, but **inert on the lab** until NDP answers. The end-to-end proof lands with this PR rather than that one; 0.94.31's changelog entry should be read with that caveat.

## Linked Issue

Related to #1151. Found producing the verification for the program ledger's SNMP/IPv6 item.

## Type

- [x] Bug fix

## Risk

Moderate surface, well covered. The send signature gained a `vlan` parameter threaded from the request at all three call sites, so an untagged request still sends untagged (`vlan` 0) exactly as before. The checksum binding is required for serialization to succeed at all — code paths that previously errored now emit packets, which is the intent.

## Testing Evidence

New `internal/protocols/icmpv6_vlan_test.go` builds a stack in segment mode — the shape every pack runs in — and hands the handler a solicitation sent to the solicited-node multicast address, as a host on the trunk actually sends it.

RED, before the fix:

```
--- FAIL: TestNeighborSolicitationOnATaggedSegmentIsAnswered
    no Neighbor Advertisement queued: the device is unreachable over IPv6 on its own segment
--- FAIL: TestNeighborAdvertisementEchoesVLAN
--- FAIL: TestNeighborAdvertisementAnswersForTheAddressSolicited
```

Intermediate states were informative and are worth recording: fixing only the lookup produced `ICMPv6: Error sending NA: failed to serialize ICMPv6 packet: TCP/IP layer 4 checksum cannot be computed without network layer`, which is how fault 2 was found.

GREEN, after:

```
$ go test ./internal/protocols/ -run "TestNeighborSolicitationOnATagged|TestNeighborAdvertisement" -v
--- PASS: TestNeighborSolicitationOnATaggedSegmentIsAnswered (0.00s)
--- PASS: TestNeighborAdvertisementEchoesVLAN (0.00s)
--- PASS: TestNeighborAdvertisementAnswersForTheAddressSolicited (0.00s)

$ go test ./internal/...
44 packages ok, 0 failures

$ golangci-lint run internal/protocols/...
0 issues.
```

Lab proof runs against the 0.94.32 release binary on CT304 once this merges: `snmpget` over IPv6 global and link-local against a device that also answers over IPv4, with `tcpdump` confirming the reply source and valid checksums. The six signed-off packs are untouched — the probe runs as a separate session on the already-approved VLAN 299.

## Security and Release Checklist

- [x] No new secrets, credentials, or tokens
- [x] No new listener or privilege — this is the existing pcap reply path
- [x] `golangci-lint` clean, `gosec` clean
- [x] No customer-facing copy changes