### PR TITLE
ci: stop the PR body lint cutting Testing Evidence at a fenced heading

### DIFF
--- a/.github/workflows/pr-body-lint.yml
+++ b/.github/workflows/pr-body-lint.yml
@@ -28,14 +28,23 @@ jobs:
           script: |
             const body = context.payload.pull_request.body || "";
             const errors = [];
+            // Headings are matched on their own line. `includes` would accept a
+            // heading that only appears inside a fenced code block, which is a
+            // description of a PR body rather than one.
             const requiredHeadings = ["## Summary", "## Linked Issue", "## Testing Evidence", "## Security and Release Checklist"];
             for (const heading of requiredHeadings) {
-              if (!body.includes(heading)) errors.push(`Missing ${heading}`);
+              if (!new RegExp(`^${heading}\\s*$`, "m").test(body)) errors.push(`Missing ${heading}`);
             }
             if (!/(Fixes|Closes|Resolves|Related to)\s+#\d+/i.test(body)) {
               errors.push("Link the tracked issue with Fixes #123, Closes #123, Resolves #123, or Related to #123.");
             }
-            const testing = body.split("## Testing Evidence")[1]?.split("## ")[0] || "";
+            // Slice the section on line-anchored level-2 headings. Splitting on
+            // a bare "## " matched it anywhere, including inside a fenced block:
+            // an evidence block containing "### RED" was cut mid-fence, so the
+            // regex below saw an unterminated code block and reported missing
+            // evidence on a PR that had two full command transcripts.
+            const afterHeading = body.split(/^## Testing Evidence\s*$/m)[1] ?? "";
+            const testing = afterHeading.split(/^## /m)[0];
             if (!/```[\s\S]*\S[\s\S]*```/.test(testing) && !/not run/i.test(testing)) {
               errors.push("Testing Evidence must include command output or an explicit not-run reason.");
             }


### PR DESCRIPTION
## Summary

`Lint PR Body` sliced the Testing Evidence section with:

```js
body.split("## Testing Evidence")[1]?.split("## ")[0]
```

`split("## ")` matches `## ` **anywhere**, including inside a fenced code block. An evidence block containing a `### RED` / `### GREEN` heading was therefore cut mid-fence — the regex below then saw an unterminated code block and reported *"Testing Evidence must include command output"* on a PR carrying two full command transcripts.

That is a **false positive on a blocking gate**, which is the worst kind: it teaches people the gate is noise and to route around it. MustardSeedNetworks/stem#674 sat blocked on exactly this for three days.

Both slices are now anchored to line-start level-2 headings, so a heading inside a fence cannot truncate the section. The required-heading check moves off `includes` for the same reason — it would otherwise accept a heading that only appears inside a code block.

## Linked Issue

Related to #1338

## Type of Change

- [x] Defect fix
- [x] CI / tooling

## Risk

- [x] Low

The check becomes strictly more accurate: it stops rejecting valid bodies, and stops accepting headings that are only illustrative. Verified in both directions below.

## Testing Evidence

Ran the old and new logic against the real body that was being rejected, and against a body with a genuinely empty evidence section:

```text
ORIGINAL body (### inside fence):
  old linter: ["Testing Evidence must include command output or an explicit not-run reason."]
  new linter: []
EDITED body:
  new linter: []
EMPTY evidence (must still fail):
  new linter: ["Testing Evidence must include command output or an explicit not-run reason."]
```

So the false positive is gone and the real check still fires.

```text
$ actionlint -ignore SC2129 .github/workflows/pr-body-lint.yml
(clean)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] No routes, auth surfaces, or output encoding touched.
- [x] No dependency changes; the pinned `actions/github-script` SHA is unchanged.
- [x] The gate still rejects a body with no evidence — verified, not assumed.
