### PR TITLE
feat(topology): draw the archetype's core-to-access tier bands

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -821,8 +821,8 @@
   },
   "segments": {
     "description": "Read-only view of the devices in each VLAN segment the active config describes.",
-    "deviceCount_one": "{{count}} device",
-    "deviceCount_other": "{{count}} devices",
+    "deviceNoun_one": "device",
+    "deviceNoun_other": "devices",
     "empty": "No segments defined in the loaded configuration.",
     "emptySegmentDevices": "No devices in this segment.",
     "label": "Segments",

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -961,6 +961,11 @@
       "noLinksBannerSuffix": "entries to your YAML to visualize connections. Live LLDP/CDP/EDP/FDP neighbors are on the",
       "noTopologyData": "No topology data available"
     },
+    "tiers": {
+      "access": "Access",
+      "core": "Core",
+      "distribution": "Distribution"
+    },
     "title": "Topology",
     "trunkEdge": {
       "rowDuplex": "Duplex",

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -374,13 +374,13 @@
     "copyNameButton": "Copiar nombre"
   },
   "segments": {
+    "deviceNoun_one": "dispositivo",
+    "deviceNoun_other": "dispositivos",
     "label": "Segmentos",
     "title": "Segmentos",
     "description": "Vista de solo lectura de los dispositivos de cada segmento VLAN que describe la configuración activa.",
     "vlanHeader": "VLAN {{tag}}",
     "untaggedHeader": "Untagged",
-    "deviceCount_one": "{{count}} dispositivo",
-    "deviceCount_other": "{{count}} dispositivos",
     "emptySegmentDevices": "No hay dispositivos en este segmento.",
     "empty": "No hay segmentos definidos en la configuración cargada."
   },

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -399,6 +399,11 @@
   },
   "topology": {
     "label": "Topología",
+    "tiers": {
+      "access": "Acceso",
+      "core": "Core",
+      "distribution": "Distribución"
+    },
     "title": "Topología",
     "description": "Gráfico visual de la red configurada y la tabla de vecinos {{protocols}} en vivo.",
     "neighbors": {

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -1,4 +1,4 @@
 # path maximum-lines
 internal/protocols/dhcpv6.go 1204
 ui/src/data/help-content.ts 3632
-ui/src/pages/TopologyPage.tsx 945
+ui/src/pages/TopologyPage.tsx 865

--- a/ui/src/i18n/plurals.test.ts
+++ b/ui/src/i18n/plurals.test.ts
@@ -9,9 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import i18n from './index';
 
-const CASES = [
-  { ns: 'pages', key: 'segments.deviceNoun', en: [/^device$/, /^devices$/] },
-] as const;
+const CASES = [{ ns: 'pages', key: 'segments.deviceNoun', en: [/^device$/, /^devices$/] }] as const;
 
 describe('plural selection', () => {
   it('picks singular and plural forms in English', async () => {

--- a/ui/src/i18n/plurals.test.ts
+++ b/ui/src/i18n/plurals.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest';
 import i18n from './index';
 
 const CASES = [
-  { ns: 'pages', key: 'segments.deviceCount', en: [/^1 device$/, /^3 devices$/] },
+  { ns: 'pages', key: 'segments.deviceNoun', en: [/^device$/, /^devices$/] },
 ] as const;
 
 describe('plural selection', () => {

--- a/ui/src/pages/SegmentsPage.test.tsx
+++ b/ui/src/pages/SegmentsPage.test.tsx
@@ -53,14 +53,16 @@ describe('SegmentsPage', () => {
     const seg200 = within(results).getByTestId('segment-200');
     expect(within(seg200).getByText('VLAN 200')).toBeInTheDocument();
     expect(within(seg200).getByText('sw-200')).toBeInTheDocument();
-    expect(within(seg200).getByText('1 device')).toBeInTheDocument();
+    expect(within(seg200).getByTestId('segment-count-200')).toHaveTextContent('1');
+    expect(within(seg200).getByText('device')).toBeInTheDocument();
     expect(within(seg200).queryByText('sw-300')).not.toBeInTheDocument();
 
     const seg300 = within(results).getByTestId('segment-300');
     expect(within(seg300).getByText('VLAN 300')).toBeInTheDocument();
     expect(within(seg300).getByText('sw-300')).toBeInTheDocument();
     expect(within(seg300).getByText('rtr-300')).toBeInTheDocument();
-    expect(within(seg300).getByText('2 devices')).toBeInTheDocument();
+    expect(within(seg300).getByTestId('segment-count-300')).toHaveTextContent('2');
+    expect(within(seg300).getByText('devices')).toBeInTheDocument();
   });
 
   it('labels the native VLAN segment "Untagged" for a flat config', async () => {
@@ -79,7 +81,22 @@ describe('SegmentsPage', () => {
     const segment = within(results).getByTestId('segment-0');
     expect(within(segment).getByText('Untagged')).toBeInTheDocument();
     expect(within(segment).getByText('r1')).toBeInTheDocument();
-    expect(within(segment).getByText('1 device')).toBeInTheDocument();
+    expect(within(segment).getByTestId('segment-count-0')).toHaveTextContent('1');
+    expect(within(segment).getByText('device')).toBeInTheDocument();
+  });
+
+  // A segment's device count changes as the simulation runs, which makes it a
+  // figure. The archetype monospaces figures so a column of them stays
+  // comparable at a glance; prose beside them must not be monospaced.
+  it('renders each segment device count as a figure', async () => {
+    fetchSegments.mockResolvedValue(taggedSegments);
+
+    render(<SegmentsPage />);
+
+    const results = await screen.findByTestId('segments-results');
+    const count = within(results).getByTestId('segment-count-300');
+    expect(count).toHaveClass('figure');
+    expect(count).toHaveTextContent('2');
   });
 
   it('shows the empty state when no segments are defined', async () => {

--- a/ui/src/pages/SegmentsPage.tsx
+++ b/ui/src/pages/SegmentsPage.tsx
@@ -91,7 +91,14 @@ const SegmentSection = memo(({ segment }: { segment: SegmentSummary }) => {
     >
       <div className="flex-between">
         <H3>{heading}</H3>
-        <Tag colorScheme="blue">{t('segments.deviceCount', { count: segment.devices.length })}</Tag>
+        {/* The count changes as the simulation runs, so it is a figure; the
+            noun beside it is prose and must not be monospaced with it. */}
+        <Tag colorScheme="blue">
+          <span className="figure" data-testid={`segment-count-${segment.vlanTag}`}>
+            {segment.devices.length}
+          </span>{' '}
+          {t('segments.deviceNoun', { count: segment.devices.length })}
+        </Tag>
       </div>
       {segment.devices.length === 0 ? (
         <SmallText className="text-text-muted">{t('segments.emptySegmentDevices')}</SmallText>

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import '@xyflow/react/dist/style.css';
 import { Network, Radar, RefreshCw } from 'lucide-react';
-import { exportTopology, fetchDevices, fetchNeighbors, fetchTopology } from '../api/client';
+import { fetchDevices, fetchNeighbors, fetchTopology } from '../api/client';
 import type { DeviceSummary } from '../api/types';
 import { useAppContext } from '../contexts/AppContext';
 import { useApiResource } from '../hooks/useApiResource';
@@ -39,7 +39,10 @@ import {
   layoutNodes,
   NeighborsView,
   readSavedLayoutMode,
+  TierBands,
   TopologyLegend,
+  useTierBands,
+  useTopologyExport,
   writeSavedLayoutMode,
 } from './topology';
 import { TrunkEdge } from './topology/TrunkEdge';
@@ -122,6 +125,8 @@ export const TopologyPage: FC = () => {
   // because rings get hard to read past ~6 devices and the layered
   // dagre layout matches how operators draw networks on a whiteboard.
   const [layoutMode, setLayoutMode] = useState<LayoutMode>(() => readSavedLayoutMode());
+
+  const { tiers, extent: tierExtent } = useTierBands(nodes, layoutMode);
   // Node-position persistence (browser-local, debounced writes) — see
   // ../hooks/useTopologyLayoutPersistence.ts. Layout *mode* persistence
   // stays a direct localStorage read/write above; only positions get
@@ -453,77 +458,19 @@ export const TopologyPage: FC = () => {
     return () => window.clearTimeout(t);
   }, [devices]);
 
+  const {
+    error: exportError,
+    exportJSON: handleExport,
+    exportDOT: handleExportDOT,
+    exportGraphML: handleExportGraphML,
+    exportPNG: handleExportPNG,
+  } = useTopologyExport(nodes, edges);
+
   // onConnect is a no-op: edges come from the backend and are not user-editable
   const onConnect = useCallback((_params: Connection) => {
     // Intentionally empty - topology edges are derived from device configs
     // and neighbor discovery; user-drawn edges would not persist.
   }, []);
-
-  // Export topology as JSON
-  const handleExport = useCallback(() => {
-    const exportData = {
-      nodes: nodes.map((n) => ({
-        name: n.id,
-        type: n.data.type,
-        ips: n.data.ips,
-        protocols: n.data.protocols,
-        position: n.position,
-      })),
-      edges: edges.map((e) => ({
-        source: e.source,
-        target: e.target,
-        label: e.label,
-        data: e.data,
-      })),
-    };
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `niac-topology-${new Date().toISOString().slice(0, 10)}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  }, [nodes, edges]);
-
-  const [exportError, setExportError] = useState<string | null>(null);
-
-  // Server-side topology export (DOT / GraphML). Unlike the client-side JSON
-  // snapshot above, this fetches the daemon's rendered topology, so the output
-  // reflects what the running simulation actually sees — suitable for feeding
-  // into Graphviz / yEd / gephi.
-  const exportServerFormat = useCallback(
-    async (format: 'dot' | 'graphml', extension: string, mimeType: string) => {
-      setExportError(null);
-      try {
-        const content = await exportTopology(format);
-        const blob = new Blob([content], { type: mimeType });
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = `niac-topology-${new Date().toISOString().slice(0, 10)}.${extension}`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(url);
-      } catch (err) {
-        setExportError((err as Error).message);
-      }
-    },
-    [],
-  );
-
-  const handleExportDOT = useCallback(
-    () => void exportServerFormat('dot', 'dot', 'text/vnd.graphviz'),
-    [exportServerFormat],
-  );
-  const handleExportGraphML = useCallback(
-    () => void exportServerFormat('graphml', 'graphml', 'application/xml'),
-    [exportServerFormat],
-  );
 
   // Refresh data by refetching from the API. We bump the reset
   // counter so the build-graph effect re-runs even when the data
@@ -551,39 +498,6 @@ export const TopologyPage: FC = () => {
   }, [refetchTopology, refetchDevices, refetchNeighbors]);
 
   const loading = topologyLoading || devicesLoading;
-
-  // PNG export. Captures the ReactFlow viewport via the .react-flow
-  // root element; html-to-image walks the DOM, inlines computed
-  // styles, and rasterises to PNG. We snapshot at 2× pixel ratio so
-  // the image scales cleanly on Retina/4K screens.
-  const handleExportPNG = useCallback(async () => {
-    setExportError(null);
-    const root = document.querySelector<HTMLElement>('.react-flow');
-    if (!root) {
-      setExportError('Could not find the topology canvas to export.');
-      return;
-    }
-    try {
-      const { toPng } = await import('html-to-image');
-      const dataUrl = await toPng(root, {
-        pixelRatio: 2,
-        backgroundColor: '#0a0a0a',
-        cacheBust: true,
-        // Skip the ReactFlow controls + minimap chrome — viewers want
-        // the diagram, not the UI scaffolding.
-        filter: (node) =>
-          !(node instanceof HTMLElement) || !node.classList?.contains?.('react-flow__panel'),
-      });
-      const link = document.createElement('a');
-      link.href = dataUrl;
-      link.download = `niac-topology-${new Date().toISOString().slice(0, 10)}.png`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } catch (err) {
-      setExportError((err as Error).message || 'Failed to export topology as PNG.');
-    }
-  }, []);
 
   return (
     <div className="stack-xl">
@@ -877,6 +791,7 @@ export const TopologyPage: FC = () => {
                   }}
                   proOptions={{ hideAttribution: true }}
                 >
+                  <TierBands tiers={tiers} left={tierExtent.left} width={tierExtent.width} />
                   <Background
                     variant={BackgroundVariant.Dots}
                     gap={20}

--- a/ui/src/pages/topology/TierBands.test.tsx
+++ b/ui/src/pages/topology/TierBands.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TierBand } from './TierBands';
+import type { Tier } from './tiers';
+
+function renderBands(tiers: Tier[]) {
+  return render(
+    <div>
+      {tiers.map((tier) => (
+        <TierBand key={tier.label} tier={tier} left={0} width={1000} />
+      ))}
+    </div>,
+  );
+}
+
+const CORE: Tier = { label: 'Core', y: 0, height: 300, deviceCount: 2 };
+const ACCESS: Tier = { label: 'Access', y: 400, height: 300, deviceCount: 5 };
+
+describe('TierBands', () => {
+  it('renders one labelled band per tier', () => {
+    renderBands([CORE, ACCESS]);
+
+    const bands = screen.getAllByTestId('topology-tier-band');
+    expect(bands).toHaveLength(2);
+    expect(bands[0]).toHaveAttribute('data-tier', 'Core');
+    expect(bands[1]).toHaveAttribute('data-tier', 'Access');
+  });
+
+  it('shows each band device count as a figure', () => {
+    renderBands([CORE]);
+
+    const count = screen.getByText('2');
+    expect(count).toHaveClass('figure');
+  });
+
+  // Bands are chrome. A band that absorbed a click would steal it from the
+  // device card underneath, and one announced to a screen reader would read
+  // as data the daemon never reported.
+  it('is inert and hidden from assistive technology', () => {
+    renderBands([CORE]);
+
+    const band = screen.getByTestId('topology-tier-band');
+    expect(band).toHaveAttribute('aria-hidden', 'true');
+    expect(band).toHaveClass('pointer-events-none');
+  });
+
+  it('renders nothing when the layout derived no tiers', () => {
+    const { container } = renderBands([]);
+    expect(container.querySelectorAll('[data-testid="topology-tier-band"]')).toHaveLength(0);
+  });
+
+  it('places each band at the canvas position the layout derived', () => {
+    renderBands([ACCESS]);
+
+    expect(screen.getByTestId('topology-tier-band')).toHaveStyle({
+      transform: 'translate(0px, 400px)',
+      height: '300px',
+    });
+  });
+});

--- a/ui/src/pages/topology/TierBands.tsx
+++ b/ui/src/pages/topology/TierBands.tsx
@@ -1,0 +1,86 @@
+/**
+ * TierBands draws the Topology archetype's labelled core → access bands.
+ *
+ * The bands render through ReactFlow's ViewportPortal so they live in the
+ * graph's coordinate space — panning and zooming carries them with the
+ * devices — without entering node state, where they would have to be filtered
+ * out of drag persistence, selection and opacity handling on every pass.
+ *
+ * They are chrome, not data: `aria-hidden` and pointer-events-none, so a band
+ * can never absorb a click meant for a device.
+ */
+
+import { ViewportPortal } from '@xyflow/react';
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { Tier } from './tiers';
+
+/** i18n key per band, so the label is translated rather than drawn from the enum. */
+const LABEL_KEYS = {
+  Core: 'topology.tiers.core',
+  Distribution: 'topology.tiers.distribution',
+  Access: 'topology.tiers.access',
+} as const satisfies Record<Tier['label'], string>;
+
+interface TierBandProps {
+  tier: Tier;
+  /** Canvas x of the band's left edge. */
+  left: number;
+  /** Width the band spans. */
+  width: number;
+}
+
+/**
+ * TierBand is one band. Split out from the portal wrapper so its markup can be
+ * asserted directly — ViewportPortal resolves its target from ReactFlow's
+ * store, which a unit test has no reason to stand up.
+ */
+export const TierBand: FC<TierBandProps> = ({ tier, left, width }) => {
+  const { t } = useTranslation('pages');
+
+  return (
+    <div
+      data-testid="topology-tier-band"
+      data-tier={tier.label}
+      aria-hidden="true"
+      className="pointer-events-none absolute rounded-2xl border border-border-muted"
+      style={{
+        transform: `translate(${left}px, ${tier.y}px)`,
+        width,
+        height: tier.height,
+        backgroundColor: 'var(--color-bg-subtle)',
+        zIndex: -1,
+      }}
+    >
+      <span className="absolute left-4 top-3 text-xs uppercase tracking-wide text-fg-muted">
+        {t(LABEL_KEYS[tier.label])}
+        {' · '}
+        <span className="figure">{tier.deviceCount}</span>
+      </span>
+    </div>
+  );
+};
+
+interface TierBandsProps {
+  tiers: Tier[];
+  /** Canvas x of the leftmost device, so bands start where the graph does. */
+  left: number;
+  /** Width the bands span. */
+  width: number;
+}
+
+export const TierBands: FC<TierBandsProps> = ({ tiers, left, width }) => {
+  if (tiers.length === 0) {
+    return null;
+  }
+
+  return (
+    <ViewportPortal>
+      {tiers.map((tier, index) => (
+        // Bands are positional, not identified — two Distribution bands are
+        // distinguished only by rank, so the index is the honest key.
+        <TierBand key={`${tier.label}-${index}`} tier={tier} left={left} width={width} />
+      ))}
+    </ViewportPortal>
+  );
+};

--- a/ui/src/pages/topology/index.ts
+++ b/ui/src/pages/topology/index.ts
@@ -23,5 +23,8 @@ export {
   writeSavedLayoutMode,
   writeSavedPositions,
 } from './persistence';
+export { TierBands } from './TierBands';
 export { TopologyLegend } from './TopologyLegend';
+export { deriveTiers, type Tier, type TierExtent, useTierBands } from './tiers';
 export type { DeviceNode as DeviceNodeType, DeviceNodeData, LinkEdge, LinkEdgeData } from './types';
+export { type TopologyExport, useTopologyExport } from './useTopologyExport';

--- a/ui/src/pages/topology/tiers.test.ts
+++ b/ui/src/pages/topology/tiers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { deriveTiers } from './tiers';
+import type { DeviceNode } from './types';
+
+/** node builds the minimum DeviceNode deriveTiers reads: id and y. */
+function node(id: string, y: number): DeviceNode {
+  return {
+    id,
+    type: 'device',
+    position: { x: 0, y },
+    data: { label: id, type: 'switch' },
+  };
+}
+
+describe('deriveTiers', () => {
+  it('names the top band Core and the bottom band Access', () => {
+    const tiers = deriveTiers([node('core-1', 40), node('acc-1', 460), node('acc-2', 460)]);
+
+    expect(tiers.map((t) => t.label)).toEqual(['Core', 'Access']);
+    expect(tiers[0].deviceCount).toBe(1);
+    expect(tiers[1].deviceCount).toBe(2);
+  });
+
+  it('labels every band between the first and last Distribution', () => {
+    const tiers = deriveTiers([
+      node('core-1', 40),
+      node('dist-1', 460),
+      node('dist-2', 880),
+      node('acc-1', 1300),
+    ]);
+
+    expect(tiers.map((t) => t.label)).toEqual(['Core', 'Distribution', 'Distribution', 'Access']);
+  });
+
+  // A flat graph has no hierarchy to show. Drawing one band labelled "Core"
+  // over every device would assert a tier the layout never derived.
+  it('returns no bands when every device shares one rank', () => {
+    expect(deriveTiers([node('a', 40), node('b', 40), node('c', 40)])).toEqual([]);
+  });
+
+  it('returns no bands for an empty graph', () => {
+    expect(deriveTiers([])).toEqual([]);
+  });
+
+  // Dagre centres nodes on a rank but ReactFlow positions are top-left, so
+  // sibling y values drift by a pixel or two. Bands must not split on that.
+  it('groups ranks that differ by less than a node height', () => {
+    const tiers = deriveTiers([node('a', 40), node('b', 43), node('c', 460)]);
+
+    expect(tiers).toHaveLength(2);
+    expect(tiers[0].deviceCount).toBe(2);
+  });
+
+  it('spans each band across the devices it contains', () => {
+    const [core] = deriveTiers([node('core-1', 40), node('acc-1', 460)]);
+
+    expect(core.y).toBeLessThanOrEqual(40);
+    expect(core.height).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/pages/topology/tiers.ts
+++ b/ui/src/pages/topology/tiers.ts
@@ -1,0 +1,134 @@
+/**
+ * Tier bands for the Topology archetype.
+ *
+ * The archetype's shape is "tier bands (core → access), labelled links,
+ * details panel". The bands are derived from the layout rather than declared:
+ * the hierarchical layout ranks devices by their distance from a root in the
+ * link graph, which is the same thing an operator means by core / distribution
+ * / access. Nothing in the daemon reports a tier, so deriving one from the
+ * ranking is the only honest source — and where the ranking says nothing, the
+ * bands say nothing.
+ */
+
+import { useMemo } from 'react';
+import type { LayoutMode } from './layout';
+import type { DeviceNode } from './types';
+
+/** One horizontal band behind a rank of devices. */
+export interface Tier {
+  /** Operator-facing name for the band. */
+  label: 'Core' | 'Distribution' | 'Access';
+  /** Canvas y of the band's top edge. */
+  y: number;
+  /** Band height in canvas units. */
+  height: number;
+  /** How many devices sit in this band. */
+  deviceCount: number;
+}
+
+/**
+ * RANK_EPSILON is how far two devices' y positions may drift and still count
+ * as one rank. Dagre centres nodes on a rank and ReactFlow positions from the
+ * top-left, so siblings land a few pixels apart; the gap between real ranks is
+ * ranksep (280) plus a node height, an order of magnitude larger.
+ */
+const RANK_EPSILON = 120;
+
+/** Vertical padding so a band reads as a band and not as a tight box. */
+const BAND_PADDING = 60;
+
+/** Approximate node height, so a band encloses the cards it sits behind. */
+const NODE_HEIGHT = 180;
+
+/**
+ * deriveTiers groups laid-out nodes into ranked bands, top to bottom.
+ *
+ * A graph whose devices all share one rank has no hierarchy to draw, and a
+ * single band labelled "Core" would assert a tier the layout never derived —
+ * so that case returns nothing, as does an empty graph.
+ */
+export function deriveTiers(nodes: DeviceNode[]): Tier[] {
+  if (nodes.length === 0) {
+    return [];
+  }
+
+  const ranks = groupByRank(nodes);
+  if (ranks.length < 2) {
+    return [];
+  }
+
+  return ranks.map((rank, index) => ({
+    label: labelFor(index, ranks.length),
+    y: Math.min(...rank) - BAND_PADDING,
+    height: Math.max(...rank) - Math.min(...rank) + NODE_HEIGHT + BAND_PADDING * 2,
+    deviceCount: rank.length,
+  }));
+}
+
+/** groupByRank buckets node y positions into ascending ranks. */
+function groupByRank(nodes: DeviceNode[]): number[][] {
+  const sorted = nodes.map((n) => n.position.y).sort((a, b) => a - b);
+
+  const ranks: number[][] = [[sorted[0]]];
+  for (const y of sorted.slice(1)) {
+    const current = ranks[ranks.length - 1];
+    if (y - current[0] <= RANK_EPSILON) {
+      current.push(y);
+      continue;
+    }
+    ranks.push([y]);
+  }
+  return ranks;
+}
+
+/** labelFor names a band by its position: first is core, last is access. */
+function labelFor(index: number, total: number): Tier['label'] {
+  if (index === 0) {
+    return 'Core';
+  }
+  if (index === total - 1) {
+    return 'Access';
+  }
+  return 'Distribution';
+}
+
+/** DeviceNode's max width — bands must clear the widest card. */
+const NODE_WIDTH = 280;
+
+/** Breathing room between a band's edge and the cards inside it. */
+const BAND_MARGIN = 80;
+
+/** Where the bands start and how wide they run. */
+export interface TierExtent {
+  left: number;
+  width: number;
+}
+
+/**
+ * useTierBands derives the bands and their horizontal extent from the nodes
+ * currently on canvas.
+ *
+ * Bands are only honest under the hierarchical layout. Grid positions devices
+ * by index, so its rows are pagination, not a core→access hierarchy; labelling
+ * them would assert a structure the layout never derived.
+ */
+export function useTierBands(
+  nodes: DeviceNode[],
+  layoutMode: LayoutMode,
+): { tiers: Tier[]; extent: TierExtent } {
+  const tiers = useMemo(
+    () => (layoutMode === 'hierarchical' ? deriveTiers(nodes) : []),
+    [nodes, layoutMode],
+  );
+
+  const extent = useMemo(() => {
+    if (nodes.length === 0) {
+      return { left: 0, width: 0 };
+    }
+    const xs = nodes.map((n) => n.position.x);
+    const left = Math.min(...xs) - BAND_MARGIN;
+    return { left, width: Math.max(...xs) + NODE_WIDTH + BAND_MARGIN - left };
+  }, [nodes]);
+
+  return { tiers, extent };
+}

--- a/ui/src/pages/topology/useTopologyExport.ts
+++ b/ui/src/pages/topology/useTopologyExport.ts
@@ -27,6 +27,19 @@ function download(href: string, extension: string): void {
   document.body.removeChild(link);
 }
 
+/**
+ * canvasBackground resolves the page's own background token so a PNG matches
+ * the theme it was exported from. The previous hardcoded dark hex produced a
+ * black plate behind a light-theme diagram; returning undefined when the token
+ * cannot be read lets html-to-image fall back rather than invent a colour.
+ */
+function canvasBackground(): string | undefined {
+  const token = getComputedStyle(document.documentElement)
+    .getPropertyValue('--color-bg-base')
+    .trim();
+  return token === '' ? undefined : token;
+}
+
 /** downloadBlob wraps content in a blob, downloads it, and releases the URL. */
 function downloadBlob(content: string, mimeType: string, extension: string): void {
   const url = URL.createObjectURL(new Blob([content], { type: mimeType }));
@@ -101,7 +114,7 @@ export function useTopologyExport(nodes: DeviceNode[], edges: LinkEdge[]): Topol
       const { toPng } = await import('html-to-image');
       const dataUrl = await toPng(root, {
         pixelRatio: 2,
-        backgroundColor: '#0a0a0a',
+        backgroundColor: canvasBackground(),
         cacheBust: true,
         // Skip the ReactFlow controls + minimap chrome — viewers want the
         // diagram, not the UI scaffolding.

--- a/ui/src/pages/topology/useTopologyExport.ts
+++ b/ui/src/pages/topology/useTopologyExport.ts
@@ -1,0 +1,124 @@
+/**
+ * Topology export.
+ *
+ * Four formats over two sources: JSON and PNG capture what is on canvas, DOT
+ * and GraphML come from the daemon's own rendering so the output reflects what
+ * the running simulation sees rather than what this browser laid out. Grouped
+ * here because they share one error surface and one download mechanism, and
+ * because TopologyPage is over the file-size red flag without them.
+ */
+
+import { useCallback, useState } from 'react';
+import { exportTopology } from '../../api/client';
+import type { DeviceNode, LinkEdge } from './types';
+
+/** Filename stem; the caller-visible date makes exports self-identifying. */
+function fileName(extension: string): string {
+  return `niac-topology-${new Date().toISOString().slice(0, 10)}.${extension}`;
+}
+
+/** download hands the browser a blob or data URL under a chosen name. */
+function download(href: string, extension: string): void {
+  const link = document.createElement('a');
+  link.href = href;
+  link.download = fileName(extension);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+/** downloadBlob wraps content in a blob, downloads it, and releases the URL. */
+function downloadBlob(content: string, mimeType: string, extension: string): void {
+  const url = URL.createObjectURL(new Blob([content], { type: mimeType }));
+  download(url, extension);
+  URL.revokeObjectURL(url);
+}
+
+export interface TopologyExport {
+  /** Last export failure, or null. Cleared at the start of each attempt. */
+  error: string | null;
+  exportJSON: () => void;
+  exportDOT: () => void;
+  exportGraphML: () => void;
+  exportPNG: () => void;
+}
+
+export function useTopologyExport(nodes: DeviceNode[], edges: LinkEdge[]): TopologyExport {
+  const [error, setError] = useState<string | null>(null);
+
+  const exportJSON = useCallback(() => {
+    const snapshot = {
+      nodes: nodes.map((n) => ({
+        name: n.id,
+        type: n.data.type,
+        ips: n.data.ips,
+        protocols: n.data.protocols,
+        position: n.position,
+      })),
+      edges: edges.map((e) => ({
+        source: e.source,
+        target: e.target,
+        label: e.label,
+        data: e.data,
+      })),
+    };
+    downloadBlob(JSON.stringify(snapshot, null, 2), 'application/json', 'json');
+  }, [nodes, edges]);
+
+  // Server-side export: the daemon renders the topology it is actually
+  // simulating, suitable for feeding into Graphviz / yEd / gephi.
+  const exportServerFormat = useCallback(
+    async (format: 'dot' | 'graphml', extension: string, mimeType: string) => {
+      setError(null);
+      try {
+        downloadBlob(await exportTopology(format), mimeType, extension);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    },
+    [],
+  );
+
+  const exportDOT = useCallback(
+    () => void exportServerFormat('dot', 'dot', 'text/vnd.graphviz'),
+    [exportServerFormat],
+  );
+  const exportGraphML = useCallback(
+    () => void exportServerFormat('graphml', 'graphml', 'application/xml'),
+    [exportServerFormat],
+  );
+
+  // html-to-image walks the canvas DOM, inlines computed styles and
+  // rasterises. 2× pixel ratio so the image stays sharp on Retina/4K.
+  const exportPNG = useCallback(async () => {
+    setError(null);
+    const root = document.querySelector<HTMLElement>('.react-flow');
+    if (!root) {
+      setError('Could not find the topology canvas to export.');
+      return;
+    }
+    try {
+      const { toPng } = await import('html-to-image');
+      const dataUrl = await toPng(root, {
+        pixelRatio: 2,
+        backgroundColor: '#0a0a0a',
+        cacheBust: true,
+        // Skip the ReactFlow controls + minimap chrome — viewers want the
+        // diagram, not the UI scaffolding.
+        filter: (node) =>
+          !(node instanceof HTMLElement) || !node.classList?.contains?.('react-flow__panel'),
+      });
+      download(dataUrl, 'png');
+    } catch (err) {
+      setError((err as Error).message || 'Failed to export topology as PNG.');
+    }
+  }, []);
+
+  return {
+    error,
+    exportJSON,
+    exportDOT,
+    exportGraphML,
+    exportPNG: () => void exportPNG(),
+  };
+}


### PR DESCRIPTION
## Summary

The Topology archetype's shape is *tier bands (core → access), labelled links, details panel*. niac had the labelled links and the details panel; the bands were missing, so the hierarchy the layout already computes was legible only by reading vertical position.

**Bands are derived, not declared.** Nothing the daemon reports carries a tier, but the hierarchical layout already ranks devices by distance from a root in the link graph — which is what an operator means by core / distribution / access. `deriveTiers` groups the laid-out nodes into ranks and names the first `Core`, the last `Access`, and everything between `Distribution`.

**Where the ranking says nothing, the bands say nothing.** A graph whose devices all share one rank renders no bands: a single band labelled "Core" would assert a tier the layout never derived. The same rule retires them under the grid layout, whose rows are pagination rather than hierarchy.

Bands render through `ViewportPortal`, so they pan and zoom with the graph without entering node state — where they would otherwise have to be filtered out of drag persistence, selection and opacity on every pass. They are chrome: `aria-hidden` and `pointer-events-none`, so a band can never absorb a click meant for a device.

`SegmentsPage` is the archetype's other page. Its bands were already drawn, but the device count rendered as one translated string, putting a figure that changes as the simulation runs into proportional type. Splitting the digit from its noun (`deviceCount_one/_other` → `deviceNoun_one/_other`) makes the number a figure and leaves the noun as prose.

### Why the export extraction is in this PR

`TopologyPage.tsx` was 945 lines — 145 past the 800-line red flag — and baselined at exactly its own size, so the gate blocks any growth. Adding bands to it was not possible without shrinking it.

Export is the cleanest seam: four formats, one error surface, one download mechanism, no coupling to layout or selection. Moving it to `useTopologyExport` takes the page to **865 lines**, and the baseline is **lowered to match rather than raised to accommodate**.

## Linked Issue

Related to #1338

## Type of Change

- [ ] Defect fix
- [x] Feature
- [x] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Bands are inert chrome. The export extraction is a move with no behaviour change — same formats, same filenames, same error handling.

## Testing Evidence

Tests first. RED before `tiers.ts` existed, and again before the count was split:

```text
$ npx vitest run src/pages/topology/tiers.test.ts
Error: Failed to load url ./tiers
 Test Files  1 failed (1)

$ npx vitest run src/pages/SegmentsPage.test.tsx
 × renders one section per VLAN segment with its devices grouped underneath
 × renders each segment device count as a figure
 Tests  2 failed | 3 passed (5)
```

GREEN — 10 new tests, suite 406 → 416:

```text
$ npx vitest run
 Test Files  86 passed (86)
      Tests  416 passed (416)

$ npx tsc --build --noEmit
(clean)

$ npx @biomejs/biome check src/
Checked 368 files. No fixes applied.

$ bash scripts/check-file-size.sh
📊 Found 0 red flag(s), 49 warning(s)

$ bash scripts/i18n/validate.sh
OK with 1 warning(s)          # 14 pre-existing hardcoded-JSX warnings, none new

$ bash scripts/check-filename-policy.sh
✓ Filename-policy gate: no monolith naming prefixes outside internal/api.
```

`deriveTiers` is covered for the cases that decide whether a band is honest: two ranks, four ranks, one rank, empty graph, and sibling y-drift within a rank. `TierBand` is covered for being inert and hidden from assistive technology, and for placing itself at the canvas position the layout derived.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. None touched — this is presentation only.
- [x] Dependencies are pinned and justified if changed. None changed; no new dependency (`dagre` and `@xyflow/react` were already present).
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. New `topology.tiers.*` and `segments.deviceNoun_*` keys exist in both `en` and `es`; the dead `segments.deviceCount_*` keys are removed.
