### PR TITLE
chore(ts): turn on noUncheckedIndexedAccess across niac's UI

### DIFF
--- a/ui/src/api/client.preflight.test.ts
+++ b/ui/src/api/client.preflight.test.ts
@@ -48,8 +48,8 @@ describe('simulation preflight client', () => {
 
     expect(report.safe).toBe(true);
     expect(report.topology.binding.physicalVlan).toBe(2);
-    expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/simulation/preflight');
-    const body = JSON.parse(mockFetch.mock.calls[1][1].body as string);
+    expect(mockFetch.mock.calls[1]?.[0]).toContain('/api/v1/simulation/preflight');
+    const body = JSON.parse(mockFetch.mock.calls[1]?.[1].body as string);
     expect(body).toMatchObject({
       configData: 'devices: []',
       attachmentMode: 'access',

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { required } from '../test/required';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -84,8 +85,7 @@ describe('API Client', () => {
       const { fetchVersion } = await import('./client');
       const result = await fetchVersion();
       const typed = result as unknown as Record<string, Record<string, string>>;
-      expect(typed.outerKey).toBeDefined();
-      expect(typed.outerKey.innerKey).toBe('value');
+      expect(typed.outerKey?.innerKey).toBe('value');
     });
 
     it('handles arrays', async () => {
@@ -165,9 +165,7 @@ describe('API Client', () => {
       const { fetchVersion } = await import('./client');
       await fetchVersion();
 
-      const callArgs = mockFetch.mock.calls[0];
-      const headers = callArgs[1]?.headers;
-      expect(headers).toBeDefined();
+      expect(mockFetch.mock.calls[0]?.[1]?.headers).toBeDefined();
     });
   });
 
@@ -187,9 +185,9 @@ describe('API Client', () => {
       await updateAlerts({ packetsThreshold: 100, webhookUrl: '' });
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/csrf-token');
+      expect(mockFetch.mock.calls[0]?.[0]).toContain('/api/v1/csrf-token');
 
-      const headers = mockFetch.mock.calls[1][1]?.headers as Headers;
+      const headers = mockFetch.mock.calls[1]?.[1]?.headers as Headers;
       expect(headers.get('X-Csrf-Token')).toBe('csrf-token');
     });
   });
@@ -270,7 +268,7 @@ describe('API Client', () => {
       const promise = uploadPcapWithProgress({ filename: 'x.pcap', data: 'AAAA' }, onProgress);
 
       await vi.waitFor(() => expect(FakeXHR.instances).toHaveLength(1));
-      const xhr = FakeXHR.instances[0];
+      const xhr = required(FakeXHR.instances[0], 'the upload XHR');
       expect(xhr.method).toBe('POST');
       // Headers normalizes names to lowercase when iterated.
       expect(xhr.headers['x-csrf-token']).toBe('csrf-token');
@@ -303,7 +301,7 @@ describe('API Client', () => {
       const promise = uploadPcapWithProgress({ filename: 'big.pcap', data: 'AAAA' }, vi.fn());
 
       await vi.waitFor(() => expect(FakeXHR.instances).toHaveLength(1));
-      const xhr = FakeXHR.instances[0];
+      const xhr = required(FakeXHR.instances[0], 'the upload XHR');
 
       xhr.status = 413;
       xhr.statusText = 'Request Entity Too Large';

--- a/ui/src/api/library-client.test.ts
+++ b/ui/src/api/library-client.test.ts
@@ -46,13 +46,13 @@ describe('scenario draft client', () => {
     await createScenarioDraft('campus-draft', 'devices: []\n');
     await fetchScenarioDraft('campus-draft');
 
-    expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/library/drafts');
-    expect(mockFetch.mock.calls[1][1]).toMatchObject({
+    expect(mockFetch.mock.calls[1]?.[0]).toContain('/api/v1/library/drafts');
+    expect(mockFetch.mock.calls[1]?.[1]).toMatchObject({
       method: 'POST',
       body: JSON.stringify({ name: 'campus-draft', content: 'devices: []\n' }),
     });
-    expect(mockFetch.mock.calls[2][0]).toContain('/api/v1/library/drafts/campus-draft');
-    expect(mockFetch.mock.calls[2][1]).toMatchObject({ credentials: 'same-origin' });
+    expect(mockFetch.mock.calls[2]?.[0]).toContain('/api/v1/library/drafts/campus-draft');
+    expect(mockFetch.mock.calls[2]?.[1]).toMatchObject({ credentials: 'same-origin' });
   });
 
   it('sends the current revision when replacing and deleting a draft', async () => {
@@ -80,12 +80,12 @@ describe('scenario draft client', () => {
     await replaceScenarioDraft('campus-draft', 'revision-1', 'devices:\n  - name: router-1\n');
     await deleteScenarioDraft('campus-draft', 'revision-2');
 
-    const replaceHeaders = mockFetch.mock.calls[1][1]?.headers as Headers;
-    expect(mockFetch.mock.calls[1][1]).toMatchObject({ method: 'PUT' });
+    const replaceHeaders = mockFetch.mock.calls[1]?.[1]?.headers as Headers;
+    expect(mockFetch.mock.calls[1]?.[1]).toMatchObject({ method: 'PUT' });
     expect(replaceHeaders.get('If-Match')).toBe('"revision-1"');
 
-    const deleteHeaders = mockFetch.mock.calls[2][1]?.headers as Headers;
-    expect(mockFetch.mock.calls[2][1]).toMatchObject({ method: 'DELETE' });
+    const deleteHeaders = mockFetch.mock.calls[2]?.[1]?.headers as Headers;
+    expect(mockFetch.mock.calls[2]?.[1]).toMatchObject({ method: 'DELETE' });
     expect(deleteHeaders.get('If-Match')).toBe('"revision-2"');
   });
 
@@ -112,7 +112,7 @@ describe('scenario draft client', () => {
     const { createScenarioDraftFromTemplate } = await import('./library-client');
     await createScenarioDraftFromTemplate('switch-draft', 'catalyst-9300-48p');
 
-    expect(mockFetch.mock.calls[1][1]).toMatchObject({
+    expect(mockFetch.mock.calls[1]?.[1]).toMatchObject({
       method: 'POST',
       body: JSON.stringify({
         name: 'switch-draft',
@@ -149,8 +149,8 @@ describe('scenario draft client', () => {
       },
     });
 
-    expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/library/drafts/campus-draft/topology');
-    const options = mockFetch.mock.calls[1][1];
+    expect(mockFetch.mock.calls[1]?.[0]).toContain('/api/v1/library/drafts/campus-draft/topology');
+    const options = mockFetch.mock.calls[1]?.[1];
     const headers = options?.headers as Headers;
     expect(options).toMatchObject({
       method: 'PATCH',
@@ -203,7 +203,7 @@ describe('scenario draft client', () => {
       },
     ]);
 
-    const options = mockFetch.mock.calls[1][1];
+    const options = mockFetch.mock.calls[1]?.[1];
     expect(options).toMatchObject({
       method: 'PUT',
       body: JSON.stringify({

--- a/ui/src/api/runtimeAuth.test.ts
+++ b/ui/src/api/runtimeAuth.test.ts
@@ -23,7 +23,7 @@ describe('runtime bearer authentication', () => {
     setRuntimeAPIToken('browser-token');
     await request('/api/v1/auth/scope');
 
-    const headers = mockFetch.mock.calls[0][1]?.headers as Headers;
+    const headers = mockFetch.mock.calls[0]?.[1]?.headers as Headers;
     expect(headers.get('Authorization')).toBe('Bearer browser-token');
     expect(localStorage.length).toBe(0);
     expect(sessionStorage.length).toBe(0);
@@ -59,9 +59,9 @@ describe('runtime bearer authentication', () => {
     setRuntimeAPIToken('second-token');
     await request('/api/v1/alerts', { method: 'PUT' });
 
-    expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/csrf-token');
-    expect(mockFetch.mock.calls[2][0]).toContain('/api/v1/csrf-token');
-    const secondHeaders = mockFetch.mock.calls[3][1]?.headers as Headers;
+    expect(mockFetch.mock.calls[0]?.[0]).toContain('/api/v1/csrf-token');
+    expect(mockFetch.mock.calls[2]?.[0]).toContain('/api/v1/csrf-token');
+    const secondHeaders = mockFetch.mock.calls[3]?.[1]?.headers as Headers;
     expect(secondHeaders.get('Authorization')).toBe('Bearer second-token');
     expect(secondHeaders.get('X-Csrf-Token')).toBe('new-csrf');
   });
@@ -82,7 +82,7 @@ describe('runtime bearer authentication', () => {
     await request('/api/v1/walk/import', { method: 'POST' }, { maxRetries: 0, baseDelay: 0 });
 
     expect(mockFetch).toHaveBeenCalledTimes(4);
-    const retriedHeaders = mockFetch.mock.calls[3][1]?.headers as Headers;
+    const retriedHeaders = mockFetch.mock.calls[3]?.[1]?.headers as Headers;
     expect(retriedHeaders.get('X-Csrf-Token')).toBe('fresh-csrf');
   });
 
@@ -105,7 +105,7 @@ describe('runtime bearer authentication', () => {
       capture: { authProtocol: 'sha256', timeoutSeconds: 20 },
     });
 
-    const body = JSON.parse(String(mockFetch.mock.calls[0][1]?.body)) as Record<string, unknown>;
+    const body = JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
     expect(body).toEqual({
       walkName: 'captured/access.walk',
       capture: { authProtocol: 'sha256', timeoutSeconds: 20 },

--- a/ui/src/api/scenario-client.test.ts
+++ b/ui/src/api/scenario-client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { required } from '../test/required';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -23,8 +24,8 @@ describe('scenario generator client', () => {
     const response = await generateScenario(request);
 
     expect(response.manifest.deviceCount).toBe(0);
-    expect(mockFetch.mock.calls[1][0]).toContain('/api/v1/scenario/generate');
-    const payload = JSON.parse(mockFetch.mock.calls[1][1]?.body as string);
+    expect(mockFetch.mock.calls[1]?.[0]).toContain('/api/v1/scenario/generate');
+    const payload = JSON.parse(mockFetch.mock.calls[1]?.[1]?.body as string);
     expect(payload).toMatchObject({
       counts: { accessSwitches: 16, accessPointsPerAccess: 2 },
       attachmentName: 'cyberscope',
@@ -50,7 +51,7 @@ describe('scenario generator client', () => {
     request.counts.coreSwitches = 1;
     expect(isScenarioRequestValid(request)).toBe(true);
 
-    request.sites[0].octet = 254;
+    required(request.sites[0], 'the first site').octet = 254;
     expect(isScenarioRequestValid(request)).toBe(false);
 
     Object.assign(request, { endpointProfile: 'invalid' });
@@ -73,7 +74,7 @@ describe('scenario generator client', () => {
     expect(isScenarioRequestValid(request)).toBe(false);
     request.attachmentName = 'cyberscope';
 
-    request.sites[0].location = 'é'.repeat(65);
+    required(request.sites[0], 'the first site').location = 'é'.repeat(65);
     expect(isScenarioRequestValid(request)).toBe(false);
   });
 });

--- a/ui/src/components/ColoringRulesPanel.tsx
+++ b/ui/src/components/ColoringRulesPanel.tsx
@@ -147,7 +147,13 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
       if (index <= 0) return;
       setLocalRules((prev) => {
         const next = [...prev];
-        [next[index - 1], next[index]] = [next[index], next[index - 1]];
+        const above = next[index - 1];
+        const current = next[index];
+        if (!above || !current) {
+          return prev;
+        }
+        next[index - 1] = current;
+        next[index] = above;
         return next;
       });
     }, []);
@@ -156,7 +162,13 @@ export const ColoringRulesPanel: FC<ColoringRulesPanelProps> = memo(
       setLocalRules((prev) => {
         if (index >= prev.length - 1) return prev;
         const next = [...prev];
-        [next[index], next[index + 1]] = [next[index + 1], next[index]];
+        const current = next[index];
+        const below = next[index + 1];
+        if (!current || !below) {
+          return prev;
+        }
+        next[index] = below;
+        next[index + 1] = current;
         return next;
       });
     }, []);

--- a/ui/src/components/DataTable.test.tsx
+++ b/ui/src/components/DataTable.test.tsx
@@ -5,8 +5,10 @@
  * empty/loading states, testid passthrough, client-side sort toggling,
  * and row selection (select-one / select-all).
  */
+
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { required } from '../test/required';
 import { DataTable, type DataTableColumn } from './DataTable';
 
 interface Row {
@@ -58,8 +60,8 @@ describe('DataTable', () => {
 
   it('renders one row per item and passes through column data-testid', () => {
     const columns: DataTableColumn<Row>[] = [
-      { ...baseColumns[0], 'data-testid': 'name-cell' },
-      baseColumns[1],
+      { ...required(baseColumns[0], 'the name column'), 'data-testid': 'name-cell' },
+      required(baseColumns[1], 'the second column'),
     ];
     render(
       <DataTable

--- a/ui/src/components/ErrorInjectionPanel.test.tsx
+++ b/ui/src/components/ErrorInjectionPanel.test.tsx
@@ -5,10 +5,12 @@
  * navigates here with the type in the query string; the real injection
  * form must land with that type already selected.
  */
+
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ErrorInjectionInfo } from '../api/types';
+import { required } from '../test/required';
 import '../i18n';
 import { ErrorInjectionPanel } from './ErrorInjectionPanel';
 
@@ -126,7 +128,7 @@ describe('ErrorInjectionPanel', () => {
     );
 
     const clearButtons = await screen.findAllByRole('button', { name: /Clear error on/ });
-    fireEvent.click(clearButtons[0]);
+    fireEvent.click(required(clearButtons[0], 'a clear button'));
     await waitFor(() => expect(clearError).toHaveBeenCalledWith('sw-core', 'Gi0/1', 'FCS Errors'));
   });
 });

--- a/ui/src/components/FilterBar.tsx
+++ b/ui/src/components/FilterBar.tsx
@@ -55,8 +55,8 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
       const textAfter = value.substring(cursorPos);
 
       // Find the current word being typed
-      const wordMatch = textBefore.match(/([a-zA-Z0-9_.]+)$/);
-      const wordStart = wordMatch ? cursorPos - wordMatch[1].length : cursorPos;
+      const currentWord = textBefore.match(/([a-zA-Z0-9_.]+)$/)?.[1];
+      const wordStart = currentWord ? cursorPos - currentWord.length : cursorPos;
 
       const newValue = value.substring(0, wordStart) + suggestion.insertText + textAfter;
       onChange(newValue);
@@ -83,9 +83,10 @@ export const FilterBar: FC<FilterBarProps> = memo(({ value, onChange, placeholde
         e.preventDefault();
         setSelectedSuggestion((prev) => Math.max(prev - 1, -1));
       } else if (e.key === 'Tab' || e.key === 'Enter') {
-        if (selectedSuggestion >= 0) {
+        const chosen = suggestions[selectedSuggestion];
+        if (chosen) {
           e.preventDefault();
-          applySuggestion(suggestions[selectedSuggestion]);
+          applySuggestion(chosen);
         }
       } else if (e.key === 'Escape') {
         setSuggestions([]);

--- a/ui/src/components/PacketList.tsx
+++ b/ui/src/components/PacketList.tsx
@@ -144,7 +144,7 @@ export const PacketList: FC<PacketListProps> = memo(
                 packet.timestamp,
                 timeMode,
                 packets[0]?.timestamp ?? null,
-                idx > 0 ? packets[idx - 1].timestamp : null,
+                packets[idx - 1]?.timestamp ?? null,
               )}
               rowStyle={getRowStyle?.(packet)}
             />

--- a/ui/src/components/ProtocolTree.test.tsx
+++ b/ui/src/components/ProtocolTree.test.tsx
@@ -6,8 +6,10 @@
  * layers closed first to prove the buttons actually drive every layer at
  * once rather than being a no-op.
  */
+
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { required } from '../test/required';
 import type { Packet } from './PacketList';
 import { ProtocolTree } from './ProtocolTree';
 
@@ -51,8 +53,8 @@ describe('ProtocolTree — expand-all / collapse-all', () => {
     const { container } = render(<ProtocolTree packet={makePacket()} />);
 
     const layerButtons = layerToggleButtons(container);
-    fireEvent.click(layerButtons[0]);
-    fireEvent.click(layerButtons[1]);
+    fireEvent.click(required(layerButtons[0], 'the first layer button'));
+    fireEvent.click(required(layerButtons[1], 'the second layer button'));
     expect(container.querySelectorAll('.border-l.border-surface-border').length).toBe(
       layerButtons.length - 2,
     );

--- a/ui/src/components/config/MergeControls.test.tsx
+++ b/ui/src/components/config/MergeControls.test.tsx
@@ -10,9 +10,11 @@
  *      files + all decisions, no "reload the page" claim) and must call
  *      onClearAll, not onReset.
  */
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { required } from '../../test/required';
 import '../../i18n';
 import type { DiffBlock, MergeDecision } from './DiffViewer';
 import { MergeControls } from './MergeControls';
@@ -92,7 +94,7 @@ describe('MergeControls — Clear All', () => {
 
     await user.click(screen.getByRole('button', { name: 'Clear All' }));
     const confirmButtons = screen.getAllByRole('button', { name: 'Clear All' });
-    await user.click(confirmButtons[confirmButtons.length - 1]);
+    await user.click(required(confirmButtons.at(-1), 'the last confirm button'));
 
     expect(onClearAll).toHaveBeenCalledTimes(1);
     expect(onReset).not.toHaveBeenCalled();

--- a/ui/src/components/config/YamlEditor.tsx
+++ b/ui/src/components/config/YamlEditor.tsx
@@ -360,8 +360,7 @@ function validateYaml(content: string): string[] {
   const errors: string[] = [];
   const lines = content.split('\n');
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (const [i, line] of lines.entries()) {
     const lineNum = i + 1;
 
     // Check for tabs (YAML should use spaces)
@@ -370,7 +369,7 @@ function validateYaml(content: string): string[] {
     }
 
     // Check for inconsistent indentation
-    const leadingSpaces = line.match(/^(\s*)/)?.[1].length ?? 0;
+    const leadingSpaces = line.match(/^(\s*)/)?.[1]?.length ?? 0;
     if (leadingSpaces > 0 && leadingSpaces % 2 !== 0) {
       errors.push(i18n.t('configDiff.yamlIndentationError', { ns: 'pages', lineNum }));
     }

--- a/ui/src/components/config/diff-viewer/diff-algorithm.test.ts
+++ b/ui/src/components/config/diff-viewer/diff-algorithm.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The config diff had no tests, and it is an LCS implementation — the kind of
+ * code where an off-by-one produces a plausible-looking diff rather than a
+ * crash. These are characterization tests: they were written against the
+ * behaviour as it stood, before the loops were restructured for
+ * noUncheckedIndexedAccess, so that the restructure is provably a refactor.
+ */
+import { describe, expect, it } from 'vitest';
+import { computeDiff, computeLcs } from './diff-algorithm';
+
+describe('computeLcs', () => {
+  it('returns the common subsequence in order', () => {
+    expect(computeLcs(['a', 'b', 'c', 'd'], ['a', 'x', 'c', 'd'])).toEqual(['a', 'c', 'd']);
+  });
+
+  it('is empty when nothing is shared', () => {
+    expect(computeLcs(['a', 'b'], ['x', 'y'])).toEqual([]);
+  });
+
+  it('handles either side being empty', () => {
+    expect(computeLcs([], ['a'])).toEqual([]);
+    expect(computeLcs(['a'], [])).toEqual([]);
+    expect(computeLcs([], [])).toEqual([]);
+  });
+
+  it('prefers the longer subsequence, not the first match', () => {
+    /* The greedy answer here is ['a']; the longest is ['b','c']. */
+    expect(computeLcs(['a', 'b', 'c'], ['b', 'c', 'a'])).toEqual(['b', 'c']);
+  });
+
+  it('keeps duplicates that genuinely appear in both', () => {
+    expect(computeLcs(['a', 'a', 'b'], ['a', 'a', 'c'])).toEqual(['a', 'a']);
+  });
+});
+
+describe('computeDiff', () => {
+  it('reports identical input as one unchanged block', () => {
+    const blocks = computeDiff('one\ntwo', 'one\ntwo');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.type).toBe('unchanged');
+    expect(blocks[0]?.leftLines.map((l) => l.content)).toEqual(['one', 'two']);
+  });
+
+  it('pairs a replaced line as a modified block', () => {
+    const blocks = computeDiff('one\ntwo\nthree', 'one\nCHANGED\nthree');
+    const modified = blocks.filter((b) => b.type === 'modified');
+    expect(modified).toHaveLength(1);
+    expect(modified[0]?.leftLines.map((l) => l.content)).toEqual(['two']);
+    expect(modified[0]?.rightLines.map((l) => l.content)).toEqual(['CHANGED']);
+  });
+
+  it('reports an insertion as added on the right only', () => {
+    const blocks = computeDiff('one\nthree', 'one\ntwo\nthree');
+    const added = blocks.filter((b) => b.type === 'added');
+    expect(added).toHaveLength(1);
+    expect(added[0]?.rightLines.map((l) => l.content)).toEqual(['two']);
+    expect(added[0]?.leftLines).toEqual([]);
+  });
+
+  it('reports a deletion as removed on the left only', () => {
+    const blocks = computeDiff('one\ntwo\nthree', 'one\nthree');
+    const removed = blocks.filter((b) => b.type === 'removed');
+    expect(removed).toHaveLength(1);
+    expect(removed[0]?.leftLines.map((l) => l.content)).toEqual(['two']);
+    expect(removed[0]?.rightLines).toEqual([]);
+  });
+
+  it('numbers lines from one, per side', () => {
+    const blocks = computeDiff('a\nb', 'a\nZ');
+    const modified = blocks.find((b) => b.type === 'modified');
+    expect(modified?.leftLines[0]?.leftLineNumber).toBe(2);
+    expect(modified?.rightLines[0]?.rightLineNumber).toBe(2);
+  });
+
+  it('handles an empty side without losing the other', () => {
+    const added = computeDiff('', 'only');
+    expect(added.flatMap((b) => b.rightLines.map((l) => l.content))).toContain('only');
+
+    const removed = computeDiff('only', '');
+    expect(removed.flatMap((b) => b.leftLines.map((l) => l.content))).toContain('only');
+  });
+
+  it('gives every block a distinct id', () => {
+    const blocks = computeDiff('a\nb\nc\nd', 'a\nX\nc\nY');
+    const ids = blocks.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/ui/src/components/config/diff-viewer/diff-algorithm.ts
+++ b/ui/src/components/config/diff-viewer/diff-algorithm.ts
@@ -63,26 +63,28 @@ const collectChangedLines = (
   let nextLeftIdx = leftIdx;
   let nextRightIdx = rightIdx;
 
-  while (
-    nextLeftIdx < leftLines.length &&
-    (currentLcs === null || leftLines[nextLeftIdx] !== currentLcs)
-  ) {
+  while (nextLeftIdx < leftLines.length) {
+    const content = leftLines[nextLeftIdx];
+    if (content === undefined || (currentLcs !== null && content === currentLcs)) {
+      break;
+    }
     leftChanged.push({
       lineNumber: nextLeftIdx + 1,
-      content: leftLines[nextLeftIdx],
+      content,
       type: 'removed',
       leftLineNumber: nextLeftIdx + 1,
     });
     nextLeftIdx++;
   }
 
-  while (
-    nextRightIdx < rightLines.length &&
-    (currentLcs === null || rightLines[nextRightIdx] !== currentLcs)
-  ) {
+  while (nextRightIdx < rightLines.length) {
+    const content = rightLines[nextRightIdx];
+    if (content === undefined || (currentLcs !== null && content === currentLcs)) {
+      break;
+    }
     rightChanged.push({
       lineNumber: nextRightIdx + 1,
-      content: rightLines[nextRightIdx],
+      content,
       type: 'added',
       rightLineNumber: nextRightIdx + 1,
     });
@@ -118,12 +120,19 @@ export function computeLcs(left: string[], right: string[]): string[] {
   );
 
   for (let i = 1; i <= m; i++) {
+    // Holding the two rows makes each cell one lookup instead of two, and is
+    // what lets the table be indexed at all once an index is not a promise
+    // that something is there.
+    const row = dp[i];
+    const previousRow = dp[i - 1];
+    if (!row || !previousRow) {
+      continue;
+    }
     for (let j = 1; j <= n; j++) {
-      if (left[i - 1] === right[j - 1]) {
-        dp[i][j] = dp[i - 1][j - 1] + 1;
-      } else {
-        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-      }
+      row[j] =
+        left[i - 1] === right[j - 1]
+          ? (previousRow[j - 1] ?? 0) + 1
+          : Math.max(previousRow[j] ?? 0, row[j - 1] ?? 0);
     }
   }
 
@@ -133,11 +142,12 @@ export function computeLcs(left: string[], right: string[]): string[] {
   let j = n;
 
   while (i > 0 && j > 0) {
-    if (left[i - 1] === right[j - 1]) {
-      lcs.unshift(left[i - 1]);
+    const leftLine = left[i - 1];
+    if (leftLine !== undefined && leftLine === right[j - 1]) {
+      lcs.unshift(leftLine);
       i--;
       j--;
-    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+    } else if ((dp[i - 1]?.[j] ?? 0) > (dp[i]?.[j - 1] ?? 0)) {
       i--;
     } else {
       j--;
@@ -164,13 +174,19 @@ export function computeDiff(left: string, right: string): DiffBlock[] {
   let lcsIdx = 0;
 
   while (leftIdx < leftLines.length || rightIdx < rightLines.length) {
-    const currentLcs = lcsIdx < lcs.length ? lcs[lcsIdx] : null;
+    // `?? null` rather than a length check: past the end of the LCS there is
+    // no anchor line, which is the same thing the length check meant.
+    const currentLcs = lcs[lcsIdx] ?? null;
+    const unchangedContent = leftLines[leftIdx];
 
-    if (isLcsMatch(currentLcs, leftLines, rightLines, leftIdx, rightIdx)) {
+    if (
+      unchangedContent !== undefined &&
+      isLcsMatch(currentLcs, leftLines, rightLines, leftIdx, rightIdx)
+    ) {
       // Unchanged line
       const line: DiffLine = {
         lineNumber: leftIdx + 1,
-        content: leftLines[leftIdx],
+        content: unchangedContent,
         type: 'unchanged',
         leftLineNumber: leftIdx + 1,
         rightLineNumber: rightIdx + 1,

--- a/ui/src/components/device-editor/DHCPSection.tsx
+++ b/ui/src/components/device-editor/DHCPSection.tsx
@@ -143,7 +143,7 @@ export const DhcpSection: FC<ProtocolSectionProps> = ({
                   onChange={(e) => {
                     const leases = [...(device.dhcp?.clientLeases || [])];
                     leases[index] = {
-                      ...leases[index],
+                      ...lease,
                       macAddress: e.target.value,
                     };
                     updateDhcp({ ...getDhcpConfig(), clientLeases: leases });
@@ -157,7 +157,7 @@ export const DhcpSection: FC<ProtocolSectionProps> = ({
                   onChange={(e) => {
                     const leases = [...(device.dhcp?.clientLeases || [])];
                     leases[index] = {
-                      ...leases[index],
+                      ...lease,
                       clientIp: e.target.value,
                     };
                     updateDhcp({ ...getDhcpConfig(), clientLeases: leases });

--- a/ui/src/components/device-editor/DNSSection.tsx
+++ b/ui/src/components/device-editor/DNSSection.tsx
@@ -58,7 +58,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                   onChange={(e) => {
                     const records = [...(device.dns?.forwardRecords || [])];
                     records[index] = {
-                      ...records[index],
+                      ...record,
                       name: e.target.value,
                     };
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
@@ -71,7 +71,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                   value={record.ip || ''}
                   onChange={(e) => {
                     const records = [...(device.dns?.forwardRecords || [])];
-                    records[index] = { ...records[index], ip: e.target.value };
+                    records[index] = { ...record, ip: e.target.value };
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
                   }}
                   placeholder={t('editor.sections.dns.ipPlaceholder')}
@@ -83,7 +83,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                   onChange={(e) => {
                     const records = [...(device.dns?.forwardRecords || [])];
                     records[index] = {
-                      ...records[index],
+                      ...record,
                       ttl: Number.parseInt(e.target.value, 10),
                     };
                     updateDns({ ...getDnsConfig(), forwardRecords: records });
@@ -138,7 +138,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                   value={record.ip || ''}
                   onChange={(e) => {
                     const records = [...(device.dns?.reverseRecords || [])];
-                    records[index] = { ...records[index], ip: e.target.value };
+                    records[index] = { ...record, ip: e.target.value };
                     updateDns({ ...getDnsConfig(), reverseRecords: records });
                   }}
                   placeholder={t('editor.sections.dns.ipPlaceholder')}
@@ -150,7 +150,7 @@ export const DnsSection: FC<ProtocolSectionProps> = ({
                   onChange={(e) => {
                     const records = [...(device.dns?.reverseRecords || [])];
                     records[index] = {
-                      ...records[index],
+                      ...record,
                       name: e.target.value,
                     };
                     updateDns({ ...getDnsConfig(), reverseRecords: records });

--- a/ui/src/components/device-editor/FTPSection.tsx
+++ b/ui/src/components/device-editor/FTPSection.tsx
@@ -117,7 +117,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                   onChange={(e) => {
                     const users = [...(device.ftp?.users || [])];
                     users[index] = {
-                      ...users[index],
+                      ...user,
                       username: e.target.value,
                     };
                     updateFtp({ ...getFtpConfig(), users });
@@ -132,7 +132,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                   onChange={(e) => {
                     const users = [...(device.ftp?.users || [])];
                     users[index] = {
-                      ...users[index],
+                      ...user,
                       password: e.target.value,
                     };
                     updateFtp({ ...getFtpConfig(), users });
@@ -145,7 +145,7 @@ export const FtpSection: FC<ProtocolSectionProps> = ({
                   value={user.homeDir || ''}
                   onChange={(e) => {
                     const users = [...(device.ftp?.users || [])];
-                    users[index] = { ...users[index], homeDir: e.target.value };
+                    users[index] = { ...user, homeDir: e.target.value };
                     updateFtp({ ...getFtpConfig(), users });
                   }}
                   placeholder={t('editor.sections.ftp.homeDirPlaceholder')}

--- a/ui/src/components/device-editor/HTTPSection.tsx
+++ b/ui/src/components/device-editor/HTTPSection.tsx
@@ -70,7 +70,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                     onChange={(e) => {
                       const endpoints = [...(device.http?.endpoints || [])];
                       endpoints[index] = {
-                        ...endpoints[index],
+                        ...endpoint,
                         method: e.target.value as HTTPEndpoint['method'],
                       };
                       updateHttp({ ...getHttpConfig(), endpoints });
@@ -88,7 +88,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                     onChange={(e) => {
                       const endpoints = [...(device.http?.endpoints || [])];
                       endpoints[index] = {
-                        ...endpoints[index],
+                        ...endpoint,
                         path: e.target.value,
                       };
                       updateHttp({ ...getHttpConfig(), endpoints });
@@ -102,7 +102,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                     onChange={(e) => {
                       const endpoints = [...(device.http?.endpoints || [])];
                       endpoints[index] = {
-                        ...endpoints[index],
+                        ...endpoint,
                         statusCode: Number.parseInt(e.target.value, 10),
                       };
                       updateHttp({ ...getHttpConfig(), endpoints });
@@ -131,7 +131,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                     onChange={(e) => {
                       const endpoints = [...(device.http?.endpoints || [])];
                       endpoints[index] = {
-                        ...endpoints[index],
+                        ...endpoint,
                         contentType: e.target.value,
                       };
                       updateHttp({ ...getHttpConfig(), endpoints });
@@ -145,7 +145,7 @@ export const HttpSection: FC<ProtocolSectionProps> = ({
                     onChange={(e) => {
                       const endpoints = [...(device.http?.endpoints || [])];
                       endpoints[index] = {
-                        ...endpoints[index],
+                        ...endpoint,
                         body: e.target.value,
                       };
                       updateHttp({ ...getHttpConfig(), endpoints });

--- a/ui/src/components/library/ContentBundleUploader.test.tsx
+++ b/ui/src/components/library/ContentBundleUploader.test.tsx
@@ -61,7 +61,7 @@ describe('ContentBundleUploader', () => {
         type: 'success',
         title: 'Content bundle installed',
       });
-      expect(notifications[0].message).toContain('1 networks, 1 walks, 1 pcaps');
+      expect(notifications[0]?.message).toContain('1 networks, 1 walks, 1 pcaps');
     });
 
     // Selection resets after a successful install.
@@ -81,8 +81,8 @@ describe('ContentBundleUploader', () => {
     await waitFor(() => {
       const notifications = useUIStore.getState().notifications;
       expect(notifications).toHaveLength(1);
-      expect(notifications[0].type).toBe('error');
-      expect(notifications[0].message).toContain('bundle is corrupt');
+      expect(notifications[0]?.type).toBe('error');
+      expect(notifications[0]?.message).toContain('bundle is corrupt');
     });
   });
 });

--- a/ui/src/components/pcap/PcapPacketList.tsx
+++ b/ui/src/components/pcap/PcapPacketList.tsx
@@ -149,7 +149,7 @@ export const PcapPacketList: FC<PcapPacketListProps> = memo(
                         packet.timestamp,
                         timeMode,
                         packets[0]?.timestamp ?? null,
-                        idx > 0 ? packets[idx - 1].timestamp : null,
+                        packets[idx - 1]?.timestamp ?? null,
                       )}
                       rowStyle={getRowStyle?.(packet)}
                     />

--- a/ui/src/components/walk/WalkProfileCreator.test.tsx
+++ b/ui/src/components/walk/WalkProfileCreator.test.tsx
@@ -93,7 +93,7 @@ describe('WalkProfileCreator', () => {
     fireEvent.click(screen.getByTestId('walk-profile-capture'));
 
     await waitFor(() => expect(captureWalkProfile).toHaveBeenCalled());
-    expect(captureWalkProfile.mock.calls[0][1]).toEqual(
+    expect(captureWalkProfile.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
         target: '192.0.2.10',
         community: 'private-secret',

--- a/ui/src/components/wizard/DraftTopologyComposer.test.tsx
+++ b/ui/src/components/wizard/DraftTopologyComposer.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { type ReactNode, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ScenarioDraft } from '../../api/library-client';
+import { required } from '../../test/required';
 import '../../i18n';
 import { DraftTopologyComposer } from './DraftTopologyComposer';
 
@@ -70,7 +71,7 @@ vi.mock('@xyflow/react', () => ({
   }) => (
     <div>
       {edges[0] && (
-        <button type="button" onClick={() => onEdgeClick({}, edges[0])}>
+        <button type="button" onClick={() => onEdgeClick({}, required(edges[0], 'the first edge'))}>
           Edit first link
         </button>
       )}

--- a/ui/src/components/wizard/FleetGeneratorCard.test.tsx
+++ b/ui/src/components/wizard/FleetGeneratorCard.test.tsx
@@ -49,7 +49,7 @@ describe('FleetGeneratorCard', () => {
         sites: expect.arrayContaining([expect.objectContaining({ code: 'COS' })]),
       }),
     );
-    expect(onChange.mock.calls[0][0].sites).toHaveLength(3);
+    expect(onChange.mock.calls[0]?.[0]?.sites).toHaveLength(3);
   });
 
   it('keeps redundant layers and endpoint totals valid', () => {

--- a/ui/src/components/wizard/PreflightStep.test.tsx
+++ b/ui/src/components/wizard/PreflightStep.test.tsx
@@ -84,8 +84,8 @@ describe('PreflightStep', () => {
     expect(preflightSimulation).toHaveBeenCalledWith(
       expect.objectContaining({ attachmentMode: 'direct' }),
     );
-    expect(preflightSimulation.mock.calls[0][0]).not.toHaveProperty('accessVlan');
-    expect(preflightSimulation.mock.calls[0][0]).not.toHaveProperty('dedicated');
+    expect(preflightSimulation.mock.calls[0]?.[0]).not.toHaveProperty('accessVlan');
+    expect(preflightSimulation.mock.calls[0]?.[0]).not.toHaveProperty('dedicated');
     expect(screen.getByTestId('wizard-preflight-start')).toBeDisabled();
   });
 

--- a/ui/src/components/wizard/draft-topology.test.ts
+++ b/ui/src/components/wizard/draft-topology.test.ts
@@ -38,8 +38,8 @@ devices:
       reciprocal: true,
     });
     expect(model.positions['core-1']).toEqual({ x: 120.5, y: 240 });
-    expect(model.interfaces['core-1'][0].occupied).toBe(true);
-    expect(model.interfaces['dist-1'][2].occupied).toBe(false);
+    expect(model.interfaces['core-1']?.[0]?.occupied).toBe(true);
+    expect(model.interfaces['dist-1']?.[2]?.occupied).toBe(false);
     expect(model.segmented).toBe(false);
   });
 
@@ -56,8 +56,8 @@ devices:
     interfaces: [{ name: Ethernet1/49, type: ethernet }]
 `);
     expect(model.links).toHaveLength(1);
-    expect(model.links[0].reciprocal).toBe(false);
-    expect(model.interfaces['dist-1'][0].occupied).toBe(true);
+    expect(model.links[0]?.reciprocal).toBe(false);
+    expect(model.interfaces['dist-1']?.[0]?.occupied).toBe(true);
   });
 
   it('marks reciprocal links with asymmetric properties as read-only', () => {
@@ -75,7 +75,7 @@ devices:
       - { interface: Ethernet1/49, remote_device: core-1, remote_interface: Ethernet1/1, vlans: [200, 210] }
 `);
     expect(model.links).toHaveLength(1);
-    expect(model.links[0].reciprocal).toBe(false);
+    expect(model.links[0]?.reciprocal).toBe(false);
   });
 
   it('projects devices from segmented drafts', () => {

--- a/ui/src/constants/device-types.ts
+++ b/ui/src/constants/device-types.ts
@@ -110,13 +110,20 @@ export const deviceTypeOptions: { value: DeviceType; label: string }[] = [
  * Get device icon by type with fallback
  */
 export function getDeviceIcon(type: DeviceType | string): LucideIcon {
-  if (type in deviceTypeIcons) {
-    return deviceTypeIcons[type as DeviceType];
-  }
-  if (type in topologyDeviceIcons) {
-    return topologyDeviceIcons[type];
-  }
-  return Server;
+  // `type in map` narrows the key, not the value that comes back, so each
+  // lookup is read once and tested rather than probed and then re-read.
+  return deviceTypeIcons[type as DeviceType] ?? topologyDeviceIcons[type] ?? Server;
+}
+
+/**
+ * Get the topology icon for a device type.
+ *
+ * The two topology components each had this lookup inline with an `unknown`
+ * fallback that was itself an open-Record read — so the fallback needed a
+ * fallback. It belongs here, next to the map and the Server default.
+ */
+export function getTopologyDeviceIcon(type: string): LucideIcon {
+  return topologyDeviceIcons[type] ?? topologyDeviceIcons.unknown ?? Server;
 }
 
 /**
@@ -133,7 +140,7 @@ export function getDeviceColor(type: DeviceType | string): TagColorScheme {
  * Get topology device color (CSS variable) by type with fallback
  */
 export function getTopologyDeviceColor(type: string): string {
-  return topologyDeviceColors[type] || topologyDeviceColors.unknown;
+  return topologyDeviceColors[type] ?? topologyDeviceColors.unknown ?? 'var(--color-text-muted)';
 }
 
 /**

--- a/ui/src/hooks/useEventSource.test.ts
+++ b/ui/src/hooks/useEventSource.test.ts
@@ -33,7 +33,7 @@ describe('consumeEventStream', () => {
       onMessage: (message) => messages.push(message),
     });
 
-    const headers = mockFetch.mock.calls[0][1]?.headers as Headers;
+    const headers = mockFetch.mock.calls[0]?.[1]?.headers as Headers;
     expect(headers.get('Authorization')).toBe('Bearer stream-token');
     expect(headers.get('Accept')).toBe('text/event-stream');
     expect(messages).toEqual([{ type: 'log', message: 'ready' }, 'plain text']);

--- a/ui/src/hooks/useFocusTrap.ts
+++ b/ui/src/hooks/useFocusTrap.ts
@@ -41,12 +41,15 @@ function handleTabKey(
   container: HTMLElement,
   focusableElements: HTMLElement[],
 ): void {
-  if (focusableElements.length === 0) {
+  const firstElement = focusableElements.at(0);
+  const lastElement = focusableElements.at(-1);
+  // An empty list has no ends to trap focus between. Checking the ends rather
+  // than the length is the same condition, stated so the type system can hold
+  // us to it.
+  if (!firstElement || !lastElement) {
     return;
   }
 
-  const [firstElement] = focusableElements;
-  const lastElement = focusableElements.at(-1);
   const isAtFirst = document.activeElement === firstElement;
   const isAtLast = document.activeElement === lastElement;
   const isOutside = !container.contains(document.activeElement);
@@ -54,7 +57,7 @@ function handleTabKey(
   // Shift+Tab from first element -> go to last
   if (event.shiftKey && isAtFirst) {
     event.preventDefault();
-    lastElement?.focus();
+    lastElement.focus();
     return;
   }
 
@@ -158,9 +161,10 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
         return;
       }
 
+      const firstFocusable = focusableElements.at(0);
       requestAnimationFrame(() => {
-        if (container && !container.contains(document.activeElement)) {
-          focusableElements[0].focus();
+        if (firstFocusable && container && !container.contains(document.activeElement)) {
+          firstFocusable.focus();
         }
       });
     }

--- a/ui/src/pages/PcapAnalyzerPage.tsx
+++ b/ui/src/pages/PcapAnalyzerPage.tsx
@@ -142,8 +142,9 @@ export const PcapAnalyzerPage: FC = () => {
       setSuccess(tPages('libraryPcaps.analyzer.analyzeSuccess', { count: result.packets.length }));
 
       // Auto-select first packet
-      if (result.packets.length > 0) {
-        setSelectedPacket(result.packets[0]);
+      const firstPacket = result.packets[0];
+      if (firstPacket) {
+        setSelectedPacket(firstPacket);
       }
     } catch (err) {
       // The server enforces its own upload size cap (independent of the

--- a/ui/src/pages/WalkAnalyzerPage.tsx
+++ b/ui/src/pages/WalkAnalyzerPage.tsx
@@ -64,8 +64,9 @@ export const WalkAnalyzerPage: FC = () => {
         if (cancelled) return;
         setFiles(entries);
         setFilesError(null);
-        if (entries.length > 0 && !selectedFile) {
-          setSelectedFile(entries[0].name);
+        const firstEntry = entries[0];
+        if (firstEntry && !selectedFile) {
+          setSelectedFile(firstEntry.name);
         }
       })
       .catch((err: Error) => {

--- a/ui/src/pages/WalkValidatorPage.test.tsx
+++ b/ui/src/pages/WalkValidatorPage.test.tsx
@@ -7,8 +7,10 @@
  * .bak behavior, and the file must only be rewritten after the user
  * confirms — never on the click itself.
  */
+
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { required } from '../test/required';
 import '../i18n';
 import { useUIStore } from '../stores/ui-store';
 import { ToastContainer } from '../ui/ToastContainer';
@@ -64,7 +66,7 @@ describe('WalkValidatorPage — Auto-fix confirmation', () => {
     fireEvent.click(screen.getByRole('button', { name: /auto-fix/i }));
     const confirmButtons = screen.getAllByRole('button', { name: /auto-fix/i });
     // The dialog's confirm button is the last "Auto-fix"-labeled control.
-    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    fireEvent.click(required(confirmButtons.at(-1), 'the last confirm button'));
 
     await waitFor(() => expect(fixWalk).toHaveBeenCalledWith('cisco/c3900.walk'));
   });

--- a/ui/src/pages/WalkValidatorPage.tsx
+++ b/ui/src/pages/WalkValidatorPage.tsx
@@ -65,8 +65,9 @@ export const WalkValidatorPage: FC = () => {
         if (cancelled) return;
         setFiles(entries);
         setFilesError(null);
-        if (entries.length > 0 && !selectedFile) {
-          setSelectedFile(entries[0].name);
+        const firstEntry = entries[0];
+        if (firstEntry && !selectedFile) {
+          setSelectedFile(firstEntry.name);
         }
       })
       .catch((err: Error) => {

--- a/ui/src/pages/topology/ActionsMenu.test.tsx
+++ b/ui/src/pages/topology/ActionsMenu.test.tsx
@@ -4,8 +4,10 @@
  * Guards the server-side DOT + GraphML export options (wired to
  * GET /api/v1/topology/export) alongside the existing PNG + JSON.
  */
+
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { required } from '../../test/required';
 import { ActionsMenu } from './ActionsMenu';
 
 describe('ActionsMenu — topology export', () => {
@@ -38,14 +40,14 @@ describe('ActionsMenu — topology export', () => {
     const { onExportDOT } = renderMenu();
     openMenu();
     // Order matches the menu: [0]=PNG, [1]=JSON, [2]=DOT, [3]=GraphML.
-    fireEvent.click(screen.getAllByRole('menuitem')[2]);
+    fireEvent.click(required(screen.getAllByRole('menuitem')[2], 'the third menu item'));
     expect(onExportDOT).toHaveBeenCalledTimes(1);
   });
 
   it('invokes the GraphML export handler', () => {
     const { onExportGraphML } = renderMenu();
     openMenu();
-    fireEvent.click(screen.getAllByRole('menuitem')[3]);
+    fireEvent.click(required(screen.getAllByRole('menuitem')[3], 'the fourth menu item'));
     expect(onExportGraphML).toHaveBeenCalledTimes(1);
   });
 

--- a/ui/src/pages/topology/DeviceDetailsPanel.tsx
+++ b/ui/src/pages/topology/DeviceDetailsPanel.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import type { DeviceSummary } from '../../api/types';
 import {
   topologyDeviceColors as deviceColors,
-  topologyDeviceIcons as deviceIcons,
+  getTopologyDeviceIcon,
 } from '../../constants/device-types';
 import { Button } from '../../ui/Button';
 import { Tag } from '../../ui/Tag';
@@ -33,7 +33,7 @@ export const DeviceDetailsPanel: FC<DeviceDetailsPanelProps> = ({ device, onClos
   }
 
   const deviceType = device.type?.toLowerCase() || 'unknown';
-  const Icon = deviceIcons[deviceType] || deviceIcons.unknown;
+  const Icon = getTopologyDeviceIcon(deviceType);
   const color = deviceColors[deviceType] || deviceColors.unknown;
 
   return (

--- a/ui/src/pages/topology/DeviceNode.tsx
+++ b/ui/src/pages/topology/DeviceNode.tsx
@@ -7,7 +7,7 @@ import { type FC, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   topologyDeviceColors as deviceColors,
-  topologyDeviceIcons as deviceIcons,
+  getTopologyDeviceIcon,
 } from '../../constants/device-types';
 import type { DeviceNodeData } from './types';
 
@@ -23,7 +23,7 @@ interface DeviceNodeProps {
 export const DeviceNode: FC<DeviceNodeProps> = memo(({ data, selected }) => {
   const { t } = useTranslation('pages');
   const deviceType = (data.type as string)?.toLowerCase() || 'unknown';
-  const Icon = deviceIcons[deviceType] || deviceIcons.unknown;
+  const Icon = getTopologyDeviceIcon(deviceType);
   const color = deviceColors[deviceType] || deviceColors.unknown;
 
   // The card truncates the device name and shows `+N` overflow for IPs and

--- a/ui/src/pages/topology/TrunkEdge.tsx
+++ b/ui/src/pages/topology/TrunkEdge.tsx
@@ -210,14 +210,18 @@ const EdgeTooltip: FC<{ x: number; y: number; data: LinkEdgeData }> = ({ x, y, d
 };
 
 function formatVlans(vlans: number[]): string {
-  if (vlans.length === 0) return '';
-  if (vlans.length === 1) return `VLAN ${vlans[0]}`;
-  const sorted = [...vlans].sort((a, b) => a - b);
+  const [firstVlan, ...restVlans] = [...vlans].sort((a, b) => a - b);
+  if (firstVlan === undefined) {
+    return '';
+  }
+  if (restVlans.length === 0) {
+    return `VLAN ${firstVlan}`;
+  }
+
   const runs: string[] = [];
-  let start = sorted[0];
-  let prev = sorted[0];
-  for (let i = 1; i < sorted.length; i++) {
-    const v = sorted[i];
+  let start = firstVlan;
+  let prev = firstVlan;
+  for (const v of restVlans) {
     if (v === prev + 1) {
       prev = v;
       continue;

--- a/ui/src/pages/topology/layout.ts
+++ b/ui/src/pages/topology/layout.ts
@@ -193,7 +193,11 @@ export function getLinkSpeed(label?: string): string | undefined {
   if (!speedMatch) {
     return;
   }
-  const num = Number.parseInt(speedMatch[1], 10);
+  const digits = speedMatch[1];
+  if (digits === undefined) {
+    return;
+  }
+  const num = Number.parseInt(digits, 10);
   const unit = speedMatch[2]?.toUpperCase() || 'M';
   const multiplier = unit === 'G' ? 1000 : unit === 'T' ? 1000000 : 1;
   return String(num * multiplier);
@@ -227,20 +231,22 @@ export function getVlan(label?: string): number | undefined {
   if (!vlanMatch) {
     return;
   }
-  return Number.parseInt(vlanMatch[1], 10);
+  const digits = vlanMatch[1];
+  return digits === undefined ? undefined : Number.parseInt(digits, 10);
 }
 
 /**
  * Get edge color based on link type and speed
  */
 export function getEdgeColor(data: LinkEdgeData): string {
+  // linkSpeedColors is keyed by speeds that arrive in the data, so it stays an
+  // open Record and every read — including trunk — falls back rather than
+  // asserting the key is there.
+  const fallback = 'var(--color-border-muted)';
   if (data.linkType === 'trunk' || data.linkType === 'lag') {
-    return linkSpeedColors.trunk;
+    return linkSpeedColors.trunk ?? fallback;
   }
-  if (data.speed && linkSpeedColors[data.speed]) {
-    return linkSpeedColors[data.speed];
-  }
-  return 'var(--color-border-muted)';
+  return (data.speed ? linkSpeedColors[data.speed] : undefined) ?? fallback;
 }
 
 /**

--- a/ui/src/pages/topology/tiers.test.ts
+++ b/ui/src/pages/topology/tiers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { required } from '../../test/required';
 import { deriveTiers } from './tiers';
 import type { DeviceNode } from './types';
 
@@ -17,8 +18,8 @@ describe('deriveTiers', () => {
     const tiers = deriveTiers([node('core-1', 40), node('acc-1', 460), node('acc-2', 460)]);
 
     expect(tiers.map((t) => t.label)).toEqual(['Core', 'Access']);
-    expect(tiers[0].deviceCount).toBe(1);
-    expect(tiers[1].deviceCount).toBe(2);
+    expect(tiers[0]?.deviceCount).toBe(1);
+    expect(tiers[1]?.deviceCount).toBe(2);
   });
 
   it('labels every band between the first and last Distribution', () => {
@@ -48,11 +49,14 @@ describe('deriveTiers', () => {
     const tiers = deriveTiers([node('a', 40), node('b', 43), node('c', 460)]);
 
     expect(tiers).toHaveLength(2);
-    expect(tiers[0].deviceCount).toBe(2);
+    expect(tiers[0]?.deviceCount).toBe(2);
   });
 
   it('spans each band across the devices it contains', () => {
-    const [core] = deriveTiers([node('core-1', 40), node('acc-1', 460)]);
+    const core = required(
+      deriveTiers([node('core-1', 40), node('acc-1', 460)])[0],
+      'the core band',
+    );
 
     expect(core.y).toBeLessThanOrEqual(40);
     expect(core.height).toBeGreaterThan(0);

--- a/ui/src/pages/topology/tiers.ts
+++ b/ui/src/pages/topology/tiers.ts
@@ -67,16 +67,30 @@ export function deriveTiers(nodes: DeviceNode[]): Tier[] {
 
 /** groupByRank buckets node y positions into ascending ranks. */
 function groupByRank(nodes: DeviceNode[]): number[][] {
-  const sorted = nodes.map((n) => n.position.y).sort((a, b) => a - b);
+  const [firstY, ...restY] = nodes.map((n) => n.position.y).sort((a, b) => a - b);
 
-  const ranks: number[][] = [[sorted[0]]];
-  for (const y of sorted.slice(1)) {
-    const current = ranks[ranks.length - 1];
-    if (y - current[0] <= RANK_EPSILON) {
+  // No nodes means no ranks. The previous form seeded the first bucket with
+  // sorted[0] unconditionally, so an empty graph produced one phantom tier
+  // holding undefined — which the caller then counted as a device.
+  if (firstY === undefined) {
+    return [];
+  }
+
+  // The anchor is carried rather than re-read from the bucket: it is the value
+  // every member of the current rank is compared against, which is a fact
+  // about the rank, not about the array's first slot.
+  let anchor = firstY;
+  let current = [firstY];
+  const ranks: number[][] = [current];
+
+  for (const y of restY) {
+    if (y - anchor <= RANK_EPSILON) {
       current.push(y);
       continue;
     }
-    ranks.push([y]);
+    anchor = y;
+    current = [y];
+    ranks.push(current);
   }
   return ranks;
 }

--- a/ui/src/stores/device-store.test.ts
+++ b/ui/src/stores/device-store.test.ts
@@ -80,7 +80,7 @@ describe('useDeviceStore', () => {
         useDeviceStore.getState().updateDevice('router-1', { ip: '10.0.0.1' });
       });
 
-      expect(useDeviceStore.getState().devices[0].ip).toBe('10.0.0.1');
+      expect(useDeviceStore.getState().devices[0]?.ip).toBe('10.0.0.1');
     });
 
     it('does nothing for non-existent hostname', () => {
@@ -89,7 +89,7 @@ describe('useDeviceStore', () => {
         useDeviceStore.getState().updateDevice('nonexistent', { ip: '10.0.0.1' });
       });
 
-      expect(useDeviceStore.getState().devices[0].ip).toBe('192.168.1.1');
+      expect(useDeviceStore.getState().devices[0]?.ip).toBe('192.168.1.1');
     });
   });
 
@@ -102,7 +102,7 @@ describe('useDeviceStore', () => {
 
       const state = useDeviceStore.getState();
       expect(state.devices).toHaveLength(1);
-      expect(state.devices[0].hostname).toBe('switch-1');
+      expect(state.devices[0]?.hostname).toBe('switch-1');
     });
 
     it('clears selection if removed device was selected', () => {
@@ -166,7 +166,7 @@ describe('useDeviceStore', () => {
 
       const filtered = useDeviceStore.getState().filteredDevices();
       expect(filtered).toHaveLength(1);
-      expect(filtered[0].hostname).toBe('router-1');
+      expect(filtered[0]?.hostname).toBe('router-1');
     });
 
     it('filters by device type', () => {
@@ -179,7 +179,7 @@ describe('useDeviceStore', () => {
 
       const filtered = useDeviceStore.getState().filteredDevices();
       expect(filtered).toHaveLength(1);
-      expect(filtered[0].type).toBe('switch');
+      expect(filtered[0]?.type).toBe('switch');
     });
 
     it('returns all devices when filter is "all"', () => {

--- a/ui/src/stores/device-store.ts
+++ b/ui/src/stores/device-store.ts
@@ -107,8 +107,9 @@ export const useDeviceStore = create<DeviceStoreState>()(
         updateDevice: (hostname, updates) =>
           set((state) => {
             const index = state.devices.findIndex((d) => d.hostname === hostname);
-            if (index !== -1) {
-              state.devices[index] = { ...state.devices[index], ...updates };
+            const existing = state.devices[index];
+            if (existing) {
+              state.devices[index] = { ...existing, ...updates };
             }
           }),
 

--- a/ui/src/test/required.ts
+++ b/ui/src/test/required.ts
@@ -1,0 +1,19 @@
+/**
+ * required reads a value the test's own setup guarantees is there.
+ *
+ * Tests are full of `calls[0]`, `instances[0]` and `result[2]` — reads that
+ * are safe because the lines above put something there. Under
+ * noUncheckedIndexedAccess the compiler cannot see that, and the two usual
+ * answers are both bad: a non-null assertion silences the check, and an
+ * inline `if (!x) throw` at every site buries the assertion being made.
+ *
+ * This keeps the check and improves the failure. When the setup did not
+ * produce what the test assumed, the error names the thing that was missing
+ * rather than surfacing later as "cannot read properties of undefined".
+ */
+export function required<T>(value: T | undefined | null, what = 'value'): T {
+  if (value === undefined || value === null) {
+    throw new Error(`expected ${what} to be present, got ${String(value)}`);
+  }
+  return value;
+}

--- a/ui/src/ui/ToastContainer.stories.tsx
+++ b/ui/src/ui/ToastContainer.stories.tsx
@@ -20,7 +20,7 @@ function SeededToasts({ kinds }: { kinds: ToastType[] }) {
     for (const type of kinds) {
       useUIStore.getState().addNotification({
         type,
-        title: `${type[0].toUpperCase()}${type.slice(1)} notification`,
+        title: `${type.charAt(0).toUpperCase()}${type.slice(1)} notification`,
         message: `This is a ${type}-level toast example.`,
         duration: -1,
       });

--- a/ui/src/utils/filter/autocomplete.ts
+++ b/ui/src/utils/filter/autocomplete.ts
@@ -34,8 +34,7 @@ export function getAutocompleteSuggestions(
 }
 
 function extractCurrentWord(text: string): string {
-  const match = text.match(/([a-zA-Z0-9_.]+)$/);
-  return match ? match[1] : '';
+  return text.match(/([a-zA-Z0-9_.]+)$/)?.[1] ?? '';
 }
 
 function getFieldSuggestions(prefix: string): AutocompleteSuggestion[] {

--- a/ui/src/utils/filter/evaluator.ts
+++ b/ui/src/utils/filter/evaluator.ts
@@ -94,7 +94,7 @@ function evaluateComparison(
 ): boolean {
   // Special case: tcp.port/udp.port should check both source and dest
   if (field === 'tcp.port' || field === 'udp.port') {
-    const proto = field.split('.')[0].toUpperCase();
+    const proto = (field.split('.')[0] ?? '').toUpperCase();
     if (getProtocol(packet).toUpperCase() !== proto) {
       return false;
     }

--- a/ui/src/utils/filter/lexer.ts
+++ b/ui/src/utils/filter/lexer.ts
@@ -11,8 +11,15 @@ export function tokenize(input: string): Token[] {
   let pos = 0;
 
   while (pos < input.length) {
+    // Read the character once: `pos < input.length` bounds the loop but does
+    // not tell the type system what came back.
+    const ch = input[pos];
+    if (ch === undefined) {
+      break;
+    }
+
     // Skip whitespace
-    if (/\s/.test(input[pos])) {
+    if (/\s/.test(ch)) {
       pos++;
       continue;
     }
@@ -48,7 +55,7 @@ export function tokenize(input: string): Token[] {
     }
 
     // Field names (dotted identifiers) or bare literals/keywords
-    if (/[a-zA-Z0-9_.]/.test(input[pos])) {
+    if (/[a-zA-Z0-9_.]/.test(ch)) {
       pos = tokenizeIdentifier(input, pos, tokens);
       continue;
     }
@@ -90,8 +97,12 @@ function tokenizeQuotedString(input: string, startPos: number, tokens: Token[]):
 function tokenizeIdentifier(input: string, startPos: number, tokens: Token[]): number {
   let pos = startPos;
   let value = '';
-  while (pos < input.length && /[a-zA-Z0-9_./:-]/.test(input[pos])) {
-    value += input[pos];
+  while (pos < input.length) {
+    const ch = input[pos];
+    if (ch === undefined || !/[a-zA-Z0-9_./:-]/.test(ch)) {
+      break;
+    }
+    value += ch;
     pos++;
   }
   if (value === 'contains') {

--- a/ui/src/utils/filter/parser.ts
+++ b/ui/src/utils/filter/parser.ts
@@ -139,7 +139,9 @@ class Parser {
   }
 
   private advance(): Token {
-    const token = this.tokens[this.pos];
+    // Past the end is EOF, the same answer peek() already gives — advancing
+    // off the end should not hand the caller undefined typed as a Token.
+    const token = this.peek();
     this.pos++;
     return token;
   }

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -233,7 +233,10 @@ export function useFormatBytes(): (size: number) => string {
       const formatted = new Intl.NumberFormat(locale, {
         maximumFractionDigits: value >= 10 ? 0 : 1,
       }).format(value);
-      return t(`format.${units[idx]}`, { value: formatted });
+      // The loop bounds idx; units[0] is the fallback because a size that
+      // never divided is bytes, which is what the zero case returns too.
+      const unit = units[idx] ?? units[0];
+      return t(`format.${unit}`, { value: formatted });
     },
     [locale, t],
   );

--- a/ui/src/utils/time-display.ts
+++ b/ui/src/utils/time-display.ts
@@ -76,7 +76,9 @@ export function formatTimeByMode(
 export function nextTimeDisplayMode(current: TimeDisplayMode): TimeDisplayMode {
   const modes: TimeDisplayMode[] = ['absolute', 'relative', 'delta'];
   const idx = modes.indexOf(current);
-  return modes[(idx + 1) % modes.length];
+  // The modulo keeps this in range; the fallback is what says so to the type
+  // system, and returning the first mode is what wrapping already means.
+  return modes[(idx + 1) % modes.length] ?? 'absolute';
 }
 
 /**

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -30,6 +30,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
+    "noUncheckedIndexedAccess": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## Summary

Finishes **Step 6** of the React 19 / TS 7 modernization. Measured per repo before starting, which is why niac went last:

| repo | errors | |
|---|---|---|
| trellis | 2 | MustardSeedNetworks/trellis#78 |
| stem | 7 | MustardSeedNetworks/stem#688 |
| seed | 41 | MustardSeedNetworks/seed#1986 |
| **niac** | **149** | **this PR** — 75 source, 74 tests |

niac is the one repo that already typechecks its test files, which is why its count is roughly double everyone else's.

## Two source fixes worth reading

**The config diff had no tests at all** — and it is an LCS implementation, where an off-by-one produces a plausible-looking diff rather than a crash. It now has twelve characterization tests written against the behaviour *as it stood*, so the loop restructure that followed is provably a refactor rather than a rewrite:

- the LCS table holds its two rows instead of indexing the table twice per cell
- the change collector binds each line before deciding about it, rather than reading the same index in the condition and again in the body

**`groupByRank` produced a phantom tier.** It seeded its first bucket with `sorted[0]` unconditionally, so an empty graph yielded `[[undefined]]` — which the caller counted as one tier holding one device. It now returns no ranks for no nodes, and carries the rank's anchor rather than re-reading the bucket's first slot.

## The rest, and one correction

The remaining classes are the ones the earlier repos showed: a length check followed by an index, a regex capture group treated as certain, spreads of a possibly-absent array element, and `type in map` — which narrows the *key* but not the value that comes back. Two icon lookups whose fallback was itself an open-`Record` read moved into `device-types`, next to the map and the `Server` default.

**One correction inside this change:** I applied `satisfies` to `linkSpeedColors` and then reverted it. That map is looked up by a speed that arrives in the data, so it is genuinely open-keyed and every read must fall back — unlike a fixture whose keys are read as literals, where `satisfies` is right. Same operator, opposite answer, depending on whether the keys are known at the call site.

## Test-file approach

Two rules, applied consistently:

- **An assertion read takes optional chaining.** `expect(calls[1]?.[0]).toContain(…)` keeps exactly the meaning it had — if the call never happened, the matcher fails.
- **A read that is *used*** — `fireEvent`, `JSON.parse`, a spread — **takes a new `required()` helper** (`src/test/required.ts`). It keeps the check and names what was missing, instead of surfacing later as "cannot read properties of undefined".

## Linked Issue

Related to #1338

## Type of Change

- [x] Chore / refactor
- [x] Defect fix

## Risk

- [x] Medium

51 files. Type-level throughout, but the diff algorithm's loops and the tier banding were restructured — hence the characterization tests before the refactor, and the full suite after.

## Testing Evidence

```text
$ npx tsc --noEmit --noUncheckedIndexedAccess -p ui/tsconfig.app.json    # before
149 errors  (75 source, 74 test)

$ npm run typecheck && npm run lint && npm run test
(clean) · Checked 370 files, no fixes · Test Files 87 passed · Tests 428 passed

$ python3 scripts/check-banned-vocabulary.py && ./scripts/check-filename-policy.sh
banned-vocabulary check passed
✓ Filename-policy gate: no monolith naming prefixes outside internal/api.
$ ./scripts/check-file-size.sh && (cd ui && ../scripts/check-token-discipline.sh)
0 red flag(s), 49 warning(s)      # pre-existing debt, nothing grown
OK: blocking color-token discipline is clean
$ go build ./...
(clean)
```

The 428 tests passed before the source changes, after them, and after the test-file changes — checked at each stage, not just at the end. Flag verified live rather than assumed: a deliberate `xs[0].length` errors and clears when removed.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] No routes, auth surfaces, or output encoding touched.
- [x] No dependency changes.
- [x] Nothing suppressed — no non-null assertions, no `@ts-expect-error`, no `any`.

## What this unblocks

All four repos now carry the flag, so **the plan's convergence guard** — CI checking the four `tsconfig.app.json` blocks agree — is the next thing and no longer fails on a repo that lacks it. Per the owner's call, niac's pending release is cut after this lands, so the CVE bump, the Biome fix and Step 6 ship together.
