### PR TITLE
ci: remove lint exclusions for files that no longer exist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -605,11 +605,6 @@ linters:
       - text: 'newexpr: '
         path: 'internal/api/schema.*\.go'
         linters: [ modernize ]
-      # sse_log_handler_test.go uses NewTextHandler(io.Discard) so the tee
-      # wrapper's Handle() runs unconditionally. slog.DiscardHandler's
-      # Enabled() short-circuits propagation, breaking the test setup.
-      - path: 'internal/api/sse_log_handler_test\.go'
-        linters: [ modernize, sloglint ]
       # JSON Schema + config-vocabulary literals repeated across api/*.go
       # (hostname/interface/name/enabled/disabled/ips/router/ipv4/etc).
       # These are wire-format field names + Schema "type" enums — the
@@ -730,10 +725,6 @@ linters:
           - gochecknoglobals
       # SNMP MIB standard OIDs are package-level constants.
       - path: 'internal/protocols/snmp/mib\.go'
-        linters:
-          - gochecknoglobals
-      # SNMP secure random is a package-level singleton.
-      - path: 'internal/protocols/snmp/securerandom\.go'
         linters:
           - gochecknoglobals
       # Template registry is a package-level singleton.


### PR DESCRIPTION
## Summary

Removes lint exclusion rules whose `path:` regex matches **no file in the tree**. They suppress nothing, and they actively mislead — a reader assumes a suppression is load-bearing when the file it names is gone.

Found by regex-matching every exclusion path against `git ls-files '*.go'` across the fleet: **5 stale rules total**. Two trace to known history — stem's license validator was deleted in the foundation migration, and niac-go is mid-removal of `internal/license`.

## Linked Issue

Related to #1311

## Testing Evidence

Removed **one at a time**, with a full lint run after each:

```
$ golangci-lint config verify
(valid)

$ golangci-lint run --max-issues-per-linter=0 ./...
0 issues.
```

0 findings before, 0 after — confirming the rules were inert.

The one-at-a-time discipline is deliberate: an earlier bulk-removal script corrupted the exclusions block by orphaning `linters:` continuation lines into neighbouring rules, which sent findings from 0 to 51. Surgical, verified edits only.

Note `--max-issues-per-linter=0` — the default cap of 50 was itself hiding findings elsewhere in this fleet, so verification runs uncapped.

## Security and Release Checklist

- [x] Removes dead configuration; no active suppression touched.
- [x] Verified 0 findings before and after, uncapped.
- [x] No linter enabled or disabled; no gate weakened.
- [x] No secrets touched.
