### PR TITLE
fix(ui): load the device into the editor from the flat API response

### DIFF
--- a/ui/src/api/device-config-types.ts
+++ b/ui/src/api/device-config-types.ts
@@ -160,9 +160,13 @@ export interface DeviceListResponse {
 /**
  * Response from GET /api/v1/config/devices/:id
  */
-export interface DeviceDetailResponse {
-  device: Device;
-}
+/**
+ * GET /api/v1/config/devices/:id returns the device **flat**, not wrapped.
+ * This used to declare `{ device: Device }`, so the editor's `fetchedDevice?.device`
+ * was always undefined and the form silently stayed empty (D10). Typed as the
+ * device itself so the compiler enforces the real shape.
+ */
+export type DeviceDetailResponse = Device;
 
 /**
  * Request body for POST /api/v1/config/devices

--- a/ui/src/components/device-editor/useDeviceEditor.load.test.tsx
+++ b/ui/src/components/device-editor/useDeviceEditor.load.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Device editor load path — regression guard for D10.
+ *
+ * `GET /api/v1/config/devices/{hostname}` returns the device **flat**, but the
+ * hook waited for a `{ device: … }` wrapper that the server never sends. The
+ * condition was therefore never true: `reset()` never ran, the form kept
+ * react-hook-form's empty defaults, and `originalDevice` stayed null so Discard
+ * had nothing to restore. Save remained enabled on a blank form bound to a real
+ * hostname, so opening a device and saving would overwrite it with an empty one.
+ *
+ * The existing useDeviceEditor.test.tsx pins `useParams` to `{hostname:'new'}`
+ * for the whole file, and the hook short-circuits that case — so the edit-load
+ * path had no coverage at all. This file supplies it, and deliberately mocks
+ * `fetchConfigDevice` with the **flat** shape the server actually returns.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const EXISTING_DEVICE = {
+  hostname: 'LAB-EDGE-R1',
+  type: 'router',
+  mac: '00:00:0c:00:01:01',
+  ip: '10.254.200.1',
+  ips: ['10.254.200.1', '203.0.113.1'],
+  interfaceDetails: [{ name: 'TenGigabitEthernet0/0/0', speed: 10000, duplex: 'full' }],
+  snmpAgent: { enabled: true, community: 'NetAllyDemo', sysname: 'LAB-EDGE-R1' },
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useParams: () => ({ hostname: 'LAB-EDGE-R1' }),
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: '/device-config/LAB-EDGE-R1', hash: '', search: '' }),
+  };
+});
+
+vi.mock('../../api/client', () => ({
+  // Flat — exactly what handleDeviceGet writes. Not { device: … }.
+  fetchConfigDevice: vi.fn().mockResolvedValue(EXISTING_DEVICE),
+  fetchDeviceEditorSchema: vi.fn().mockResolvedValue({ visibleSections: [] }),
+  createDevice: vi.fn(),
+  updateDevice: vi.fn(),
+  deleteDevice: vi.fn(),
+}));
+
+vi.mock('../../api/library-client', () => ({
+  fetchLibraryWalks: vi.fn().mockResolvedValue([]),
+}));
+
+describe('useDeviceEditor — loading an existing device', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('populates the form from the flat device response', async () => {
+    const { useDeviceEditor } = await import('./useDeviceEditor');
+    const { result } = renderHook(() => useDeviceEditor());
+
+    await waitFor(() => {
+      expect(result.current.device.hostname).toBe('LAB-EDGE-R1');
+    });
+
+    expect(result.current.device.mac).toBe('00:00:0c:00:01:01');
+    expect(result.current.device.type).toBe('router');
+  });
+
+  it('captures originalDevice so Discard has something to restore', async () => {
+    const { useDeviceEditor } = await import('./useDeviceEditor');
+    const { result } = renderHook(() => useDeviceEditor());
+
+    await waitFor(() => {
+      expect(result.current.originalDevice).not.toBeNull();
+    });
+
+    expect(result.current.originalDevice?.hostname).toBe('LAB-EDGE-R1');
+  });
+});

--- a/ui/src/components/device-editor/useDeviceEditor.ts
+++ b/ui/src/components/device-editor/useDeviceEditor.ts
@@ -124,7 +124,7 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     refetch,
   } = useApiResource(() => {
     if (isNewDevice || !hostname) {
-      return Promise.resolve({ device: createEmptyDevice() });
+      return Promise.resolve(createEmptyDevice());
     }
     return fetchConfigDevice(hostname);
   }, [hostname, isNewDevice]);
@@ -160,11 +160,12 @@ export const useDeviceEditor = (): UseDeviceEditorReturn => {
     ]);
   }, [schema]);
 
-  // Update local state when fetched device changes
+  // Update local state when fetched device changes. The response is the device
+  // itself — it is not wrapped in { device } (D10).
   useEffect(() => {
-    if (fetchedDevice?.device) {
-      reset(fetchedDevice.device);
-      setOriginalDevice(fetchedDevice.device);
+    if (fetchedDevice?.hostname) {
+      reset(fetchedDevice);
+      setOriginalDevice(fetchedDevice);
     }
   }, [fetchedDevice, reset]);
 


### PR DESCRIPTION
## Summary

`GET /api/v1/config/devices/{hostname}` returns the device **flat**, but the editor waited for a
`{ device: … }` wrapper the server never sends. The condition was never true: `reset()` never ran, the
form kept react-hook-form's empty defaults, and `originalDevice` stayed null so **Discard** had nothing
to restore. SNMP showed "Disabled" on a device whose agent was enabled.

Worse than "cannot edit": **Save stayed enabled on a blank form bound to a real hostname**, so opening a
device and saving would overwrite it with an empty one.

`DeviceDetailResponse` claimed the wrapper, so TypeScript could not catch the mismatch. It is now typed
as `Device` to match the wire, and the new-device branch no longer fabricates a wrapper to satisfy it.

## Linked Issue

Fixes #1422

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Restores a path that is currently 100% broken; nothing depends on the old wrapper shape.

## Testing Evidence

The edit-load path had **no coverage at all** — the existing `useDeviceEditor.test.tsx` pins `useParams`
to `{hostname:'new'}` for the whole file and the hook short-circuits that case. The guard is new, and it
mocks the flat shape the server actually returns. Proven red first:

```text
$ npx vitest run src/components/device-editor/useDeviceEditor.load.test.tsx   # BEFORE
  × populates the form from the flat device response
  × captures originalDevice so Discard has something to restore
AssertionError: expected '' to be 'LAB-EDGE-R1'
AssertionError: expected null not to be null
      Tests  2 failed (2)

$ npx vitest run src/components/device-editor/                                 # AFTER
 Test Files  6 passed (6)
      Tests  25 passed (25)

$ npx vitest run
 Test Files  91 passed (91)
      Tests  451 passed (451)

$ npx playwright test e2e/device-editor.spec.ts e2e/device-crud.spec.ts
  8 passed (5.8s)

$ npx tsc --build --noEmit    # clean after retyping the response
```

Post-merge on CT304: open a real device, confirm the fields populate, Discard restores, Save round-trips.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched. This removes a data-loss hazard: a blank form could previously be saved over a real device.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
