### PR TITLE
fix(fabric): marshal empty topology collections as [] rather than null

### DIFF
--- a/internal/fabric/compiler.go
+++ b/internal/fabric/compiler.go
@@ -18,6 +18,9 @@ func Compile(cfg *config.Config, binding Binding) Report {
 		devices:            make(map[string]struct{}),
 		addresses:          make(map[netip.Addr]string),
 		dhcpLeaseAddresses: make(map[netip.Addr]string),
+		// Seed the report's collections so a scenario that produces none of
+		// them still marshals as [] rather than null. (D6)
+		report: Report{Topology: NewTopology(), Diagnostics: []Diagnostic{}},
 	}
 	compiler.compileBinding()
 	compiler.compileNetworks()
@@ -28,7 +31,10 @@ func Compile(cfg *config.Config, binding Binding) Report {
 
 // CompilePhysicalBinding validates a physical binding for a flat scenario.
 func CompilePhysicalBinding(binding Binding) Report {
-	compiler := scenarioCompiler{binding: binding}
+	compiler := scenarioCompiler{
+		binding: binding,
+		report:  Report{Topology: NewTopology(), Diagnostics: []Diagnostic{}},
+	}
 	compiler.validateBindingMode()
 	compiler.report.Topology.Binding = CompiledBinding{
 		Binding: binding, WireTagged: binding.Mode == ModeTrunk,

--- a/internal/fabric/report_json_test.go
+++ b/internal/fabric/report_json_test.go
@@ -1,0 +1,62 @@
+package fabric_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+)
+
+// TestReportMarshalsEmptyCollectionsAsArrays guards D6.
+//
+// Topology.Networks/Interfaces/Routes/DHCPScopes and Report.Diagnostics are
+// populated only via append. A config that produces none of them leaves the
+// slices nil, and encoding/json renders a nil slice as `null` — not `[]`.
+// omitempty does not help; the field has to be initialised.
+//
+// The UI declares all five as non-nullable arrays and reads
+// `report.topology.networks.length` on the *success* branch, so a clean
+// preflight of a minimal config crashed the New Simulation wizard into an
+// error boundary. The better the config, the harder it failed.
+//
+// This asserts the wire bytes rather than the Go value, because a nil slice
+// and an empty slice are indistinguishable to len() — only the JSON differs.
+func TestReportMarshalsEmptyCollectionsAsArrays(t *testing.T) {
+	// A config with no networks, no devices and no DHCP: every collection empty.
+	report := fabric.Compile(&config.Config{}, fabric.Binding{
+		Attachment: "cyberscope",
+		Interface:  "eth0",
+		Mode:       fabric.ModeTrunk,
+		AccessVLAN: 299,
+	})
+
+	raw, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	body := string(raw)
+
+	for _, field := range []string{"networks", "interfaces", "routes", "dhcpScopes", "diagnostics"} {
+		if strings.Contains(body, `"`+field+`":null`) {
+			t.Errorf("%s marshalled as null; the UI types it as a non-nullable array\n%s", field, body)
+		}
+	}
+}
+
+// TestTopologyZeroValueMarshalsAsArrays covers the type directly, so any new
+// caller that hands out a zero-value Topology is caught too.
+func TestTopologyZeroValueMarshalsAsArrays(t *testing.T) {
+	raw, err := json.Marshal(fabric.NewTopology())
+	if err != nil {
+		t.Fatalf("marshal topology: %v", err)
+	}
+	body := string(raw)
+
+	for _, field := range []string{"networks", "interfaces", "routes", "dhcpScopes"} {
+		if !strings.Contains(body, `"`+field+`":[]`) {
+			t.Errorf("%s is not an empty array in %s", field, body)
+		}
+	}
+}

--- a/internal/fabric/types.go
+++ b/internal/fabric/types.go
@@ -135,6 +135,19 @@ type Topology struct {
 	DHCPScopes []DHCPScope     `json:"dhcpScopes"`
 }
 
+// NewTopology returns a Topology whose collections are empty slices rather
+// than nil. encoding/json renders a nil slice as `null`, and the wire contract
+// (mirrored by ui/src/api/fabric-types.ts) declares these as arrays, so a
+// consumer doing `topology.networks.length` must never be handed null (D6).
+func NewTopology() Topology {
+	return Topology{
+		Networks:   []Network{},
+		Interfaces: []Interface{},
+		Routes:     []Route{},
+		DHCPScopes: []DHCPScope{},
+	}
+}
+
 // Diagnostic explains why a topology is unsafe.
 type Diagnostic struct {
 	Code    DiagnosticCode `json:"code"`

--- a/ui/src/api/fabric-types.ts
+++ b/ui/src/api/fabric-types.ts
@@ -48,16 +48,24 @@ export interface FabricDiagnostic {
   message: string;
 }
 
+/**
+ * The daemon now seeds these collections so they marshal as `[]` (see
+ * internal/fabric.NewTopology). They are still typed nullable because a Go nil
+ * slice renders as `null`, and asserting non-null here is what let D6 ship: the
+ * success branch did `topology.networks.length` and crashed the wizard on a
+ * preflight that had *passed*. Keep the nullability so the compiler forces a
+ * guard at every read, including against an older daemon.
+ */
 export interface SimulationPreflightReport {
   safe: boolean;
   topology: {
     binding: FabricBinding;
-    networks: FabricNetwork[];
-    interfaces: FabricInterface[];
-    routes: FabricRoute[];
-    dhcpScopes: FabricDhcpScope[];
+    networks: FabricNetwork[] | null;
+    interfaces: FabricInterface[] | null;
+    routes: FabricRoute[] | null;
+    dhcpScopes: FabricDhcpScope[] | null;
   };
-  diagnostics: FabricDiagnostic[];
+  diagnostics: FabricDiagnostic[] | null;
 }
 
 export interface SimulationFabricStatus {

--- a/ui/src/components/wizard/PreflightStep.test.tsx
+++ b/ui/src/components/wizard/PreflightStep.test.tsx
@@ -36,6 +36,41 @@ beforeEach(() => {
 });
 
 describe('PreflightStep', () => {
+  // D6: a Go nil slice marshals as `null`, not `[]`. The success branch read
+  // `topology.networks.length`, so a preflight that PASSED crashed the wizard
+  // into an error boundary. Both pre-existing fixtures used `[]`, which is
+  // exactly why this shipped — this one reproduces the wire shape the daemon
+  // actually sent for a config with no networks.
+  it('renders a safe report whose collections came back null', async () => {
+    const user = userEvent.setup();
+    preflightSimulation.mockResolvedValue({
+      safe: true,
+      topology: {
+        binding: {
+          attachment: 'cyberscope',
+          interface: 'eth0',
+          mode: 'trunk',
+          physicalVlan: 299,
+          network: '',
+          wireTagged: true,
+        },
+        networks: null,
+        interfaces: null,
+        routes: null,
+        dhcpScopes: null,
+      },
+      diagnostics: null,
+    });
+
+    render(<PreflightStep request={{ interface: 'eth0' }} onStart={vi.fn()} />);
+    await user.click(screen.getByTestId('wizard-preflight-check'));
+
+    // Must reach the success state rather than throwing on `.length`.
+    await waitFor(() => {
+      expect(screen.getByTestId('wizard-preflight-start')).toBeEnabled();
+    });
+  });
+
   it('checks access mode with VLAN 200 by default and starts only after a safe report', async () => {
     const user = userEvent.setup();
     const onStart = vi.fn();

--- a/ui/src/components/wizard/PreflightStep.tsx
+++ b/ui/src/components/wizard/PreflightStep.tsx
@@ -144,7 +144,7 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
             role="status"
           >
             <SmallText className="text-status-success">
-              {t('newSimWizard.preflight.safe', { count: report.topology.networks.length })}
+              {t('newSimWizard.preflight.safe', { count: report.topology.networks?.length ?? 0 })}
             </SmallText>
             <SmallText className="mt-tight block text-text-secondary">
               {t('newSimWizard.preflight.physicalVlanSummary', {
@@ -162,7 +162,7 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
               {t('newSimWizard.preflight.unsafeTitle')}
             </p>
             <ul className="mt-tight list-disc pl-5 text-sm text-status-error">
-              {report.diagnostics.map((diagnostic) => (
+              {(report.diagnostics ?? []).map((diagnostic) => (
                 <li key={`${diagnostic.code}-${diagnostic.field}`}>{diagnostic.message}</li>
               ))}
             </ul>

--- a/ui/src/pages/runtime/RunningSimulationCard.tsx
+++ b/ui/src/pages/runtime/RunningSimulationCard.tsx
@@ -130,7 +130,7 @@ export const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
                   {t('runtime.fabric.virtualNetworks')}
                 </SmallText>
                 <ul className="mt-tight text-sm text-text-primary">
-                  {simStatus.fabric.topology.networks.map((network) => (
+                  {(simStatus.fabric.topology.networks ?? []).map((network) => (
                     <li key={network.name}>
                       {network.name} · {network.prefix} · {t('runtime.fabric.virtualVlan')}:{' '}
                       {network.virtualVlan ?? t('runtime.fabric.none')}
@@ -143,7 +143,7 @@ export const RunningSimulationCard: FC<RunningSimulationCardProps> = ({
                   {t('runtime.fabric.routes')}
                 </SmallText>
                 <ul className="mt-tight text-sm text-text-primary">
-                  {simStatus.fabric.topology.routes.map((route) => (
+                  {(simStatus.fabric.topology.routes ?? []).map((route) => (
                     <li key={`${route.device}-${route.destination}-${route.via}`}>
                       {route.device}: {route.destination} → {route.via}
                     </li>


### PR DESCRIPTION
## Summary

`Topology.Networks/Interfaces/Routes/DHCPScopes` and `Report.Diagnostics` were populated only via
`append`, and `Compile()` never seeded them. A scenario producing none of them left the slices nil, and
`encoding/json` renders a nil slice as `null`. `omitempty` would not have helped — the fields have to be
initialised.

The UI declares all five as non-nullable arrays and read `report.topology.networks.length` on the
**success** branch, so a preflight returning `{"safe":true}` crashed the New Simulation wizard into an
error boundary. The better the config, the harder it failed.

`SimulationFabricStatus` embeds the same `fabric.Topology`, so `GET /api/v1/simulation` carried the
identical exposure and is fixed by the same change.

**The TS type is now nullable rather than quietly corrected.** Asserting non-null is what let this ship,
and a nil slice is still what an older daemon sends. Making the compiler enforce a guard at every read
immediately surfaced **two more unguarded dereferences the sweep never hit**, in
`RunningSimulationCard` — same latent crash, different page.

## Linked Issue

Fixes #1421

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Additive: collections are seeded, reads are guarded. No behaviour change for configs that already
produced networks.

## Testing Evidence

The guard asserts the **wire bytes**, not the Go value — a nil slice and an empty slice are
indistinguishable to `len()`; only the JSON differs. Proven red first:

```text
$ go test ./internal/fabric/ -run TestReportMarshalsEmptyCollections   # BEFORE
--- FAIL: TestReportMarshalsEmptyCollectionsAsArrays
    networks marshalled as null; the UI types it as a non-nullable array
    {"safe":false,"topology":{...,"networks":null,"interfaces":null,"routes":null,"dhcpScopes":null}}
FAIL

$ go test ./internal/fabric/                                            # AFTER
ok  github.com/MustardSeedNetworks/niac-go/internal/fabric  0.304s

$ npx tsc --build --noEmit    # after making the type honest — found 4 unguarded reads
src/components/wizard/PreflightStep.tsx(147,58): 'report.topology.networks' is possibly 'null'.
src/components/wizard/PreflightStep.tsx(165,16): 'report.diagnostics' is possibly 'null'.
src/pages/runtime/RunningSimulationCard.tsx(133,20): 'simStatus.fabric.topology.networks' is possibly 'null'.
src/pages/runtime/RunningSimulationCard.tsx(146,20): 'simStatus.fabric.topology.routes' is possibly 'null'.

$ make test
EXIT=0

$ golangci-lint run internal/fabric/...
0 issues.
```

`PreflightStep.test.tsx` gains a null-topology fixture. Both pre-existing fixtures used `[]`, which is
exactly why this shipped.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched; this only affects JSON rendering of empty collections.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
