### PR TITLE
fix(ci): make the i18n gate actually gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1325,6 +1325,7 @@ jobs:
       - docs
       - build
       - e2e
+      - i18n
     if: always()
     steps:
       - name: Verify upstream results


### PR DESCRIPTION
## Summary

The `i18n` job runs `scripts/i18n/validate.sh --ratchet` — "Validate i18n (parity, glossary, banned vocab, etc.)" — but was **missing from `ci-complete`'s `needs:` list**.

Branch protection requires only `CI Complete`, `Lint PR Title` and `Lint PR Body`, so an i18n failure could not block a PR. A banned-vocabulary string landing in a locale file would go in with CI green — against a rule CLAUDE.md states has no exceptions.

seed and stem both list `i18n` in their `ci-complete` needs; **niac was the only repo that did not.** The comment above the needs list explains why `lighthouse` is deliberately excluded and is silent on i18n, so this was an omission rather than a decision.

Found by a CI audit, verified by comparing all three repos' wiring.

## Linked Issue

Related to #1285

## Testing Evidence

```
$ for r in seed stem niac-go; do ... done
seed      i18n job=yes  in ci-complete needs=YES
stem      i18n job=yes  in ci-complete needs=YES
niac-go   i18n job=yes  in ci-complete needs=NO

$ actionlint -ignore 'SC2129' .github/workflows/ci.yml
(clean, no output)
```

## Security and Release Checklist

- [x] Strengthens an existing gate; weakens nothing.
- [x] CI-configuration only — no product code, dependency or route touched.
- [x] No action pins changed; no secrets touched.
- [x] Brings niac into line with seed and stem rather than inventing a new policy.
