### PR TITLE
fix(icmpv6): send the reply body, not just the ICMPv6 header

### DIFF
--- a/internal/protocols/icmpv6.go
+++ b/internal/protocols/icmpv6.go
@@ -712,8 +712,10 @@ func (h *ICMPv6Handler) sendICMPv6PacketWithDevice(vlan int, srcIP, dstIP net.IP
 		DstIP:        dstIP,
 	}
 
-	// Set ICMPv6 payload
-	icmpv6.Payload = payload
+	// The body travels as its own layer: gopacket serializes only the 4-byte
+	// header from layers.ICMPv6 and ignores its Payload field, which sent every
+	// advertisement out empty -- parseable as NDP, but telling the host nothing.
+	body := gopacket.Payload(payload)
 
 	// An ICMPv6 checksum covers the IPv6 pseudo-header, so serialization fails
 	// outright without this -- every reply this function built was discarded
@@ -729,7 +731,7 @@ func (h *ICMPv6Handler) sendICMPv6PacketWithDevice(vlan int, srcIP, dstIP net.IP
 		ComputeChecksums: true,
 	}
 
-	err := gopacket.SerializeLayers(buf, opts, eth, ipv6, icmpv6)
+	err := gopacket.SerializeLayers(buf, opts, eth, ipv6, icmpv6, body)
 	if err != nil {
 		return fmt.Errorf("failed to serialize ICMPv6 packet: %w", err)
 	}

--- a/internal/protocols/icmpv6_vlan_test.go
+++ b/internal/protocols/icmpv6_vlan_test.go
@@ -78,6 +78,34 @@ func TestNeighborAdvertisementAnswersForTheAddressSolicited(t *testing.T) {
 	}
 }
 
+// TestNeighborAdvertisementCarriesItsBody: the advertisement's target address
+// and link-layer option live in the message body. A reply carrying only the
+// 4-byte ICMPv6 header parses as an advertisement and tells the host nothing,
+// so the neighbour entry stays unresolved and the address is unusable.
+func TestNeighborAdvertisementCarriesItsBody(t *testing.T) {
+	stack, device := ndpSegmentStack(t)
+	target := net.ParseIP("fd00:6a::21")
+
+	solicit(t, stack, device, target)
+
+	select {
+	case pkt := <-stack.sendQueue:
+		reply := gopacket.NewPacket(pkt.Buffer[:pkt.Length], layers.LayerTypeEthernet, gopacket.Default)
+		na, ok := reply.Layer(layers.LayerTypeICMPv6NeighborAdvertisement).(*layers.ICMPv6NeighborAdvertisement)
+		if !ok {
+			t.Fatal("advertisement body missing: the reply carried only an ICMPv6 header")
+		}
+		if !na.TargetAddress.Equal(target) {
+			t.Errorf("advertisement target = %s, want %s", na.TargetAddress, target)
+		}
+		if len(na.Options) == 0 {
+			t.Error("advertisement carried no target link-layer address option")
+		}
+	default:
+		t.Fatal("no Neighbor Advertisement queued")
+	}
+}
+
 // ndpSegmentStack builds a stack in segment mode -- the shape every scenario
 // pack runs in -- holding one device with a global and a link-local address.
 func ndpSegmentStack(t *testing.T) (*Stack, *config.Device) {


### PR DESCRIPTION
## Summary

Follow-on to #1247, found by the same lab proof. With that fix in place, Neighbor Advertisements finally reached the host on CT304 — and the host still refused to resolve the neighbour, leaving `ip -6 neigh` at `FAILED`.

`tcpdump` gave the reason:

```
IP6 (hlim 255, next-header ICMPv6 (58) payload length: 4) fd00:6a::1 > fd00:6a::240:
    [icmp6 sum ok] ICMP6, neighbor advertisement, length 4 [|icmp6]
    0x0030:  0000 0000 0240 8800 7aaa 0000
```

Four bytes of ICMPv6: type `0x88`, code, checksum. The flags, target address and target link-layer option — the entire 28-byte body — never left. A 4-byte reply still parses *as* an advertisement, which is exactly why this looked like success on the wire and only showed up as a neighbour that would not resolve.

The cause: gopacket serializes only the 4-byte header from `layers.ICMPv6` and **ignores its `Payload` field**. The body has to be handed to `SerializeLayers` as its own layer. This affected every ICMPv6 reply built by `sendICMPv6PacketWithDevice` — neighbor advertisements, router advertisements, and echo replies alike, so `ping6` to a simulated device would have answered with an empty echo reply too.

## Linked Issue

Related to #1151. Continues the SNMP/IPv6 verification chain: #1244 (feature) → #1247 (NDP answers at all) → this (the answer carries content).

## Type

- [x] Bug fix

## Risk

Low, and narrowly scoped: one serialization call gains the body layer it was always meant to carry. Replies that previously went out empty now go out complete.

## Testing Evidence

The gap in my own tests is worth naming: #1247's tests asserted the advertisement was *queued*, on the right *VLAN*, from the right *source* — and all three passed against a reply with no body. The new assertion is the one that had to exist.

RED, before the fix:

```
$ go test ./internal/protocols/ -run TestNeighborAdvertisementCarriesItsBody -v
    icmpv6_vlan_test.go:96: advertisement body missing: the reply carried only an ICMPv6 header
--- FAIL: TestNeighborAdvertisementCarriesItsBody (0.00s)
```

That failure matches the wire capture above byte for byte.

GREEN, after:

```
$ go test ./internal/protocols/ -run TestNeighbor
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols	0.230s

$ go test ./internal/...
44 packages ok, 0 failures

$ golangci-lint run internal/protocols/...
0 issues.
```

Lab proof runs against the next release binary on CT304: `snmpget` over IPv6 global and link-local against a device that also answers over IPv4, with `tcpdump` confirming reply source and checksums.

## Security and Release Checklist

- [x] No new secrets, credentials, or tokens
- [x] No new listener or privilege
- [x] `golangci-lint` clean, `gosec` clean
- [x] No customer-facing copy changes