### PR TITLE
fix(ui): paint modal dialogs above their own backdrop

### DIFF
--- a/ui/e2e/modal-hit-testing.spec.ts
+++ b/ui/e2e/modal-hit-testing.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Modal hit-testing E2E — regression guard for D8.
+ *
+ * `ui/Modal.tsx` renders a full-viewport scrim button and the dialog as
+ * siblings. The scrim is `position: absolute`; the dialog was `static`. CSS
+ * paints positioned descendants above non-positioned ones regardless of DOM
+ * order, so the scrim covered the dialog's own buttons: a real mouse click on
+ * "Stop" hit the scrim's close handler and dismissed the dialog **without
+ * stopping the simulation**.
+ *
+ * The important part of this guard is that it hit-tests. A test that asserts
+ * the button exists, is visible, or is enabled passes against the broken code —
+ * every one of those was true while the dialog was unclickable. Only
+ * `document.elementFromPoint()` at the button's centre catches it.
+ *
+ * jsdom cannot express this: it has no layout engine, so this has to be an E2E
+ * test rather than a Vitest one.
+ */
+
+/** Resolve what the browser would actually deliver a click to, at an element's centre. */
+async function hitTestCentre(
+  page: import('@playwright/test').Page,
+  selector: string,
+): Promise<{ isSelf: boolean; actual: string }> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return { isSelf: false, actual: 'element-not-found' };
+    const r = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+    const isSelf = hit === el || el.contains(hit);
+    const actual = isSelf
+      ? 'self'
+      : `${hit?.tagName ?? 'none'}[${hit?.getAttribute('aria-label') ?? hit?.className ?? ''}]`;
+    return { isSelf, actual };
+  }, selector);
+}
+
+test.describe('Modal buttons are reachable by mouse', () => {
+  test('every button in an open ConfirmModal hit-tests to itself', async ({ page }) => {
+    await page.goto('/debug');
+    await page.waitForLoadState('domcontentloaded');
+
+    // "Clear all logs" opens a ConfirmModal, which is the shared component
+    // behind every destructive confirmation in the app.
+    await page.locator('main button[aria-label="Clear all logs"]').click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 10000 });
+
+    const buttons = page.locator('[role="dialog"] button');
+    const count = await buttons.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const label = (await buttons.nth(i).innerText()).trim() || `button ${i}`;
+      const result = await hitTestCentre(page, `[role="dialog"] button:nth-of-type(${i + 1})`);
+      expect(result.isSelf, `dialog button "${label}" is covered by ${result.actual}`).toBe(true);
+    }
+  });
+
+  test('the dialog paints above its own backdrop', async ({ page }) => {
+    await page.goto('/debug');
+    await page.waitForLoadState('domcontentloaded');
+    await page.locator('main button[aria-label="Clear all logs"]').click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 10000 });
+
+    // The dialog must establish its own positioned context; a `static` dialog
+    // loses to the absolutely-positioned scrim no matter the DOM order.
+    const position = await page
+      .locator('[role="dialog"]')
+      .evaluate((el) => getComputedStyle(el).position);
+    expect(position, 'dialog must be positioned to beat the absolute scrim').not.toBe('static');
+  });
+});

--- a/ui/src/components/device-list/CloneDeviceModal.tsx
+++ b/ui/src/components/device-list/CloneDeviceModal.tsx
@@ -39,7 +39,7 @@ export const CloneDeviceModal: FC<CloneDeviceModalProps> = ({ hostname, onClone,
         aria-label={t('list.cloneModal.closeAria')}
       />
       <div
-        className="mx-4 w-full max-w-md rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl"
+        className="relative z-10 mx-4 w-full max-w-md rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl"
         role="dialog"
         aria-modal="true"
       >

--- a/ui/src/hooks/useFocusTrap.ts
+++ b/ui/src/hooks/useFocusTrap.ts
@@ -105,6 +105,15 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
   const containerRef = useRef<T>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
 
+  // Consumers pass inline arrows for onEscape (e.g. `onCancel={() => setOpen(false)}`),
+  // so its identity changes on every parent render. Holding it in a ref keeps it out
+  // of the effect's dependency list: otherwise the whole trap tears down and re-arms
+  // on each render, and the teardown's restoreFocus() yanks focus back out of the
+  // dialog. On a continuously re-rendering page (the log stream at Trace level) that
+  // thrashes focus many times a second and makes Escape unreliable. (D18)
+  const onEscapeRef = useRef(onEscape);
+  onEscapeRef.current = onEscape;
+
   useEffect(() => {
     if (!isActive) {
       return;
@@ -134,10 +143,11 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
     // Handle keyboard navigation
     function handleKeyDown(event: KeyboardEvent): void {
       // Handle Escape key
-      if (event.key === 'Escape' && onEscape) {
+      const escapeHandler = onEscapeRef.current;
+      if (event.key === 'Escape' && escapeHandler) {
         event.preventDefault();
         event.stopPropagation();
-        onEscape();
+        escapeHandler();
         return;
       }
 
@@ -181,7 +191,7 @@ export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
         previousActiveElement.current.focus();
       }
     };
-  }, [isActive, onEscape, autoFocus, restoreFocus]);
+  }, [isActive, autoFocus, restoreFocus]);
 
   return containerRef;
 }

--- a/ui/src/ui/Modal.tsx
+++ b/ui/src/ui/Modal.tsx
@@ -77,7 +77,7 @@ export const Modal: FC<ModalProps> = ({
       )}
       <div
         ref={containerRef}
-        className={`mx-4 w-full ${sizeClasses[size]} rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl ${className}`}
+        className={`relative z-10 mx-4 w-full ${sizeClasses[size]} rounded-2xl border border-surface-border bg-bg-surface/95 shadow-2xl ${className}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'modal-title' : undefined}


### PR DESCRIPTION
## Summary

`Modal` renders a full-viewport scrim button and the dialog as siblings. The scrim is
`position: absolute`; the dialog had no positioning class. CSS paints positioned descendants above
non-positioned ones regardless of DOM order — so **the scrim covered the dialog's own buttons**.

`document.elementFromPoint()` at the centre of every button in an open ConfirmModal returned the scrim.
A real mouse click on **Stop** hit the scrim's close handler: the dialog dismissed and the simulation
kept running. The same button driven by keyboard worked, which is the only reason the sweep could
confirm anything at all.

This is the shared `Modal`, so one line covers all eight `ConfirmModal` consumers.
`CloneDeviceModal` reimplements the pattern independently and gets the same fix.
`TemplatePreviewModal` and `MergePreviewModal` already set `relative` and are untouched — they are the
proof the fix is correct.

Also fixes **D18**: `Modal` passes `onEscape: closeOnEscape ? onClose : undefined` into `useFocusTrap`,
whose effect depended on it, while consumers pass inline arrows. The trap tore down and re-armed on
every parent render, each teardown calling `restoreFocus()` and pulling focus back out of the dialog. On
a continuously re-rendering page (the log stream at Trace level) that thrashes focus many times a second
and makes Escape unreliable. The handler now lives in a ref and is out of the dependency list.

## Linked Issue

Fixes #1419
Fixes #1420

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Two class additions and one hook dependency change. No API, routing or state changes.

## Testing Evidence

The guard hit-tests, because asserting the button exists / is visible / is enabled **passes against the
broken code** — all three were true while the dialog was unclickable. jsdom has no layout engine, so it
has to be E2E.

```text
$ npx playwright test e2e/modal-hit-testing.spec.ts     # BEFORE
Error: dialog button "Cancel" is covered by BUTTON[Close modal]
Expected: not "static"
  2 failed   (chromium; same on webkit)

$ npx playwright test e2e/modal-hit-testing.spec.ts     # AFTER
  4 passed (4.2s)

$ npx playwright test e2e/modal-hit-testing.spec.ts e2e/debug-console-page.spec.ts \
    e2e/device-crud.spec.ts e2e/runtime-control-page.spec.ts
  18 passed (7.0s)

$ npx vitest run
 Test Files  89 passed (89)
      Tests  444 passed (444)
```

Post-merge on CT304: re-drive Stop-simulation with a real mouse click and confirm the session actually
stops.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched. Note this *restores* the confirmation step for destructive actions, which was
      effectively bypassed for mouse users.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
