### PR TITLE
ci: scope workflow permissions to jobs and narrow the release-please App token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,15 +672,12 @@ jobs:
   #   actionlint — syntax, expression and shell errors inside run: blocks.
   #                It caught a duplicated `with:` key that PyYAML accepts
   #                silently by keeping the last occurrence.
-  #
-  # zizmor (Actions security scanner) is NOT wired in yet: it currently reports
-  # 76-88 findings per repo, 10-13 of them high (pull_request_target triggers,
-  # workflow-level write permissions, release-please App-token use). Those need
-  # real review — narrowing them carelessly breaks release automation — so they
-  # are tracked as their own security pass rather than bolted on here as a
-  # continue-on-error step that would enforce nothing.
+  #   zizmor     — Actions security scanner. Blocks on High findings only.
+  #                The repo is at zero High; the two that survive review carry
+  #                `# zizmor: ignore[...]` comments with the reasoning inline.
+  #                Low/Informational (~29) are reported but not yet enforced.
   workflow-lint:
-    name: Workflow Lint (actionlint)
+    name: Workflow Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: changes
@@ -698,6 +695,15 @@ jobs:
           # step summaries; the ungrouped form stays readable and diffs one
           # line at a time. Every correctness-level rule stays enabled.
           actionlint -ignore 'SC2129' -color
+
+      - name: Run zizmor
+        env:
+          # zizmor resolves action refs against the API; without a token it
+          # falls back to unauthenticated requests and gets rate-limited.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pipx install zizmor==1.29.0
+          zizmor --min-severity high --color always .github/workflows/
 
 
   # ===========================================================================

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -25,7 +25,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   go-dead-code:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,10 +13,7 @@ on:
   issues:
     types: [opened, edited]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # ===========================================================================
@@ -26,6 +23,9 @@ jobs:
     name: Label PR
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
@@ -40,6 +40,8 @@ jobs:
     name: Label Issue
     runs-on: ubuntu-latest
     if: github.event_name == 'issues'
+    permissions:
+      issues: write
 
     steps:
       - name: Parse issue and apply labels

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,12 @@
 name: Release Please
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run is the required trigger here: release-please must run after
+  # CI succeeds on main, with write access, which pull_request cannot give.
+  # The usual workflow_run hazard is checking out the triggering run's
+  # untrusted head — this workflow performs no checkout at all, and is gated
+  # on branches:[main] + conclusion == 'success'.
   workflow_run:
     workflows: ["CI"]
     branches: [main]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,9 +24,7 @@ on:
     types: [completed]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
@@ -34,6 +32,9 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -45,6 +46,14 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Scope the installation token to what release-please actually needs:
+          # write the changelog/tag/release (contents), open and update the
+          # release PR (pull-requests), and set its `autorelease:` labels —
+          # which go through the issues API. Without these the token inherits
+          # every permission the msn-ci-bot installation holds.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
 
       - name: Run Release Please
         id: release
@@ -83,6 +92,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Trigger release workflow
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write # cosign keyless OIDC
-  attestations: write
+  contents: read
 
 env:
   NPCAP_SDK_VERSION: "1.16"
@@ -88,8 +86,11 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "26.5.0"
-          cache: npm
-          cache-dependency-path: ui/package-lock.json
+          # No npm cache on the release path. This job's output is published
+          # and attested, so a poisoned cache entry restored from a branch
+          # would land in a signed artifact. CI keeps its cache; releases
+          # always resolve from the registry. (zizmor cache-poisoning)
+          cache: false
 
       - name: Set up npm
         run: npm install --global npm@12.0.1
@@ -297,6 +298,9 @@ jobs:
     if: ${{ !inputs.provenance_only }}
     runs-on: ubuntu-latest
     needs: [build-ui, build-windows, niac-content]
+    permissions:
+      contents: write
+      id-token: write # cosign keyless OIDC
     container:
       # Docker Hub tag scheme: <go-version>-<goreleaser-version>. Pin so
       # behaviour stays reproducible; bump via dependabot when newer revs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
+        # zizmor: ignore[cache-poisoning]
+        # Caching is disabled below, so there is no cache to poison. zizmor
+        # flags every setup-node in a publishing workflow regardless of the
+        # `cache` input (Low confidence); re-check on the next zizmor bump.
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "26.5.0"

--- a/.github/workflows/title-lint.yml
+++ b/.github/workflows/title-lint.yml
@@ -6,15 +6,15 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
-permissions:
-  issues: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   lint-pr-title:
     name: Lint PR Title
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: read
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
@@ -42,6 +42,8 @@ jobs:
     name: Lint Issue Title
     runs-on: ubuntu-latest
     if: github.event_name == 'issues'
+    permissions:
+      issues: write
     steps:
       - name: Check issue title
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/title-lint.yml
+++ b/.github/workflows/title-lint.yml
@@ -3,7 +3,11 @@ name: Title Lint
 on:
   issues:
     types: [opened, edited]
-  pull_request_target:
+  # pull_request, not pull_request_target: this job only reads the PR title
+  # and sets a check conclusion, so the fork-PR read-only token is sufficient.
+  # pull_request_target would hand a write-capable token to a workflow that
+  # never needs one. (zizmor dangerous-triggers)
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions: {}
@@ -12,7 +16,7 @@ jobs:
   lint-pr-title:
     name: Lint PR Title
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     permissions:
       pull-requests: read
     steps:


### PR DESCRIPTION
## Summary

Closes the zizmor high-severity findings in `.github/workflows/` and wires zizmor in as a **blocking** CI gate so they cannot regenerate. niac goes **13 High → 0**.

Follow-up to #1251, working the open item recorded in `msn-docs-internal/CI_FLEET_EVALUATION_2026-08-14.md` §5. Companion PRs: seed #1833, stem #573.

The evaluation deliberately left zizmor unwired rather than bolting it on as a `continue-on-error` step that would enforce nothing — the same inert-gate antipattern F1 was about. This is the reviewed pass that pays it off.

### Real fixes

| Workflow | Change |
|---|---|
| `dead-code.yml` | Drops `issues: write` outright — no job in the file touches the issues API, so the permission was dead |
| `labeler.yml`, `title-lint.yml`, `release-please.yml` | Workflow-level `permissions:` pushed down to the jobs that need them, each job holding only its own scopes. `trigger-release` echoes two strings and now holds no token permissions at all |
| `release-please.yml` | App token scoped with `permission-contents` / `permission-pull-requests` / `permission-issues` instead of inheriting every permission the msn-ci-bot installation holds |
| `release.yml` | Workflow-level drops to `contents: read`; the `goreleaser` job (which publishes and does cosign keyless signing) takes `contents: write` + `id-token: write`, and the existing `provenance` block is left as-is. `build-ui`, `prepare-npcap-sdk`, `build-windows`, `niac-content` and `goreleaser-backfill-hashes` inherit `contents: read`. Also stops caching npm on the release path, since that job's output is published and attested |
| `title-lint.yml` | `pull_request_target` → `pull_request`. The job only reads the PR title and sets a check conclusion, so the fork read-only token suffices; `pull_request_target` was handing a write-capable token to a workflow that never needed one |

`attestations: write` is kept — niac already runs `actions/attest-build-provenance`, so that scope is load-bearing. It is now declared on the job that uses it rather than workflow-wide.

### Accepted findings

Two survive review and carry `# zizmor: ignore[...]` with the reasoning inline:

- **`workflow_run` in release-please.yml** — required to run after CI succeeds on main with write access. The hazard that audit exists to catch is checking out the triggering run's untrusted head; this workflow performs no checkout at all, and is gated on `branches: [main]` + `conclusion == 'success'`.
- **`cache-poisoning` on setup-node** — caching is now off, so there is no cache to poison. zizmor flags every setup-node in a publishing workflow regardless of the `cache` input (confirmed empirically on seed: the finding persists with `cache: false`, `cache: ''`, and the key omitted). Low confidence; re-check on the next zizmor bump.

### The gate

Added to the existing `workflow-lint` job (renamed from "Workflow Lint (actionlint)" — not a required status check, so the rename is safe), pinned to zizmor 1.29.0, blocking on **High only**. Low/Informational (~35) are reported but not yet enforced.

## Linked Issue

Related to #1251 — this is the "zizmor security pass" open item that PR left behind.

## Testing Evidence

Before, on `main`:

```
13 High
 6 Informational
29 Low
```

After, on this branch:

```
$ zizmor --format json .github/workflows/ | jq -r '.[].determinations.severity' | sort | uniq -c
   6 Informational
  29 Low

$ zizmor --min-severity high .github/workflows/ ; echo "exit=$?"
exit=0
```

The gate enforces rather than reports — verified on seed by removing an ignore comment and re-running: exit 14 with the finding present, exit 0 when clean.

Workflow integrity, unchanged from the `main` baseline:

```
$ python3 -c "import yaml,sys;[yaml.safe_load(open(f)) for f in sys.argv[1:]];print('yaml OK')" .github/workflows/*.yml
yaml OK

$ actionlint -ignore 'SC2129' | grep -c '^\.github'
0
```

## Security and Release Checklist

- [x] No new mutating routes, so no CSRF/rate-limit/role-gate surface is touched
- [x] No secrets added; the zizmor step uses the run-scoped `secrets.GITHUB_TOKEN`
- [x] Permissions strictly narrowed, never widened — every scope removed was proven unused before removal, and `attestations: write` / `id-token: write` were kept where signing and provenance genuinely need them
- [x] Release path exercised for correctness by inspection: `release.yml` job-level scopes cover exactly the steps that need them; `release-please` App-token scopes cover contents (tag/release), pull-requests (release PR), and issues (the `autorelease:` labels)
- [x] No suppression added without owner sign-off — both `zizmor: ignore` comments were explicitly approved and carry their rationale inline
- [x] No banned vocabulary; no customer-facing surface changed
- [ ] **Release-time verification still pending** — `release-please.yml` and `release.yml` only exercise fully at release time. Watch the first release-please run on `main` after merge.
