### PR TITLE
feat(scenario): bump the manifest to v4 with observations SEED can assert

### DIFF
--- a/internal/scenario/generator.go
+++ b/internal/scenario/generator.go
@@ -3,19 +3,31 @@ package scenario
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 	"github.com/MustardSeedNetworks/niac-go/internal/converter"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
 )
 
 const (
+	// congestionWarningPercent is the utilization at which Link-Live raises an
+	// interface Warning; a pack authors its trouble spots at or above it.
+	congestionWarningPercent = 80
+
+	// neighborSettleCycles is how many advertisement intervals a consumer waits
+	// before a neighbour table is trustworthy: one to transmit, one to prove
+	// nothing further arrives.
+	neighborSettleCycles = 2
+
 	transitSubnet    = "10.254.200.0/24"
 	transitGateway   = "10.254.200.1"
 	internetLoopback = "8.8.8.8"
@@ -76,7 +88,14 @@ func Generate(request Request) (Result, error) {
 		return Result{}, errors.New(validation.Format())
 	}
 
-	return Result{YAML: data, Manifest: buildManifest(&authored)}, nil
+	identity, err := buildIdentity(request)
+	if err != nil {
+		return Result{}, err
+	}
+	manifest := buildManifest(&authored)
+	manifest.Identity = identity
+
+	return Result{YAML: data, Manifest: manifest}, nil
 }
 
 func buildDevices(request Request, links linkMap) []converter.Device {
@@ -158,9 +177,161 @@ func buildManifest(authored *converter.Config) Manifest {
 	sort.Strings(edges)
 
 	return Manifest{
-		DeviceCount: len(authored.Devices), NetworkCount: len(authored.Networks), LinkCount: len(edges),
+		SchemaVersion: ManifestSchemaVersion,
+		DeviceCount:   len(authored.Devices), NetworkCount: len(authored.Networks), LinkCount: len(edges),
 		DeviceNamesSHA256: hashLines(names), NetworksSHA256: hashLines(networks), LinksSHA256: hashLines(edges),
+		Interfaces:   buildInterfaceTruth(authored),
+		Observations: buildObservations(authored),
+		Timing:       buildTiming(authored),
 	}
+}
+
+// buildIdentity digests the request that produced the scenario. Generation is
+// deterministic, so this digest is the seed a consumer replays from.
+func buildIdentity(request Request) (Identity, error) {
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		return Identity{}, fmt.Errorf("digest scenario request: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+
+	return Identity{
+		RequestSHA256:   hex.EncodeToString(sum[:]),
+		Domain:          request.Domain,
+		AccessLayer:     string(request.AccessLayer),
+		EndpointProfile: request.EndpointProfile,
+	}, nil
+}
+
+// buildInterfaceTruth digests the operational facts an ifTable collector reads,
+// and lifts out the authored congestion because that is the whole of the
+// behaviour a pack currently authors.
+func buildInterfaceTruth(authored *converter.Config) InterfaceTruth {
+	lines := make([]string, 0)
+	congested := make([]CongestedLink, 0)
+	for _, device := range authored.Devices {
+		for _, iface := range device.Interfaces {
+			lines = append(lines, fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%d",
+				device.Name, iface.Name, iface.Type, iface.Speed, iface.Duplex,
+				iface.AdminStatus, iface.OperStatus, iface.MTU))
+			if iface.InUtilization >= congestionWarningPercent ||
+				iface.OutUtilization >= congestionWarningPercent {
+				congested = append(congested, CongestedLink{
+					Device: device.Name, Interface: iface.Name,
+					InUtilization: iface.InUtilization, OutUtilization: iface.OutUtilization,
+				})
+			}
+		}
+	}
+	sort.Strings(lines)
+	sort.Slice(congested, func(i, j int) bool {
+		if congested[i].Device != congested[j].Device {
+			return congested[i].Device < congested[j].Device
+		}
+
+		return congested[i].Interface < congested[j].Interface
+	})
+
+	return InterfaceTruth{Count: len(lines), SHA256: hashLines(lines), Congested: congested}
+}
+
+// buildObservations records what each SEED collector should find. A collector
+// the scenario authors nothing for is omitted rather than recorded as zero —
+// see the Observation doc comment for why those are different claims.
+func buildObservations(authored *converter.Config) map[string]Observation {
+	observations := make(map[string]Observation)
+
+	// Collectors whose answer is one row per device report only a device count;
+	// table collectors also report how many rows those devices contribute.
+	perDevice := func(collector string, rows deviceCounter) {
+		if devices, _ := countDevices(authored, rows); devices > 0 {
+			observations[collector] = Observation{Devices: devices}
+		}
+	}
+	tabular := func(collector string, rows deviceCounter) {
+		if devices, total := countDevices(authored, rows); devices > 0 {
+			observations[collector] = Observation{Devices: devices, Rows: total}
+		}
+	}
+
+	perDevice(CollectorSysInfo, func(d converter.Device) int { return present(d.SnmpAgent != nil) })
+	perDevice(CollectorLLDP, func(d converter.Device) int {
+		return present(d.Lldp != nil && d.Lldp.Enabled)
+	})
+	perDevice(CollectorCDP, func(d converter.Device) int {
+		return present(d.Cdp != nil && d.Cdp.Enabled)
+	})
+	perDevice(CollectorFDP, func(d converter.Device) int {
+		return present(d.Fdp != nil && d.Fdp.Enabled)
+	})
+	tabular(CollectorIfTable, func(d converter.Device) int { return len(d.Interfaces) })
+	tabular(CollectorRouting, func(d converter.Device) int { return len(d.Routes) })
+	tabular(CollectorFDB, countFDBPorts)
+
+	return observations
+}
+
+// deviceCounter reports how many rows one device contributes to a collector.
+type deviceCounter func(converter.Device) int
+
+// countDevices returns how many devices contribute at least one row, and the
+// total row count across them.
+func countDevices(authored *converter.Config, rows deviceCounter) (int, int) {
+	devices, total := 0, 0
+	for _, device := range authored.Devices {
+		count := rows(device)
+		if count == 0 {
+			continue
+		}
+		devices++
+		total += count
+	}
+
+	return devices, total
+}
+
+func present(enabled bool) int {
+	if enabled {
+		return 1
+	}
+
+	return 0
+}
+
+func countFDBPorts(device converter.Device) int {
+	ports := 0
+	for _, port := range device.TrunkPorts {
+		if port.FDBOnly {
+			ports++
+		}
+	}
+
+	return ports
+}
+
+// buildTiming derives the wait tolerance from the advertisement intervals of
+// the protocols the scenario actually authors. A pack that advertises only LLDP
+// and CDP settles in two 15s cycles; one that authors FDP needs two 60s cycles.
+func buildTiming(authored *converter.Config) Timing {
+	var timing Timing
+	slowest := time.Duration(0)
+	for _, device := range authored.Devices {
+		if device.Lldp != nil && device.Lldp.Enabled {
+			timing.LLDPIntervalSeconds = int(protocols.LLDPAdvertiseInterval.Seconds())
+			slowest = max(slowest, protocols.LLDPAdvertiseInterval)
+		}
+		if device.Cdp != nil && device.Cdp.Enabled {
+			timing.CDPIntervalSeconds = int(protocols.CDPAdvertiseInterval.Seconds())
+			slowest = max(slowest, protocols.CDPAdvertiseInterval)
+		}
+		if device.Fdp != nil && device.Fdp.Enabled {
+			timing.FDPIntervalSeconds = int(protocols.FDPAdvertiseInterval.Seconds())
+			slowest = max(slowest, protocols.FDPAdvertiseInterval)
+		}
+	}
+	timing.NeighborsStableAfterSeconds = int(slowest.Seconds()) * neighborSettleCycles
+
+	return timing
 }
 
 func hashLines(lines []string) string {

--- a/internal/scenario/generator_test.go
+++ b/internal/scenario/generator_test.go
@@ -24,7 +24,7 @@ func TestGenerateEnterpriseReferenceMatchesAcceptedTopology(t *testing.T) {
 		t.Fatal("same request produced different YAML")
 	}
 
-	want := scenario.Manifest{
+	want := scenario.Parity{
 		DeviceCount:       531,
 		NetworkCount:      39,
 		LinkCount:         634,
@@ -33,8 +33,8 @@ func TestGenerateEnterpriseReferenceMatchesAcceptedTopology(t *testing.T) {
 		// Routed WAN edges carry no VLAN metadata; switched links retain their trunks.
 		LinksSHA256: "4c1acbf07eccc6464a4a86d8a53f867fdaa1cc7374d18b881bf30487a98713e6",
 	}
-	if first.Manifest != want {
-		t.Fatalf("manifest = %#v, want %#v", first.Manifest, want)
+	if first.Manifest.Parity() != want {
+		t.Fatalf("manifest = %#v, want %#v", first.Manifest.Parity(), want)
 	}
 
 	cfg, err := config.LoadYAMLBytes(first.YAML)

--- a/internal/scenario/manifest_test.go
+++ b/internal/scenario/manifest_test.go
@@ -1,0 +1,167 @@
+package scenario_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/scenario"
+)
+
+func generateHospital(t *testing.T) scenario.Manifest {
+	t.Helper()
+	result, err := scenario.Generate(hospitalPack(t).Request)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	return result.Manifest
+}
+
+func TestManifestDeclaresItsSchemaVersion(t *testing.T) {
+	if got := generateHospital(t).SchemaVersion; got != 4 {
+		t.Errorf("schema version = %d, want 4", got)
+	}
+}
+
+// Generation is deterministic, so the request digest is the seed: a consumer
+// holding it can regenerate the same scenario byte for byte.
+func TestManifestIdentityIsTheReproducibleInput(t *testing.T) {
+	first := generateHospital(t)
+	second := generateHospital(t)
+	if first.Identity.RequestSHA256 != second.Identity.RequestSHA256 {
+		t.Fatal("same request produced two identities")
+	}
+	if first.Identity.RequestSHA256 == "" {
+		t.Fatal("identity carries no request digest")
+	}
+
+	changed := hospitalPack(t).Request
+	changed.Domain = "somewhere.else"
+	other, err := scenario.Generate(changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other.Manifest.Identity.RequestSHA256 == first.Identity.RequestSHA256 {
+		t.Error("a different request kept the same identity")
+	}
+	if first.Identity.Domain == "" {
+		t.Error("identity omits the authored domain")
+	}
+}
+
+func TestManifestRecordsInterfaceTruth(t *testing.T) {
+	manifest := generateHospital(t)
+	if manifest.Interfaces.Count == 0 {
+		t.Fatal("interface truth carries no interfaces")
+	}
+	if manifest.Interfaces.SHA256 == "" {
+		t.Error("interface truth carries no digest")
+	}
+	// The guided hospital story saturates both uplinks of MED-ACC-SW02 and the
+	// matching distribution ends, deliberately above the 80% warning line.
+	if len(manifest.Interfaces.Congested) != 4 {
+		t.Errorf("congested interfaces = %d, want 4: %+v",
+			len(manifest.Interfaces.Congested), manifest.Interfaces.Congested)
+	}
+}
+
+func TestManifestExpectedObservationsFollowTheAuthoredConfig(t *testing.T) {
+	observations := generateHospital(t).Observations
+	for _, collector := range []string{"sys_info", "if_table", "lldp", "cdp"} {
+		observation, ok := observations[collector]
+		if !ok {
+			t.Errorf("no expectation for %s", collector)
+			continue
+		}
+		if observation.Devices == 0 {
+			t.Errorf("%s expects no devices", collector)
+		}
+	}
+	if observations["if_table"].Rows == 0 {
+		t.Error("if_table expectation carries no interface rows")
+	}
+	if observations["sys_info"].Devices > generateHospital(t).DeviceCount {
+		t.Error("more devices answer sys_info than exist")
+	}
+}
+
+// An absent collector means the scenario authors nothing that collector reads.
+// That is not the same claim as a count of zero, and a consumer that treats
+// them alike will assert emptiness the scenario never promised.
+func TestManifestOmitsObservationsNothingAuthors(t *testing.T) {
+	observations := generateHospital(t).Observations
+	for _, collector := range []string{"bgp4_mib", "host_resources", "fdp"} {
+		if _, ok := observations[collector]; ok {
+			t.Errorf("%s expectation exists but the hospital pack authors none", collector)
+		}
+	}
+}
+
+// Neighbour tables cannot be complete before every advertiser has transmitted
+// once, so the tolerance follows the slowest authored advertisement interval
+// rather than a number someone picked.
+func TestManifestTimingFollowsProtocolAdvertisementIntervals(t *testing.T) {
+	timing := generateHospital(t).Timing
+	if timing.LLDPIntervalSeconds != 15 || timing.CDPIntervalSeconds != 15 {
+		t.Errorf("intervals = %+v, want LLDP and CDP at 15s", timing)
+	}
+	if timing.FDPIntervalSeconds != 0 {
+		t.Error("hospital authors no FDP but the manifest states an FDP interval")
+	}
+	if timing.NeighborsStableAfterSeconds != 30 {
+		t.Errorf("stable-after = %ds, want 30 (two 15s cycles)",
+			timing.NeighborsStableAfterSeconds)
+	}
+}
+
+// Physical interface and VLAN are deployment identity. A pack is portable and
+// must stay silent about where it happens to be attached.
+func TestManifestNeverCarriesPhysicalBinding(t *testing.T) {
+	encoded, err := json.Marshal(generateHospital(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Logical interface names are pack content and appear in congestion. What
+	// must never appear is where the pack is attached: a physical VLAN, an
+	// access VLAN, an attachment mode, or a host NIC.
+	for _, forbidden := range []string{
+		"physicalVlan", "accessVlan", "attachmentMode", "eth0",
+	} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Errorf("manifest leaks physical binding %q:\n%s", forbidden, encoded)
+		}
+	}
+}
+
+// The version 4 additions are derived, not frozen, so a pack still pins only
+// the parity subset. This asserts the packs endpoint's shape is unchanged by
+// the bump — consumers reading pack.manifest.deviceCount are unaffected.
+func TestPackManifestKeepsItsPublishedShape(t *testing.T) {
+	encoded, err := json.Marshal(hospitalPack(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		ManifestVersion int                        `json:"manifestVersion"`
+		Manifest        map[string]json.RawMessage `json:"manifest"`
+	}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ManifestVersion != 4 {
+		t.Errorf("manifestVersion = %d, want 4", decoded.ManifestVersion)
+	}
+	want := []string{
+		"deviceCount", "networkCount", "linkCount",
+		"deviceNamesSha256", "networksSha256", "linksSha256",
+	}
+	if len(decoded.Manifest) != len(want) {
+		t.Fatalf("pack manifest keys = %v, want exactly %v", decoded.Manifest, want)
+	}
+	for _, key := range want {
+		if _, ok := decoded.Manifest[key]; !ok {
+			t.Errorf("pack manifest lost %s", key)
+		}
+	}
+}

--- a/internal/scenario/packs.go
+++ b/internal/scenario/packs.go
@@ -1,7 +1,7 @@
 package scenario
 
 const (
-	scenarioPackManifestVersion = 3
+	scenarioPackManifestVersion = ManifestSchemaVersion
 	hospitalSiteOctet           = 51
 	warehouseSiteOctet          = 61
 	campusSiteOctet             = 71
@@ -53,7 +53,9 @@ type Pack struct {
 	Description     string     `json:"description"`
 	MapPurpose      MapPurpose `json:"mapPurpose"`
 	Request         Request    `json:"request"`
-	Manifest        Manifest   `json:"manifest"`
+	// Manifest pins the parity contract only. The richer manifest fields are
+	// derived at generation time and would be meaningless frozen by hand.
+	Manifest Parity `json:"manifest"`
 }
 
 // Packs returns copies of the built-in scenario composer presets.
@@ -88,7 +90,7 @@ func customerScenarioPacks() []Pack {
 				warehouseAccessPointsPerAccess,
 				warehouseWorkstationsPerAccess,
 			),
-			Manifest{
+			Parity{
 				DeviceCount: warehouseDeviceCount, NetworkCount: singleSiteNetworkCount,
 				LinkCount:         warehouseLinkCount,
 				DeviceNamesSHA256: "f622b9683718ece6b665f88c858df863b6b7d54d8a4371efdc9b20cd79255b01",
@@ -105,7 +107,7 @@ func customerScenarioPacks() []Pack {
 			defaultDomain,
 			EnterpriseReferenceRequest().Sites,
 			EnterpriseReferenceRequest().Counts,
-			Manifest{
+			Parity{
 				DeviceCount: enterpriseScaleDeviceCount, NetworkCount: fourSiteNetworkCount,
 				LinkCount:         enterpriseScaleLinkCount,
 				DeviceNamesSHA256: "6da20f0044fb2f696efc3d886c209eb47c07b5fa1e64222f93d58f6dc00f1979",
@@ -147,7 +149,7 @@ func hospitalScenarioPack() Pack {
 			hospitalAccessPointsPerAccess,
 			hospitalWorkstationsPerAccess,
 		),
-		Manifest{
+		Parity{
 			DeviceCount: hospitalDeviceCount, NetworkCount: singleSiteNetworkCount,
 			LinkCount:         hospitalLinkCount,
 			DeviceNamesSHA256: "a026920162b3dcc95656a4d3d69a0aeed84482e7724b018d5a49488383609030",
@@ -200,7 +202,7 @@ func campusScenarioPack() Pack {
 			packSite{code: "ADM", location: "Administration Campus"},
 		),
 		campusCounts(),
-		Manifest{
+		Parity{
 			DeviceCount: campusDeviceCount, NetworkCount: fourSiteNetworkCount,
 			LinkCount:         campusLinkCount,
 			DeviceNamesSHA256: "c15f6f9ddff32dc30e5751858c3ea2650dd2aa1b2900abf89b5f9b23692236f7",
@@ -220,7 +222,7 @@ func newScenarioPack(
 	domain string,
 	sites []Site,
 	counts Counts,
-	manifest Manifest,
+	manifest Parity,
 ) Pack {
 	return Pack{
 		ID: id, Version: "1.3.0", ManifestVersion: scenarioPackManifestVersion,

--- a/internal/scenario/packs_test.go
+++ b/internal/scenario/packs_test.go
@@ -23,10 +23,10 @@ func TestScenarioPackManifestsMatchComposerOutput(t *testing.T) {
 			t.Errorf("Generate(%s): %v", pack.ID, err)
 			continue
 		}
-		if result.Manifest != pack.Manifest {
+		if result.Manifest.Parity() != pack.Manifest {
 			t.Errorf("%s manifest = %#v", pack.ID, result.Manifest)
 		}
-		if pack.ManifestVersion != 3 || pack.Version != "1.3.0" {
+		if pack.ManifestVersion != 4 || pack.Version != "1.3.0" {
 			t.Errorf("%s versions = %q/%d", pack.ID, pack.Version, pack.ManifestVersion)
 		}
 	}

--- a/internal/scenario/packs_vertical.go
+++ b/internal/scenario/packs_vertical.go
@@ -21,7 +21,7 @@ func retailScenarioPack() Pack {
 			retailAccessSwitches,
 			retailAccessPointsPerAccess,
 			retailWorkstationsPerAccess,
-		), Manifest{
+		), Parity{
 			DeviceCount: retailDeviceCount, NetworkCount: twoSiteNetworkCount,
 			LinkCount:         retailLinkCount,
 			DeviceNamesSHA256: "e5944f8f0f8795d3f054f6ce082c3c8c2c1dde8eab5839992487cebd554215a8",
@@ -43,7 +43,7 @@ func manufacturingScenarioPack() Pack {
 		packSites(industrialSiteOctet, packSite{code: "PLT", location: "Production Plant"}),
 		packCounts(manufacturingAccessSwitches, manufacturingAccessPointsPerAccess,
 			manufacturingWorkstationsPerAccess),
-		Manifest{
+		Parity{
 			DeviceCount: manufacturingDeviceCount, NetworkCount: singleSiteNetworkCount,
 			LinkCount:         manufacturingLinkCount,
 			DeviceNamesSHA256: "4bae5bd1de01cf8a6918eadf3e1c88754c680258ed0a6b9cffc543ab789f25f1",
@@ -69,7 +69,7 @@ func serviceProviderScenarioPack() Pack {
 			packSite{code: "SFO", location: "San Francisco Metro POP"},
 		),
 		packCounts(providerAccessSwitches, providerAccessPointsPerAccess, providerWorkstationsPerAccess),
-		Manifest{
+		Parity{
 			DeviceCount: serviceProviderDeviceCount, NetworkCount: threeSiteNetworkCount,
 			LinkCount:         serviceProviderLinkCount,
 			DeviceNamesSHA256: "00e2aa73f52847020ae7b8b2afe86329e93087efae74adecfd3835e8685e0ea3",

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -164,14 +164,106 @@ type Request struct {
 	Congestion      []CongestedLink `json:"congestion,omitempty"`
 }
 
-// Manifest summarizes authored identity and topology for parity checks.
-type Manifest struct {
+// ManifestSchemaVersion is the version of the manifest document. Version 3
+// carried counts and three hashes; version 4 adds the reproducible identity,
+// interface truth, expected observations, and timing tolerances a consumer
+// needs to assert against a running scenario without operating it by hand.
+const ManifestSchemaVersion = 4
+
+// SEED's collector names. These are the strings SEED's snmp.Collector.Name()
+// returns and the keys its polling_targets.collector_chain uses — four of them
+// differ from the package directory they live in. Neither repository imports
+// the other's internal packages, so this is a written-down contract: changing a
+// name here without changing it in SEED silently breaks the pairing.
+const (
+	CollectorSysInfo = "sys_info"
+	CollectorIfTable = "if_table"
+	CollectorLLDP    = "lldp"
+	CollectorCDP     = "cdp"
+	CollectorFDP     = "fdp"
+	CollectorRouting = "routing"
+	CollectorFDB     = "fdb"
+)
+
+// Parity is the frozen authored-truth contract a pack pins: the counts and
+// digests that must not drift. It is deliberately comparable, so a pack can
+// assert equality against a freshly generated scenario in one expression.
+type Parity struct {
 	DeviceCount       int    `json:"deviceCount"`
 	NetworkCount      int    `json:"networkCount"`
 	LinkCount         int    `json:"linkCount"`
 	DeviceNamesSHA256 string `json:"deviceNamesSha256"`
 	NetworksSHA256    string `json:"networksSha256"`
 	LinksSHA256       string `json:"linksSha256"`
+}
+
+// Identity is the reproducible input that produced a scenario. Generation is
+// deterministic and takes no random seed, so the digest of the request *is* the
+// seed: a consumer holding it can regenerate byte-identical YAML.
+type Identity struct {
+	RequestSHA256   string `json:"requestSha256"`
+	Domain          string `json:"domain"`
+	AccessLayer     string `json:"accessLayer,omitempty"`
+	EndpointProfile string `json:"endpointProfile,omitempty"`
+}
+
+// InterfaceTruth is what a consumer polling ifTable should find. The digest
+// covers the operational facts a collector actually reads, so an edit to speed,
+// duplex, or either status changes it while a cosmetic edit does not.
+type InterfaceTruth struct {
+	Count     int             `json:"count"`
+	SHA256    string          `json:"sha256"`
+	Congested []CongestedLink `json:"congested,omitempty"`
+}
+
+// Observation is what one SEED collector should find against this scenario.
+//
+// An absent collector key means the scenario authors nothing that collector
+// reads. That is a different claim from a count of zero: zero says "poll this
+// and expect an empty table", absent says "this scenario makes no promise".
+// A consumer that conflates them will assert an emptiness never promised.
+type Observation struct {
+	Devices int `json:"devices"`
+	Rows    int `json:"rows,omitempty"`
+}
+
+// Timing bounds how long a consumer must wait before an observation is stable.
+// Neighbour tables cannot be complete until every advertiser has transmitted at
+// least once, so the tolerance follows the slowest advertisement interval the
+// scenario actually authors rather than a chosen number.
+type Timing struct {
+	LLDPIntervalSeconds         int `json:"lldpIntervalSeconds,omitempty"`
+	CDPIntervalSeconds          int `json:"cdpIntervalSeconds,omitempty"`
+	FDPIntervalSeconds          int `json:"fdpIntervalSeconds,omitempty"`
+	NeighborsStableAfterSeconds int `json:"neighborsStableAfterSeconds"`
+}
+
+// Manifest is the authored truth a consumer checks a running scenario against.
+// The parity fields stay inline at the top level so existing readers of
+// deviceCount and the digests are unaffected by the version 4 additions.
+type Manifest struct {
+	SchemaVersion int `json:"schemaVersion"`
+
+	DeviceCount       int    `json:"deviceCount"`
+	NetworkCount      int    `json:"networkCount"`
+	LinkCount         int    `json:"linkCount"`
+	DeviceNamesSHA256 string `json:"deviceNamesSha256"`
+	NetworksSHA256    string `json:"networksSha256"`
+	LinksSHA256       string `json:"linksSha256"`
+
+	Identity     Identity               `json:"identity"`
+	Interfaces   InterfaceTruth         `json:"interfaces"`
+	Observations map[string]Observation `json:"expectedObservations"`
+	Timing       Timing                 `json:"timing"`
+}
+
+// Parity returns the frozen subset a pack pins.
+func (m Manifest) Parity() Parity {
+	return Parity{
+		DeviceCount: m.DeviceCount, NetworkCount: m.NetworkCount, LinkCount: m.LinkCount,
+		DeviceNamesSHA256: m.DeviceNamesSHA256, NetworksSHA256: m.NetworksSHA256,
+		LinksSHA256: m.LinksSHA256,
+	}
 }
 
 // Result contains portable YAML plus its deterministic parity manifest.

--- a/ui/src/api/scenario-client.ts
+++ b/ui/src/api/scenario-client.ts
@@ -47,13 +47,55 @@ export interface ScenarioGenerateRequest {
   }[];
 }
 
-export interface ScenarioManifest {
+/** The frozen parity contract a pack pins: counts and digests only. */
+export interface ScenarioParity {
   deviceCount: number;
   networkCount: number;
   linkCount: number;
   deviceNamesSha256: string;
   networksSha256: string;
   linksSha256: string;
+}
+
+/**
+ * What one consumer collector should find. An absent collector key means the
+ * scenario authors nothing that collector reads, which is a different claim
+ * from a count of zero.
+ */
+export interface ScenarioObservation {
+  devices: number;
+  rows?: number;
+}
+
+/**
+ * The generated scenario's full manifest. It carries the parity fields inline
+ * plus the derived identity, interface truth, observations, and timing.
+ */
+export interface ScenarioManifest extends ScenarioParity {
+  schemaVersion: number;
+  identity: {
+    requestSha256: string;
+    domain: string;
+    accessLayer?: string;
+    endpointProfile?: string;
+  };
+  interfaces: {
+    count: number;
+    sha256: string;
+    congested?: {
+      device: string;
+      interface: string;
+      inUtilization: number;
+      outUtilization: number;
+    }[];
+  };
+  expectedObservations: Record<string, ScenarioObservation>;
+  timing: {
+    lldpIntervalSeconds?: number;
+    cdpIntervalSeconds?: number;
+    fdpIntervalSeconds?: number;
+    neighborsStableAfterSeconds: number;
+  };
 }
 
 export interface ScenarioGenerateResponse {
@@ -69,7 +111,7 @@ export interface ScenarioPack {
   description: string;
   mapPurpose: 'presentation' | 'stress';
   request: ScenarioGenerateRequest;
-  manifest: ScenarioManifest;
+  manifest: ScenarioParity;
 }
 
 export interface ScenarioDeviceProfile {

--- a/ui/src/components/wizard/ScenarioPackPicker.test.tsx
+++ b/ui/src/components/wizard/ScenarioPackPicker.test.tsx
@@ -15,7 +15,7 @@ vi.mock('../../api/scenario-client', async (importOriginal) => {
 const hospital: ScenarioPack = {
   id: 'hospital',
   version: '1.2.0',
-  manifestVersion: 3,
+  manifestVersion: 4,
   name: 'Hospital network',
   description: 'Acute-care and ambulatory sites.',
   mapPurpose: 'presentation',


### PR DESCRIPTION
## Summary

Manifest v3 carried counts and three hashes — enough for a topology parity check and nothing else. A consumer polling a running scenario had no authored statement of what it should see, and no way to reproduce the scenario it was looking at.

Version 4 adds four things, in **one** bump as the implementation map requires:

- **`identity`** — the SHA-256 of the request that produced the scenario. Generation is deterministic and takes no random seed, so that digest *is* the seed: a consumer holding it regenerates byte-identical YAML.
- **`interfaces`** — a count and a digest over the operational facts an ifTable collector actually reads (type, speed, duplex, both statuses, MTU), plus the authored congestion. Congestion is the whole of the behaviour a pack authors today.
- **`expectedObservations`** — keyed by SEED's collector names.
- **`timing`** — derived from the exported advertisement-interval constants, not invented.

## Two design decisions worth your review

**1. Absent ≠ zero.** A collector the scenario authors nothing for is *omitted*, never recorded as zero. Zero says "poll this and expect an empty table"; absent says "this scenario makes no promise". The hospital pack authors no BGP, no host resources and no FDP, so those keys are absent — a test holds it, and the rule is in the type's doc comment.

**2. Packs freeze parity only, via a new `Parity` type.** The v4 fields are *derived*; freezing them by hand across seven packs would be enormous and meaningless. So `Pack.Manifest` is now `Parity` (counts + digests), while `Result.Manifest` is the full v4 document.

The published JSON is deliberately unchanged: parity fields stay **inline at the top level** of the manifest, and the packs endpoint serialises exactly the six keys it did before. `TestPackManifestKeepsItsPublishedShape` asserts that, so the API-surface change is provably nil.

**The collector names are a cross-repo contract with a trap.** Four of SEED's ten `Collector.Name()` values differ from the directory they live in — `sys_info`, `if_table`, `host_resources`, `bgp4_mib` vs `sysinfo`, `iftable`, `hostresources`, `bgp4`. Neither repo may import the other's `internal` packages, so they are written down as constants with that contract stated in the comment. A manifest keyed on directory names would look correct and pair with nothing.

## Linked Issue

Closes #1362.

## Type

- [x] Feature (schema/contract)

## Risk

Low. Generated YAML is **byte-identical** — this only adds derived fields to the manifest document.

That is also why this **does not invalidate the 2026-08-08 live acceptance results**. The ledger's rule invalidates prior acceptance on "any generator, emitted MIB, packet, or comparator change". None of those changed: the devices, networks, links and every authored value are the same bytes, so the wire is the same and the comparator is untouched. All six packs' zero-finding results stand.

`ManifestVersion` moves 3 → 4; `Version` stays `1.3.0`, since schema version is orthogonal to pack content.

Pre-v1 rules followed: no v3 fallback path, no aliases. The compiler enumerated every Go consumer (seven frozen pack literals plus the test comparisons) and all moved in this change.

## Testing Evidence

Tests were written first and failed for the intended reasons — the fields did not exist:

```
vet: manifest_test.go:22: generateHospital(t).SchemaVersion undefined
     (type scenario.Manifest has no field or method SchemaVersion)
```

The derived values were then checked against a **real generated pack** pulled off the running lab, not against assumptions. Hospital derives:

```
interfaces        332      congested        4  (the authored 88/84 story)
sys_info          71       if_table         75 devices / 332 rows
lldp              57       cdp              49
routing           9 devices / 16 rows       fdb   8 devices / 26 rows
timing            lldp 15s, cdp 15s, stable-after 30s
absent            bgp4_mib, host_resources, fdp
```

Full suite:

```
$ go test ./internal/... ./tools/...
45 packages ok, 0 failures

$ golangci-lint run ./internal/scenario/... ./tools/...
0 issues.

$ npx tsc --build --noEmit
(clean)

$ npx biome check src/api/scenario-client.ts src/components/wizard/
Checked 26 files in 3s. No fixes applied.

$ npx vitest run src/api/scenario-client.test.ts src/components/wizard/ScenarioPackPicker.test.tsx
Test Files  2 passed (2)     Tests  6 passed (6)
```

Two lint findings were raised on the first cut (`gocognit` on the observation builder, `mnd` on the settle-cycle multiplier) and both were **fixed structurally** — a `deviceCounter` seam and a named `neighborSettleCycles` constant — not suppressed.

The TypeScript types were split to stay honest: `ScenarioParity` for what a pack pins, `ScenarioManifest extends ScenarioParity` for the generated document. Sharing one interface would have described one of the two shapes incorrectly.

## Security and Release Checklist

- [x] No new route, handler, or API surface; no auth or CSRF surface touched
- [x] No secrets; the request digest covers only authored topology inputs
- [x] No dependency changes
- [x] Published JSON shape unchanged — asserted by test
- [x] Does not invalidate prior live acceptance; generated YAML is byte-identical