### PR TITLE
ci: cache Playwright browsers and document the CI pipeline

### DIFF
--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -1,0 +1,131 @@
+# CI/CD Pipeline
+
+The CI pipeline runs on every push and PR. **All checks must pass.**
+
+Every job except `changes` is gated on the `changes` job's path filters, so a
+docs-only PR does not pay for a Go build. `ci-complete` is the single required
+status check — it depends on every other job, so adding a job to `ci.yml`
+without adding it to `ci-complete`'s `needs:` list makes that job advisory.
+
+## GitHub Actions Workflows
+
+### ci.yml - Main CI Pipeline
+
+| Job             | Description              | Checks                                                                 |
+| --------------- | ------------------------ | ---------------------------------------------------------------------- |
+| `changes`       | Path filtering           | Decides which downstream jobs run                                      |
+| `backend`       | Go checks                | lint, vet, staticcheck, fmt, tests, coverage floor                     |
+| `race`          | Go race detector         | `go test -race`, split from `backend` so it fails distinctly           |
+| `frontend`      | React/TS checks          | tsgo typecheck, Biome, Vite build, Vitest, Storybook build             |
+| `c-lint`        | C lint (C23)             | clang-format, clang-tidy                                               |
+| `security`      | Security scans           | govulncheck (hard gate), gosec, npm audit, gitleaks, Trivy             |
+| `semgrep`       | SAST                     | Semgrep rules                                                          |
+| `quality`       | Code quality gates       | banned vocabulary, file size ratchet, output escaping, sensitive files |
+| `workflow-lint` | Workflow static analysis | actionlint; zizmor (blocks on High)                                    |
+| `i18n`          | Internationalization     | Catalog completeness, no translated standard terms                     |
+| `docs`          | Documentation            | Markdown lint (blocking, scoped to changed files)                      |
+| `build`         | Build verification       | Multi-arch binaries with full ldflags, UIBuildHash verified            |
+| `lighthouse`    | Frontend performance     | Lighthouse budgets                                                     |
+| `e2e`           | Browser tests            | Playwright, chromium + webkit + firefox                                |
+| `ci-complete`   | Aggregate gate           | The required status check                                              |
+
+### Other Workflows
+
+| Workflow               | Purpose                                               |
+| ---------------------- | ----------------------------------------------------- |
+| `browser-channels.yml` | Playwright browser channel coverage                   |
+| `cache-npcap-sdk.yml`  | Cache the Npcap SDK for Windows builds                |
+| `codeql.yml`           | CodeQL security analysis (Go, JS/TS)                  |
+| `dead-code.yml`        | Weekly dead code detection                            |
+| `docs-link-check.yml`  | Weekly external link check (split out of `ci.yml`)    |
+| `label-sync.yml`       | Sync label definitions                                |
+| `labeler.yml`          | Auto-label PRs and issues                             |
+| `license-check.yml`    | Verify dependency licenses                            |
+| `pr-body-lint.yml`     | Enforce the PR body template                          |
+| `release-please.yml`   | Automated version management and release PRs          |
+| `release.yml`          | goreleaser release builds, signing, SLSA provenance   |
+| `scorecard.yml`        | OpenSSF Scorecard                                     |
+| `title-lint.yml`       | Lint PR and issue titles                              |
+| `todo-tracker.yml`     | Weekly TODO tracking                                  |
+
+## Build contract
+
+`build` verifies the Universal Build Contract, not just that compilation
+succeeds: every binary embeds `Version`, `Commit`, `BuildTime` and
+`UIBuildHash`. The "Verify UIBuildHash embedded" step (added in #1251)
+recomputes the expected 32-character md5 hash from `internal/api/ui/`,
+confirms `internal/api/ui/` is not empty (the frontend-dist artifact from the
+`frontend` job actually landed), and greps the built binary's strings for
+that hash — catching a build that ships without the `-X ...UIBuildHash=...`
+ldflag actually taking effect. A raw `go build` in CI would otherwise produce
+a binary whose `/__version` reports `"unknown"`, the silent failure this
+check exists to catch.
+
+## Workflow security
+
+`workflow-lint` runs two scanners over `.github/workflows/` itself:
+
+- **actionlint** — syntax, expression and shell errors inside `run:` blocks.
+  It catches things a plain YAML parse does not, including duplicate `with:`
+  keys, which `yaml.safe_load` accepts silently by keeping the last one.
+  `SC2129` is ignored as a pure style preference; every correctness rule stays on.
+- **zizmor** (pinned 1.29.0) — Actions security scanner. **Blocks on High
+  findings.** The repo sits at zero High. Two findings survived review and
+  carry `# zizmor: ignore[...]` comments with the reasoning inline (in
+  `release-please.yml` and `release.yml`); anything else that reaches High
+  fails the build. Low/Informational are reported but not yet enforced.
+
+Permissions follow least privilege: workflows declare `permissions: {}` (or
+`contents: read`) at the top level and grant scopes per job. A new job that
+needs a write scope declares it on the job, never workflow-wide.
+
+## CI Must Pass Before Merge
+
+`main` is protected. Push a feature branch, open a PR, and let CI gate it:
+
+```bash
+gh pr create --fill
+gh pr merge --auto --squash --delete-branch
+```
+
+Fix issues locally first:
+
+```bash
+make all       # Full local verification
+make verify    # lint, test, security, build, schema
+make test-e2e  # Build and run frontend E2E tests against the HTTPS daemon
+```
+
+## Running CI Checks Locally
+
+### Backend
+
+```bash
+make lint-backend      # golangci-lint v2.12.2
+make test-backend      # Go tests
+make test-coverage     # Coverage report
+make security-backend  # govulncheck
+```
+
+### Frontend
+
+```bash
+make lint-frontend     # Biome
+make test-frontend     # Vitest
+make build-frontend    # Vite build into internal/api/ui/
+```
+
+### Security
+
+```bash
+make security          # All security scans
+make security-secrets  # gitleaks
+make security-trivy    # Trivy
+```
+
+### Workflows
+
+```bash
+actionlint -ignore 'SC2129'
+zizmor --min-severity high .github/workflows/
+```

--- a/.github/workflows/browser-channels.yml
+++ b/.github/workflows/browser-channels.yml
@@ -42,9 +42,23 @@ jobs:
       - name: Build NIAC
         run: make build
 
-      - name: Install Chrome and Edge channels
+      - name: Install Chrome and Edge OS dependencies
         working-directory: ui
-        run: npx playwright install --with-deps chrome msedge
+        run: npx playwright install-deps chrome msedge
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-channels-${{ runner.os }}-${{ hashFiles('ui/package-lock.json') }}
+          restore-keys: |
+            playwright-channels-${{ runner.os }}-
+
+      - name: Install Chrome and Edge channels
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ui
+        run: npx playwright install chrome msedge
 
       - name: Start NIAC
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -975,9 +975,23 @@ jobs:
               -X github.com/MustardSeedNetworks/niac-go/internal/version.UIBuildHash=${UI_BUILD_HASH}" \
             -o niac ./cmd/niac
 
-      - name: Install Playwright browsers
+      - name: Install Playwright OS dependencies
         working-directory: ui
-        run: npx playwright install --with-deps chromium webkit firefox
+        run: npx playwright install-deps chromium webkit firefox
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ui/package-lock.json') }}
+          restore-keys: |
+            playwright-browsers-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ui
+        run: npx playwright install chromium webkit firefox
 
       - name: Start backend server
         env:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,10 @@
 {
-  // Globs to lint
-  "globs": ["**/*.md"],
+  // No "globs" here on purpose. markdownlint-cli2 UNIONS a "globs" property
+  // with any globs passed on the command line — it does not replace them. With
+  // "globs": ["**/*.md"] set, ci.yml's changed-files-only markdown gate silently
+  // linted the whole tree and failed on pre-existing debt in files the PR never
+  // touched. Callers pass their own scope instead: `make lint-md` passes
+  // "**/*.md" for the full tree, CI passes just the changed files.
 
   // Globs to ignore
   "ignores": [


### PR DESCRIPTION
## Summary

Caches Playwright's downloaded browsers (`~/.cache/ms-playwright`) in the
`e2e` job of `ci.yml` and in `browser-channels.yml`, both of which
previously re-downloaded chromium/webkit/firefox (or chrome/msedge) on
every run. OS-level dependencies (`playwright install-deps`, apt
packages) stay unconditional since they aren't cacheable; the browser
binaries themselves now download only on a cache miss, keyed on
`runner.os` + a hash of `ui/package-lock.json`, with a same-OS
`restore-keys` fallback.

Also adds `.github/workflows/CI.md`, documenting the `ci.yml` job
graph, the purpose of every other workflow file, the Universal Build
Contract check added in #1251 (`Verify UIBuildHash embedded`), and the
`workflow-lint` job's actionlint/zizmor scanners.

**Deliberately not doing:** a shared `build-ui` artifact job across
`security`/`i18n`/`e2e`. Only `frontend` actually builds the UI in this
repo — `security`, `i18n`, and `e2e` run `npm ci` alone because they
need `node_modules`, not `dist` — so a shared artifact would serialize
those jobs behind a new one for effectively no time saved. Considered
and rejected; not something to re-propose without a change in what
those jobs need.

## Linked Issue

Related to #1251

## Testing Evidence

```
$ GH_TOKEN=$(gh auth token) zizmor --min-severity high .github/workflows/
 INFO zizmor: 🌈 zizmor v1.29.0
 INFO audit: zizmor: 🌈 completed .github/workflows/browser-channels.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/ci.yml
 ... (15 workflows scanned)
No findings to report. Good job! (37 ignored, 41 suppressed)
$ echo $?
0

$ actionlint -ignore 'SC2129'
$ echo $?
0

$ python3 -c "import yaml,sys;[yaml.safe_load(open(f)) for f in sys.argv[1:]];print('OK')" .github/workflows/*.yml
OK

$ python3 <duplicate-key strict YAML loader over .github/workflows/*.yml>
dup-key exit=0   # no duplicate keys detected

$ npx markdownlint-cli2 .github/workflows/CI.md   # run in isolation, config copied alongside
Summary: 0 issues in 0 files
```

## Security and Release Checklist

- [x] No new secrets, credentials, or tokens introduced
- [x] `actions/cache` pinned to the same SHA (`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`,
      v6.1.0) niac already uses for `actions/cache/restore` and
      `actions/cache/save` in `cache-npcap-sdk.yml` / `release.yml`
- [x] Cache key is content-derived (lockfile hash), not attacker-influenced —
      zizmor reports zero High findings, no `cache-poisoning` result
- [x] `release.yml` untouched — its build stays uncached by design
      (published/attested artifacts)
- [x] No `//nolint`, `biome-ignore`, or `zizmor: ignore` suppressions added
- [x] `main` untouched; PR only, no merge



---

## Added: markdown gate fix (found by this PR)

This PR is the first to touch a markdown file since the markdown gate was made
blocking, and it exposed a defect in that gate.

The gate was meant to be blocking but **scoped to changed files**, so pre-existing
debt would ratchet down rather than failing every PR. It did not work:
`markdownlint-cli2` **unions** the `globs` property from `.markdownlint-cli2.jsonc`
with globs passed on the command line — it does not replace them. So CI passed the
changed files and cli2 linted those *plus* the entire tree, failing on violations in
files the PR never opened.

Fix: drop `"globs"` from `.markdownlint-cli2.jsonc`. Callers already state their own
scope — `make lint-md` passes `"**/*.md"`, CI passes the changed files — and nothing
invokes bare `markdownlint-cli2` with no arguments.

```
# scoped, what CI does
Linting: 1 file(s)
Summary: 0 error(s)

# "**/*.md", what `make lint-md` does — unchanged
Linting: 635 file(s)
```