### PR TITLE
ci: declare which jobs deliberately do not gate a merge

### DIFF
--- a/.github/ci-advisory-jobs.txt
+++ b/.github/ci-advisory-jobs.txt
@@ -1,0 +1,10 @@
+# Jobs that deliberately do NOT gate a merge, each with a reason.
+# Format: job-key | why it is advisory
+#
+# check-ci-conformance.py (MustardSeedNetworks/.github) fails on any job that is
+# neither in ci-complete's needs: nor listed here. That is the point: niac's
+# i18n job validated banned vocabulary while being absent from needs:, so it
+# ran, could go red, and blocked nothing. A job is now either a gate, or it is
+# documented here with a reason.
+
+lighthouse | performance budget; informational trend, not a pass/fail contract


### PR DESCRIPTION
## Summary

Adds `.github/ci-advisory-jobs.txt`, consumed by the fleet conformance check in `MustardSeedNetworks/.github`. That check fails on any job which is neither in `ci-complete`'s `needs:` nor declared here with a reason.

The rule exists because of a real defect found today: **niac's `i18n` job — which validates banned vocabulary, a no-exceptions rule — was missing from `ci-complete`'s `needs:`.** It ran, it could go red, and it blocked nothing. seed and stem both had it wired; only niac didn't, and nobody noticed because every check was green.

Silence is no longer a valid state. A job is either a gate, or it is documented here.

## Linked Issue

Related to #1294

## Testing Evidence

```
$ python3 ../.github/scripts/check-ci-conformance.py MustardSeedNetworks/niac-go
ci-conformance: passed
```

Before this file, the same command reported the advisory jobs as ungated findings:

```
::error::job 'lighthouse' is not in ci-complete's needs and is not listed in
         .github/ci-advisory-jobs.txt — it runs but cannot block a merge
```

## Security and Release Checklist

- [x] Documents existing behaviour; no job's gating status changes in this PR.
- [x] Makes an undocumented advisory job impossible to add silently in future.
- [x] No product code, dependency, or action pin touched.
- [x] No secrets touched.
