### PR TITLE
chore(ui): remove stale license remnants

### DIFF
--- a/ui/src/components/ui/ReadOnlyView.tsx
+++ b/ui/src/components/ui/ReadOnlyView.tsx
@@ -14,7 +14,7 @@
  *
  * For controls that should remain visible-but-disabled with a custom
  * tooltip, prefer the inline `useScope().canWrite` + `disabled`
- * pattern so the title can compose with other gates (e.g. license).
+ * pattern so the title can compose with other gates.
  */
 
 import type { ReactElement, ReactNode } from 'react';

--- a/ui/src/components/ui/RequireScope.tsx
+++ b/ui/src/components/ui/RequireScope.tsx
@@ -1,7 +1,6 @@
 /**
  * RequireScope — render children only if the current token meets a
- * minimum scope. Hide-variant gating, parallel to <RequireFeature>
- * for license tier (#762).
+ * minimum scope (#762).
  *
  * Use this for entire pages, drawer sections, nav items, or any UI
  * surface that should simply not exist below the threshold:
@@ -16,7 +15,7 @@
  *
  * Fail-closed: while the initial scope fetch is in flight `canWrite`
  * and `isAdmin` are false so children render the `fallback` (default
- * null), matching <RequireFeature>'s behavior.
+ * null).
  */
 
 import type { ReactElement, ReactNode } from 'react';

--- a/ui/src/ui/Alert.stories.tsx
+++ b/ui/src/ui/Alert.stories.tsx
@@ -45,9 +45,9 @@ export const RichContent: Story = {
     status: 'warning',
     children: (
       <div className="space-y-1">
-        <p className="font-medium">License renewal due in 7 days</p>
+        <p className="font-medium">Simulation disk usage nearing capacity</p>
         <p className="text-sm">
-          Renew via Settings → License or contact{' '}
+          Trim old scenario snapshots via Settings → Storage or contact{' '}
           <a className="underline" href="mailto:support@mustardseed.io">
             support@mustardseed.io
           </a>


### PR DESCRIPTION
## Summary

NIAC no longer has runtime licensing; this removes the last customer-facing
license remnants from the UI. `Alert.stories.tsx` had a sample "License
renewal due in 7 days" alert — replaced with a storage-capacity alert that
fits a network simulator. `RequireScope.tsx` and `ReadOnlyView.tsx` had
stale doc-comment references to "license tier" / "e.g. license" (including
a mention of a `<RequireFeature>` component that no longer exists in the
codebase) — both comments now describe only the scope-gating behavior that
actually exists. `help-content.ts`'s `@license Proprietary` file header was
left untouched — that's a genuine source-file license header, not a
customer-facing licensing feature.

## Linked Issue

Closes #1305

## Type of Change

- [ ] Defect fix
- [ ] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

Run from `ui/` inside the worktree (`npm ci` first to populate `node_modules`,
which did not exist in this worktree):

```text
$ npm run lint
npm notice run niac-ui@0.94.39 lint
npm notice run biome check src/
Checked 349 files in 1495ms. No fixes applied.

$ npm run typecheck
npm notice run niac-ui@0.94.39 typecheck
npm notice run tsc --build --noEmit
(no output — success)

$ npm test
...
 Test Files  1 failed | 77 passed (78)
      Tests  5 failed | 371 passed (376)

FAIL src/ui/Button.a11y.test.tsx (5 failures): "Error: Axe is already
running. Use `await axe.run()` to wait for the previous run to finish
before starting a new run."
```

The 5 failures are a pre-existing test-isolation flake unrelated to this
change (axe-core global state racing across parallel test files in the
full suite run) — not present in the three files this PR touches. Verified
by running the failing file in isolation:

```text
$ node --disable-warning=DEP0205 ./node_modules/vitest/vitest.mjs run src/ui/Button.a11y.test.tsx --reporter=verbose
 ✓ src/ui/Button.a11y.test.tsx > Button — a11y > solid+violet has no axe violations 152ms
 ✓ src/ui/Button.a11y.test.tsx > Button — a11y > all tones+variants render without a11y violations 319ms
 ✓ src/ui/Button.a11y.test.tsx > Button — a11y > disabled button has no a11y violations 15ms
 ✓ src/ui/Button.a11y.test.tsx > Button — a11y > button with leading icon + label has no a11y violations 20ms
 ✓ src/ui/Button.a11y.test.tsx > IconButton — a11y > icon-only button with aria-label is accessible 14ms
 ✓ src/ui/Button.a11y.test.tsx > IconButton — a11y > all tones+variants render without a11y violations 147ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. (Not applicable — comment/copy-only change, no logic touched.)
- [x] Dependencies are pinned and justified if changed. (No dependency changes.)
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. (No behavior change — Storybook sample copy and doc comments only.)
