### PR TITLE
ci: serialise Release Please so concurrent runs stop racing the ref

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,6 +54,20 @@ on:
     - cron: '27 */3 * * *'
   workflow_dispatch:
 
+# Serialise the runs. All three triggers can fire close together — a burst of
+# merges produces a workflow_run each, and the reconciling schedule lands on
+# top — and two overlapping runs both force-update
+# heads/release-please--branches--main. One wins, the other dies with
+# "Error updating ref", which is a red build for a race rather than a problem.
+# It happened on stem, trellis and niac during a 29-PR drain on 2026-08-22.
+#
+# cancel-in-progress is false on purpose: cancelling a run mid-release is a
+# worse failure than queueing behind it. release-please is idempotent, so a
+# queued run simply converges on whatever main looks like when it starts.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary

`Release Please` fails intermittently with:

```text
✔ Successfully created commit. See commit at .../f63aab5d...
✔ Updating reference heads/release-please--branches--main to f63aab5d...
##[error]release-please failed: Error updating ref heads/release-please--branches--main
```

It gets all the way to updating the branch ref and loses. That is a **race**, not a broken release: all three triggers can fire close together — a burst of merges produces a `workflow_run` each, and the 3-hourly reconciling schedule lands on top — and two overlapping runs both force-update the same ref. One wins, the other dies.

Measured across the last 30 runs per repo: **1 failure each in stem, trellis and niac**, 0 in seed. Rare, and it self-heals because the next run converges — which is exactly what the schedule in this file exists for. But it leaves a red build on main that means nothing, and a red build that means nothing is the one that trains people to ignore red builds.

It fired on three repos during a 29-PR drain on 2026-08-22.

### Why `cancel-in-progress: false`

Cancelling a run mid-release is a worse failure than queueing behind one. `release-please` is idempotent, so a queued run simply converges on whatever `main` looks like when it starts — no work is lost by waiting.

## Linked Issue

Related to #1338

## Type of Change

- [x] Defect fix
- [x] CI / tooling

## Risk

- [x] Low

Serialises a workflow that was never safe to run concurrently. No logic, permissions or triggers change.

## Testing Evidence

```text
$ actionlint -ignore SC2129 .github/workflows/release-please.yml
(clean)
```

The failure this prevents, from the real run:

```text
$ gh run view <id> --log-failed
✔ Successfully created a tree with the desired changes
✔ Successfully created commit
✔ Updating reference heads/release-please--branches--main to f63aab5d
##[error]release-please failed: Error updating ref ...
```

Frequency before the fix:

```text
$ gh run list --workflow "Release Please" --limit 30 --json conclusion
seed:    0 failures / 30
stem:    1 failure  / 30
trellis: 1 failure  / 30
niac-go: 1 failure  / 30
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] No routes, auth surfaces, or output encoding touched.
- [x] No dependency changes; no action versions moved.
- [x] `permissions:` blocks unchanged.
