### PR TITLE
fix(protocols): emit a conforming CDP Address TLV protocol type

### DIFF
--- a/internal/protocols/cdp.go
+++ b/internal/protocols/cdp.go
@@ -95,6 +95,15 @@ const (
 	cdpTLVHeaderSize      = 4      // TLV header overhead (Type 2 + Length 2)
 	capabilitiesTLVLen    = 8      // fixed capabilities TLV length
 	cdpAddressLenFieldLen = 2      // address length field size (2 bytes)
+
+	// cdpProtocolTypeNLPID is the Address TLV protocol-type naming the NLPID
+	// encoding. It labels the encoding; the NLPID itself follows in the protocol
+	// field. A decoder that reads anything else here abandons the TLV walk, so
+	// every field after the addresses — Port ID, Platform, Version — is lost.
+	cdpProtocolTypeNLPID = 0x01
+
+	cdpNLPIDIPv4 = 0xCC // NLPID identifying an IPv4 address
+	cdpNLPIDIPv6 = 0x8E // NLPID identifying an IPv6 address
 )
 
 // CDPHandler handles CDP advertisements.
@@ -308,16 +317,14 @@ func (h *CDPHandler) buildAddressesTLV(device *config.Device) []byte {
 
 	var (
 		addrBytes []byte
-		protoType byte
+		nlpid     byte
 	)
 
 	if ip.To4() != nil {
-		// IPv4
-		protoType = 0xCC // NLPID for IPv4
+		nlpid = cdpNLPIDIPv4
 		addrBytes = ip.To4()
 	} else {
-		// IPv6
-		protoType = 0x8E // NLPID for IPv6
+		nlpid = cdpNLPIDIPv6
 		addrBytes = ip.To16()
 	}
 
@@ -342,11 +349,11 @@ func (h *CDPHandler) buildAddressesTLV(device *config.Device) []byte {
 	binary.BigEndian.PutUint32(tlv[4:8], 1) // Number of addresses
 
 	offset := 8
-	tlv[offset] = protoType
+	tlv[offset] = cdpProtocolTypeNLPID
 	offset++
 	tlv[offset] = 1 // Protocol length
 	offset++
-	tlv[offset] = protoType // Protocol value
+	tlv[offset] = nlpid
 	offset++
 	addrBytesLen := min(len(addrBytes), cdpMaxUint16)
 	binary.BigEndian.PutUint16(

--- a/internal/protocols/cdp_test.go
+++ b/internal/protocols/cdp_test.go
@@ -1,10 +1,14 @@
 package protocols_test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
@@ -184,6 +188,34 @@ func TestBuildDeviceIDTLV(t *testing.T) {
 	}
 }
 
+// assertNLPIDAddressEntry checks one Address TLV entry: Protocol Type, Protocol
+// Length, Protocol, then the address length and the address.
+//
+// The protocol type names the encoding — 1 for NLPID — and is not the NLPID
+// value, which follows it. Emitting the value in both fields makes a conforming
+// decoder abandon the whole TLV walk, dropping every field after the addresses.
+func assertNLPIDAddressEntry(t *testing.T, entry []byte, wantNLPID byte, wantAddr []byte) {
+	t.Helper()
+
+	if protoType := entry[0]; protoType != 0x01 {
+		t.Errorf("Expected protocol type 0x01 (NLPID), got 0x%02X", protoType)
+	}
+	if protoLen := entry[1]; protoLen != 1 {
+		t.Errorf("Expected protocol length 1, got %d", protoLen)
+	}
+	if nlpid := entry[2]; nlpid != wantNLPID {
+		t.Errorf("Expected NLPID 0x%02X, got 0x%02X", wantNLPID, nlpid)
+	}
+
+	addrLen := binary.BigEndian.Uint16(entry[3:5])
+	if int(addrLen) != len(wantAddr) {
+		t.Fatalf("Expected address length %d, got %d", len(wantAddr), addrLen)
+	}
+	if got := entry[5 : 5+addrLen]; !bytes.Equal(got, wantAddr) {
+		t.Errorf("Expected address %x, got %x", wantAddr, got)
+	}
+}
+
 // TestBuildAddressesTLV verifies Addresses TLV construction.
 func TestBuildAddressesTLV(t *testing.T) {
 	cfg := &config.Config{}
@@ -191,16 +223,17 @@ func TestBuildAddressesTLV(t *testing.T) {
 	handler := protocols.NewCDPHandler(stack)
 
 	tests := []struct {
-		name         string
-		ip           net.IP
-		expectedType byte
+		name          string
+		ip            net.IP
+		expectedNLPID byte
+		expectedAddr  []byte
 	}{
-		{"IPv4 address", net.ParseIP("192.168.1.1"), 0xCC},
-		{"IPv6 address", net.ParseIP("2001:db8::1"), 0x8E},
+		{"IPv4 address", net.ParseIP("192.168.1.1"), 0xCC, []byte{192, 168, 1, 1}},
+		{"IPv6 address", net.ParseIP("2001:db8::1"), 0x8E, net.ParseIP("2001:db8::1").To16()},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(_ *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			device := &config.Device{
 				IPAddresses: []net.IP{tt.ip},
 			}
@@ -227,11 +260,7 @@ func TestBuildAddressesTLV(t *testing.T) {
 				t.Errorf("Expected 1 address, got %d", numAddrs)
 			}
 
-			// Verify protocol type
-			protoType := tlv[8]
-			if protoType != tt.expectedType {
-				t.Errorf("Expected protocol type 0x%02X, got 0x%02X", tt.expectedType, protoType)
-			}
+			assertNLPIDAddressEntry(t, tlv[8:], tt.expectedNLPID, tt.expectedAddr)
 		})
 	}
 }
@@ -525,6 +554,68 @@ func TestCalculateChecksum(t *testing.T) {
 			// Verify checksum is calculated (non-panic test)
 			_ = checksum
 		})
+	}
+}
+
+// TestBuildCDPFrameDecodesEndToEnd feeds a built advertisement to an independent
+// decoder and reads back the fields after the Address TLV.
+//
+// The byte-level tests above check each TLV in isolation, which is exactly how a
+// malformed Address TLV escaped notice: it is well-formed on its own terms, and
+// only a decoder walking the TLV chain in order notices that it derails the
+// walk. Everything after the addresses — Port ID, Platform, Version — was
+// silently lost on the wire.
+func TestBuildCDPFrameDecodesEndToEnd(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewCDPHandler(stack)
+
+	srcMAC := net.HardwareAddr{0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}
+	device := &config.Device{
+		Name:        "Switch-1",
+		Type:        "switch",
+		MACAddress:  srcMAC,
+		IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+		Interfaces:  []config.Interface{{Name: "GigabitEthernet0/1"}},
+	}
+
+	payload := handler.BuildCDPFrame(device)
+
+	// An 802.3 frame: addresses, the payload length in place of an EtherType,
+	// then the LLC/SNAP-framed advertisement.
+	dstMAC, err := net.ParseMAC(protocols.CDPMulticastMAC)
+	if err != nil {
+		t.Fatalf("parse CDP multicast MAC: %v", err)
+	}
+
+	frame := make([]byte, 0, 14+len(payload))
+	frame = append(frame, dstMAC...)
+	frame = append(frame, srcMAC...)
+	frame = binary.BigEndian.AppendUint16(frame, uint16(len(payload)))
+	frame = append(frame, payload...)
+
+	packet := gopacket.NewPacket(frame, layers.LinkTypeEthernet, gopacket.Default)
+	if errLayer := packet.ErrorLayer(); errLayer != nil {
+		t.Fatalf("decode failed: %v", errLayer.Error())
+	}
+
+	infoLayer := packet.Layer(layers.LayerTypeCiscoDiscoveryInfo)
+	if infoLayer == nil {
+		t.Fatal("no CDP info layer decoded")
+	}
+	info, ok := infoLayer.(*layers.CiscoDiscoveryInfo)
+	if !ok {
+		t.Fatalf("unexpected layer type %T", infoLayer)
+	}
+
+	if info.DeviceID != "Switch-1" {
+		t.Errorf("DeviceID = %q, want %q", info.DeviceID, "Switch-1")
+	}
+	if info.PortID != "GigabitEthernet0/1" {
+		t.Errorf("PortID = %q, want %q", info.PortID, "GigabitEthernet0/1")
+	}
+	if len(info.Addresses) != 1 || !info.Addresses[0].Equal(net.ParseIP("192.168.1.1")) {
+		t.Errorf("Addresses = %v, want [192.168.1.1]", info.Addresses)
 	}
 }
 


### PR DESCRIPTION
## Summary

The CDP Address TLV wrote the NLPID *value* into the protocol-*type* field as well as the protocol field, so an IPv4 advertisement carried `cc 01 cc` where `01 01 cc` belongs.

The protocol type names the *encoding* — 1 for NLPID, 2 for 802.2 — and is not the NLPID itself. A decoder that validates the field abandons the TLV walk there, losing **every TLV after the addresses**: Port ID, Capabilities, Software Version, Platform. Every simulated device therefore advertised itself to real collectors as a bare Device ID with no port, platform or version. That affects what NetAlly gear sees in the demo lab, not just seed.

Found while investigating seed#1922. Captured from the live lab trunk on CT313:

```
TLV 0x0002 len=13 value=00 00 00 01 cc 01 cc 00 04 0a fe c8 01
                                    ^^ protocol type; must be 01 (NLPID)
```

The existing per-TLV test asserted the *defect* as its expected value (`expectedType: 0xCC`), and could not have caught this: the TLV reads as well-formed on its own, and only a decoder walking the chain in order notices it derails the walk. Hence the added round-trip test.

IPv6 still uses NLPID `0x8E` (type 1, length 1) — structurally valid and no longer derails decoding, though gopacket only recognises IPv6 addresses in the 802.2 form. Out of scope here.

## Linked Issue

Related to #1922 (MustardSeedNetworks/seed), fixed on the seed side in MustardSeedNetworks/seed#1923.

## Type of Change

- [x] Defect fix

## Risk

- [x] Low

## Testing Evidence

Mutation-verified — reverting the fix (assertion confirms the mutation applied) fails both tests:

```text
$ go test ./internal/protocols/ -run "TestBuildCDPFrameDecodesEndToEnd|TestBuildAddressesTLV"
mutation applied (reverted to pre-fix behaviour)
--- FAIL: TestBuildAddressesTLV/IPv4_address
        cdp_test.go:262: Expected protocol type 0x01 (NLPID), got 0xCC
--- FAIL: TestBuildAddressesTLV/IPv6_address
        cdp_test.go:262: Expected protocol type 0x01 (NLPID), got 0x8E
--- FAIL: TestBuildCDPFrameDecodesEndToEnd
        cdp_test.go:598: decode failed: Invalid Address Protocol 204
FAIL

$ # restored
$ go test ./internal/protocols/
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols	2.633s

$ golangci-lint run ./internal/protocols/...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched — none touched; this is frame construction only.
- [x] Dependencies are pinned and justified if changed — none changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed — wire-format fix; the corrected frame is what the protocol already specified.