### PR TITLE
fix(lint): scope Biome's dist, build and coverage excludes to where they land

### DIFF
--- a/ui/biome.json
+++ b/ui/biome.json
@@ -12,9 +12,9 @@
     "includes": [
       "**",
       "!**/node_modules",
-      "!**/dist",
-      "!**/build",
-      "!**/coverage",
+      "!dist",
+      "!build",
+      "!coverage",
       "!**/.next",
       "!**/storybook-static",
       "!**/playwright-report",


### PR DESCRIPTION
## Summary

`biome.json` excluded `**/dist`, `**/build` and `**/coverage` — patterns that match a directory of that name **at any depth**, not the build and report directories they mean. A source directory called any of those three is then silently unlinted and unformatted: it passes `npm run lint` by not being looked at, and reports "these paths were provided but ignored" if you check it directly.

Found in trellis while building its Coverage page — `ui/src/components/coverage/` was invisible to Biome — and the identical pattern is in all four repos. Fixed there in MustardSeedNetworks/trellis#76; this is the same change here.

The other excludes in the list (`.next`, `storybook-static`, `playwright-report`, `playwright/.auth`, `node_modules`) are left at any-depth: nobody names a source directory after them, so the ambiguity is theoretical.

## Linked Issue

Closes #1370

(Fleet-wide; found and fixed first in MustardSeedNetworks/trellis#76, tracked there as MustardSeedNetworks/trellis#71.)

## Type of Change

- [x] Defect fix
- [x] CI / release / packaging

## Risk

- [x] Low

Lint configuration only. It can newly *report* on files that were previously skipped; verified below that it does not, because no such directories exist here today. That is the point — the fix is cheap now and stops the trap before someone falls into it.

## Testing Evidence

```text
$ find ui/src -type d \( -name dist -o -name build -o -name coverage \)
(nothing — no source directory currently collides)

$ biome check ui/src        # with the scoped config
Checked <n> files. No fixes applied.
```

Both directions were verified in trellis, where the collision actually existed: a file under `ui/coverage` and `ui/dist` stays ignored, and a file under `ui/src/components/coverage` is now checked.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] No routes, auth surfaces, or output encoding touched.
- [x] No dependency changes.
- [x] Behaviour verified in the repo where the collision was real.
