### PR TITLE
test(e2e): assert real error handling instead of #root being attached

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ web/dist/
 web/.vite/
 web/coverage/
 ui/playwright/.auth/
+# Also ignore a root-level copy: running playwright from the repo root rather
+# than ui/ writes the storage state here, and it holds a live session token.
+playwright/.auth/
 storybook-static/
 *storybook.log
 npm-debug.log*

--- a/ui/e2e/error-scenarios.spec.ts
+++ b/ui/e2e/error-scenarios.spec.ts
@@ -3,105 +3,130 @@ import { expect, test } from '@playwright/test';
 /**
  * Error Scenario Tests
  *
- * Tests for error handling and edge cases:
- * - Network errors
- * - API failures
- * - Invalid routes
+ * Every test here used to assert only `expect(page.locator('#root')).toBeAttached()`.
+ * `#root` is the mount point in index.html — it is attached before React runs and
+ * stays attached whether the app renders, renders an error, or renders nothing at
+ * all. So all seven passed regardless of how the failure was handled, and none
+ * could fail if error handling regressed.
+ *
+ * The scenarios themselves were worth keeping; only the assertions were empty.
+ * Each now asserts the specific outcome that scenario actually produces, and in
+ * no case is the ErrorBoundary fallback shown — a bad daemon degrades, it does
+ * not white-screen the operator.
+ *
+ * Note the split, which the old assertion made invisible: an unreachable daemon
+ * and 4xx/5xx responses land on the AuthGate connect screen with an error line,
+ * because the token probe fails; a slow or malformed-JSON response still boots
+ * the full shell. Both are correct, and they are different — asserting "either"
+ * is what let these tests pass for years without checking anything.
  */
 
+/** The app shell rendered, and no render-crash fallback replaced it. */
+async function expectShellSurvives(page: import('@playwright/test').Page): Promise<void> {
+  await expect(page.getByTestId('sidebar-settings-button')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('error-boundary-fallback')).toHaveCount(0);
+}
+
+/**
+ * The AuthGate connect screen with its error line — what the app correctly
+ * shows when it cannot reach or authenticate against the daemon. Asserted
+ * per-scenario rather than as a shell-or-gate alternative, because an
+ * either/or assertion is how these tests became unfalsifiable the first time.
+ */
+async function expectConnectGateWithError(page: import('@playwright/test').Page): Promise<void> {
+  await expect(page.getByTestId('api-token-input')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('auth-gate-error')).toBeVisible();
+  await expect(page.getByTestId('error-boundary-fallback')).toHaveCount(0);
+}
+
 test.describe('Error Scenarios', () => {
-  test('should handle network errors gracefully', async ({ page }) => {
-    // Set up route interception before navigation
-    await page.route('**/api/v1/**', (route) => {
-      route.abort('failed');
-    });
+  test('shows the connect gate with an error when the daemon refuses every connection', async ({
+    page,
+  }) => {
+    await page.route('**/api/v1/**', (route) => route.abort('failed'));
 
     await page.goto('/');
 
-    // React app should render despite API errors
-    const root = page.locator('#root');
-    await expect(root).toBeAttached({ timeout: 10000 });
+    await expectConnectGateWithError(page);
   });
 
-  test('should handle slow API responses', async ({ page }) => {
+  test('survives a daemon that responds slowly', async ({ page }) => {
     await page.route('**/api/v1/**', async (route) => {
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      route.continue();
+      await route.continue();
     });
 
     await page.goto('/');
-    const root = page.locator('#root');
-    await expect(root).toBeAttached({ timeout: 15000 });
+
+    await expectShellSurvives(page);
   });
 
-  test('should handle 404 routes', async ({ page }) => {
+  test('redirects an unknown route back to the dashboard', async ({ page }) => {
     await page.goto('/nonexistent-page-12345');
-    await page.waitForLoadState('domcontentloaded');
 
-    // Should show 404 page or redirect to home
-    const root = page.locator('#root');
-    await expect(root).toBeAttached();
+    // App.tsx: <Route path="*" element={<Navigate to="/" replace />} />.
+    // The old test only checked #root, so a broken catch-all would have passed.
+    await expect(page).toHaveURL(/\/$/);
+    await expectShellSurvives(page);
   });
 
-  test('should handle 500 errors from API', async ({ page }) => {
-    await page.route('**/api/v1/**', (route) => {
+  test('shows the connect gate with an error on HTTP 500', async ({ page }) => {
+    await page.route('**/api/v1/**', (route) =>
       route.fulfill({
         status: 500,
         contentType: 'application/json',
         body: JSON.stringify({ error: 'Internal Server Error' }),
-      });
-    });
+      }),
+    );
 
     await page.goto('/');
-    // Page should render with error state or fallback UI
-    const root = page.locator('#root');
-    await expect(root).toBeAttached({ timeout: 10000 });
+
+    await expectConnectGateWithError(page);
   });
 
-  test('should handle malformed API responses', async ({ page }) => {
-    await page.route('**/api/v1/**', (route) => {
+  test('survives malformed JSON from every endpoint', async ({ page }) => {
+    await page.route('**/api/v1/**', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: 'invalid json{{{',
-      });
-    });
+      }),
+    );
 
     await page.goto('/');
-    // Page should handle JSON parse errors gracefully
-    const root = page.locator('#root');
-    await expect(root).toBeAttached({ timeout: 10000 });
+
+    // A JSON parse error thrown during render is exactly what would trip the
+    // ErrorBoundary, so this is the scenario the fallback assertion is for.
+    await expectShellSurvives(page);
   });
 
-  test('should handle empty API responses', async ({ page }) => {
-    await page.route('**/api/v1/devices', (route) => {
+  test('renders the devices empty state when the daemon returns no devices', async ({ page }) => {
+    await page.route('**/api/v1/devices', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify([]),
-      });
-    });
+      }),
+    );
 
     await page.goto('/devices');
-    await page.waitForLoadState('domcontentloaded');
 
-    // Should show empty state
-    const root = page.locator('#root');
-    await expect(root).toBeAttached();
+    await expectShellSurvives(page);
+    // BaseCard swaps the table for its empty branch when the list is empty.
+    await expect(page.getByTestId('devices-card-empty')).toBeVisible({ timeout: 15000 });
   });
 
-  test('should display error state for bad requests', async ({ page }) => {
-    await page.route('**/api/v1/**', (route) => {
+  test('shows the connect gate with an error on HTTP 400', async ({ page }) => {
+    await page.route('**/api/v1/**', (route) =>
       route.fulfill({
         status: 400,
         contentType: 'application/json',
         body: JSON.stringify({ error: 'Bad Request' }),
-      });
-    });
+      }),
+    );
 
     await page.goto('/');
-    // Page should render with error indication
-    const root = page.locator('#root');
-    await expect(root).toBeAttached({ timeout: 10000 });
+
+    await expectConnectGateWithError(page);
   });
 });

--- a/ui/src/components/AuthGate.tsx
+++ b/ui/src/components/AuthGate.tsx
@@ -97,7 +97,7 @@ export function AuthGate({ children }: AuthGateProps): ReactElement {
           className="mt-2 w-full rounded-lg border border-surface-border bg-surface-sunken px-3 py-2 font-mono text-sm outline-none focus:border-brand-primary"
         />
         {error && (
-          <p role="alert" className="mt-3 text-sm text-status-error">
+          <p role="alert" data-testid="auth-gate-error" className="mt-3 text-sm text-status-error">
             {error}
           </p>
         )}

--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -71,7 +71,10 @@ export class ErrorBoundary extends Component<Props, State> {
 
       // Default error UI
       return (
-        <div className="flex min-h-[400px] flex-col items-center justify-center pad-xl">
+        <div
+          data-testid="error-boundary-fallback"
+          className="flex min-h-[400px] flex-col items-center justify-center pad-xl"
+        >
           <div className="mx-auto max-w-md text-center">
             <div className="mb-content flex justify-center">
               <div className="rounded-full bg-status-error pad dark:bg-status-error/20">

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -56,6 +56,7 @@ const DeviceListCard: FC = () => {
       error={error?.message}
       getStatus={(d) => (d.length > 0 ? 'success' : 'unknown')}
       emptyMessage={t('devices.emptyMessage')}
+      testId="devices-card"
     >
       {(data) => (
         <>

--- a/ui/src/ui/BaseCard.tsx
+++ b/ui/src/ui/BaseCard.tsx
@@ -63,6 +63,12 @@ interface BaseCardProps<T> {
   className?: string;
   /** Click handler for interactive cards */
   onClick?: () => void;
+  /**
+   * Test hook prefix. The empty branch renders `${testId}-empty`, so a test can
+   * target one card's empty state; a page mounts several BaseCards and a shared
+   * testid trips Playwright strict mode.
+   */
+  testId?: string;
 }
 
 /**
@@ -109,6 +115,7 @@ export function BaseCard<T>({
   emptyMessage = 'No data available',
   className,
   onClick,
+  testId,
 }: BaseCardProps<T>): React.JSX.Element {
   // Loading state (highest priority)
   if (loading) {
@@ -154,7 +161,11 @@ export function BaseCard<T>({
         className={className}
         enableLiveRegion={true}
       >
-        <CardValue value={emptyMessage} size="md" />
+        {/* Test hook: the empty branch is otherwise selectable only by its
+            translated message, which breaks under the es locale. */}
+        <div data-testid={testId ? `${testId}-empty` : undefined}>
+          <CardValue value={emptyMessage} size="md" />
+        </div>
       </StatusCard>
     );
   }


### PR DESCRIPTION
## Summary

All seven error-scenario tests asserted only `expect(page.locator('#root')).toBeAttached()`. `#root` is the mount point in `index.html` — attached before React runs, and still attached whether the app renders, errors, or renders nothing at all. Every test passed regardless of how the failure was handled, and none could fail if error handling regressed.

The scenarios were worth keeping; only the assertions were empty. Each now asserts the outcome that scenario actually produces, and in none of them may the ErrorBoundary fallback appear.

Running them surfaced a split the old assertion made invisible: **an unreachable daemon and 4xx/5xx land on the AuthGate connect screen with an error line** (the token probe fails), while **slow and malformed-JSON responses still boot the full shell**. Both are correct, and they are different — asserting "either" is exactly what let these tests pass for years while checking nothing.

Test hooks added, each because the only alternative selector was English copy that breaks under the `es` locale: `error-boundary-fallback`, `auth-gate-error`, and an opt-in `testId` prefix on `BaseCard` rendering `${testId}-empty` (a shared constant testid tripped Playwright strict mode, since a page mounts several BaseCards).

Also ignores a root-level `playwright/.auth/` — running Playwright from the repo root instead of `ui/` writes storage state there, and it holds a live session token.

## Linked Issue

Closes #1322

## Testing Evidence

Both engines:

```
  14 passed (38.4s)
```

Mutation-tested — inverting the auth-gate assertion fails the three scenarios that depend on it:

```
MUTATION APPLIED
  3 failed
  4 passed (43.1s)
```

Unit tests and typecheck unaffected:

```
 Test Files  78 passed (78)
      Tests  376 passed (376)
```

## Security and Release Checklist

- Production changes are additive test hooks (`data-testid`) plus one opt-in `testId` prop on `BaseCard` — no logic or rendering behaviour altered.
- No new dependencies.
- **Adds a `.gitignore` entry for `playwright/.auth/`**, which holds a live session token and must never be committed. No such file is included in this PR.
- No user-facing copy; no banned vocabulary.
