### PR TITLE
fix(protocols): correct LLDP and CDP management address encodings

### DIFF
--- a/internal/protocols/cdp.go
+++ b/internal/protocols/cdp.go
@@ -102,8 +102,12 @@ const (
 	// every field after the addresses — Port ID, Platform, Version — is lost.
 	cdpProtocolTypeNLPID = 0x01
 
+	// cdpProtocolType802_2 is the other permitted protocol-type: the protocol
+	// field then carries an 8-byte SNAP header rather than a 1-byte NLPID. IPv6
+	// is only recognised in this form.
+	cdpProtocolType802_2 = 0x02
+
 	cdpNLPIDIPv4 = 0xCC // NLPID identifying an IPv4 address
-	cdpNLPIDIPv6 = 0x8E // NLPID identifying an IPv6 address
 )
 
 // CDPHandler handles CDP advertisements.
@@ -316,16 +320,25 @@ func (h *CDPHandler) buildAddressesTLV(device *config.Device) []byte {
 	}
 
 	var (
-		addrBytes []byte
-		nlpid     byte
+		addrBytes    []byte
+		protocolType byte
+		protocol     []byte
 	)
 
-	if ip.To4() != nil {
-		nlpid = cdpNLPIDIPv4
-		addrBytes = ip.To4()
+	// IPv4 is named by a 1-byte NLPID; IPv6 only by an 8-byte SNAP header under
+	// protocol type 2. Verified against tcpdump, which prints "IPv6 2001:db8::1"
+	// for the SNAP form and falls back to raw bytes for an NLPID 0x8E — the form
+	// this emitted before. Note gopacket's CDPAddressTypeIPV6 constant carries
+	// the IPv4 ethertype (0x0800) and so misses the correct encoding too; the
+	// wire format is what matters here, not any one decoder.
+	if v4 := ip.To4(); v4 != nil {
+		addrBytes = v4
+		protocolType = cdpProtocolTypeNLPID
+		protocol = []byte{cdpNLPIDIPv4}
 	} else {
-		nlpid = cdpNLPIDIPv6
 		addrBytes = ip.To16()
+		protocolType = cdpProtocolType802_2
+		protocol = []byte{0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x86, 0xDD}
 	}
 
 	// Address format:
@@ -337,7 +350,7 @@ func (h *CDPHandler) buildAddressesTLV(device *config.Device) []byte {
 	//   Address Length (2 bytes)
 	//   Address (variable)
 
-	addrLen := 1 + 1 + 1 + cdpAddressLenFieldLen + len(addrBytes)
+	addrLen := 1 + 1 + len(protocol) + cdpAddressLenFieldLen + len(addrBytes)
 	length := min(
 		4+4+addrLen,
 		cdpMaxUint16,
@@ -349,12 +362,12 @@ func (h *CDPHandler) buildAddressesTLV(device *config.Device) []byte {
 	binary.BigEndian.PutUint32(tlv[4:8], 1) // Number of addresses
 
 	offset := 8
-	tlv[offset] = cdpProtocolTypeNLPID
+	tlv[offset] = protocolType
 	offset++
-	tlv[offset] = 1 // Protocol length
+	tlv[offset] = safeconv.Byte(len(protocol))
 	offset++
-	tlv[offset] = nlpid
-	offset++
+	copy(tlv[offset:], protocol)
+	offset += len(protocol)
 	addrBytesLen := min(len(addrBytes), cdpMaxUint16)
 	binary.BigEndian.PutUint16(
 		tlv[offset:offset+2],

--- a/internal/protocols/cdp_test.go
+++ b/internal/protocols/cdp_test.go
@@ -229,7 +229,6 @@ func TestBuildAddressesTLV(t *testing.T) {
 		expectedAddr  []byte
 	}{
 		{"IPv4 address", net.ParseIP("192.168.1.1"), 0xCC, []byte{192, 168, 1, 1}},
-		{"IPv6 address", net.ParseIP("2001:db8::1"), 0x8E, net.ParseIP("2001:db8::1").To16()},
 	}
 
 	for _, tt := range tests {
@@ -262,6 +261,42 @@ func TestBuildAddressesTLV(t *testing.T) {
 
 			assertNLPIDAddressEntry(t, tlv[8:], tt.expectedNLPID, tt.expectedAddr)
 		})
+	}
+}
+
+// TestBuildAddressesTLVIPv6UsesSNAPForm pins the IPv6 encoding.
+//
+// IPv6 is only recognised under protocol type 2, whose protocol field carries an
+// 8-byte SNAP header. Verified against tcpdump: it prints "IPv6 2001:db8::1" for
+// this form, and falls back to raw bytes for the NLPID 0x8E this used to emit.
+func TestBuildAddressesTLVIPv6UsesSNAPForm(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewCDPHandler(stack)
+
+	addr := net.ParseIP("2001:db8::1")
+	tlv := handler.BuildAddressesTLV(&config.Device{IPAddresses: []net.IP{addr}})
+	if tlv == nil {
+		t.Fatal("Expected TLV, got nil")
+	}
+
+	if protoType := tlv[8]; protoType != 0x02 {
+		t.Errorf("Expected protocol type 0x02 (802.2), got 0x%02X", protoType)
+	}
+	if protoLen := tlv[9]; protoLen != 8 {
+		t.Fatalf("Expected protocol length 8, got %d", protoLen)
+	}
+	wantSNAP := []byte{0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x86, 0xDD}
+	if got := tlv[10:18]; !bytes.Equal(got, wantSNAP) {
+		t.Errorf("Expected SNAP protocol %x, got %x", wantSNAP, got)
+	}
+
+	addrLen := binary.BigEndian.Uint16(tlv[18:20])
+	if addrLen != 16 {
+		t.Fatalf("Expected address length 16, got %d", addrLen)
+	}
+	if got := net.IP(tlv[20 : 20+addrLen]); !got.Equal(addr) {
+		t.Errorf("Expected address %v, got %v", addr, got)
 	}
 }
 

--- a/internal/protocols/lldp.go
+++ b/internal/protocols/lldp.go
@@ -94,9 +94,11 @@ const (
 	lldpMaxTTL              = 65535 // Maximum TTL value (uint16 max)
 	lldpIfIndexSubtype      = 2     // Interface numbering subtype: ifIndex
 	lldpIfIndexSize         = 4     // Interface index size (uint32)
-	lldpIPv4AddrLen         = 4     // IPv4 address length in bytes
 	lldpIPv6AddrLen         = 16    // IPv6 address length in bytes
-	lldpMACAddrLen          = 6     // MAC address length in bytes
+	// Management Address TLV subtypes, from the IANA address-family registry.
+	lldpAddrSubtypeIPv4 = 1
+	lldpAddrSubtypeIPv6 = 2
+	lldpMACAddrLen      = 6 // MAC address length in bytes
 )
 
 // LLDPHandler handles LLDP advertisements.
@@ -490,12 +492,15 @@ func (h *LLDPHandler) buildManagementAddressTLV(device *config.Device) []byte {
 		addressBytes   []byte
 	)
 
-	switch len(ip) {
-	case lldpIPv4AddrLen:
-		addressSubtype = 1 // IPv4
-		addressBytes = ip
-	case lldpIPv6AddrLen:
-		addressSubtype = 2 // IPv6
+	// Select the family with To4, not len(ip): net.ParseIP returns the 16-byte
+	// IPv4-in-IPv6 form for a v4 address, so switching on the length advertised
+	// every configured IPv4 management address under the IPv6 subtype.
+	switch v4 := ip.To4(); {
+	case v4 != nil:
+		addressSubtype = lldpAddrSubtypeIPv4
+		addressBytes = v4
+	case len(ip) == lldpIPv6AddrLen:
+		addressSubtype = lldpAddrSubtypeIPv6
 		addressBytes = ip
 	default:
 		return nil

--- a/internal/protocols/lldp_roundtrip_test.go
+++ b/internal/protocols/lldp_roundtrip_test.go
@@ -1,0 +1,94 @@
+package protocols_test
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+)
+
+// lldpFrame wraps a built LLDP payload in the Ethernet header the handler sends
+// it under, so an independent decoder sees what the wire sees.
+func lldpFrame(t *testing.T, payload []byte, srcMAC net.HardwareAddr) []byte {
+	t.Helper()
+
+	dstMAC, err := net.ParseMAC(protocols.LLDPMulticastMAC)
+	if err != nil {
+		t.Fatalf("parse LLDP multicast MAC: %v", err)
+	}
+
+	frame := make([]byte, 0, 14+len(payload))
+	frame = append(frame, dstMAC...)
+	frame = append(frame, srcMAC...)
+	frame = binary.BigEndian.AppendUint16(frame, uint16(layers.EthernetTypeLinkLayerDiscovery))
+	return append(frame, payload...)
+}
+
+// TestBuildLLDPFrameDecodesEndToEnd feeds a built advertisement to an
+// independent decoder rather than checking each TLV against expected bytes.
+//
+// The per-TLV tests around it are the same shape that let a malformed CDP
+// Address TLV ship (#1326): a TLV can be well-formed read on its own and still
+// derail a decoder walking the chain in order, and only a decode of the whole
+// frame notices. Everything after the derailing TLV is silently lost on the wire.
+func TestBuildLLDPFrameDecodesEndToEnd(t *testing.T) {
+	cfg := &config.Config{}
+	stack := protocols.NewStack(nil, cfg, logging.NewDebugConfig(0))
+	handler := protocols.NewLLDPHandler(stack)
+
+	srcMAC := net.HardwareAddr{0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}
+	device := &config.Device{
+		Name:        "Switch-1",
+		Type:        "switch",
+		MACAddress:  srcMAC,
+		IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+		Interfaces:  []config.Interface{{Name: "GigabitEthernet0/1"}},
+	}
+
+	packet := gopacket.NewPacket(
+		lldpFrame(t, handler.BuildLLDPFrame(device), srcMAC),
+		layers.LinkTypeEthernet,
+		gopacket.Default,
+	)
+	if errLayer := packet.ErrorLayer(); errLayer != nil {
+		t.Fatalf("decode failed: %v", errLayer.Error())
+	}
+
+	discovery, ok := packet.Layer(layers.LayerTypeLinkLayerDiscovery).(*layers.LinkLayerDiscovery)
+	if !ok {
+		t.Fatal("no LLDP layer decoded")
+	}
+	if got := string(discovery.PortID.ID); got != "GigabitEthernet0/1" {
+		t.Errorf("PortID = %q, want %q", got, "GigabitEthernet0/1")
+	}
+
+	infoLayer := packet.Layer(layers.LayerTypeLinkLayerDiscoveryInfo)
+	if infoLayer == nil {
+		t.Fatal("no LLDP info layer decoded")
+	}
+	info, ok := infoLayer.(*layers.LinkLayerDiscoveryInfo)
+	if !ok {
+		t.Fatalf("unexpected layer type %T", infoLayer)
+	}
+
+	if info.SysName != "Switch-1" {
+		t.Errorf("SysName = %q, want %q", info.SysName, "Switch-1")
+	}
+
+	// The management address is the TLV most like CDP's: a length-prefixed
+	// address whose family is chosen by the emitter. Advertising an IPv4 address
+	// under the IPv6 subtype is invisible to a per-field test.
+	if got := info.MgmtAddress.Subtype; got != layers.IANAAddressFamilyIPV4 {
+		t.Errorf("management address subtype = %d, want IPv4 (%d)",
+			got, layers.IANAAddressFamilyIPV4)
+	}
+	if got := net.IP(info.MgmtAddress.Address); !got.Equal(net.ParseIP("192.168.1.1")) {
+		t.Errorf("management address = %v, want 192.168.1.1", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a round-trip decode test for the LLDP emitter — the approach that found #1326 — and fixes the two defects it exposed. Both were invisible to the existing per-TLV tests, which assert expected bytes field by field and so cannot see a field that is well-formed but *wrong*.

**1. LLDP advertised every IPv4 management address as IPv6.** `buildManagementAddressTLV` chose the family with `switch len(ip)`. `net.ParseIP` returns the 16-byte IPv4-in-IPv6 form for a v4 address, and a device's `IPAddresses` come straight from config, so a configured IPv4 management address went out under subtype 2 (IPv6) with 16 bytes of payload. Collectors read a v4 address labelled v6. The managed path was correct only by accident, because `netip.Addr.AsSlice` returns 4 bytes there. Now selects on `To4`, as the CDP emitter already did.

**2. CDP IPv6 addresses were named by NLPID `0x8E`.** Structurally valid — it stopped derailing the TLV walk in #1326 — but no decoder recognises it, so the address was silently dropped. IPv6 is only recognised under protocol type 2, whose protocol field carries an 8-byte SNAP header.

Worth noting: gopacket's own `CDPAddressTypeIPV6` constant carries the **IPv4** ethertype (`0xaaaa030000000800`), so it misses the correct encoding too. tcpdump decided this, not any single library.

## Linked Issue

Closes #1330. Related to #1329 — this covers the LLDP half; EDP and FDP are being split out, see below.

## Type of Change

- [x] Defect fix

## Risk

- [x] Low

## Testing Evidence

tcpdump against real emitter output — both families decode, and Port-ID still follows, so the whole chain walks:

```text
=== emitted v4 ===
	Device-ID (0x01), value length: 8 bytes: 'Switch-1'
	Address (0x02), value length: 13 bytes: IPv4 (1) 192.168.1.1
	Port-ID (0x03), value length: 18 bytes: 'GigabitEthernet0/1'
=== emitted v6 ===
	Device-ID (0x01), value length: 8 bytes: 'Switch-1'
	Address (0x02), value length: 32 bytes: IPv6 (1) 2001:db8::1
	Port-ID (0x03), value length: 18 bytes: 'GigabitEthernet0/1'
```

Encoding comparison that settled the IPv6 question — only the SNAP/86dd form is recognised:

```text
=== v6_8e_nlpid (what this emitted before) ===
	Address (0x02): pt=0x01, pl=1, pb= 8e, al=16, a= 20 01 0d b8 ...
=== v6_8022_86dd (what it emits now) ===
	Address (0x02): IPv6 (1) 2001:db8::1
=== v6_8022_0800 (gopacket's constant) ===
	Address (0x02): pt=0x02, pl=8, pb= aa aa 03 00 00 00 08 00, al=16, a= 20 01 0d b8 ...
```

The LLDP fix is mutation-verified — restoring the length-based selection fails the new test:

```text
mutation applied (restores len-based selection)
--- FAIL: TestBuildLLDPFrameDecodesEndToEnd
    lldp_roundtrip_test.go:88: management address subtype = 2, want IPv4 (1)

$ # restored
$ go test ./internal/protocols/
ok  	github.com/MustardSeedNetworks/niac-go/internal/protocols	2.558s

$ golangci-lint run ./internal/protocols/...
0 issues.
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched — none touched; this is frame construction only.
- [x] Dependencies are pinned and justified if changed — none changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed — these are wire-format corrections toward what the protocols already specify.

## Note on EDP and FDP

#1329 also asked for EDP and FDP round-trips. gopacket has no decoder for either, and decoding niac's frames with tcpdump surfaced something bigger than a missing test: the EDP header layout does not match seed's parser *or* the real protocol. That needs the specs and ideally real captures, so it is split into its own issue rather than guessed at here.