### PR TITLE
ci: pin the remaining go install tool versions

### DIFF
--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -42,17 +42,17 @@ tools-go: ## Install Go development tools
 	@echo "Installing golangci-lint..."
 	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 	@echo "Installing gosec..."
-	@go install github.com/securego/gosec/v2/cmd/gosec@latest
+	@go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 	@echo "Installing gofumpt..."
-	@go install mvdan.cc/gofumpt@latest
+	@go install mvdan.cc/gofumpt@v0.11.0
 	@echo "Installing goimports..."
-	@go install golang.org/x/tools/cmd/goimports@latest
+	@go install golang.org/x/tools/cmd/goimports@v0.49.0
 	@echo "Installing gotestsum..."
-	@go install gotest.tools/gotestsum@latest
+	@go install gotest.tools/gotestsum@v1.13.0
 	@echo "Installing gitleaks..."
-	@go install github.com/zricethezav/gitleaks/v8@latest
+	@go install github.com/zricethezav/gitleaks/v8@v8.30.1
 	@echo "Installing go-licenses..."
-	@go install github.com/google/go-licenses@latest
+	@go install github.com/google/go-licenses@v1.6.0
 	@printf "$(GREEN)✓ Go development tools installed$(RESET)\n"
 
 tools-frontend: ## Install frontend development tools

--- a/mk/lint.mk
+++ b/mk/lint.mk
@@ -132,7 +132,7 @@ fix-all: fix fix-md ## Auto-fix all code and documentation
 fmt: ## Format Go code with gofumpt
 	@if ! command -v gofumpt > /dev/null 2>&1; then \
 		echo "📦 Installing gofumpt..."; \
-		go install mvdan.cc/gofumpt@latest; \
+		go install mvdan.cc/gofumpt@v0.11.0; \
 	fi
 	@gofumpt -w .
 	@echo "✅ Go code formatted"

--- a/mk/security.mk
+++ b/mk/security.mk
@@ -72,7 +72,7 @@ security-secrets: ## Scan for secrets in codebase (gitleaks)
 	@GITLEAKS=$$(command -v gitleaks 2>/dev/null || echo "$$(go env GOPATH)/bin/gitleaks"); \
 	if [ ! -x "$$GITLEAKS" ]; then \
 		printf "📦 Installing gitleaks...\n"; \
-		go install github.com/zricethezav/gitleaks/v8@latest; \
+		go install github.com/zricethezav/gitleaks/v8@v8.30.1; \
 		GITLEAKS="$$(go env GOPATH)/bin/gitleaks"; \
 	fi; \
 	if [ -f .gitleaks.toml ]; then \
@@ -85,7 +85,7 @@ security-secrets: ## Scan for secrets in codebase (gitleaks)
 security-secrets-quiet:
 	@GITLEAKS=$$(command -v gitleaks 2>/dev/null || echo "$$(go env GOPATH)/bin/gitleaks"); \
 	if [ ! -x "$$GITLEAKS" ]; then \
-		go install github.com/zricethezav/gitleaks/v8@latest; \
+		go install github.com/zricethezav/gitleaks/v8@v8.30.1; \
 		GITLEAKS="$$(go env GOPATH)/bin/gitleaks"; \
 	fi; \
 	printf "   Scanning for secrets...\n"; \


### PR DESCRIPTION
## Summary

`go install <module>@latest` appeared throughout `mk/` fragments and workflows. An unpinned tool changes behaviour with **no code change** — either a spurious break unrelated to any PR, or a silent loss of coverage if a check regresses upstream.

Not hypothetical: `make lint` installed **golangci-lint v2.12.1** while CI pinned **v2.12.2**, so developers linted with a different tool than the one gating their PR — the textbook "passes locally, fails in CI" generator.

Tools pinned: govulncheck v1.7.0, staticcheck v0.7.0, gosec v2.28.0, goimports/deadcode v0.49.0, gofumpt v0.11.0, gotestsum v1.13.0, go-licenses v1.6.0, gitleaks v8.30.1.

**Versions were resolved from the module proxy, not written from memory** — a fabricated action SHA earlier in this programme is exactly why that distinction matters.

These are now visible to Renovate via the `customManager` added to `MustardSeedNetworks/.github`, so pinning them does not mean they rot: a pin Renovate cannot see is worse than a floating version.

## Linked Issue

Related to #1309

## Testing Evidence

```
$ grep -rc 'go install .*@latest' mk/*.mk Makefile .github/workflows/*.yml | awk -F: '{s+=$2} END{print s+0}'
0

$ actionlint -ignore 'SC2129' .github/workflows/*.yml
(clean, no output)

$ python3 ../.github/scripts/check-ci-conformance.py MustardSeedNetworks/niac-go
ci-conformance: passed
```

Conformance previously reported these as findings; this clears them.

## Security and Release Checklist

- [x] Pins a security gate (govulncheck, gosec, gitleaks) that could previously shift underneath us.
- [x] No version moved backward — each pin is the current release.
- [x] No linter enabled or disabled; no gate weakened.
- [x] No secrets touched.
