### PR TITLE
chore(ts): converge the strictness flags and gate the contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,12 @@ jobs:
       - name: Filename-policy gate — no monolith naming outside internal/api
         run: ./scripts/check-filename-policy.sh
 
+      # The four products each own their tsconfig, so the strictness flags
+      # drift silently — a missing one never announces itself, it just checks
+      # less than its sibling does.
+      - name: TypeScript strictness contract
+        run: python3 scripts/check-tsconfig-flags.py
+
       - name: Banned-vocabulary gate (strategy reset)
         # Ported from seed, which was the only repo enforcing it. "magic" in
         # the capture/pcap/snoop parsers is file-format terminology, not

--- a/scripts/check-tsconfig-flags.py
+++ b/scripts/check-tsconfig-flags.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""TypeScript strictness contract for the MSN family.
+
+The four products keep their own `ui/tsconfig.app.json` — there is no master
+repo — so the flag sets drift silently. They did: for a while seed and stem
+set `isolatedModules` without `verbatimModuleSyntax`, trellis the reverse, and
+niac had `verbatimModuleSyntax: false` written out explicitly. Nothing failed,
+because a missing strictness flag never announces itself; it just quietly
+checks less than its sibling does.
+
+This asserts the flags this repo has agreed to carry, with the value each must
+have. It deliberately does *not* reach into a sibling checkout — a gate that
+does only works on a machine that has one. The list below is the contract;
+changing it is a decision someone makes on purpose, in four places.
+
+Flags are read with a per-flag match rather than by parsing the file as JSON:
+tsconfig is JSONC, and the obvious "strip the comments first" regex eats the
+`/*` inside a path glob like `"@/*": ["./src/*"]`. A contract gate that cannot
+read three of the four repos is worse than no gate.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+CONFIG = Path(__file__).resolve().parent.parent / "ui" / "tsconfig.app.json"
+
+# Flag -> required value. Keep in step with the sibling repos' copies.
+REQUIRED: dict[str, bool] = {
+    "strict": True,
+    "isolatedModules": True,
+    "verbatimModuleSyntax": True,
+    "erasableSyntaxOnly": True,
+    "noUncheckedIndexedAccess": True,
+    "noUnusedLocals": True,
+    "noUnusedParameters": True,
+    "noFallthroughCasesInSwitch": True,
+    "noUncheckedSideEffectImports": True,
+}
+
+# Not yet agreed anywhere; listed so its absence reads as pending rather than
+# forgotten. See the modernization plan's Step 6.
+PENDING: tuple[str, ...] = ("exactOptionalPropertyTypes",)
+
+
+def read_flag(text: str, flag: str) -> bool | None:
+    """Return the flag's value, or None when it is not set at all."""
+    match = re.search(rf'"{re.escape(flag)}"\s*:\s*(true|false)', text)
+    return None if match is None else match.group(1) == "true"
+
+
+def uncommented(path: Path) -> str:
+    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if not ln.lstrip().startswith("//")]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if not CONFIG.is_file():
+        print(f"no {CONFIG} - nothing to check")
+        return 0
+
+    text = uncommented(CONFIG)
+    problems: list[str] = []
+
+    for flag, want in REQUIRED.items():
+        value = read_flag(text, flag)
+        if value is None:
+            problems.append(f"  {flag} is missing - the fleet sets it to {str(want).lower()}")
+        elif value != want:
+            problems.append(
+                f"  {flag} is {str(value).lower()} - the fleet sets it to {str(want).lower()}"
+            )
+
+    if problems:
+        print("FAIL: ui/tsconfig.app.json has drifted from the fleet's strictness contract:")
+        print("\n".join(problems))
+        print("\nIf the change is intended, land it in seed, stem, trellis and niac-go,")
+        print("then update REQUIRED in each repo's scripts/check-tsconfig-flags.py.")
+        return 1
+
+    pending = [flag for flag in PENDING if read_flag(text, flag) is not None]
+    if pending:
+        print(f"note: {', '.join(pending)} is set here but not yet agreed fleet-wide")
+
+    print(f"OK: all {len(REQUIRED)} agreed strictness flags are set.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -13,7 +13,8 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": false,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

Step 6's convergence guard, now that all four repos carry `noUncheckedIndexedAccess` and the flag sets can finally agree.

Two things land here:

**`verbatimModuleSyntax` and `isolatedModules` — both measured at zero errors.** niac was the last repo out of step, and the only one with `verbatimModuleSyntax` written out as **`false`** rather than simply absent. An absent flag reads as an oversight; a false one reads as a decision — and neither had a reason recorded. Whatever it was, the code no longer needs it.

**A strictness contract gate.** It asserts *this* repo's flags against the agreed list rather than reaching into sibling checkouts — a gate that reads a sibling only works on a machine that has one. Changing the contract is then a deliberate act in four places, which is the point.

## What had drifted

Nothing failed, because a missing strictness flag never announces itself — it just quietly checks less than its sibling does:

| repo | before |
|---|---|
| seed, stem | `isolatedModules` ✓, `verbatimModuleSyntax` **missing** |
| trellis | `verbatimModuleSyntax` ✓, `isolatedModules` **missing** |
| niac-go | `verbatimModuleSyntax: false`, written out explicitly |

`verbatimModuleSyntax` costs seed and stem **zero** errors, incidentally — the plan predicted "import-type churn in seed/stem" and there is none. Their halves follow in their own PRs.

`exactOptionalPropertyTypes` is listed as **pending** rather than omitted, so its absence reads as a decision not yet taken instead of an oversight.

## Linked Issue

Related to #1338

## Type of Change

- [x] Chore / refactor
- [x] CI / release / packaging

## Risk

- [x] Low

One compiler flag that costs nothing here, plus a gate.

## Testing Evidence

```text
$ npx tsc --noEmit --verbatimModuleSyntax -p ui/tsconfig.app.json   # before
0 errors

$ npm run typecheck && npm run lint && npm run test
(clean) · lint clean · full suite passed

$ python3 scripts/check-tsconfig-flags.py
OK: all 9 agreed strictness flags are set.

$ actionlint -ignore 'SC2129' .github/workflows/ci.yml
(clean)
```

And the guard verified to fail on drift rather than assumed to:

```text
$ # remove noUncheckedIndexedAccess from ui/tsconfig.app.json
$ python3 scripts/check-tsconfig-flags.py; echo "exit=$?"
FAIL: ui/tsconfig.app.json has drifted from the fleet's strictness contract:
  noUncheckedIndexedAccess is missing - the fleet sets it to true
exit=1
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] No routes, auth surfaces, or output encoding touched.
- [x] No dependency changes.
- [x] The contract documents how to change it, so the gate does not become something people work around.


## A bug in the first version of this gate, worth recording

My first implementation stripped JSONC comments with `re.sub(r"/\*.*?\*/", ...)` and then parsed as JSON. That regex eats the `/*` inside a path glob — `"@/*": ["./src/*"]` — so it threw on three of the four repos and passed on the fourth by luck of ordering. It now matches each flag directly instead. A contract gate that cannot read most of the fleet is worse than no gate.
