### PR TITLE
fix(ci): bound apt waits in remaining install steps

### DIFF
--- a/.github/workflows/browser-channels.yml
+++ b/.github/workflows/browser-channels.yml
@@ -30,10 +30,32 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap
+        timeout-minutes: 8
+        # A stalled Ubuntu mirror can hang apt for the whole job budget
+        # without running a test, because apt waits forever on a dead
+        # connection by default. Bound apt's own network waits, then retry
+        # the transient case.
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
-          sudo apt-get update
-          sudo apt-get install -y libpcap-dev
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
+          for i in 1 2 3; do
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
 
       - name: Install frontend dependencies
         working-directory: ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,16 +129,33 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
         # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
         # so a broken third-party mirror can't red the job, then retry the
         # install with backoff for genuinely transient hiccups.
+        #
+        # A stalled Ubuntu mirror can also hang apt itself for the whole job
+        # budget without running a test (job 95072124340 hung 25 minutes on
+        # this exact step), because apt waits forever on a dead connection by
+        # default. Bound apt's own network waits too, then retry the transient
+        # case.
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
           for i in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
               exit 0
             fi
             echo "apt attempt $i failed; retrying in $((i * 5))s..."
@@ -245,16 +262,33 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
         # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
         # so a broken third-party mirror can't red the job, then retry the
         # install with backoff for genuinely transient hiccups.
+        #
+        # A stalled Ubuntu mirror can also hang apt itself for the whole job
+        # budget without running a test (job 95072124340 hung 25 minutes on
+        # this exact step), because apt waits forever on a dead connection by
+        # default. Bound apt's own network waits too, then retry the transient
+        # case.
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
           for i in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
               exit 0
             fi
             echo "apt attempt $i failed; retrying in $((i * 5))s..."
@@ -356,16 +390,33 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
         # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
         # so a broken third-party mirror can't red the job, then retry the
         # install with backoff for genuinely transient hiccups.
+        #
+        # A stalled Ubuntu mirror can also hang apt itself for the whole job
+        # budget without running a test (job 95072124340 hung 25 minutes on
+        # this exact step), because apt waits forever on a dead connection by
+        # default. Bound apt's own network waits too, then retry the transient
+        # case.
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
           for i in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
               exit 0
             fi
             echo "apt attempt $i failed; retrying in $((i * 5))s..."
@@ -496,15 +547,34 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install C23 tools (clang-tidy, cppcheck, bear)
+        timeout-minutes: 8
+        # A stalled Ubuntu mirror can hang apt for the whole job budget
+        # without running a single check, because apt waits forever on a dead
+        # connection by default. Bound apt's own network waits, then retry
+        # the transient case before moving on to the rest of the toolchain
+        # setup.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            clang-18 \
-            clang-tidy-18 \
-            clang-format-18 \
-            cppcheck \
-            bear \
-            gcc-13
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
+          for attempt in 1 2 3; do
+            if [ "$attempt" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y clang-18 clang-tidy-18 clang-format-18 cppcheck bear gcc-13'; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::C23 toolchain install failed after 3 attempts"
+              exit 1
+            fi
+            echo "C23 toolchain install attempt ${attempt} failed; retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
 
           # Set clang-18 as default
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
@@ -824,16 +894,33 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
         # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
         # so a broken third-party mirror can't red the job, then retry the
         # install with backoff for genuinely transient hiccups.
+        #
+        # A stalled Ubuntu mirror can also hang apt itself for the whole job
+        # budget without running a test (job 95072124340 hung 25 minutes on
+        # this exact step), because apt waits forever on a dead connection by
+        # default. Bound apt's own network waits too, then retry the transient
+        # case.
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
           for i in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
               exit 0
             fi
             echo "apt attempt $i failed; retrying in $((i * 5))s..."
@@ -933,16 +1020,33 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
         # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
         # so a broken third-party mirror can't red the job, then retry the
         # install with backoff for genuinely transient hiccups.
+        #
+        # A stalled Ubuntu mirror can also hang apt itself for the whole job
+        # budget without running a test (job 95072124340 hung 25 minutes on
+        # this exact step), because apt waits forever on a dead connection by
+        # default. Bound apt's own network waits too, then retry the transient
+        # case.
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
           for i in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
               exit 0
             fi
             echo "apt attempt $i failed; retrying in $((i * 5))s..."
@@ -1098,16 +1202,33 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Install libpcap-dev
+        timeout-minutes: 8
         # packages.microsoft.com intermittently serves an unsigned/invalid
         # InRelease that aborts `apt-get update` for the whole runner, even
         # though libpcap-dev comes from the Ubuntu archive (killed Lighthouse
         # /#928 + Security Scanning/#932). Drop the unused Microsoft apt source
         # so a broken third-party mirror can't red the job, then retry the
         # install with backoff for genuinely transient hiccups.
+        #
+        # A stalled Ubuntu mirror can also hang apt itself for the whole job
+        # budget without running a test (job 95072124340 hung 25 minutes on
+        # this exact step), because apt waits forever on a dead connection by
+        # default. Bound apt's own network waits too, then retry the transient
+        # case.
         run: |
           sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | xargs -0 -r sudo rm -f
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
           for i in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y libpcap-dev; then
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
               exit 0
             fi
             echo "apt attempt $i failed; retrying in $((i * 5))s..."

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -41,7 +41,31 @@ jobs:
           cache: true
 
       - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+        timeout-minutes: 8
+        # A stalled Ubuntu mirror can hang apt for the whole job budget
+        # without running a check, because apt waits forever on a dead
+        # connection by default. Bound apt's own network waits, then retry
+        # the transient case.
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
+          for i in 1 2 3; do
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              sudo dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sudo sh -c 'apt-get update && apt-get install -y libpcap-dev'; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap-dev install failed after 3 attempts"
+          exit 1
 
       - name: Run staticcheck for unused code
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install libpcap headers for amd64 + arm64
+        timeout-minutes: 8
         # goreleaser-cross ships compilers but not libpcap headers. gopacket/pcap
         # needs pcap.h + libpcap.so (and its transitive link deps: libdbus-1-3,
         # libibverbs, …) for cgo, per target arch.
@@ -332,12 +333,35 @@ jobs:
         # match ubuntu-ports (Multi-Arch:same lockstep), which is why the image
         # pin above is kept current. `apt-get update` runs strict so a future
         # drift fails loud instead of silently shipping a broken cross-build.
+        #
+        # A stalled Ubuntu mirror can also hang apt itself for the whole job
+        # budget without producing a release artifact, because apt waits
+        # forever on a dead connection by default. Bound apt's own network
+        # waits, then retry the transient case — a genuine arch-drift failure
+        # still fails loud after 3 attempts.
         shell: bash
         run: |
           set -euo pipefail
+          tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
           dpkg --add-architecture arm64
-          apt-get update
-          apt-get install -y libpcap-dev libpcap-dev:arm64 zip
+          for i in 1 2 3; do
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sh -c 'apt-get update && apt-get install -y libpcap-dev libpcap-dev:arm64 zip'; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::libpcap headers install failed after 3 attempts"
+          exit 1
 
       - name: Download UI dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -617,13 +641,36 @@ jobs:
 
       - name: Install corpus-checkout + bundle prerequisites
         if: env.HAS_CONTENT_KEY == 'true'
+        timeout-minutes: 8
         # goreleaser-cross is Go-focused; make sure ssh (deploy-key checkout),
         # python3 and make (bundle generation) are present.
+        #
+        # A stalled Ubuntu mirror can hang apt for the whole job budget
+        # without producing the content package, because apt waits forever on
+        # a dead connection by default. Bound apt's own network waits, then
+        # retry the transient case.
         shell: bash
         run: |
           set -euo pipefail
-          apt-get update
-          apt-get install -y --no-install-recommends openssh-client python3 make
+          tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          DPkg::Lock::Timeout "60";
+          EOF
+          for i in 1 2 3; do
+            if [ "$i" -gt 1 ]; then
+              # A timeout kill can leave dpkg half-configured; recover first.
+              dpkg --configure -a >/dev/null 2>&1 || true
+            fi
+            if timeout -k 15 120 sh -c 'apt-get update && apt-get install -y --no-install-recommends openssh-client python3 make'; then
+              exit 0
+            fi
+            echo "apt attempt $i failed; retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done
+          echo "::error::corpus-checkout prerequisites install failed after 3 attempts"
+          exit 1
 
       - name: Checkout sanitized walk corpus (read-only deploy key)
         if: env.HAS_CONTENT_KEY == 'true'


### PR DESCRIPTION
## Summary

- apt has no default network timeout, so a stalled mirror can hang `apt-get update`/`apt-get install` indefinitely instead of failing. This already cost this repo 25 minutes on the "Install libpcap-dev" step (job 95072124340) and stem 28 minutes on its Playwright OS-deps step (job 95068053052), both surfacing as a red build with zero tests run.
- Applies the same fix already used for the Playwright OS-deps steps (#1278 / commit 575cb61d): a step-level `timeout-minutes`, an `/etc/apt/apt.conf.d/99-ci-timeouts` drop-in bounding `Acquire::http::Timeout`/`Acquire::https::Timeout`/`DPkg::Lock::Timeout`, and a 3-attempt retry loop with backoff plus `dpkg --configure -a` recovery, to every remaining unguarded apt site.
- Sites fixed: `ci.yml` "Install libpcap-dev" (backend, race, security, build, e2e, lighthouse jobs — already had a retry loop, only the timeout bound was missing) and "Install C23 tools" (c-lint job, fully unguarded); `browser-channels.yml` "Install libpcap"; `dead-code.yml` "Install libpcap-dev"; `release.yml` "Install libpcap headers for amd64 + arm64" and "Install corpus-checkout + bundle prerequisites" (both goreleaser-cross container steps, fully unguarded).
- No change to what is installed anywhere — only how it is invoked.

## Linked Issue

Related to #1283

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ actionlint -ignore 'SC2129' .github/workflows/*.yml
(no output, exit 0)

$ zizmor --min-severity high .github/workflows/*.yml .github/actions/*/action.yml
 INFO zizmor: 🌈 zizmor v1.29.0
 WARN audit: zizmor: zizmor is running in offline mode by default; some audits and auto-fixes will not be available. see https://docs.zizmor.sh/usage/#operating-modes for details
 INFO audit: zizmor: 🌈 completed .github/actions/setup-go/action.yml
 INFO audit: zizmor: 🌈 completed .github/actions/setup-node/action.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/browser-channels.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/cache-npcap-sdk.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/codeql.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/dead-code.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/docs-link-check.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/label-sync.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/labeler.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/license-check.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/pr-body-lint.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/release-please.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/scorecard.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/title-lint.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/todo-tracker.yml
No findings to report. Good job! (35 ignored, 41 suppressed)
exit: 0
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed.
- [ ] Documentation, screenshots, or operator notes were updated if behavior changed.