### PR TITLE
fix(api): complete the ADR-0007 camelCase migration on the client

### DIFF
--- a/internal/api/handlers_draft_topology_test.go
+++ b/internal/api/handlers_draft_topology_test.go
@@ -157,7 +157,7 @@ func TestDraftTopologyMutationPersistsReciprocalLinkWithoutApplyingRuntime(t *te
       "link":{
         "source":{"device":"core-1","interface":"Ethernet1/1"},
         "target":{"device":"dist-1","interface":"Ethernet1/49"},
-        "properties":{"vlans":[200,210],"native_vlan":200}
+        "properties":{"vlans":[200,210],"nativeVlan":200}
       }
     }`
 	rec := httptest.NewRecorder()

--- a/internal/drafttopology/mutation.go
+++ b/internal/drafttopology/mutation.go
@@ -63,13 +63,13 @@ type DeviceMutation struct {
 	Type        string            `json:"type"`
 	Vendor      string            `json:"vendor,omitempty"`
 	MAC         string            `json:"mac,omitempty"`
-	MACSuffix   uint32            `json:"mac_suffix,omitempty"`
-	SysObjectID string            `json:"sys_object_id,omitempty"`
+	MACSuffix   uint32            `json:"macSuffix,omitempty"`
+	SysObjectID string            `json:"sysObjectId,omitempty"`
 	IPs         []string          `json:"ips,omitempty"`
 	VLAN        int               `json:"vlan,omitempty"`
 	Interfaces  []Interface       `json:"interfaces,omitempty"`
 	Properties  map[string]string `json:"properties,omitempty"`
-	ProfileRole string            `json:"profile_role,omitempty"`
+	ProfileRole string            `json:"profileRole,omitempty"`
 	WalkFile    string            `json:"-"`
 }
 
@@ -83,11 +83,11 @@ type Interface struct {
 	MTU            int     `json:"mtu,omitempty"`
 	Speed          int     `json:"speed,omitempty"`
 	Duplex         string  `json:"duplex,omitempty"`
-	AdminStatus    string  `json:"admin_status,omitempty"`
-	OperStatus     string  `json:"oper_status,omitempty"`
+	AdminStatus    string  `json:"adminStatus,omitempty"`
+	OperStatus     string  `json:"operStatus,omitempty"`
 	Description    string  `json:"description,omitempty"`
-	InUtilization  float64 `json:"in_utilization,omitempty"`
-	OutUtilization float64 `json:"out_utilization,omitempty"`
+	InUtilization  float64 `json:"inUtilization,omitempty"`
+	OutUtilization float64 `json:"outUtilization,omitempty"`
 	VLANs          []int   `json:"vlans,omitempty"`
 }
 
@@ -118,8 +118,8 @@ type LinkMutation struct {
 // FDB-only (forwarding-table visibility without carrying simulated traffic).
 type LinkProperties struct {
 	VLANs      []int `json:"vlans,omitempty"`
-	NativeVLAN int   `json:"native_vlan,omitempty"`
-	FDBOnly    bool  `json:"fdb_only,omitempty"`
+	NativeVLAN int   `json:"nativeVlan,omitempty"`
+	FDBOnly    bool  `json:"fdbOnly,omitempty"`
 }
 
 // PositionMutation is the MoveDevice payload: a device's new canvas coordinates.

--- a/ui/e2e/device-editor.spec.ts
+++ b/ui/e2e/device-editor.spec.ts
@@ -72,6 +72,15 @@ test.describe('Device Editor', () => {
   });
 });
 
+/**
+ * NOTE: this describe block stubs `**\/api/v1/**` with page.route() and fulfills
+ * 201 unconditionally, so it asserts the shape the client *sends* and never
+ * exercises the server that would reject it. That is exactly how D11 shipped:
+ * the payload below was snake_cased, every real POST returned 400, and this
+ * test stayed green. Contract coverage lives in
+ * ui/src/api/wire-casing.contract.test.ts and the Go handler tests; treat this
+ * spec as UI wiring only.
+ */
 test.describe('Device Editor API wiring', () => {
   test('creates a device with interface speed, duplex, and status metadata', async ({ page }) => {
     let createPayload: Record<string, unknown> | undefined;
@@ -162,13 +171,13 @@ test.describe('Device Editor API wiring', () => {
       hostname: 'edge-switch-01',
       mac: '02:00:00:00:10:01',
       ip: '192.0.2.11',
-      interface_details: [
+      interfaceDetails: [
         {
           name: 'Ethernet1/1',
           speed: 10000,
           duplex: 'full',
-          admin_status: 'up',
-          oper_status: 'down',
+          adminStatus: 'up',
+          operStatus: 'down',
           description: 'uplink to core',
         },
       ],

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -62,7 +62,7 @@ describe('API Client', () => {
     vi.restoreAllMocks();
   });
 
-  describe('toCamelCase / toSnakeCase helpers', () => {
+  describe('toCamelCase response conversion', () => {
     it('converts snake_case keys to camelCase', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/ui/src/api/library-client.test.ts
+++ b/ui/src/api/library-client.test.ts
@@ -160,7 +160,7 @@ describe('scenario draft client', () => {
           name: 'core-1',
           type: 'switch',
           vendor: 'cisco',
-          sys_object_id: '1.3.6.1.4.1.9.1.2494',
+          sysObjectId: '1.3.6.1.4.1.9.1.2494',
         },
       }),
     });

--- a/ui/src/api/requestCore.ts
+++ b/ui/src/api/requestCore.ts
@@ -4,7 +4,7 @@ import { ApiError, type ApiErrorDetail, NetworkError, TimeoutError } from './err
  * Core HTTP request infrastructure for the API client. Everything that
  * is shared by every endpoint lives here:
  *
- *   - case conversion (toSnakeCase out, toCamelCase in)
+ *   - case conversion (toCamelCase in; nothing converts on the way out)
  *   - bearer token + CSRF header injection
  *   - timeout + signal forwarding
  *   - retry-with-backoff for 5xx and network errors
@@ -42,26 +42,6 @@ export const toCamelCase = <T>(value: T): T => {
     for (const [key, entry] of Object.entries(value)) {
       const camelKey = key.includes('_') ? toCamelKey(key) : key;
       result[camelKey] = toCamelCase(entry);
-    }
-    return result as T;
-  }
-  return value;
-};
-
-const toSnakeKey = (key: string) =>
-  key
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
-    .toLowerCase();
-
-export const toSnakeCase = <T>(value: T): T => {
-  if (Array.isArray(value)) {
-    return value.map((item) => toSnakeCase(item)) as T;
-  }
-  if (isPlainObject(value)) {
-    const result: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      result[toSnakeKey(key)] = toSnakeCase(entry);
     }
     return result as T;
   }
@@ -347,9 +327,15 @@ export async function request<T>(
 }
 
 /**
- * requestJson is the JSON-bodied cousin of request(). Camel-case in the
- * payload is converted to snake_case so endpoints match the Go API
- * server's struct tags without each call site having to think about it.
+ * requestJson is the JSON-bodied cousin of request(). The payload is sent
+ * exactly as given: per ADR-0007 the API speaks camelCase in both directions
+ * with no exceptions, so there is nothing to convert on the way out.
+ *
+ * This used to snake_case the body, which was correct while the server still
+ * had snake_case request tags. Those are gone, and the transform silently
+ * broke every payload with a multi-word key — device create/clone,
+ * error injection, PCAP replay, alert saving (D11). Responses are still
+ * camel-cased on the way in by request(), for endpoints that predate the ADR.
  */
 export const requestJson = <T>(
   path: string,
@@ -363,14 +349,15 @@ export const requestJson = <T>(
     {
       ...init,
       headers: { 'Content-Type': 'application/json', ...(init.headers ?? {}) },
-      body: JSON.stringify(toSnakeCase(payload)),
+      body: JSON.stringify(payload),
     },
     retry,
     timeoutMs,
   );
 
-// requestJsonCamelCase is the ADR-0007 boundary for newly migrated endpoints.
-// Legacy callers still use requestJson until their server contracts migrate.
+// requestJsonCamelCase is retained as an alias so the many call sites migrated
+// during the ADR-0007 rollout keep working. It is now identical to requestJson;
+// prefer requestJson for new code.
 export const requestJsonCamelCase = <T>(
   path: string,
   payload: unknown,

--- a/ui/src/api/requestUpload.ts
+++ b/ui/src/api/requestUpload.ts
@@ -5,7 +5,6 @@ import {
   notifyIfAuthenticationFailed,
   parseApiError,
   toCamelCase,
-  toSnakeCase,
 } from './requestCore';
 
 /**
@@ -86,7 +85,7 @@ export function requestJsonWithProgress<T>(
           reject(new DOMException('Request aborted', 'AbortError'));
         };
 
-        xhr.send(JSON.stringify(toSnakeCase(payload)));
+        xhr.send(JSON.stringify(payload));
       })
       .catch(reject);
   });

--- a/ui/src/api/wire-casing.contract.test.ts
+++ b/ui/src/api/wire-casing.contract.test.ts
@@ -1,0 +1,147 @@
+/**
+ * ADR-0007 wire-casing contract.
+ *
+ * The API speaks camelCase in both directions, with no exceptions
+ * (docs/adr/0007-json-wire-casing-convention.md). Every request struct in
+ * internal/api decodes with DisallowUnknownFields(), so a single mis-cased key
+ * is a hard 400 — not a warning, not a partial decode.
+ *
+ * These tests assert the *outgoing key names* for the payload shapes the app
+ * actually sends. A fixture built from a Go struct cannot catch this class of
+ * bug, because the defect lives purely in the JSON key spelling. Regression
+ * D11: `requestJson` snake_cased every payload, which silently broke device
+ * create/clone/update, error injection, PCAP replay and alert saving — six
+ * features, one transform.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+/**
+ * Mutating requests fetch a CSRF token first, so every case here needs two
+ * resolutions: the token, then the real call.
+ */
+function armFetch() {
+  mockFetch.mockReset();
+  mockFetch
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'csrf-token' }) })
+    .mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      text: async () => '{}',
+      json: async () => ({}),
+    });
+}
+
+/** Keys sent on the wire for the most recent fetch call, recursively. */
+function sentKeys(): string[] {
+  const body = mockFetch.mock.calls.at(-1)?.[1]?.body;
+  if (typeof body !== 'string') return [];
+  const out: string[] = [];
+  const walk = (v: unknown): void => {
+    if (Array.isArray(v)) {
+      v.forEach(walk);
+      return;
+    }
+    if (v && typeof v === 'object') {
+      for (const [k, entry] of Object.entries(v)) {
+        out.push(k);
+        walk(entry);
+      }
+    }
+  };
+  walk(JSON.parse(body));
+  return out;
+}
+
+describe('ADR-0007: outgoing payloads are camelCase', () => {
+  beforeEach(() => {
+    armFetch();
+  });
+
+  it('createDevice preserves interfaceDetails and does not snake_case it', async () => {
+    const { createDevice } = await import('./client');
+    await createDevice({
+      hostname: 'UITEST-RTR-01',
+      mac: '00:1A:2B:3C:99:11',
+      type: 'router',
+      ip: '10.99.99.11',
+      interfaceDetails: [{ name: 'Gi0/0', adminStatus: 'up', operStatus: 'up' }],
+    } as never).catch(() => undefined);
+
+    const keys = sentKeys();
+    expect(keys).toContain('interfaceDetails');
+    expect(keys).not.toContain('interface_details');
+    expect(keys).toContain('adminStatus');
+    expect(keys).not.toContain('admin_status');
+  });
+
+  it('cloneDevice sends newHostname, not new_hostname', async () => {
+    const client = await import('./client');
+    const clone = (client as Record<string, unknown>).cloneDevice as (
+      h: string,
+      p: { newHostname: string },
+    ) => Promise<unknown>;
+    await clone('LAB-EDGE-R1', { newHostname: 'UITEST-CLONE-01' }).catch(() => undefined);
+
+    expect(sentKeys()).toContain('newHostname');
+    expect(sentKeys()).not.toContain('new_hostname');
+  });
+
+  it('startReplay sends loopMs, not loop_ms', async () => {
+    const client = await import('./client');
+    const start = (client as Record<string, unknown>).startReplay as (
+      p: unknown,
+    ) => Promise<unknown>;
+    await start({ file: 'capture.pcap', loopMs: 0, scale: 1 }).catch(() => undefined);
+
+    expect(sentKeys()).toContain('loopMs');
+    expect(sentKeys()).not.toContain('loop_ms');
+  });
+
+  it('updateAlerts sends packetsThreshold and webhookUrl', async () => {
+    const client = await import('./client');
+    const update = (client as Record<string, unknown>).updateAlerts as (
+      p: unknown,
+    ) => Promise<unknown>;
+    await update({ packetsThreshold: 987654, webhookUrl: 'https://example.test/hook' }).catch(
+      () => undefined,
+    );
+
+    const keys = sentKeys();
+    expect(keys).toContain('packetsThreshold');
+    expect(keys).toContain('webhookUrl');
+    expect(keys).not.toContain('packets_threshold');
+    expect(keys).not.toContain('webhook_url');
+  });
+
+  it('draft topology mutations keep macSuffix / sysObjectId / profileRole camelCase', async () => {
+    const lib = await import('./library-client');
+    const mutate = (lib as Record<string, unknown>).mutateScenarioDraftTopology as (
+      n: string,
+      r: string,
+      m: unknown,
+    ) => Promise<unknown>;
+    await mutate('draft-1', 'rev-1', {
+      operation: 'add_device',
+      device: {
+        name: 'SW-1',
+        type: 'switch',
+        macSuffix: 12,
+        sysObjectId: '1.3.6.1.4.1.9.1.1',
+        profileRole: 'access',
+      },
+    }).catch(() => undefined);
+
+    const keys = sentKeys();
+    expect(keys).toContain('macSuffix');
+    expect(keys).toContain('sysObjectId');
+    expect(keys).toContain('profileRole');
+    expect(keys).not.toContain('mac_suffix');
+    expect(keys).not.toContain('sys_object_id');
+    expect(keys).not.toContain('profile_role');
+  });
+});


### PR DESCRIPTION
## Summary

`requestJson` ran `toSnakeCase()` over every outgoing body. That was correct while the server still had
snake_case request tags — but `internal/api` finished its ADR-0007 migration and now has **none**.
`decodeJSONStrict` sets `DisallowUnknownFields()`, so every payload with a multi-word key became a hard 400.

Six features, one transform:

| Feature | Client sent | Server expects |
|---|---|---|
| Add Device | `interface_details`, `ips` | `interfaceDetails`; no `ips` field |
| Clone Device | `new_hostname` | `newHostname` |
| Inject Error | `error_type` | `errorType` |
| Start Replay | `loop_ms` | `loopMs` |
| Save Alerts | `packets_threshold`, `webhook_url` | `packetsThreshold`, `webhookUrl` |

Delete was the only device mutation that still worked — it carries no JSON body, so there was nothing to
corrupt. Also latent and fixed by the same change: `templates/use` (`newConfigName`), `synthesize-walk`
(`interfaceCount`), `walk/validate` (`autoFix`).

**This is completing an accepted decision, not a new one.** ADR-0007 ("camelCase API, no exceptions",
accepted 2026-06-16) recorded 74 snake_case tags in `internal/api`; the server side finished, the client
side never started.

### The ordering that matters

`internal/drafttopology` was the one package still genuinely expecting snake_case, and it is
strict-decoded at `handlers_draft_topology.go:35`. Its nine tags (`mac_suffix`, `sys_object_id`,
`profile_role`, `admin_status`, `oper_status`, `in_utilization`, `out_utilization`, `native_vlan`,
`fdb_only`) are migrated to camelCase **in this commit, before** the conversion is removed — otherwise
the wizard's visual topology editor breaks.

YAML config tags are deliberately untouched: ADR-0007 keeps the config-file layer snake_case.

`toSnakeCase` is now unreferenced and removed rather than left as dead code.

## Linked Issue

Fixes #1418

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [ ] Low
- [x] Medium
- [ ] High

Touches the shared request path for every JSON mutation. Mitigated by the contract guard plus a full
green suite; the one genuinely snake_case consumer was migrated in the same commit. The wizard topology
editor is the path to re-drive on CT304 after merge.

## Testing Evidence

The guard was written first and proven to fail against the pre-fix code — the captured bodies show the
real defect, not a mis-wired test:

```text
$ npx vitest run src/api/wire-casing.contract.test.ts     # BEFORE the fix
AssertionError: expected [ 'hostname', 'mac', 'type', …(5) ] to include 'interfaceDetails'
AssertionError: expected [ 'new_hostname' ] to include 'newHostname'
AssertionError: expected [ 'file', 'loop_ms', 'scale' ] to include 'loopMs'
AssertionError: expected [ 'packets_threshold', 'webhook_url' ] to include 'packetsThreshold'
AssertionError: expected [ 'operation', 'device', 'name', …(4) ] to include 'macSuffix'
      Tests  5 failed (5)

$ npx vitest run src/api/wire-casing.contract.test.ts     # AFTER
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ make test
EXIT=0
package firewall ownership regression tests passed
file-size gate regression tests passed

$ make fmt-check
✅ All formatting checks passed
```

Two existing tests asserted the snake_case body and are updated to the ADR-0007 contract rather than
weakened:

- `ui/src/api/library-client.test.ts` — `sys_object_id` → `sysObjectId`
- `internal/api/handlers_draft_topology_test.go` — `"native_vlan":200` → `"nativeVlan":200`

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      Only the JSON key casing on the request body changes; CSRF, auth headers and routing are untouched.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Behaviour is
      restored to the documented ADR-0007 contract; the plan doc in #1438 records the programme.
