### PR TITLE
ci: refuse to start tests while orphaned test binaries are running

### DIFF
--- a/mk/test.mk
+++ b/mk/test.mk
@@ -11,13 +11,20 @@
 # =============================================================================
 
 .PHONY: test test-all test-backend test-backend-quiet test-frontend test-frontend-quiet \
-        test-hooks test-e2e test-e2e-ui test-e2e-install test-coverage
+        test-hooks test-e2e test-e2e-ui test-e2e-install test-coverage check-stale-tests
 
 # =============================================================================
 # Main Test Targets
 # =============================================================================
 
-test: ## Run unit tests (backend + frontend)
+# check-stale-tests refuses to start while orphaned test binaries from an
+# earlier run are still holding the machine. Go's -test.timeout cannot kill a
+# binary stuck in a cgo call, so they accumulate silently and make every
+# subsequent timing meaningless — see the script for what that cost once.
+check-stale-tests:
+	@./scripts/check-stale-tests.sh
+
+test: check-stale-tests ## Run unit tests (backend + frontend)
 	@printf "$(BOLD)$(CYAN)┌─ Unit Tests ─────────────────────────────────────────────────────────────────┐$(RESET)\n"
 	@printf "$(CYAN)│$(RESET) $(BOLD)[1/3]$(RESET) Backend (Go)                                                          $(CYAN)│$(RESET)\n"
 	$(call timer-start,test-backend)
@@ -31,7 +38,7 @@ test: ## Run unit tests (backend + frontend)
 	@$(MAKE) --no-print-directory test-hooks
 	@printf "$(CYAN)└──────────────────────────────────────────────────────────────────────────────┘$(RESET)\n"
 
-test-all: ## Run ALL tests (unit + E2E)
+test-all: check-stale-tests ## Run ALL tests (unit + E2E)
 	@printf "$(BOLD)$(CYAN)┌─ Full Test Suite ────────────────────────────────────────────────────────────┐$(RESET)\n"
 	@printf "$(CYAN)│$(RESET) $(BOLD)[1/4]$(RESET) Backend unit tests                                                    $(CYAN)│$(RESET)\n"
 	$(call timer-start,test-backend)
@@ -53,7 +60,7 @@ test-all: ## Run ALL tests (unit + E2E)
 # Backend Tests
 # =============================================================================
 
-test-backend: ## Run Go tests with progress
+test-backend: check-stale-tests ## Run Go tests with progress
 	@printf "\n$(BOLD)🧪 Running backend tests...$(RESET)\n"
 	@PKGS=$$(go list ./... | grep -v '/ui$$'); \
 	PKG_COUNT=$$(echo "$$PKGS" | wc -l | tr -d ' '); \

--- a/scripts/check-stale-tests.sh
+++ b/scripts/check-stale-tests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# check-stale-tests.sh — refuse to start a test run while orphaned test binaries
+# are still holding the machine.
+#
+# Go's `-test.timeout` cannot always kill a stuck test binary: if the process is
+# blocked in a cgo call or a syscall, the timeout panic never lands and the
+# binary keeps running after `go test` has given up on it. They accumulate
+# silently. On 2026-08-21 this machine was carrying eleven of them, the oldest
+# three days old, holding the load average at 317 — a suite that runs in 72s was
+# timing out at 660s, and the obvious reading ("flaky test", "slow machine") was
+# wrong in a way no amount of re-running would have revealed.
+#
+# The threshold is deliberately far above any real run. Every suite here
+# finishes in minutes and CI caps at -test.timeout=10m, so a test binary older
+# than STALE_AFTER_MINUTES has definitively outlived its own timeout and is
+# stuck, not busy. That is what makes failing safe rather than annoying.
+
+set -euo pipefail
+
+STALE_AFTER_MINUTES="${STALE_AFTER_MINUTES:-30}"
+
+# elapsed_seconds converts ps's [[dd-]hh:]mm:ss into seconds. macOS ps has no
+# `etimes` keyword, so the parsing is done here rather than asked for.
+elapsed_seconds() {
+	local etime="$1"
+	local days=0 hours=0 minutes seconds
+	local rest="$etime"
+	if [[ "$rest" == *-* ]]; then
+		days="${rest%%-*}"
+		rest="${rest#*-}"
+	fi
+	local IFS=:
+	read -ra parts <<<"$rest"
+	case "${#parts[@]}" in
+		3) hours="${parts[0]}"; minutes="${parts[1]}"; seconds="${parts[2]}" ;;
+		2) minutes="${parts[0]}"; seconds="${parts[1]}" ;;
+		*) return 1 ;;
+	esac
+	echo $(( (10#$days * 86400) + (10#$hours * 3600) + (10#$minutes * 60) + 10#$seconds ))
+}
+
+threshold=$((STALE_AFTER_MINUTES * 60))
+stale_pids=()
+stale_rows=()
+
+# `read pid etime command` rather than parameter expansion: ps pads its pid
+# column with leading spaces, which %% would otherwise read as an empty field.
+while read -r pid etime command; do
+	[ -n "$pid" ] || continue
+	seconds="$(elapsed_seconds "$etime")" || continue
+	if [ "$seconds" -gt "$threshold" ]; then
+		stale_pids+=("$pid")
+		stale_rows+=("  $pid  $etime  ${command##*/}")
+	fi
+# shellcheck disable=SC2009  # pgrep cannot report elapsed time, which is the
+# whole signal here; ps is the only source for it.
+done < <(ps -axo pid=,etime=,command= | grep -E '/[a-z0-9_.-]+\.test( |$)' | grep -v grep || true)
+
+if [ "${#stale_pids[@]}" -eq 0 ]; then
+	exit 0
+fi
+
+cat >&2 <<EOF
+
+Refusing to run: ${#stale_pids[@]} orphaned test binar$( [ "${#stale_pids[@]}" -eq 1 ] && echo y || echo ies ) still running.
+
+Each has outlived its own -test.timeout, so it is stuck rather than busy, and
+it is competing with the run you are about to start. Timings taken now would be
+meaningless and a suite may appear to hang.
+
+  PID   ELAPSED  PROCESS
+$(printf '%s\n' "${stale_rows[@]}")
+
+  kill -9 ${stale_pids[*]}
+
+Set STALE_AFTER_MINUTES to change the ${STALE_AFTER_MINUTES}-minute threshold.
+EOF
+exit 1


### PR DESCRIPTION
## Summary

Go`s `-test.timeout` cannot always kill a stuck test binary. If the process is blocked in a cgo call or a syscall, the timeout panic never lands and the binary keeps running after `go test` has given up on it. They accumulate silently — nothing reports them, and the only symptom is that everything else gets slower.

The dev machine was carrying **eleven of them, the oldest three days old**, holding the load average at **317**. A seed suite that runs in 72s was timing out at 660s. Every obvious reading of that was wrong: not a flaky test, not a slow machine, not the change under test.

```text
13 processes, ages up to 3 days 10 hours, each with -test.timeout=10m0s
load averages: 317.65 314.50 289.46
```

After killing the eleven strays: load 317 → 104, and the suite ran in **71.9s**.

## The guard

`check-stale-tests` runs before the test targets and refuses to start when it finds a test binary older than 30 minutes.

**The threshold is what makes failing safe rather than annoying.** Every suite here finishes in minutes and CI caps at `-test.timeout=10m`, so a binary past 30 minutes has definitively outlived its own timeout and is stuck, not busy. A guard that fires on healthy runs just teaches people to bypass it. `STALE_AFTER_MINUTES` overrides it if a long run is ever legitimate.

The failure prints pids, ages and a ready-to-paste `kill` command.

Fleet-wide, matching MustardSeedNetworks/seed#1997.

## Linked Issue

Related to #1338

Same change as MustardSeedNetworks/seed#1997.

## Type of Change

- [x] CI / tooling

## Risk

- [x] Low

A precondition on local test targets. It cannot fire on a clean machine.

## Testing Evidence

```text
$ make check-stale-tests
(silent, exit 0)

$ make test
(runs normally)
```

With a deliberately-planted stale binary and the threshold lowered:

```text
$ STALE_AFTER_MINUTES=0 ./scripts/check-stale-tests.sh
Refusing to run: 2 orphaned test binaries still running.

  PID   ELAPSED  PROCESS
  962  00:20  fake.test
  56989  11:23:52  api.test -test.paniconexit0 -test.timeout=20m0s

  kill -9 962 56989
exit=1
```

`shellcheck` findings addressed rather than suppressed, except `SC2009` (prefer `pgrep`), disabled with a comment because `pgrep` cannot report elapsed time and elapsed time is the entire signal.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] No routes, auth surfaces, or output encoding touched.
- [x] No dependency changes.
- [x] The script only reads `ps` and prints; it never kills anything itself.
