### PR TITLE
ci: reconcile skipped releases with a 3-hourly release-please run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,22 @@
 #
 # Trigger pattern (shared with seed, stem, niac):
 #   - workflow_run on CI completion: real trigger; gated on success
+#   - schedule: reconciles a release that a flaky CI run skipped
 #   - workflow_dispatch: manual debug / force trigger
+#
+# Why the schedule exists (stem#662): the workflow_run gate means a TRANSIENT
+# CI failure on main does not merely go red, it skips the release outright and
+# says nothing — a merged release PR, no tag, and a workflow that "succeeded"
+# by skipping. That fired for real on 2026-08-18 (stem v0.24.14 and seed the
+# same day) and was only caught because someone was watching.
+#
+# The fix is convergence, not alerting. release-please is idempotent: with
+# nothing to release it does nothing, so a periodic run is free of false
+# positives — unlike a "release was skipped" alarm, which cannot tell a
+# skipped release from a main CI failure on a commit that was never going to
+# release anything. A skipped release now self-heals within the interval
+# instead of waiting to be noticed. workflow_dispatch remains for recovering
+# it immediately.
 #
 # The tag release-please pushes is what starts release.yml — there is no
 # explicit hand-off job. This works ONLY because the tag is pushed with the
@@ -34,14 +49,18 @@ on:
     workflows: ["CI"]
     branches: [main]
     types: [completed]
+  # Offset from the hour so the fleet's four repos do not all fire at :00.
+  schedule:
+    - cron: '27 */3 * * *'
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
   release-please:
-    # Only run if CI workflow succeeded (or this is a manual dispatch).
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # Only run if CI succeeded — or if this is the reconciling schedule or a
+    # manual dispatch, neither of which carries a workflow_run to gate on.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     name: Release Please
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Ports MustardSeedNetworks/stem#669 to this repo: a 3-hourly reconciling run of
`release-please`, so a release skipped by a transient CI failure self-heals.

`release-please.yml` is triggered by `workflow_run` on CI and gated on
`conclusion == 'success'`. That gate means a **flaky** CI run on `main` does not
merely go red — it skips the release outright and says nothing. The result is a
merged release PR, no tag, and a workflow that "succeeded" by skipping. It is
indistinguishable from "no release was needed". This fired for real on
2026-08-18 on both stem and seed.

The fix is convergence rather than alerting. `release-please` is idempotent:
with nothing to release it does nothing, so a periodic trigger has **zero**
false positives. An alarm cannot achieve that — it cannot tell a skipped
release from a main-CI failure on a commit that was never going to release
anything.

Three changes, all in `.github/workflows/release-please.yml`:

- `schedule: - cron: '27 */3 * * *'` — offset off the hour so the fleet's
  four repos do not all fire at `:00`.
- The job gate becomes `github.event_name != 'workflow_run' || ...success'`.
  The CI-success gate on `workflow_run` is **deliberately unchanged**; the
  schedule and `workflow_dispatch` simply carry no `workflow_run` to gate on.
- The header comment records why the schedule exists, so it reads as a decision.

Note: `workflow_dispatch` was already present in every repo — stem#662's
recommended "option 1" was a no-op. This is the missing half.

## Linked Issue

Related to #1338
Ports MustardSeedNetworks/stem#669, which addresses MustardSeedNetworks/stem#662.

## Testing Evidence

Workflow-only change; the gates that apply are the YAML/action linters. Both
were run because `yaml.safe_load` **accepts** duplicate keys (it silently takes
the last) while `actionlint` does not — neither alone is sufficient.

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"
  safe_load OK

$ actionlint -ignore 'SC2129' .github/workflows/release-please.yml
  actionlint OK

$ zizmor --min-severity high .github/workflows/release-please.yml
 INFO zizmor: zizmor v1.29.0
 INFO audit: zizmor: completed .github/workflows/release-please.yml
No findings to report. Good job! (1 ignored, 4 suppressed)
```

Behavioural verification of the **schedule path is still pending observation**
and is deliberately not claimed here. stem merged the same change and a release
PR (stem#671) did follow, but `gh run list --workflow=release-please.yml` on
stem shows every run to date with `event = workflow_run` and **no `schedule`
event yet** — so #671 was cut by the ordinary post-merge trigger, not by the
reconcile. The schedule will be confirmed by a `schedule`-event run appearing in
that list; until one does, this change is verified by the linters only.

The same listing does show the defect this fixes, on 2026-08-18T08:57:35Z:
`workflow_run  skipped` — a release-please run that skipped rather than
released, which is exactly the silent case the reconcile converges out of.

## Security and Release Checklist

- [x] No change to `permissions:` — still `{}` at workflow level, `contents: write` +
      `pull-requests: write` on the job only.
- [x] No new secrets, no new action references, no pin changes.
- [x] The `workflow_run` CI-success gate is unchanged; the schedule cannot bypass
      it, because a scheduled event carries no `workflow_run` to bypass.
- [x] `zizmor --min-severity high` clean; the pre-existing `dangerous-triggers`
      ignore for `workflow_run` is untouched and still justified (no checkout).
- [x] No release/versioning semantics change — `release-please` decides what to
      release exactly as before; only how often it is asked.
