### PR TITLE
fix(ci): bound apt steps so a stalled mirror fails fast

### DIFF
--- a/.github/workflows/browser-channels.yml
+++ b/.github/workflows/browser-channels.yml
@@ -30,6 +30,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap
+        timeout-minutes: 8
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
@@ -245,6 +246,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
@@ -356,6 +358,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
@@ -496,6 +499,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install C23 tools (clang-tidy, cppcheck, bear)
+        timeout-minutes: 8
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -824,6 +828,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
@@ -933,6 +938,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
@@ -1098,6 +1104,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -41,6 +41,7 @@ jobs:
           cache: true
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 
       - name: Run staticcheck for unused code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install libpcap headers for amd64 + arm64
+        timeout-minutes: 8
         # goreleaser-cross ships compilers but not libpcap headers. gopacket/pcap
         # needs pcap.h + libpcap.so (and its transitive link deps: libdbus-1-3,
         # libibverbs, …) for cgo, per target arch.
@@ -616,6 +617,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install corpus-checkout + bundle prerequisites
+        timeout-minutes: 8
         if: env.HAS_CONTENT_KEY == 'true'
         # goreleaser-cross is Go-focused; make sure ssh (deploy-key checkout),
         # python3 and make (bundle generation) are present.


### PR DESCRIPTION
## Summary

`apt` blocks forever on a dead mirror connection by default, and these steps
carried no step-level timeout — so one stalled Ubuntu mirror consumed the whole
job budget and surfaced as a red build with no test ever having run.

Two incidents today: niac's `Install libpcap-dev` hung 25 minutes (job
95072124340) and stem's `Install Playwright OS dependencies` hung 28 (job
95068053052). The Playwright steps were fixed separately; this covers the rest.

Every apt step that lacked one now carries `timeout-minutes: 8`, so a stall
fails in minutes instead of burning the job. Composite-action steps cannot take
`timeout-minutes`, so seed's `setup-libpcap` bounds apt's own
`Acquire::*::Timeout` / `DPkg::Lock::Timeout` and retries the transient case
instead.

Steps already carrying a retry guard were left alone — no double-wrapping. What
is installed is unchanged; only how long it may block. No `continue-on-error`:
a genuinely broken install still fails the build.

## Linked Issue

Related to #1280

## Testing Evidence

```
$ actionlint -ignore 'SC2129' .github/workflows/*.yml
(clean, no output)

$ zizmor --min-severity high .github/workflows/*.yml
No findings to report. Good job!
```

Sample of the change:

```diff
       - name: Install libpcap
+        timeout-minutes: 8
         run: |
```

## Security and Release Checklist

- [x] CI-configuration only — no product code, dependency or route touched.
- [x] Changes how long a step may block, never what gets installed.
- [x] No `continue-on-error` added; a real install failure still fails the build.
- [x] No action pins changed; no secrets touched.
