### PR TITLE
fix(release): generate SBOMs for .deb and .rpm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -246,6 +246,14 @@ sboms:
     artifacts: archive
     documents:
       - "{{ .ArtifactName }}.sbom.json"
+  # .deb/.rpm are `package` artifacts in goreleaser, not `archive` — without
+  # this block the native packages, the ones customers actually install, ship
+  # with no bill of materials. seed has always had both; this repo had only the
+  # archive block, so 4 of its artifacts were SBOM-less.
+  - id: packages-sbom
+    artifacts: package
+    documents:
+      - "{{ .ArtifactName }}.sbom.json"
 
 signs:
   # Sign all release artifacts via cosign keyless OIDC. Mirrors release.yml's


### PR DESCRIPTION
## Summary

Every release artifact was signed, but the **native packages had no bill of materials** — 4 per release, and they are the ones customers actually install via apt/dnf.

| repo | artifacts | SBOMs before |
|---|---|---|
| seed | 9 | 9 ✅ |
| stem | 9 | 5 ⚠️ |
| niac-go | 11 | 7 ⚠️ |

**Root cause:** in goreleaser, `.deb`/`.rpm` are `package` artifacts, not `archive`. seed declares two `sboms` entries; this repo declared only the archive one, so packages were never covered:

```yaml
sboms:
  - id: archives-sbom
    artifacts: archive        # tar.gz, zip — covered
  - id: packages-sbom         # <-- was missing here
    artifacts: package        # deb, rpm — NOT covered
```

## Linked Issue

Related to #1298

## Testing Evidence

```
$ goreleaser check
  • thanks for using GoReleaser!

$ grep -c 'id:.*sbom' .goreleaser.yml
2
```

Final proof is the next release: every `.tar.gz`/`.zip`/`.deb`/`.rpm` should have a matching `.sbom.json`. Expected counts after this lands — stem 5 → 9, niac-go 7 → 11.

A planned release-conformance check will assert this automatically so it cannot regress (see `~/.claude/plans/fleet-release-artifact-parity.md`).

## Security and Release Checklist

- [x] Adds supply-chain coverage; removes none.
- [x] Config-only change, verified with `goreleaser check`.
- [x] Signing and provenance untouched — both were already correct.
- [x] No secrets touched.
