### PR TITLE
fix(topology): stop reporting a device status the daemon never measured

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -878,7 +878,7 @@
     "deviceNode": {
       "tooltipIps": "IPs: {{ips}}",
       "tooltipProtocols": "Protocols: {{protocols}}",
-      "tooltipSummary": "{{label}} ({{type}}, {{status}})"
+      "tooltipSummary": "{{label}} ({{type}})"
     },
     "header": {
       "clearTypeFiltersTitle": "Remove all device-type filters and show every device in the topology",
@@ -921,10 +921,6 @@
       "linkSpeedsHeading": "Link Speeds",
       "nodesHeading": "Nodes",
       "showLegend": "Show Legend",
-      "statusHeading": "Status",
-      "statusOffline": "Offline",
-      "statusOnline": "Online",
-      "statusWarning": "Warning",
       "utilizationCritical": "Critical (85%+)",
       "utilizationHeading": "Utilization",
       "utilizationHigh": "High (60–84%)"

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -441,10 +441,6 @@
       "deviceTypesHeading": "Tipos de dispositivo",
       "linkSpeedsHeading": "Velocidades de enlace",
       "nodesHeading": "Nodos",
-      "statusHeading": "Estado",
-      "statusOnline": "En línea",
-      "statusOffline": "Fuera de línea",
-      "statusWarning": "Advertencia",
       "focusHint": "Haga clic en un nodo para resaltar sus vecinos: los dispositivos no relacionados se atenúan.",
       "edgesHeading": "Enlaces",
       "utilizationHeading": "Utilización",
@@ -496,7 +492,7 @@
       "closeAriaLabel": "Cerrar detalles del dispositivo"
     },
     "deviceNode": {
-      "tooltipSummary": "{{label}} ({{type}}, {{status}})",
+      "tooltipSummary": "{{label}} ({{type}})",
       "tooltipIps": "IPs: {{ips}}",
       "tooltipProtocols": "Protocolos: {{protocols}}"
     },

--- a/ui/src/pages/topology/DeviceNode.tooltip.test.tsx
+++ b/ui/src/pages/topology/DeviceNode.tooltip.test.tsx
@@ -5,7 +5,11 @@
  * `+N` overflow for IPs and protocols, so the full data is invisible to users.
  * PR-A surfaces all that data through both `title` (native hover tooltip) and
  * `aria-label` (screen readers). This test fails if either disappears or stops
- * including any one of label / type / status / IPs / protocols.
+ * including any one of label / type / IPs / protocols.
+ *
+ * Status is deliberately absent: the node never had a real one. It was
+ * hardcoded 'online' over an API type with no status field (niac-go#1352), so
+ * the tooltip was reporting a fact nobody had measured.
  */
 import { render, screen } from '@testing-library/react';
 import { ReactFlowProvider } from '@xyflow/react';
@@ -25,7 +29,6 @@ function renderNode(data: Partial<DeviceNodeData>) {
             {
               label: 'edge-router-01',
               type: 'router',
-              status: 'online',
               ips: ['10.0.0.1', '10.0.1.1', '10.0.2.1'],
               protocols: ['BGP', 'OSPF', 'SNMP', 'ARP'],
               ...data,
@@ -38,7 +41,7 @@ function renderNode(data: Partial<DeviceNodeData>) {
 }
 
 describe('DeviceNode — hover tooltip + accessible name', () => {
-  it('surfaces label, type, status, all IPs, and all protocols', () => {
+  it('surfaces label, type, all IPs, and all protocols', () => {
     renderNode({});
     const btn = screen.getByRole('button');
     const tooltip = btn.getAttribute('title') ?? '';
@@ -47,7 +50,6 @@ describe('DeviceNode — hover tooltip + accessible name', () => {
     expect(tooltip).toBe(ariaLabel);
     expect(tooltip).toContain('edge-router-01');
     expect(tooltip).toContain('router');
-    expect(tooltip).toContain('online');
     expect(tooltip).toContain('10.0.0.1');
     expect(tooltip).toContain('10.0.1.1');
     expect(tooltip).toContain('10.0.2.1');
@@ -66,9 +68,13 @@ describe('DeviceNode — hover tooltip + accessible name', () => {
     expect(tooltip).not.toContain('Protocols:');
   });
 
-  it('defaults missing status to "online"', () => {
-    renderNode({ status: undefined });
-    const tooltip = screen.getByRole('button').getAttribute('title') ?? '';
-    expect(tooltip).toContain('online');
+  it('never claims a reachability state the daemon does not report', () => {
+    // This replaces a test that asserted the opposite — it was named
+    // 'defaults missing status to "online"' and encoded the defect as intent.
+    const tooltip = renderNode({}).container.querySelector('button')?.getAttribute('title') ?? '';
+
+    expect(tooltip).not.toContain('online');
+    expect(tooltip).not.toContain('offline');
+    expect(tooltip).not.toContain('warning');
   });
 });

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -26,19 +26,12 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
   const Icon = deviceIcons[deviceType] || deviceIcons.unknown;
   const color = deviceColors[deviceType] || deviceColors.unknown;
 
-  const statusColor = {
-    online: 'bg-status-success',
-    offline: 'bg-bg-muted',
-    warning: 'bg-status-warning',
-  }[data.status || 'online'];
-
   // The card truncates the device name and shows `+N` overflow for IPs and
   // protocols, so the full data is invisible without a tooltip. Build a
   // multi-line description and surface it through both title (native hover
   // tooltip) and aria-label (screen readers).
-  const status = data.status || 'online';
   const tooltipLines: string[] = [
-    t('topology.deviceNode.tooltipSummary', { label: data.label, type: data.type, status }),
+    t('topology.deviceNode.tooltipSummary', { label: data.label, type: data.type }),
   ];
   if (data.ips && data.ips.length > 0) {
     tooltipLines.push(t('topology.deviceNode.tooltipIps', { ips: data.ips.join(', ') }));
@@ -88,11 +81,6 @@ export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
         type="source"
         position={Position.Right}
         className="!w-2 !h-2 !bg-brand-accent !border-0"
-      />
-
-      {/* Status indicator */}
-      <div
-        className={`absolute -top-1 -right-1 w-3 h-3 rounded-full ${statusColor} border-2 border-border-muted`}
       />
 
       {/* Icon and name */}

--- a/ui/src/pages/topology/TopologyLegend.test.tsx
+++ b/ui/src/pages/topology/TopologyLegend.test.tsx
@@ -21,12 +21,18 @@ function renderLegend() {
 }
 
 describe('TopologyLegend — complete encoding coverage', () => {
-  it('documents node status dot colors (DeviceNode.tsx statusColor map)', () => {
+  it('does not advertise node states the data layer cannot produce', () => {
+    // Was 'documents node status dot colors'. The legend showed Online /
+    // Offline / Warning swatches while every node was hardcoded 'online' and
+    // DeviceSummary carried no status field at all — so two of the three
+    // states were unreachable and the third was fabricated (niac-go#1352).
+    // A legend that documents a non-existent encoding is what made the green
+    // read as meaningful.
     renderLegend();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Online')).toBeInTheDocument();
-    expect(screen.getByText('Offline')).toBeInTheDocument();
-    expect(screen.getByText('Warning')).toBeInTheDocument();
+
+    expect(screen.queryByText('Online')).not.toBeInTheDocument();
+    expect(screen.queryByText('Offline')).not.toBeInTheDocument();
+    expect(screen.queryByText('Warning')).not.toBeInTheDocument();
   });
 
   it('documents discovered (dashed) vs declared (solid) edge line style (TrunkEdge.tsx)', () => {

--- a/ui/src/pages/topology/TopologyLegend.tsx
+++ b/ui/src/pages/topology/TopologyLegend.tsx
@@ -36,12 +36,6 @@ const DEVICE_TYPES = [
 // Matches DeviceNode.tsx's statusColor map (bg-status-success /
 // bg-bg-muted / bg-status-warning) — kept as CSS custom properties so
 // the legend swatches track the same theme tokens as the live dots.
-const STATUS_DOTS = [
-  { status: 'online', swatchClass: 'bg-status-success', labelKey: 'statusOnline' },
-  { status: 'offline', swatchClass: 'bg-bg-muted', labelKey: 'statusOffline' },
-  { status: 'warning', swatchClass: 'bg-status-warning', labelKey: 'statusWarning' },
-] as const;
-
 // Matches layout.ts's linkSpeedColors / getEdgeColor.
 const LINK_SPEEDS = [
   { label: '100M', color: 'var(--color-link-100m)' },
@@ -124,23 +118,6 @@ export const TopologyLegend: FC<TopologyLegendProps> = ({ show, onToggle }) => {
                     </div>
                   );
                 })}
-              </div>
-            </div>
-
-            {/* Status dot colors */}
-            <div>
-              <div className="text-xs text-text-muted uppercase tracking-wide mb-2">
-                {t('topology.legend.statusHeading')}
-              </div>
-              <div className="space-y-1.5">
-                {STATUS_DOTS.map(({ status, swatchClass, labelKey }) => (
-                  <div key={status} className="flex items-center gap-compact">
-                    <div className={`w-2.5 h-2.5 rounded-full ${swatchClass}`} />
-                    <span className="text-xs text-text-secondary">
-                      {t(`topology.legend.${labelKey}`)}
-                    </span>
-                  </div>
-                ))}
               </div>
             </div>
 

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -179,7 +179,6 @@ function makeData(device: DeviceSummary): DeviceNodeData {
     type: device.type || 'unknown',
     ips: device.ips,
     protocols: device.protocols,
-    status: 'online',
   };
 }
 

--- a/ui/src/pages/topology/types.ts
+++ b/ui/src/pages/topology/types.ts
@@ -12,7 +12,6 @@ export interface DeviceNodeData extends Record<string, unknown> {
   type: string;
   ips?: string[];
   protocols?: string[];
-  status?: 'online' | 'offline' | 'warning';
   selected?: boolean;
   onClick?: (id: string) => void;
 }


### PR DESCRIPTION
## Summary

Every node on `/topology` rendered a green **"online"** dot, always, for every
device. The value came from a literal in `layout.ts` `makeData()`:

```ts
status: 'online',
```

That was the **only writer anywhere in the feature**, and it could not have been
anything else — `DeviceSummary`, the API type it is built from, carries no
reachability, health or state field at all. `DeviceNode.tsx:33` then defaulted
the same way a second time (`data.status || 'online'`), and put the fabricated
value into the tooltip **as text**, so hovering a device reported
"status: online" in words.

The legend made it worse rather than better: it advertised **Online / Offline /
Warning** swatches, two of which the data layer can never produce. A legend
documenting a non-existent encoding is what made the green read as meaningful
rather than as decoration.

Green is the strongest "nothing to see here" signal on the page, and it was
being emitted by a constant. An operator scanning the topology for a problem got
a uniformly healthy picture carrying **zero** information — worse than showing
nothing, because it suppresses the question.

### Why removed, not recoloured to `unknown`

The fleet rule that unmeasurable is `unknown` applies to a field that **exists**
and has not been measured. Here the concept does not exist at all, so a muted
dot on every node forever would be noise asserting nothing. Removed: the field,
the dot, the tooltip fragment, the legend section, and four locale keys in both
`en` and `es`.

**This does not foreclose the better answer.** Giving `DeviceSummary` a real
reachability field is a separate change — the daemon is simulating these devices
so it *does* know which are running, but exposing it is an API addition and a
product decision, not a layout fix.

## Linked Issue

Fixes #1352
Related to #1338

## Testing Evidence

**Two existing tests had encoded the defect as intent** and now assert the
opposite. One was literally named `defaults missing status to "online"`; the
other, `documents node status dot colors`, asserted the unreachable legend
swatches. Before the test updates, exactly the three status-asserting cases
failed and nothing else did — which is the change's blast radius, measured:

```
     × surfaces label, type, status, all IPs, and all protocols
     × defaults missing status to "online"
     × documents node status dot colors (DeviceNode.tsx statusColor map)
 Test Files  2 failed | 1 passed (3)
      Tests  3 failed | 11 passed (14)
```

After:

```
$ npx vitest run src/pages/topology/
 Test Files  3 passed (3)
      Tests  14 passed (14)

$ npx vitest run          # full UI suite
 Test Files  84 passed (84)
      Tests  404 passed (404)
```

All three i18n gates — `validate.sh` is **not** the whole gate, so each was run
explicitly (niac#1342):

```
$ npm run i18n:lint    exit=0    Checked 7 files in 782ms. No fixes applied.
$ npm run i18n:check   exit=0
$ npm run i18n:test    exit=0    ✔ Extraction complete!  ✅ No files were updated.
```

`i18n:check` passing matters here specifically: the four removed keys are gone
from **both** locales, so key parity holds and no orphan is left behind.

Remaining gates:

```
$ npm run typecheck            exit=0
$ npx biome check src          exit=0   Checked 363 files
$ go build ./...               OK
$ ./scripts/check-file-size.sh 📊 Found 0 red flag(s), 49 warning(s)
$ ./scripts/check-token-discipline.sh
OK: blocking color-token discipline is clean
```

Net −33 lines.

## Security and Release Checklist

- [x] Presentational removal only — no API, no data flow, no authz surface, no
      new dependency.
- [x] **Removes a false assurance**; adds no new claim. Nothing can now render a
      node as healthy, because nothing renders node health at all.
- [x] Locale keys removed from `en` **and** `es` together, so no key-parity or
      orphan-key drift (verified by `i18n:check`).
- [x] `TrunkEdge`'s `data.status` is a different type (`LinkEdgeData`, link
      status) and is left untouched — it is already guarded by `if (data.status)`
      so it only renders when genuinely present.
- [x] No release/versioning impact beyond a normal patch.
