### PR TITLE
refactor(ui): settle the status vocabulary and stop bypassing StatusConfig

### DIFF
--- a/ui/src/ui/Card.tsx
+++ b/ui/src/ui/Card.tsx
@@ -27,6 +27,7 @@
 
 import type { FC, HTMLAttributes, KeyboardEvent, ReactNode } from 'react';
 import { type Status, StatusBadge } from './StatusBadge';
+import { getStatusConfig } from './StatusConfig';
 
 // Re-export Status type for convenience
 export type { Status };
@@ -275,16 +276,7 @@ export const CardValue: FC<CardValueProps> = ({
   status,
   mono = false,
 }) => {
-  const statusColor = status
-    ? {
-        success: 'text-status-success',
-        warning: 'text-status-warning',
-        error: 'text-status-error',
-        info: 'text-status-info',
-        unknown: 'text-text-muted',
-        loading: 'text-status-info',
-      }[status]
-    : 'text-text-primary';
+  const statusColor = status ? getStatusConfig(status).color : 'text-text-primary';
 
   return (
     <div>
@@ -315,16 +307,7 @@ interface CardRowProps {
  * CardRow - Displays a label-value pair in a horizontal row.
  */
 export const CardRow: FC<CardRowProps> = ({ label, value, status, mono = false }) => {
-  const statusColor = status
-    ? {
-        success: 'text-status-success',
-        warning: 'text-status-warning',
-        error: 'text-status-error',
-        info: 'text-status-info',
-        unknown: 'text-text-muted',
-        loading: 'text-status-info',
-      }[status]
-    : 'text-text-primary';
+  const statusColor = status ? getStatusConfig(status).color : 'text-text-primary';
 
   return (
     <div className="flex justify-between items-center py-compact">

--- a/ui/src/ui/StatusBadge.stories.tsx
+++ b/ui/src/ui/StatusBadge.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof StatusBadge> = {
   argTypes: {
     status: {
       control: 'select',
-      options: ['success', 'warning', 'error', 'loading', 'unknown', 'info'],
+      options: ['success', 'warning', 'error', 'loading', 'unknown'],
     },
     variant: { control: 'select', options: ['icon', 'dot'] },
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
@@ -30,7 +30,6 @@ export const ErrorState: Story = {
   args: { status: 'error', variant: 'icon' },
 };
 export const Loading: Story = { args: { status: 'loading', variant: 'icon' } };
-export const Info: Story = { args: { status: 'info', variant: 'icon' } };
 export const Unknown: Story = { args: { status: 'unknown', variant: 'icon' } };
 
 export const DotVariant: Story = { args: { status: 'success', variant: 'dot' } };
@@ -38,10 +37,10 @@ export const DotVariant: Story = { args: { status: 'success', variant: 'dot' } }
 export const FullMatrix: Story = {
   render: () => (
     <div className="grid grid-cols-6 gap-3 items-center">
-      {(['success', 'warning', 'error', 'loading', 'unknown', 'info'] as const).map((s) => (
+      {(['success', 'warning', 'error', 'loading', 'unknown'] as const).map((s) => (
         <StatusBadge key={s} status={s} variant="icon" />
       ))}
-      {(['success', 'warning', 'error', 'loading', 'unknown', 'info'] as const).map((s) => (
+      {(['success', 'warning', 'error', 'loading', 'unknown'] as const).map((s) => (
         <StatusBadge key={`dot-${s}`} status={s} variant="dot" />
       ))}
     </div>

--- a/ui/src/ui/StatusConfig.tsx
+++ b/ui/src/ui/StatusConfig.tsx
@@ -9,7 +9,7 @@
 
 import type { ReactNode } from 'react';
 
-export type Status = 'success' | 'warning' | 'error' | 'unknown' | 'loading' | 'info';
+export type Status = 'success' | 'warning' | 'error' | 'unknown' | 'loading';
 
 interface StatusConfigItem {
   readonly icon: ReactNode;
@@ -62,20 +62,6 @@ export const statusConfig: Record<Status, StatusConfigItem> = {
     color: 'text-status-error',
     bgColor: 'bg-status-error/15',
     label: 'Status: error',
-  },
-  info: {
-    icon: (
-      <svg className="w-full h-full" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path
-          fillRule="evenodd"
-          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-          clipRule="evenodd"
-        />
-      </svg>
-    ),
-    color: 'text-status-info',
-    bgColor: 'bg-status-info/15',
-    label: 'Status: info',
   },
   unknown: {
     icon: (
@@ -149,8 +135,6 @@ export function getStatusConfig(status: Status): StatusConfigItem {
       return statusConfig.warning;
     case 'error':
       return statusConfig.error;
-    case 'info':
-      return statusConfig.info;
     case 'unknown':
       return statusConfig.unknown;
     case 'loading':


### PR DESCRIPTION
## Summary

Settles the fleet status vocabulary (MustardSeedNetworks/.github#21) for niac, and stops two components bypassing `StatusConfig`.

Two vocabularies were live and disagreed on the same screen. The agreed resolution is a **layered split**, not the wholesale rename that issue originally proposed:

- `ok | warn | crit | unknown` stays canonical for the design system's **state layer** (`StatusRollup`). Untouched by this PR.
- The card `Status` union is a view of a backend diagnostic verdict, **not** the state layer, so it keeps the backend's own words.

**The original proposal to fold `loading` into `unknown` is rejected because it would have regressed this repo.** `BaseCard` renders `loading` during real fetches on `/devices` and `/segments`, driving a distinct animated spinner, while `unknown` renders a static question mark. Collapsing them turns "still fetching" into "no data" — exactly the class of dishonest-state bug this design system exists to prevent. The rule *"loading is never `ok`"* governs the **rollup**, and `RollupState` has no `loading` member; `RuntimeRollup` already maps it to `unknown` correctly. The rule is satisfied where it applies.

Changes:

- **Drop `info`** from the union. Instantiated **zero** times against the card vocabulary — declared, mapped with icon/colour/label, never passed. `info` is real only in `AlertStatus` and the toast type, both structurally separate.
- **`CardValue` and `CardRow` each carried a byte-identical inline colour map that bypassed `StatusConfig` entirely.** That duplication is *how `info` survived here as a live-looking branch* — three mapping tables meant dropping it from one left two behind. Both now call `getStatusConfig`, already the single source of truth for icon, bgColor and label. Verified behaviour-preserving: the inline values matched `StatusConfig`'s `color` field exactly for all six members.

The union is now byte-identical across seed, stem and niac.

Observed but deliberately **not** changed: `CardRow`'s `status` prop has no callers, unlike `CardValue`'s. Removing it is an API decision that belongs with the card-grid archetype work, not the vocabulary contract.

## Linked Issue

Related to #1338

Fleet contract: https://github.com/MustardSeedNetworks/.github/issues/21

## Type of Change

- [x] Chore / refactor / dependency update

## Risk

- [x] Low

## Testing Evidence

```text
$ npm run lint
Checked 361 files in 1999ms. No fixes applied.

$ npm run typecheck
tsc --build --noEmit          (exit 0)

$ npm run test
Test Files  83 passed (83)
     Tests  399 passed (399)

$ npm run i18n:lint
Checked 7 files in 770ms. No fixes applied.

$ npm run i18n:check ; echo EXIT=$?
EXIT=0

$ npm run i18n:test
ℹ pass 1
ℹ fail 0
✔ Extraction complete!  ✅ No files were updated.

$ npm run build
✓ built in 1.30s

$ go build ./...
(exit 0)

Union byte-comparison across seed/stem/niac after this change — exactly one definition:
$ grep -h '^export type Status = ' <seed|stem|niac StatusConfig> | sort -u | wc -l
1
export type Status = 'success' | 'warning' | 'error' | 'unknown' | 'loading';
```

The full i18n gate was run (`i18n:lint && i18n:check && i18n:test`), not just `scripts/i18n/validate.sh` — per #1342 that script is not the whole gate. No locale keys change: no status literal is used to build an i18n key anywhere in this repo.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. — UI-only; no routes, auth or output encoding touched. No wire format changed; daemon state strings are a separate vocabulary and are untouched.
- [x] Dependencies are pinned and justified if changed. — none changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. — no user-visible behaviour change; the colour consolidation is verified byte-equivalent and `loading` is deliberately preserved.
