### PR TITLE
feat(ui): add the Inspector archetype and converge the two packet inspectors

### DIFF
--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -38,6 +38,7 @@ import { isPacketStreamEvent, usePacketStream } from '../hooks/useEventSource';
 import { useSimulationStatus } from '../hooks/useSimulationStatus';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
+import { Inspector, InspectorPane, InspectorPanes, InspectorRecords } from '../ui/Inspector';
 import { Tag } from '../ui/Tag';
 import { H2, SmallText } from '../ui/Typography';
 import { getStreamFilter } from '../utils/conversations';
@@ -492,11 +493,9 @@ export const PacketInspectorPage: FC = () => {
             </CardContent>
           </Card>
 
-          {/* Main content grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-12 gap-spacious">
-            {/* Packet List - Left sidebar */}
-            <div className="lg:col-span-4 xl:col-span-3">
-              <Card className="border-surface-border bg-bg-surface/70 h-[600px]">
+          <Inspector>
+            <InspectorRecords>
+              <Card className="border-surface-border bg-bg-surface/70 h-full">
                 <CardContent className="h-full flex flex-col">
                   <div className="flex-between mb-heading">
                     <SmallText className="text-text-muted uppercase tracking-wide font-semibold">
@@ -519,42 +518,25 @@ export const PacketInspectorPage: FC = () => {
                   </div>
                 </CardContent>
               </Card>
-            </div>
+            </InspectorRecords>
 
-            {/* Right panel - Hex dump and details */}
-            <div className="lg:col-span-8 xl:col-span-9 stack-xl">
-              {/* Hex Dump Viewer */}
-              <Card className="border-surface-border bg-bg-surface/70 h-[350px]">
-                <CardContent className="h-full flex flex-col">
-                  <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-heading">
-                    {t('packets.inspector.hexDumpLabel')}
-                  </SmallText>
-                  <div className="flex-1 min-h-0">
-                    <HexDumpViewer
-                      rawData={selectedPacket?.rawData ?? ''}
-                      headerLength={hexHeaderLength}
-                      highlightRange={highlightRange}
-                    />
-                  </div>
-                </CardContent>
-              </Card>
+            <InspectorPanes>
+              <InspectorPane label={t('packets.inspector.hexDumpLabel')}>
+                <HexDumpViewer
+                  rawData={selectedPacket?.rawData ?? ''}
+                  headerLength={hexHeaderLength}
+                  highlightRange={highlightRange}
+                />
+              </InspectorPane>
 
-              {/* Packet Details */}
-              <Card className="border-surface-border bg-bg-surface/70 h-[220px]">
-                <CardContent className="h-full flex flex-col">
-                  <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-heading">
-                    {t('packets.inspector.packetDetailsLabel')}
-                  </SmallText>
-                  <div className="flex-1 min-h-0 overflow-y-auto">
-                    <PacketDetails
-                      packet={selectedPacket}
-                      onFieldSelect={(start, end) => setHighlightRange([start, end])}
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
+              <InspectorPane label={t('packets.inspector.packetDetailsLabel')} scroll>
+                <PacketDetails
+                  packet={selectedPacket}
+                  onFieldSelect={(start, end) => setHighlightRange([start, end])}
+                />
+              </InspectorPane>
+            </InspectorPanes>
+          </Inspector>
 
           {/* Coloring Rules Panel */}
           {showColoringRules && (

--- a/ui/src/pages/PcapAnalyzerPage.tsx
+++ b/ui/src/pages/PcapAnalyzerPage.tsx
@@ -21,6 +21,7 @@ import { useErrorToast } from '../hooks/useErrorToast';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { InfoPopover } from '../ui/InfoPopover';
+import { Inspector, InspectorPane, InspectorPanes, InspectorRecords } from '../ui/Inspector';
 import { Tag } from '../ui/Tag';
 import { H2, SmallText } from '../ui/Typography';
 import { getStreamFilter } from '../utils/conversations';
@@ -361,61 +362,36 @@ export const PcapAnalyzerPage: FC = () => {
 
           {/* Packets View */}
           {viewMode === 'packets' && (
-            <>
-              {/* Filter Bar */}
-              <div className="mb-content">
-                <FilterBar value={filterExpression} onChange={setFilterExpression} />
-              </div>
+            <Inspector
+              filter={<FilterBar value={filterExpression} onChange={setFilterExpression} />}
+            >
+              <InspectorRecords>
+                <PcapPacketList
+                  packets={filteredPackets}
+                  totalPackets={analysisResult.packets.length}
+                  selectedPacketId={selectedPacket?.id ?? null}
+                  onSelectPacket={handleSelectPacket}
+                  getRowStyle={getRowStyle}
+                />
+              </InspectorRecords>
 
-              <div className="grid grid-cols-1 lg:grid-cols-12 gap-spacious">
-                {/* Packet List */}
-                <div className="lg:col-span-7 xl:col-span-8">
-                  <div className="h-[600px]">
-                    <PcapPacketList
-                      packets={filteredPackets}
-                      totalPackets={analysisResult.packets.length}
-                      selectedPacketId={selectedPacket?.id ?? null}
-                      onSelectPacket={handleSelectPacket}
-                      getRowStyle={getRowStyle}
-                    />
-                  </div>
-                </div>
+              <InspectorPanes>
+                <InspectorPane label={tPages('libraryPcaps.analyzer.hexDumpLabel')}>
+                  <HexDumpViewer
+                    rawData={selectedPacket?.rawData ?? ''}
+                    headerLength={14}
+                    highlightRange={highlightRange}
+                  />
+                </InspectorPane>
 
-                {/* Right panel - Details */}
-                <div className="lg:col-span-5 xl:col-span-4 stack-xl">
-                  {/* Hex Dump Viewer */}
-                  <Card className="border-surface-border bg-bg-surface/70 h-[280px]">
-                    <CardContent className="h-full flex flex-col">
-                      <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-heading">
-                        {tPages('libraryPcaps.analyzer.hexDumpLabel')}
-                      </SmallText>
-                      <div className="flex-1 min-h-0">
-                        <HexDumpViewer
-                          rawData={selectedPacket?.rawData ?? ''}
-                          headerLength={14}
-                          highlightRange={highlightRange}
-                        />
-                      </div>
-                    </CardContent>
-                  </Card>
-
-                  {/* Packet Details */}
-                  <Card className="border-surface-border bg-bg-surface/70 h-[280px]">
-                    <CardContent className="h-full flex flex-col">
-                      <SmallText className="text-text-muted uppercase tracking-wide font-semibold mb-heading">
-                        {tPages('libraryPcaps.analyzer.packetDetailsLabel')}
-                      </SmallText>
-                      <div className="flex-1 min-h-0 overflow-y-auto">
-                        <PacketDetails
-                          packet={selectedPacketForDetails}
-                          onFieldSelect={(start, end) => setHighlightRange([start, end])}
-                        />
-                      </div>
-                    </CardContent>
-                  </Card>
-                </div>
-              </div>
-            </>
+                <InspectorPane label={tPages('libraryPcaps.analyzer.packetDetailsLabel')} scroll>
+                  <PacketDetails
+                    packet={selectedPacketForDetails}
+                    onFieldSelect={(start, end) => setHighlightRange([start, end])}
+                  />
+                </InspectorPane>
+              </InspectorPanes>
+            </Inspector>
           )}
 
           {/* Statistics View */}

--- a/ui/src/ui/Inspector.test.tsx
+++ b/ui/src/ui/Inspector.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Inspector, InspectorPane, InspectorPanes, InspectorRecords } from './Inspector';
+
+describe('Inspector', () => {
+  it('renders the filter above the columns, and only when given one', () => {
+    const { container, rerender } = render(
+      <Inspector filter={<input aria-label="Display filter" />}>
+        <InspectorRecords>rows</InspectorRecords>
+      </Inspector>,
+    );
+    expect(screen.getByLabelText('Display filter')).toBeInTheDocument();
+
+    rerender(
+      <Inspector>
+        <InspectorRecords>rows</InspectorRecords>
+      </Inspector>,
+    );
+    expect(container.querySelector('input')).toBeNull();
+  });
+
+  it('gives the record list the wider column', () => {
+    // The two packet inspectors had drifted into mirror images of each other —
+    // the live view gave the list 4/12 and the pcap view 8/12, on two tabs of
+    // one route. The list is what an operator scans, so it takes the wide half;
+    // this asserts the two can no longer disagree.
+    const { container } = render(
+      <Inspector>
+        <InspectorRecords>rows</InspectorRecords>
+        <InspectorPanes>
+          <InspectorPane label="Hex dump">bytes</InspectorPane>
+        </InspectorPanes>
+      </Inspector>,
+    );
+    const records = container.querySelector('.lg\\:col-span-7');
+    const panes = container.querySelector('.lg\\:col-span-5');
+    expect(records).not.toBeNull();
+    expect(panes).not.toBeNull();
+    expect(records?.textContent).toBe('rows');
+  });
+
+  it('shares the column height evenly between panes', () => {
+    // Hand-set pixel heights are what let the same two panes ship as 350/220
+    // in one implementation and 280/280 in the other.
+    const { container } = render(
+      <InspectorPanes>
+        <InspectorPane label="Hex dump">bytes</InspectorPane>
+        <InspectorPane label="Packet details">fields</InspectorPane>
+      </InspectorPanes>,
+    );
+    const panes = container.querySelectorAll('.flex-1.min-h-0');
+    expect(panes.length).toBeGreaterThanOrEqual(2);
+    for (const pane of panes) {
+      expect(pane.className).not.toMatch(/h-\[\d+px\]/);
+    }
+  });
+
+  it('scrolls only the pane that asks to', () => {
+    const { container } = render(
+      <InspectorPanes>
+        <InspectorPane label="Hex dump">bytes</InspectorPane>
+        <InspectorPane label="Packet details" scroll>
+          fields
+        </InspectorPane>
+      </InspectorPanes>,
+    );
+    expect(container.querySelectorAll('.overflow-y-auto')).toHaveLength(1);
+  });
+
+  it('labels each pane as prose, not as a figure', () => {
+    render(<InspectorPane label="Packet details">fields</InspectorPane>);
+    const label = screen.getByText('Packet details');
+    expect(label.className).not.toMatch(/font-mono/);
+  });
+});

--- a/ui/src/ui/Inspector.tsx
+++ b/ui/src/ui/Inspector.tsx
@@ -1,0 +1,93 @@
+/**
+ * Inspector — the Inspector page archetype: a filter bar over a record list,
+ * with the selected record's structure and payload beside it.
+ *
+ * Shared shell pattern, kept visually and behaviourally consistent across
+ * seed / stem / niac / trellis by convention; each repo owns this file
+ * independently (no master, no sync). All colours reference theme tokens.
+ *
+ * Presentational only — selection, filtering and data live in the page, and
+ * the record list itself stays page-owned because its markup legitimately
+ * differs per record type (the live capture renders a button list, the pcap
+ * analyzer a table). What this file fixes is the frame around them, which had
+ * drifted into mirror images: the same archetype, on two tabs of one route,
+ * gave the record list 3/12 of the width in one and 8/12 in the other.
+ *
+ * Where a record's colour comes from is the one rule that differs from the
+ * List + detail archetype. There, colour comes from state and never category.
+ * An Inspector's list is a dissection surface whose primary axis IS category —
+ * protocol identity is the thing being read, and Wireshark-style coloring
+ * rules are a first-class feature, not decoration. So category colour is
+ * legitimate here and nowhere else. Severity-coloured lists (the debug
+ * console) keep using state colour; the two coexist deliberately.
+ *
+ * Usage:
+ *   <Inspector filter={<FilterBar … />}>
+ *     <InspectorRecords><PacketList … /></InspectorRecords>
+ *     <InspectorPanes>
+ *       <InspectorPane label="Hex dump"><HexDumpViewer … /></InspectorPane>
+ *       <InspectorPane label="Packet details" scroll><PacketDetails … /></InspectorPane>
+ *     </InspectorPanes>
+ *   </Inspector>
+ */
+import type { FC, ReactNode } from 'react';
+import { cn } from '../styles/theme';
+import { Card, CardContent } from './Card';
+
+/**
+ * Height of the record list and of the pane column beside it. They match so
+ * the two columns bottom-align; a short pane column next to a tall list reads
+ * as a rendering fault rather than as a design.
+ */
+const COLUMN_HEIGHT = 'h-[600px]';
+
+export const Inspector: FC<{ filter?: ReactNode; children: ReactNode }> = ({
+  filter,
+  children,
+}) => (
+  <div className="stack-xl">
+    {filter ? <div>{filter}</div> : null}
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-spacious">{children}</div>
+  </div>
+);
+
+/**
+ * The record list column. Deliberately the wider half: the list is what the
+ * operator reads and scans, while the panes answer a question about the one
+ * row already chosen.
+ */
+export const InspectorRecords: FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="lg:col-span-7 xl:col-span-8">
+    <div className={COLUMN_HEIGHT}>{children}</div>
+  </div>
+);
+
+export const InspectorPanes: FC<{ children: ReactNode }> = ({ children }) => (
+  <div className={cn('lg:col-span-5 xl:col-span-4 flex flex-col gap-spacious', COLUMN_HEIGHT)}>
+    {children}
+  </div>
+);
+
+interface InspectorPaneProps {
+  /** Kicker above the pane. Prose, so it is not monospaced. */
+  label: string;
+  /** Content that scrolls rather than clipping — a structure tree, usually. */
+  scroll?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * One labelled pane. Panes share the column height evenly instead of carrying
+ * hand-set pixel heights, which is what let the two implementations drift to
+ * 350/220 and 280/280 for the same two panes.
+ */
+export const InspectorPane: FC<InspectorPaneProps> = ({ label, scroll = false, children }) => (
+  <Card className="border-surface-border bg-bg-surface/70 flex-1 min-h-0">
+    <CardContent className="h-full flex flex-col">
+      <p className="text-xs uppercase tracking-wide font-semibold text-text-muted mb-heading">
+        {label}
+      </p>
+      <div className={cn('flex-1 min-h-0', scroll && 'overflow-y-auto')}>{children}</div>
+    </CardContent>
+  </Card>
+);


### PR DESCRIPTION
## Summary

Adds the **Inspector** page archetype and converges niac's two packet inspectors onto it.

The rollout's route map lists five niac routes as Inspector candidates. Triaging them against the actual pages found **only two** with the shape the spec describes (`filter bar → record list + structure tree + payload pane`) — and both are inside `/packets`:

- the live capture view in `PacketInspectorPage`
- `PcapAnalyzerPage`, the "PCAP files" tab

These are near-duplicate implementations of one archetype. They already share `FilterBar`, `PacketDetails` (which owns `ProtocolTree`), `HexDumpViewer`, `useColoringRules` and `useDisplayFilter`, and their two record lists already agree on a prop contract (`selectedPacketId` / `onSelectPacket` / `getRowStyle`).

**What had drifted was the frame — into mirror images:**

| | record list | panes |
|---|---|---|
| live | `lg:col-span-4 xl:col-span-3` | 350px + 220px |
| pcap | `lg:col-span-7 xl:col-span-8` | 280px + 280px |

Two tabs of one route, so switching tabs flipped the layout.

Both now use `ui/Inspector.tsx`. The list takes the wide half — it is what an operator scans, while the panes answer a question about the row already chosen — and panes share the column height evenly instead of carrying hand-set pixel heights. **The record lists stay page-owned**: their markup legitimately differs (one a button list, one a table), so the archetype fixes the frame rather than forcing one widget on both.

## One rule deliberately differs from List + detail

In `ListDetail`, a record's colour comes from its state and **never** its category. An Inspector's list is a dissection surface whose primary axis *is* category — protocol identity is the thing being read, and Wireshark-style coloring rules are a first-class feature here, not decoration. So category colour is legitimate in this archetype and nowhere else. Severity-coloured lists (the debug console's `LogViewer`) keep using state colour; the two coexist on purpose, and the file records the reasoning so it is a decision rather than an inconsistency.

## Not converted, with reasons

- `/config-diff` — two-document compare, no list, no selection state. Showing everything at once is what a diff tool is *for*.
- `/walk-analyzer`, `/walk-validator` — form → one-shot report, read-only result tables, no selection. They match each other, not this archetype.
- `/debug` — has a real filter bar and list, but expands rows inline: an accordion, not master-detail. Converting would remove a working interaction, not relabel one.

Converting any of these would mean inventing selection state, a tree, or a payload pane that does not exist — the pattern that has now over-promised twice in this rollout.

## Linked Issue

Related to #1338

## Type of Change

- [x] Feature

## Risk

- [x] Low — layout only. No data flow, selection logic, or record markup changed.

## Testing Evidence

```text
$ npm run lint
Checked 363 files in 2s. No fixes applied.

$ npm run typecheck
tsc --build --noEmit          (exit 0)

$ npm run test
Test Files  84 passed (84)
     Tests  404 passed (404)          # 399 + 5 new

$ npm run i18n:lint && npm run i18n:check && npm run i18n:test
exit 0 / exit 0 / exit 0

$ npm run build
✓ built in 1.31s

$ go build ./...
(exit 0)

$ scripts/check-file-size.sh
📊 Found 0 red flag(s), 49 warning(s)

$ scripts/check-token-discipline.sh
OK: blocking color-token discipline is clean

$ git diff --stat
 ui/src/pages/PacketInspectorPage.tsx | 60 +++++-------------
 ui/src/pages/PcapAnalyzerPage.tsx    | 82 +++++++++-----------------
 2 files changed, 50 insertions(+), 92 deletions(-)
```

Net **-42 lines** across the two pages. The full i18n gate was run (`i18n:lint && i18n:check && i18n:test`), not just `scripts/i18n/validate.sh` — per #1342 that script is not the whole gate. No locale keys change; the pane labels reuse the existing `packets.inspector.*` and `libraryPcaps.analyzer.*` keys.

The five new tests lock exactly what drifted: the record list keeps the wide column, panes carry no hand-set pixel heights, only the pane that asks for it scrolls, the filter renders only when supplied, and the pane label stays prose rather than a figure.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. — UI layout only; no routes, auth, or output encoding touched.
- [x] Dependencies are pinned and justified if changed. — none changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. — the live view's record list gets more width and its panes equal height; `ui/Inspector.tsx` documents the archetype and the category-colour exception inline.
