### PR TITLE
ci: split race tests, verify UIBuildHash, add missing gates

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint configuration.
+#
+# GitHub added Windows-on-Arm hosted runners after actionlint's built-in label
+# list was cut, so `windows-11-arm` is reported as unknown. It is a real
+# GitHub-hosted label, used by the Windows arm64 release build.
+self-hosted-runner:
+  labels:
+    - windows-11-arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
   changes:
     name: Changed paths
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -118,6 +119,7 @@ jobs:
   backend:
     name: Backend (Go)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: changes
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.schema == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.https == 'true'
     steps:
@@ -183,8 +185,23 @@ jobs:
       - name: Filename-policy gate — no monolith naming outside internal/api
         run: ./scripts/check-filename-policy.sh
 
+      - name: Banned-vocabulary gate (strategy reset, CLAUDE.md)
+        # Ported from seed, which was the only repo enforcing it. "magic" in
+        # the capture/pcap/snoop parsers is file-format terminology, not
+        # marketing copy, and the IEEE OUI registry carries vendor names the
+        # policy would otherwise flag; both are exact, reviewable exceptions
+        # in scripts/banned-vocabulary-exclusions.txt.
+        run: |
+          python3 scripts/test-check-banned-vocabulary.py
+          python3 scripts/check-banned-vocabulary.py
+
       - name: Run tests
-        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+        # Plain run: fast feedback plus the coverage profile. The race
+        # detector runs in its own `race` job so a race-detector crash (see
+        # the Go GC segfault flake seen on stem) cannot take out the entire
+        # test signal, and so a non-race failure is distinguishable at a
+        # glance. This matches seed and stem.
+        run: go test -v -coverprofile=coverage.out ./...
 
       - name: Check coverage threshold
         run: |
@@ -215,12 +232,48 @@ jobs:
           flags: backend
           fail_ci_if_error: false
 
+  race:
+    name: Backend (race detector)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.schema == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.https == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install libpcap-dev
+        # packages.microsoft.com intermittently serves an unsigned/invalid
+        # InRelease that aborts `apt-get update` for the whole runner, even
+        # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
+        # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
+        # so a broken third-party mirror can't red the job, then retry the
+        # install with backoff for genuinely transient hiccups.
+        run: |
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
+
+
+      - name: Run tests with race detector
+        run: go test -race ./...
+
   # ===========================================================================
   # Frontend (TypeScript)
   # ===========================================================================
   frontend:
     name: Frontend (TypeScript)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflows == 'true'
     defaults:
@@ -276,6 +329,7 @@ jobs:
   security:
     name: Security Scanning
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Always runs — security checks are non-negotiable on every PR.
     permissions:
       # Job-level `permissions:` REPLACES the workflow-level block entirely
@@ -435,6 +489,7 @@ jobs:
   c-lint:
     name: C Lint (C23)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: needs.changes.outputs.c == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
@@ -465,10 +520,10 @@ jobs:
         id: check-c
         run: |
           if find . -name '*.c' -o -name '*.h' 2>/dev/null | grep -v node_modules | grep -q .; then
-            echo "has_c=true" >> $GITHUB_OUTPUT
+            echo "has_c=true" >> "$GITHUB_OUTPUT"
             echo "Found C source files"
           else
-            echo "has_c=false" >> $GITHUB_OUTPUT
+            echo "has_c=false" >> "$GITHUB_OUTPUT"
             echo "No C source files found - C23 linting ready for when C code is added"
           fi
 
@@ -536,6 +591,7 @@ jobs:
   quality:
     name: Quality Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.c == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.hooks == 'true'
     steps:
@@ -609,12 +665,49 @@ jobs:
   # ===========================================================================
   # Internationalization (i18n) Checks
   # ===========================================================================
+  # Workflow Linting
+  # ===========================================================================
+  # Static analysis of the workflows themselves. Kept out of `quality` so it
+  # runs in parallel and only when workflow files actually change.
+  #   actionlint — syntax, expression and shell errors inside run: blocks.
+  #                It caught a duplicated `with:` key that PyYAML accepts
+  #                silently by keeping the last occurrence.
+  #
+  # zizmor (Actions security scanner) is NOT wired in yet: it currently reports
+  # 76-88 findings per repo, 10-13 of them high (pull_request_target triggers,
+  # workflow-level write permissions, release-please App-token use). Those need
+  # real review — narrowing them carelessly breaks release automation — so they
+  # are tracked as their own security pass rather than bolted on here as a
+  # continue-on-error step that would enforce nothing.
+  workflow-lint:
+    name: Workflow Lint (actionlint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Run actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          # SC2129 is a pure style preference about grouping `>>` redirects in
+          # step summaries; the ungrouped form stays readable and diffs one
+          # line at a time. Every correctness-level rule stays enabled.
+          actionlint -ignore 'SC2129' -color
+
+
+  # ===========================================================================
   # Validates the translation locale files in internal/i18n/locales/ against
   # the cross-repo conventions in msn-docs-internal/05-Engineering/. Uses the
   # shared script in scripts/i18n/, byte-identical to seed and stem.
   i18n:
     name: i18n Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: |
       needs.changes.outputs.frontend == 'true'
@@ -650,25 +743,49 @@ jobs:
   docs:
     name: Documentation Quality
     runs-on: ubuntu-latest
-    # Always runs — cheap (runs in seconds) and applies to every PR.
+    timeout-minutes: 10
+    # External link checking is NOT here: it walked every URL in every .md file
+    # and measured ~6 min — the longest job in this workflow and, on a
+    # backend-only change, the entire critical path. It also failed on
+    # third-party link rot rather than on the change under review, which is why
+    # it was pinned to continue-on-error and enforced nothing.
+    # It now runs on a schedule: .github/workflows/docs-link-check.yml
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Check markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
-        continue-on-error: true
         with:
-          use-quiet-mode: "yes"
+          # Needed to diff against the base ref for changed-file scoping.
+          fetch-depth: 0
 
-      - name: Lint markdown files
+      - name: Collect changed markdown files
+        id: changed-md
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BASE_SHA}" ] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            files=$(git diff --name-only --diff-filter=ACMR "${BASE_SHA}" HEAD -- '*.md')
+          else
+            files=$(git ls-files '*.md')
+          fi
+          files=$(printf '%s\n' "${files}" | grep -vE '^(node_modules|build|dist|coverage)/' | grep -v 'CHANGELOG.md$' || true)
+          {
+            echo "files<<EOF"
+            printf '%s\n' "${files}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ -z "${files}" ]; then echo "empty=true" >> "$GITHUB_OUTPUT"; fi
+
+      # Blocking, but scoped to the files this change touches. The repo carries
+      # ~1.2k pre-existing violations of its own markdownlint config; gating the
+      # full tree would fail every PR, and gating nothing (the previous
+      # continue-on-error) enforced nothing. Scoping ratchets the debt down as
+      # files are touched, matching the file-size gate's baseline approach.
+      - name: Lint changed markdown files
+        if: steps.changed-md.outputs.empty != 'true'
         uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
-        continue-on-error: true
         with:
-          globs: |
-            **/*.md
-            !**/node_modules/**
-            !**/dist/**
+          globs: ${{ steps.changed-md.outputs.files }}
 
   # ===========================================================================
   # Build
@@ -677,6 +794,7 @@ jobs:
     name: Build (${{ matrix.os }}-${{ matrix.arch }})
     needs: [changes, backend, frontend]
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     # gopacket/pcap requires CGO + libpcap. CI verifies a native amd64 build
     # only — release.yml handles the arm64 cross-compile (gcc-aarch64-linux-gnu
     # + libpcap-dev:arm64) when actually publishing artifacts.
@@ -748,6 +866,33 @@ jobs:
 
       - name: Verify binary
         run: ./niac-${{ matrix.os }}-${{ matrix.arch }} --help || ./niac-${{ matrix.os }}-${{ matrix.arch }} version || echo "Binary runs"
+
+      - name: Verify UIBuildHash embedded (Universal Build Contract)
+        # seed and stem both verify this; niac injected the ldflag but never
+        # checked it landed. Without the check a build that misses the flag
+        # ships happily and /__version returns uiBuildHash="unknown" — exactly
+        # the silent contract violation Build Contract rule #6 exists to catch.
+        # Static check: the binary must contain the md5 of the embedded UI
+        # assets. Cheaper and more reliable than booting the server in CI.
+        run: |
+          if [ -z "$(find internal/api/ui -mindepth 1 ! -name '.gitkeep' -print -quit 2>/dev/null)" ]; then
+            echo "::error::internal/api/ui is empty — frontend-dist artifact missing?"
+            exit 1
+          fi
+          EXPECTED=$(find internal/api/ui -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum 2>/dev/null | cut -d' ' -f1)
+          if [ "${#EXPECTED}" -ne 32 ]; then
+            echo "::error::Computed UI_BUILD_HASH is not 32 chars: '${EXPECTED}'"
+            exit 1
+          fi
+          echo "Expected UIBuildHash: ${EXPECTED}"
+          BIN="niac-${{ matrix.os }}-${{ matrix.arch }}"
+          if strings "${BIN}" | grep -qF "${EXPECTED}"; then
+            echo "  ✓ ${BIN}: UIBuildHash embedded correctly"
+          else
+            echo "::error::${BIN} does not contain UIBuildHash ${EXPECTED}"
+            echo "  → Universal Build Contract violated. Check the -X ...UIBuildHash=... ldflag in the 'Build binary' step."
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -951,7 +1096,7 @@ jobs:
           # Backend is HTTPS-only since #663. Self-signed cert auto-generated.
           # Use canonical TLS port 8445.
           nohup ./niac daemon --listen 127.0.0.1:8445 > server.log 2>&1 &
-          for i in {1..30}; do
+          for _ in {1..30}; do
             if curl -skf https://localhost:8445/__version 2>/dev/null; then
               echo "Server ready"
               exit 0
@@ -962,7 +1107,7 @@ jobs:
           exit 1
 
       - name: Run Lighthouse
-        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12.6.2
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           # configPath drives all collect/assert/upload settings via
           # .lighthouserc.json. That file includes
@@ -997,17 +1142,20 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Browser-engine E2E is release-blocking. Lighthouse remains independent:
     # it measures performance and accessibility rather than functional browser
     # compatibility, and its thresholds are enforced by its own job.
     needs:
       - changes
       - backend
+      - race
       - frontend
       - security
       - semgrep
       - c-lint
       - quality
+      - workflow-lint
       - docs
       - build
       - e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Filename-policy gate — no monolith naming outside internal/api
         run: ./scripts/check-filename-policy.sh
 
-      - name: Banned-vocabulary gate (strategy reset, CLAUDE.md)
+      - name: Banned-vocabulary gate (strategy reset)
         # Ported from seed, which was the only repo enforcing it. "magic" in
         # the capture/pcap/snoop parsers is file-format terminology, not
         # marketing copy, and the IEEE OUI registry carries vendor names the

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -48,26 +48,26 @@ jobs:
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 
-          echo "### Go Dead Code Analysis" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Go Dead Code Analysis" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           # Run staticcheck and capture unused code warnings
           staticcheck -checks="U*" ./... 2>&1 | tee staticcheck-unused.txt || true
 
           UNUSED_COUNT=$(wc -l < staticcheck-unused.txt | tr -d ' ')
-          echo "Found $UNUSED_COUNT potential unused code items" >> $GITHUB_STEP_SUMMARY
+          echo "Found $UNUSED_COUNT potential unused code items" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$UNUSED_COUNT" -gt 0 ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            cat staticcheck-unused.txt >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            cat staticcheck-unused.txt >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Check for unused dependencies
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Unused Go Dependencies" >> $GITHUB_STEP_SUMMARY
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Unused Go Dependencies" >> "$GITHUB_STEP_SUMMARY"
 
           # Check if go mod tidy would change anything
           cp go.mod go.mod.backup
@@ -76,10 +76,10 @@ jobs:
           go mod tidy
 
           if ! diff -q go.mod go.mod.backup > /dev/null 2>&1; then
-            echo "go.mod has unused dependencies:" >> $GITHUB_STEP_SUMMARY
-            diff go.mod.backup go.mod >> $GITHUB_STEP_SUMMARY || true
+            echo "go.mod has unused dependencies:" >> "$GITHUB_STEP_SUMMARY"
+            diff go.mod.backup go.mod >> "$GITHUB_STEP_SUMMARY" || true
           else
-            echo "No unused dependencies found" >> $GITHUB_STEP_SUMMARY
+            echo "No unused dependencies found" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           # Restore original files
@@ -113,27 +113,27 @@ jobs:
       - name: Check for unused exports
         working-directory: ui
         run: |
-          echo "### Frontend Dead Code Analysis" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Frontend Dead Code Analysis" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           # Run ts-prune to find unused exports
           ts-prune --error 2>&1 | tee ts-prune-output.txt || true
 
           UNUSED_COUNT=$(grep -c "unused" ts-prune-output.txt || echo "0")
-          echo "Found $UNUSED_COUNT potentially unused exports" >> $GITHUB_STEP_SUMMARY
+          echo "Found $UNUSED_COUNT potentially unused exports" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$UNUSED_COUNT" -gt 0 ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            head -50 ts-prune-output.txt >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            head -50 ts-prune-output.txt >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Check for unused npm dependencies
         working-directory: ui
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Unused npm Dependencies" >> $GITHUB_STEP_SUMMARY
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Unused npm Dependencies" >> "$GITHUB_STEP_SUMMARY"
 
           npx depcheck --json 2>/dev/null | tee depcheck-output.json || true
 
@@ -142,12 +142,12 @@ jobs:
           DEV_UNUSED=$(jq -r '.devDependencies[]' depcheck-output.json 2>/dev/null | wc -l || echo "0")
 
           if [ "$UNUSED" -gt 0 ] || [ "$DEV_UNUSED" -gt 0 ]; then
-            echo "Potentially unused dependencies:" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
-            cat depcheck-output.json >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "Potentially unused dependencies:" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`json" >> "$GITHUB_STEP_SUMMARY"
+            cat depcheck-output.json >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "No unused dependencies detected" >> $GITHUB_STEP_SUMMARY
+            echo "No unused dependencies detected" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   orphaned-files:
@@ -159,12 +159,12 @@ jobs:
 
       - name: Check for orphaned files
         run: |
-          echo "### Orphaned File Analysis" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Orphaned File Analysis" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           # Find Go files not imported anywhere
-          echo "#### Go Files" >> $GITHUB_STEP_SUMMARY
-          for file in $(find . -name "*.go" -not -path "./vendor/*" -not -name "*_test.go"); do
+          echo "#### Go Files" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r -d '' file; do
             pkg=$(dirname "$file" | sed 's|^\./||')
             # Check if package is imported
             if ! grep -r "\"github.com/MustardSeedNetworks/niac-go/$pkg\"" --include="*.go" . > /dev/null 2>&1; then
@@ -172,20 +172,20 @@ jobs:
               if grep -q "^package main" "$file"; then
                 continue  # Main packages don't need to be imported
               fi
-              echo "- Potentially orphaned: $file" >> $GITHUB_STEP_SUMMARY
+              echo "- Potentially orphaned: $file" >> "$GITHUB_STEP_SUMMARY"
             fi
-          done || echo "All Go packages appear to be used" >> $GITHUB_STEP_SUMMARY
+          done < <(find . -name "*.go" -not -path "./vendor/*" -not -name "*_test.go" -print0) || echo "All Go packages appear to be used" >> "$GITHUB_STEP_SUMMARY"
 
           # Find TypeScript files not imported anywhere
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "#### TypeScript Files" >> $GITHUB_STEP_SUMMARY
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### TypeScript Files" >> "$GITHUB_STEP_SUMMARY"
           cd ui/src
-          for file in $(find . -name "*.tsx" -o -name "*.ts" | grep -v ".test." | grep -v ".stories." | grep -v ".d.ts"); do
+          while IFS= read -r file; do
             basename=$(basename "$file" | sed 's/\.[^.]*$//')
             # Check if file is imported
-            if ! grep -r "from.*['\"].*$basename['\"]" --include="*.ts" --include="*.tsx" . > /dev/null 2>&1; then
-              if ! grep -r "import.*$basename" --include="*.ts" --include="*.tsx" . > /dev/null 2>&1; then
-                echo "- Potentially orphaned: $file" >> $GITHUB_STEP_SUMMARY
+            if ! grep -r "from.*['\"].*${basename}['\"]" --include="*.ts" --include="*.tsx" . > /dev/null 2>&1; then
+              if ! grep -r "import.*${basename}" --include="*.ts" --include="*.tsx" . > /dev/null 2>&1; then
+                echo "- Potentially orphaned: $file" >> "$GITHUB_STEP_SUMMARY"
               fi
             fi
-          done || echo "All TypeScript files appear to be used" >> $GITHUB_STEP_SUMMARY
+          done < <(find . \( -name "*.tsx" -o -name "*.ts" \) | grep -v ".test." | grep -v ".stories." | grep -v ".d.ts") || echo "All TypeScript files appear to be used" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,37 @@
+# Documentation link check.
+#
+# Split out of the CI `docs` job: walking every external URL in every .md file
+# took ~6 minutes — the longest job in ci.yml — and its failures are caused by
+# third-party links rotting, not by the change under review. Running it per-PR
+# therefore meant either red PRs for unrelated reasons or (as was the case)
+# continue-on-error, enforcing nothing.
+#
+# On a schedule it can be blocking: a failure here is a real, actionable repo
+# defect rather than PR noise.
+name: Docs Link Check
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check markdown links
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+        with:
+          use-quiet-mode: "yes"

--- a/.github/workflows/todo-tracker.yml
+++ b/.github/workflows/todo-tracker.yml
@@ -65,28 +65,28 @@ jobs:
           # Count TODOs
           TODO_COUNT=$(wc -l < "$TODOS_FILE" | tr -d ' ')
           echo "Found $TODO_COUNT TODO items"
-          echo "count=$TODO_COUNT" >> $GITHUB_OUTPUT
+          echo "count=$TODO_COUNT" >> "$GITHUB_OUTPUT"
 
           # Save for later steps
-          echo "todos_file=$TODOS_FILE" >> $GITHUB_OUTPUT
+          echo "todos_file=$TODOS_FILE" >> "$GITHUB_OUTPUT"
 
           # Output summary
           if [ "$TODO_COUNT" -gt 0 ]; then
-            echo "### TODO Items Found: $TODO_COUNT" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| File | Line | Comment |" >> $GITHUB_STEP_SUMMARY
-            echo "|------|------|---------|" >> $GITHUB_STEP_SUMMARY
+            echo "### TODO Items Found: $TODO_COUNT" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "| File | Line | Comment |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|------|------|---------|" >> "$GITHUB_STEP_SUMMARY"
             head -50 "$TODOS_FILE" | while IFS=: read -r file line content; do
               # Escape pipe characters for markdown
               safe_content=$(echo "$content" | sed 's/|/\\|/g' | head -c 100)
-              echo "| $file | $line | $safe_content |" >> $GITHUB_STEP_SUMMARY
+              echo "| $file | $line | $safe_content |" >> "$GITHUB_STEP_SUMMARY"
             done
             if [ "$TODO_COUNT" -gt 50 ]; then
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "_...and $((TODO_COUNT - 50)) more_" >> $GITHUB_STEP_SUMMARY
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "_...and $((TODO_COUNT - 50)) more_" >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            echo "### No TODO items found" >> $GITHUB_STEP_SUMMARY
+            echo "### No TODO items found" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Check for new TODOs
@@ -95,7 +95,7 @@ jobs:
           echo "Checking for new TODOs in this commit..."
 
           # Get changed files
-          git diff --name-only HEAD~1 HEAD 2>/dev/null | while read file; do
+          git diff --name-only HEAD~1 HEAD 2>/dev/null | while read -r file; do
             if [[ "$file" =~ \.(go|ts|tsx|js|jsx)$ ]]; then
               # Check for TODOs in changed lines
               git diff HEAD~1 HEAD -- "$file" | grep "^+" | grep -i "TODO\|FIXME" && \

--- a/scripts/banned-vocabulary-exclusions.txt
+++ b/scripts/banned-vocabulary-exclusions.txt
@@ -48,3 +48,4 @@ internal/api/decode.go | capture file-format magic bytes
 internal/api/pcap.go | pcap file-format magic bytes
 internal/api/pcap_validation.go | pcap file-format magic bytes
 internal/capture/playback.go | pcap/pcapng file-format magic bytes
+scripts/banned-vocabulary-exclusions.txt | policy exclusion list; its reasons must name the terms

--- a/scripts/banned-vocabulary-exclusions.txt
+++ b/scripts/banned-vocabulary-exclusions.txt
@@ -1,0 +1,50 @@
+# Exact, reviewable exceptions for text that is not current product copy.
+# Format: git path pattern | why the immutable or developer-only text is exempt
+
+# Immutable history and legal source text.
+CHANGELOG.md | release-please generated immutable release history
+LICENSE | unmodified proprietary legal source text
+docs/archive/** | archived reports retained as immutable history
+
+# Imported immutable reference data.
+internal/oui/data/oui.txt | IEEE vendor registry; vendor names are not NIAC-authored copy
+
+# File-format and protocol terminology. "magic" here is the standard name for
+# a format's identifying byte sequence (snoop/pcap/zip magic), not marketing
+# copy, and standard terms are never renamed.
+internal/api/capture/snoop.go | snoop file-format magic bytes
+internal/api/capture/validation.go | capture file-format magic bytes
+internal/protocols/snmp/errors.go | file-format magic bytes
+internal/protocols/snmp/mibzip.go | zip archive magic bytes
+internal/protocols/udp.go | protocol magic-number constant
+
+# Developer instructions, tests, generated locks, and tool configuration.
+AGENTS.md | developer-only agent instructions
+**/AGENTS.md | developer-only agent instructions
+CODE_INDEX.md | developer-only code index
+CONTRIBUTING.md | developer-only contributor instructions naming dev tooling
+.github/** | developer CI and bot configuration
+docs/adr/** | architecture decision records are developer-facing design history
+.ignore | developer-tool path rules
+.serena/** | developer agent tooling
+.gitignore | developer-tool path rules
+.markdownlint-cli2.jsonc | developer-tool path rules
+.markdownlintignore | developer-tool path rules
+codecov.yml | developer-tool path rules
+scripts/i18n/banned-vocab.txt | policy term source
+scripts/i18n/** | developer i18n tooling
+scripts/test-check-banned-vocabulary.py | checker fixture self-tests
+**/*_test.go | developer test fixtures and protocol terminology
+ui/**/*.test.ts | developer test fixtures
+ui/**/*.test.tsx | developer test fixtures
+ui/e2e/** | developer end-to-end test fixtures
+package-lock.json | generated dependency lockfile
+ui/package-lock.json | generated dependency lockfile
+.golangci.yml | developer linter rule identifiers
+.clang-tidy | developer linter rule identifiers
+ui/vite.config.ts | developer-tool path rules
+ui/vitest.config.ts | developer-tool path rules
+internal/api/decode.go | capture file-format magic bytes
+internal/api/pcap.go | pcap file-format magic bytes
+internal/api/pcap_validation.go | pcap file-format magic bytes
+internal/capture/playback.go | pcap/pcapng file-format magic bytes

--- a/scripts/check-banned-vocabulary.py
+++ b/scripts/check-banned-vocabulary.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Reject locked customer-facing vocabulary in the tracked repository tree."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Config:
+    root: Path
+    terms: Path
+    exclusions: Path
+
+
+def parse_args() -> Config:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--terms", type=Path)
+    parser.add_argument("--exclusions", type=Path)
+    args = parser.parse_args()
+    root = args.root or Path(__file__).resolve().parent.parent
+    terms = args.terms or root / "scripts/i18n/banned-vocab.txt"
+    exclusions = args.exclusions or root / "scripts/banned-vocabulary-exclusions.txt"
+    return Config(root.resolve(), terms.resolve(), exclusions.resolve())
+
+
+def meaningful_lines(path: Path) -> list[str]:
+    if not path.is_file():
+        raise ValueError(f"required policy file is missing: {path}")
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [
+        line.strip()
+        for line in lines
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def load_terms(path: Path) -> list[str]:
+    terms = meaningful_lines(path)
+    if not terms:
+        raise ValueError(f"term policy is empty: {path}")
+    return terms
+
+
+def load_exclusions(path: Path) -> list[str]:
+    entries = meaningful_lines(path)
+    patterns: list[str] = []
+    for entry in entries:
+        parts = [part.strip() for part in entry.split("|", 1)]
+        if len(parts) != 2 or not all(parts):
+            raise ValueError(f"exclusion needs 'pattern | reason': {entry}")
+        patterns.append(parts[0])
+    return patterns
+
+
+def tracked_files(root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return sorted(item.decode() for item in result.stdout.split(b"\0") if item)
+
+
+def excluded(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def patterns_for(terms: list[str]) -> list[tuple[str, re.Pattern[str]]]:
+    return [
+        (
+            term,
+            re.compile(rf"(?<![A-Za-z]){re.escape(term)}(?![A-Za-z])", re.IGNORECASE),
+        )
+        for term in terms
+    ]
+
+
+def text_lines(path: Path) -> list[str]:
+    if path.is_symlink() or not path.is_file():
+        return []
+    content = path.read_bytes()
+    if b"\0" in content:
+        return []
+    return content.decode("utf-8", errors="replace").splitlines()
+
+
+def scan(config: Config) -> list[tuple[str, int, str]]:
+    terms = patterns_for(load_terms(config.terms))
+    exclusions = load_exclusions(config.exclusions)
+    findings: list[tuple[str, int, str]] = []
+    for relative in tracked_files(config.root):
+        if excluded(relative, exclusions):
+            continue
+        for number, line in enumerate(text_lines(config.root / relative), start=1):
+            findings.extend(
+                (relative, number, term)
+                for term, pattern in terms
+                if pattern.search(line)
+            )
+    return sorted(findings)
+
+
+def main() -> int:
+    try:
+        findings = scan(parse_args())
+    except (OSError, subprocess.CalledProcessError, UnicodeError, ValueError) as error:
+        print(f"banned-vocabulary checker error: {error}", file=sys.stderr)
+        return 2
+    for path, line, term in findings:
+        print(f"{path}:{line}: banned term '{term}'")
+    if findings:
+        print(f"banned-vocabulary check failed: {len(findings)} finding(s)")
+        return 1
+    print("banned-vocabulary check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-check-banned-vocabulary.py
+++ b/scripts/test-check-banned-vocabulary.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Self-tests for the repository banned-vocabulary gate."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+CHECKER = Path(__file__).with_name("check-banned-vocabulary.py")
+
+
+class BannedVocabularyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+        self.terms = self.root / "terms.txt"
+        self.terms.write_text("AI\nAI-powered\nopen source\n", encoding="utf-8")
+        self.exclusions = self.root / "exclusions.txt"
+        self.exclusions.write_text(
+            "CHANGELOG.md | immutable release history\n"
+            "internal/database/migrations/** | immutable migrations\n"
+            "**/AGENTS.md | developer instructions\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def write(self, path: str, content: str) -> None:
+        target = self.root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", "-f", path], check=True)
+
+    def run_checker(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--root",
+                str(self.root),
+                "--terms",
+                str(self.terms),
+                "--exclusions",
+                str(self.exclusions),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_positive_fixture_fails_with_location(self) -> None:
+        self.write("README.md", "An AI-powered network tool.\n")
+        result = self.run_checker()
+        self.assertEqual(1, result.returncode)
+        self.assertIn("README.md:1: banned term 'AI-powered'", result.stdout)
+
+    def test_negative_fixture_passes(self) -> None:
+        self.write("README.md", "A source-available network tool.\n")
+        result = self.run_checker()
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+    def test_matching_is_case_insensitive(self) -> None:
+        self.write("docs/current.md", "This is OPEN SOURCE.\n")
+        result = self.run_checker()
+        self.assertEqual(1, result.returncode)
+        self.assertIn("docs/current.md:1: banned term 'open source'", result.stdout)
+
+    def test_only_documented_paths_are_excluded(self) -> None:
+        self.write("CHANGELOG.md", "AI-powered\n")
+        self.write("internal/database/migrations/00001.sql", "AI-powered\n")
+        self.write("dev/AGENTS.md", "AI-powered\n")
+        result = self.run_checker()
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/src/hooks/useBuildVersion.ts
+++ b/ui/src/hooks/useBuildVersion.ts
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 
 /**
  * Build metadata served by the backend's unauthenticated /__version endpoint.
- * Mirrors the lowercase JSON keys defined by the Universal Build Contract
- * (CLAUDE.md): every sibling project (seed/stem/niac) exposes the same shape.
+ * Mirrors the lowercase JSON keys defined by the Universal Build Contract;
+ * every sibling project (seed/stem/niac) exposes the same shape.
  */
 export interface BuildVersion {
   version: string;


### PR DESCRIPTION
## Summary

Third of three PRs from the fleet CI/build/test evaluation.
Report: `msn-docs-internal/CI_FLEET_EVALUATION_2026-08-14.md`.

| Finding | Change |
|---|---|
| F3 | **Race split** — backend ran only `-race`, so niac had no non-race test signal. Now backend (plain + coverage) + new `race` job |
| F13 | **UIBuildHash verification** — the ldflag was injected in 3 places and never checked |
| F1 | Docs job: link check → weekly; markdown lint blocks, scoped to changed files |
| F4 | Banned-vocabulary gate ported from seed |
| F10 | `timeout-minutes` on 10 jobs that had none |
| new | `workflow-lint` job (actionlint) |

## Linked Issue

Related to #1004

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [x] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

niac already ran the newest action pins, so there is no major-version bump here.

## Testing Evidence

```text
$ actionlint -ignore 'SC2129'     # after fixes
exit=0   (seed, stem and niac all clean)

# what it found before the fixes:
dead-code.yml  SC1087:error   $basename['\"] parsed as an array index
dead-code.yml  SC2044:warning for-loop over unquoted find output
ci.yml         SC2034:warning i appears unused
release.yml    runner-label   windows-11-arm unknown
47x            SC2086:info    unquoted $GITHUB_STEP_SUMMARY / $GITHUB_OUTPUT

$ python3 scripts/check-banned-vocabulary.py     # after exclusions
banned-vocabulary check passed        -> exit 0
$ python3 scripts/test-check-banned-vocabulary.py
Ran 4 tests ... OK

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
YAML OK, jobs=15 ; ci-complete needs includes race + workflow-lint

# pre-commit hook (full local gate) on the commit:
ALL PRE-COMMIT CHECKS PASSED — 78 test files, 377 tests, file-size 0 red flags
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (No app code touched; new `run:` steps take the base SHA via `env:`, not inline interpolation.)
- [x] Dependencies are pinned and justified if changed.
- [x] Documentation updated. (Rationale recorded inline in `ci.yml`.)

## Corrections to the evaluation report

Two findings in the report were wrong and are **not** acted on here:

- **F5 schema-drift "missing"** — it exists. It is implemented inline as
  `go run ./cmd/niac-schema` + `diff`, not as `scripts/check-schema-drift.sh`,
  and the audit grepped for the script filename.
- **F5 types-drift "missing"** — does not apply. niac has no Go→TypeScript
  generation, so there is nothing to drift.

## Not done, deliberately

**zizmor** is not wired in. It reports 88 findings here, 13 high
(`pull_request_target` triggers, workflow-level write permissions,
release-please App-token use). Narrowing those carelessly breaks release
automation, so they belong in their own reviewed security pass — not bolted on
as a `continue-on-error` step that would enforce nothing.