### PR TITLE
ci: make required checks report on merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for the merge queue: `CI Complete` is a required status check, so
+  # it must report on merge_group events too. Without this the queue would
+  # accept PRs and then wait forever for a check that never fires.
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -47,18 +51,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      c: ${{ steps.filter.outputs.c }}
-      docs: ${{ steps.filter.outputs.docs }}
-      workflows: ${{ steps.filter.outputs.workflows }}
-      schema: ${{ steps.filter.outputs.schema }}
-      https: ${{ steps.filter.outputs.https }}
-      hooks: ${{ steps.filter.outputs.hooks }}
+      # merge_group has no PR base to diff against, and the queue exists to test
+      # the merged result — so every filter reports true there and the full
+      # suite runs. Path filtering stays in effect for pull_request/push.
+      backend: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.backend }}
+      frontend: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.frontend }}
+      c: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.c }}
+      docs: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.docs }}
+      workflows: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.workflows }}
+      schema: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.schema }}
+      https: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.https }}
+      hooks: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.hooks }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
+        if: github.event_name != 'merge_group'
         with:
           filters: |
             backend:

--- a/.github/workflows/title-lint.yml
+++ b/.github/workflows/title-lint.yml
@@ -9,6 +9,10 @@ on:
   # never needs one. (zizmor dangerous-triggers)
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+  # Required for the merge queue: `Lint PR Title` is a required status check.
+  # Without this trigger the workflow never fires on merge_group, the check
+  # never reports, and every queued PR waits forever.
+  merge_group:
 
 permissions: {}
 
@@ -16,11 +20,15 @@ jobs:
   lint-pr-title:
     name: Lint PR Title
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Runs on merge_group too so the required check reports; there is no PR
+    # title to validate there, so the step below no-ops and the job succeeds.
+    # Same shape as pr-body-lint. Issues keep their own separate job.
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     permissions:
       pull-requests: read
     steps:
       - name: Validate PR title
+        if: github.event_name == 'pull_request'
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `merge_group:` to `ci.yml` so the `CI Complete` required check reports on merge queue runs.
- Make every output of `ci.yml`'s `changes` job (`backend`, `frontend`, `c`, `docs`, `workflows`, `schema`, `https`, `hooks`) report `true` on `merge_group` (no PR base to diff against there, and the queue exists to validate the merged result in full); the `dorny/paths-filter` step gains `if: github.event_name != 'merge_group'`. Path filtering is unchanged for `pull_request`/`push`.
- Add `merge_group:` to `title-lint.yml` and widen the `lint-pr-title` job's `if` to include `merge_group`, moving the pull_request-only condition down to the validating step — the same shape `pr-body-lint.yml` already used. The job now runs and reports on merge_group while no-opping (there's no PR title to validate).
- `pr-body-lint.yml` already had `merge_group:` — verified, no change needed.

This only adds the triggers so the required checks can report inside a merge queue. Enabling the queue in repo settings is a separate step, taken after these are confirmed reporting.

## Linked Issue

Related to #1301

## Testing Evidence

Verified which workflow emits each required context and whether it now triggers on `merge_group`:

| Required context | Workflow | `merge_group:` present |
|---|---|---|
| `CI Complete` | `.github/workflows/ci.yml` (job `name: CI Complete`) | yes (added) |
| `Lint PR Title` | `.github/workflows/title-lint.yml` (job `name: Lint PR Title`) | yes (added) |
| `Lint PR Body` | `.github/workflows/pr-body-lint.yml` (job `name: Lint PR Body`) | yes (already present) |

No other workflow in the repo declares a job with any of these three `name:` values (checked all `.github/workflows/*.yml`, including `browser-channels.yml` which has its own separate `changes` job unrelated to these three checks).

```
$ cd niac-go && actionlint -ignore 'SC2129' .github/workflows/*.yml
(no output, exit 0)

$ cd niac-go && zizmor --min-severity high .github/workflows/*.yml
 INFO zizmor: 🌈 zizmor v1.29.0
 WARN audit: zizmor: zizmor is running in offline mode by default; some audits and auto-fixes will not be available.
 INFO audit: zizmor: 🌈 completed .github/workflows/ci.yml
 ... (all 16 workflow files)
No findings to report. Good job! (34 ignored, 40 suppressed)

$ git branch --show-current
ci/merge-queue-support
```

## Security and Release Checklist

- [x] No CSRF/rate-limit/role-scope surface touched — CI-only change, no application code.
- [x] No secrets, credentials, or tokens added or changed.
- [x] `actionlint` and `zizmor --min-severity high` both clean (see Testing Evidence).
- [x] Does not enable the merge queue itself — settings change is a separate, later step.
- [x] Conventional commit, feature branch, PR-based flow.
