### PR TITLE
ci: make CI conformance a blocking gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,18 @@ jobs:
     permissions:
       contents: read
 
+  # Asserts this repo's own gates are wired to gate: every job below is either
+  # in ci-complete's needs or documented in .github/ci-advisory-jobs.txt, the
+  # enabled linters meet the declared tier, and tool installs are pinned. Two
+  # such gaps were found by hand on 2026-08-16; both arrived via a merge, which
+  # is why this runs per PR rather than on a schedule.
+  # Defined once in MustardSeedNetworks/.github (fleet-shared); ci-complete
+  # still needs: [ci-conformance].
+  ci-conformance:
+    uses: MustardSeedNetworks/.github/.github/workflows/ci-conformance.yml@20eb29355b0448c791677c167164282da49d130f # v1.3.0
+    permissions:
+      contents: read
+
   # ===========================================================================
   # Quality Checks
   # ===========================================================================
@@ -982,6 +994,7 @@ jobs:
       - frontend
       - security
       - semgrep
+      - ci-conformance
       - quality
       - workflow-lint
       - docs

--- a/internal/protocols/cdp.go
+++ b/internal/protocols/cdp.go
@@ -95,6 +95,15 @@ const (
 	cdpTLVHeaderSize      = 4      // TLV header overhead (Type 2 + Length 2)
 	capabilitiesTLVLen    = 8      // fixed capabilities TLV length
 	cdpAddressLenFieldLen = 2      // address length field size (2 bytes)
+
+	// cdpProtocolTypeNLPID is the Address TLV protocol-type naming the NLPID
+	// encoding. It labels the encoding; the NLPID itself follows in the protocol
+	// field. A decoder that reads anything else here abandons the TLV walk, so
+	// every field after the addresses — Port ID, Platform, Version — is lost.
+	cdpProtocolTypeNLPID = 0x01
+
+	cdpNLPIDIPv4 = 0xCC // NLPID identifying an IPv4 address
+	cdpNLPIDIPv6 = 0x8E // NLPID identifying an IPv6 address
 )
 
 // CDPHandler handles CDP advertisements.
@@ -308,16 +317,14 @@ func (h *CDPHandler) buildAddressesTLV(device *config.Device) []byte {
 
 	var (
 		addrBytes []byte
-		protoType byte
+		nlpid     byte
 	)
 
 	if ip.To4() != nil {
-		// IPv4
-		protoType = 0xCC // NLPID for IPv4
+		nlpid = cdpNLPIDIPv4
 		addrBytes = ip.To4()
 	} else {
-		// IPv6
-		protoType = 0x8E // NLPID for IPv6
+		nlpid = cdpNLPIDIPv6
 		addrBytes = ip.To16()
 	}
 
@@ -342,11 +349,11 @@ func (h *CDPHandler) buildAddressesTLV(device *config.Device) []byte {
 	binary.BigEndian.PutUint32(tlv[4:8], 1) // Number of addresses
 
 	offset := 8
-	tlv[offset] = protoType
+	tlv[offset] = cdpProtocolTypeNLPID
 	offset++
 	tlv[offset] = 1 // Protocol length
 	offset++
-	tlv[offset] = protoType // Protocol value
+	tlv[offset] = nlpid
 	offset++
 	addrBytesLen := min(len(addrBytes), cdpMaxUint16)
 	binary.BigEndian.PutUint16(

--- a/internal/protocols/cdp_test.go
+++ b/internal/protocols/cdp_test.go
@@ -1,10 +1,14 @@
 package protocols_test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/logging"
@@ -184,6 +188,34 @@ func TestBuildDeviceIDTLV(t *testing.T) {
 	}
 }
 
+// assertNLPIDAddressEntry checks one Address TLV entry: Protocol Type, Protocol
+// Length, Protocol, then the address length and the address.
+//
+// The protocol type names the encoding — 1 for NLPID — and is not the NLPID
+// value, which follows it. Emitting the value in both fields makes a conforming
+// decoder abandon the whole TLV walk, dropping every field after the addresses.
+func assertNLPIDAddressEntry(t *testing.T, entry []byte, wantNLPID byte, wantAddr []byte) {
+	t.Helper()
+
+	if protoType := entry[0]; protoType != 0x01 {
+		t.Errorf("Expected protocol type 0x01 (NLPID), got 0x%02X", protoType)
+	}
+	if protoLen := entry[1]; protoLen != 1 {
+		t.Errorf("Expected protocol length 1, got %d", protoLen)
+	}
+	if nlpid := entry[2]; nlpid != wantNLPID {
+		t.Errorf("Expected NLPID 0x%02X, got 0x%02X", wantNLPID, nlpid)
+	}
+
+	addrLen := binary.BigEndian.Uint16(entry[3:5])
+	if int(addrLen) != len(wantAddr) {
+		t.Fatalf("Expected address length %d, got %d", len(wantAddr), addrLen)
+	}
+	if got := entry[5 : 5+addrLen]; !bytes.Equal(got, wantAddr) {
+		t.Errorf("Expected address %x, got %x", wantAddr, got)
+	}
+}
+
 // TestBuildAddressesTLV verifies Addresses TLV construction.
 func TestBuildAddressesTLV(t *testing.T) {
 	cfg := &config.Config{}
@@ -191,16 +223,17 @@ func TestBuildAddressesTLV(t *testing.T) {
 	handler := protocols.NewCDPHandler(stack)
 
 	tests := []struct {
-		name         string
-		ip           net.IP
-		expectedType byte
+		name          string
+		ip            net.IP
+		expectedNLPID byte
+		expectedAddr  []byte
 	}{
-		{"IPv4 address", net.ParseIP("192.168.1.1"), 0xCC},
-		{"IPv6 address", net.ParseIP("2001:db8::1"), 0x8E},
+		{"IPv4 address", net.ParseIP("192.168.1.1"), 0xCC, []byte{192, 168, 1, 1}},
+		{"IPv6 address", net.ParseIP("2001:db8::1"), 0x8E, net.ParseIP("2001:db8::1").To16()},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(_ *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			device := &config.Device{
 				IPAddresses: []net.IP{tt.ip},
 			}
@@ -227,11 +260,7 @@ func TestBuildAddressesTLV(t *testing.T) {
 				t.Errorf("Expected 1 address, got %d", numAddrs)
 			}
 
-			// Verify protocol type
-			protoType := tlv[8]
-			if protoType != tt.expectedType {
-				t.Errorf("Expected protocol type 0x%02X, got 0x%02X", tt.expectedType, protoType)
-			}
+			assertNLPIDAddressEntry(t, tlv[8:], tt.expectedNLPID, tt.expectedAddr)
 		})
 	}
 }
@@ -525,6 +554,68 @@ func TestCalculateChecksum(t *testing.T) {
 			// Verify checksum is calculated (non-panic test)
 			_ = checksum
 		})
+	}
+}
+
+// TestBuildCDPFrameDecodesEndToEnd feeds a built advertisement to an independent
+// decoder and reads back the fields after the Address TLV.
+//
+// The byte-level tests above check each TLV in isolation, which is exactly how a
+// malformed Address TLV escaped notice: it is well-formed on its own terms, and
+// only a decoder walking the TLV chain in order notices that it derails the
+// walk. Everything after the addresses — Port ID, Platform, Version — was
+// silently lost on the wire.
+func TestBuildCDPFrameDecodesEndToEnd(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewCDPHandler(stack)
+
+	srcMAC := net.HardwareAddr{0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}
+	device := &config.Device{
+		Name:        "Switch-1",
+		Type:        "switch",
+		MACAddress:  srcMAC,
+		IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+		Interfaces:  []config.Interface{{Name: "GigabitEthernet0/1"}},
+	}
+
+	payload := handler.BuildCDPFrame(device)
+
+	// An 802.3 frame: addresses, the payload length in place of an EtherType,
+	// then the LLC/SNAP-framed advertisement.
+	dstMAC, err := net.ParseMAC(protocols.CDPMulticastMAC)
+	if err != nil {
+		t.Fatalf("parse CDP multicast MAC: %v", err)
+	}
+
+	frame := make([]byte, 0, 14+len(payload))
+	frame = append(frame, dstMAC...)
+	frame = append(frame, srcMAC...)
+	frame = binary.BigEndian.AppendUint16(frame, uint16(len(payload)))
+	frame = append(frame, payload...)
+
+	packet := gopacket.NewPacket(frame, layers.LinkTypeEthernet, gopacket.Default)
+	if errLayer := packet.ErrorLayer(); errLayer != nil {
+		t.Fatalf("decode failed: %v", errLayer.Error())
+	}
+
+	infoLayer := packet.Layer(layers.LayerTypeCiscoDiscoveryInfo)
+	if infoLayer == nil {
+		t.Fatal("no CDP info layer decoded")
+	}
+	info, ok := infoLayer.(*layers.CiscoDiscoveryInfo)
+	if !ok {
+		t.Fatalf("unexpected layer type %T", infoLayer)
+	}
+
+	if info.DeviceID != "Switch-1" {
+		t.Errorf("DeviceID = %q, want %q", info.DeviceID, "Switch-1")
+	}
+	if info.PortID != "GigabitEthernet0/1" {
+		t.Errorf("PortID = %q, want %q", info.PortID, "GigabitEthernet0/1")
+	}
+	if len(info.Addresses) != 1 || !info.Addresses[0].Equal(net.ParseIP("192.168.1.1")) {
+		t.Errorf("Addresses = %v, want [192.168.1.1]", info.Addresses)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wires the fleet-shared CI-conformance gate into `ci.yml` as a **blocking** job (fleet-e2e-quality F5). It asserts this repo's own gates are wired to gate: every `ci.yml` job is either in `ci-complete`'s `needs:` or documented in `.github/ci-advisory-jobs.txt`, the enabled linters meet the declared tier, tool installs are pinned, and the governance scripts exist.

The script had only ever been run by hand — a poor fit for a check whose purpose is catching gates that silently stop gating. Both gaps it was written for arrived via a merge.

Defined once in `MustardSeedNetworks/.github` (v1.3.0) and called as a job here so it can sit in `ci-complete`'s `needs:`; a separate workflow's job cannot. Branch protection needs no change — this repo gates on the `CI Complete` aggregator alone.

It runs the repo-local checks only. The script's repo-settings and branch-protection checks need a token with `Administration:read`, which is more authority than a lint job should carry on every PR, and they test org configuration rather than anything a PR can introduce. Those move to a scheduled org-level run: MustardSeedNetworks/.github#17.

## Linked Issue

Closes #1328

Upstream: the reusable workflow is MustardSeedNetworks/.github#16; the org-config half is MustardSeedNetworks/.github#17.

## Type of Change

- [x] CI / release / packaging

## Risk

- [x] Low

## Testing Evidence

The gate passes here today, and is falsifiable — removing its own entry from `ci-complete`'s `needs:` makes it fail:

```text
$ python3 ../dotgithub/scripts/check-ci-conformance.py
ci-conformance: passed

$ # with ci-conformance removed from ci-complete needs (mutation asserted applied)
::error::job 'ci-conformance' is not in ci-complete's needs and is not listed in
  .github/ci-advisory-jobs.txt — it runs but cannot block a merge
ci-conformance: 1 finding(s)

$ actionlint -ignore 'SC2129' .github/workflows/ci.yml
(clean)
```

Upstream, an injected rogue job is also caught, and `zizmor --min-severity high` reports no findings on the reusable workflow.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included — the job runs with `contents: read` and no elevated token, which is the point of the local-only split.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched — none touched.
- [x] Dependencies are pinned and justified if changed — the reusable workflow is pinned by SHA; golangci-lint is installed via pinned `go install`.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed — rationale is inline in `ci.yml`.
