### PR TITLE
ci: exempt bots from the issue-title lint

### DIFF
--- a/.github/workflows/title-lint.yml
+++ b/.github/workflows/title-lint.yml
@@ -53,7 +53,13 @@ jobs:
   lint-issue-title:
     name: Lint Issue Title
     runs-on: ubuntu-latest
-    if: github.event_name == 'issues'
+    # Bots are exempt, for the same reason pr-body-lint exempts them: Renovate
+    # owns the Dependency Dashboard issue and re-edits it constantly, and its
+    # title is fixed by Renovate rather than by us. Without this the job fails
+    # on every edit and main carries a permanent red that means nothing.
+    if: >-
+      github.event_name == 'issues'
+      && github.event.issue.user.type != 'Bot'
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
## Summary

Every `Title Lint` failure on main — across all four repos — is Renovate's **Dependency Dashboard** issue.

Renovate owns that issue and re-edits it constantly. The `lint-issue-title` job fires on every edit, the title does not match the `Defect:/Feature:/Chore:/Docs:/Security:/Epic:` convention, and **it never will** — Renovate controls the title, not us. So main has been carrying a permanently red check that means nothing, which is precisely the failure mode that teaches people to ignore a red build.

Bots are now exempt, the same way `pr-body-lint.yml` already exempts them (`github.event.pull_request.user.type != 'Bot'`). Human-authored issues are still held to the convention.

## Linked Issue

Related to #1338

## Type of Change

- [x] Defect fix
- [x] CI / tooling

## Risk

- [x] Low

Narrows the gate to the authors it can actually apply to. Human issues are unaffected.

## Testing Evidence

The failing runs, all one issue:

```text
$ gh run list --branch main --limit 12 --json conclusion,name,displayTitle \
    --jq ".[] | select(.conclusion==\"failure\" and .name==\"Title Lint\") | .displayTitle"
Dependency Dashboard

$ gh run view <id> --log-failed
##[error]Issue titles must use "Defect:", "Feature:", "Chore:", "Docs:",
"Security:", or "Epic:" followed by a specific subject.
```

```text
$ actionlint -ignore SC2129 .github/workflows/title-lint.yml
(clean)
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] No routes, auth surfaces, or output encoding touched.
- [x] No dependency changes; the pinned action SHA is unchanged.
- [x] `permissions:` unchanged — still `issues: write` on that job only.
