### PR TITLE
ci: stop PRs writing their own cache copies

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -42,8 +42,8 @@ runs:
     # changed packages recompile, which is the cheap pure-Go work. `tag`
     # discriminates the cache by path so workspace-GOCACHE jobs don't collide
     # with default-path jobs on a shared key.
-    - name: Cache Go build and module caches
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Restore Go build and module caches
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ${{ steps.go-cache-paths.outputs.build }}
@@ -55,3 +55,17 @@ runs:
     - name: Download Go modules
       shell: bash
       run: go mod download
+
+    # Save only from the default branch. GitHub scopes caches per ref, so a PR
+    # that saves writes its OWN copy that is useless the moment it merges —
+    # this pushed niac past the 10GB cache ceiling where entries evict each
+    # other and restores fail with `tar` exit 2. PRs still READ main's cache;
+    # they simply stop littering.
+    - name: Save Go cache (default branch only)
+      if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.build }}
+          ${{ steps.go-cache-paths.outputs.mod }}
+        key: ${{ runner.os }}-go-${{ steps.go-cache-paths.outputs.tag }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/browser-channels.yml
+++ b/.github/workflows/browser-channels.yml
@@ -91,9 +91,12 @@ jobs:
         with:
           command: cd ui && npx playwright install-deps chrome msedge
 
-      - name: Cache Playwright browsers
+      # Restore always; save only from the default branch. Caches are scoped
+      # per ref, so a PR that saves writes its own copy that dies on merge —
+      # see the comment in .github/actions/setup-go for the incident.
+      - name: Restore Playwright browsers
         id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-channels-${{ runner.os }}-${{ hashFiles('ui/package-lock.json') }}
@@ -104,6 +107,13 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ui
         run: npx playwright install chrome msedge
+
+      - name: Save Playwright browsers (default branch only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-channels-${{ runner.os }}-${{ hashFiles('ui/package-lock.json') }}
 
       - name: Start NIAC
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -870,9 +870,12 @@ jobs:
           command: cd ui && npx playwright install-deps chromium webkit firefox
           command-timeout: '150'
 
-      - name: Cache Playwright browsers
+      # Restore always; save only from the default branch. Caches are scoped
+      # per ref, so a PR that saves writes its own copy that dies on merge —
+      # see the comment in .github/actions/setup-go for the incident.
+      - name: Restore Playwright browsers
         id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ui/package-lock.json') }}
@@ -883,6 +886,13 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ui
         run: npx playwright install chromium webkit firefox
+
+      - name: Save Playwright browsers (default branch only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('ui/package-lock.json') }}
 
       - name: Start backend server
         env:


### PR DESCRIPTION
## Summary

- GitHub scopes Actions caches per ref, so every PR that saves the Go build/module cache or a Playwright browser cache writes its own copy that is useless the moment it merges.
- Split `actions/cache@` into `actions/cache/restore@` (always) and `actions/cache/save@` (default branch only) in `.github/actions/setup-go/action.yml`, `.github/workflows/ci.yml`, and `.github/workflows/browser-channels.yml`. PRs still read the cache seeded by `main`; they stop writing their own copies.
- The Npcap SDK cache (`cache-npcap-sdk.yml`, `release.yml`) already used the restore/save split and needed no change.
- Mirrors seed PR #1896 (same pattern, same pinned SHA).

## Linked Issue

Related to #1296

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

```text
$ actionlint -ignore 'SC2129' .github/workflows/*.yml
(no output, exit 0)

$ zizmor --min-severity high .github/workflows/*.yml
No findings to report. Good job! (34 ignored, 40 suppressed)

$ grep -rn 'actions/cache@' .github/
(no output — all sites converted to actions/cache/restore@ or actions/cache/save@)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
- [x] Dependencies are pinned and justified if changed. (same pinned SHA, split into subpaths of the same action)
- [ ] Documentation, screenshots, or operator notes were updated if behavior changed.