### PR TITLE
fix(daemon): report device count from the running stack, not the start-time snapshot

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1115,7 +1115,12 @@ func simulationStatus(sim *Simulation, selected bool) api.SimulationStatus {
 		StartedAt:      sim.StartedAt,
 		UptimeSeconds:  time.Since(sim.StartedAt).Seconds(),
 	}
-	if sim.cfg != nil {
+	// Prefer the running stack's config: it is replaced by ReloadConfig, whereas
+	// sim.cfg is captured at session start and never reassigned, so it goes stale
+	// the moment a device is added or removed (D13).
+	if live := sim.stack.Config(); live != nil {
+		status.DeviceCount = live.DeviceCount()
+	} else if sim.cfg != nil {
 		status.DeviceCount = sim.cfg.DeviceCount()
 	}
 	if sim.fabric != nil && sim.stack != nil {

--- a/internal/protocols/stack.go
+++ b/internal/protocols/stack.go
@@ -492,6 +492,22 @@ func (s *Stack) SendRawPacketVLAN(data []byte, vlan int) error {
 	return s.send(pkt)
 }
 
+// Config returns the configuration the stack is currently running.
+//
+// ReloadConfig replaces it, so this is the live view — unlike a config pointer
+// captured when the session started, which goes stale the moment a device is
+// added or removed (D13). Safe on a nil receiver so status paths can call it
+// before a stack exists.
+func (s *Stack) Config() *config.Config {
+	if s == nil {
+		return nil
+	}
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
+
+	return s.config
+}
+
 // GetDevices returns the device table.
 func (s *Stack) GetDevices() *DeviceTable {
 	return s.devices

--- a/internal/protocols/stack_config_live_test.go
+++ b/internal/protocols/stack_config_live_test.go
@@ -1,0 +1,69 @@
+package protocols_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+	"github.com/MustardSeedNetworks/niac-go/internal/logging"
+	"github.com/MustardSeedNetworks/niac-go/internal/protocols"
+)
+
+func mustMAC(s string) net.HardwareAddr {
+	mac, err := net.ParseMAC(s)
+	if err != nil {
+		panic(err)
+	}
+	return mac
+}
+
+// TestStackConfigTracksReload guards D13.
+//
+// daemon.simulationStatus reported DeviceCount from Simulation.cfg, which is
+// captured once at session start and never reassigned — the daemon has no
+// replace-config-on-a-running-session API. Device mutations go through the API
+// layer's own state, so after deleting a device and reloading,
+// /api/v1/simulation reported the start-time count while /runtime, /stats,
+// /sessions, /config/devices and /sessions/{id}/devices all reported the live
+// one. The Dashboard rendered both numbers at once and survived a page reload.
+//
+// The running stack *does* track the live config (ReloadConfig ->
+// initializeDevices -> s.config = cfg), so Stack.Config() is the honest source.
+// This asserts that, so the accessor simulationStatus now depends on cannot
+// silently go stale again.
+func TestStackConfigTracksReload(t *testing.T) {
+	initial := &config.Config{
+		Devices: []config.Device{
+			{Name: "sw-1", Type: "switch", MACAddress: mustMAC("00:00:0c:00:00:01")},
+			{Name: "sw-2", Type: "switch", MACAddress: mustMAC("00:00:0c:00:00:02")},
+		},
+	}
+	stack := protocols.NewStack(nil, initial, logging.NewDebugConfig(0))
+
+	if got := stack.Config().DeviceCount(); got != 2 {
+		t.Fatalf("initial DeviceCount = %d, want 2", got)
+	}
+
+	// Drop a device, exactly as a delete + save & reload does.
+	replacement := &config.Config{
+		Devices: []config.Device{
+			{Name: "sw-1", Type: "switch", MACAddress: mustMAC("00:00:0c:00:00:01")},
+		},
+	}
+	if err := stack.ReloadConfig(replacement); err != nil {
+		t.Fatalf("ReloadConfig() error = %v", err)
+	}
+
+	if got := stack.Config().DeviceCount(); got != 1 {
+		t.Errorf("DeviceCount after reload = %d, want 1 — the stack is serving a stale config", got)
+	}
+}
+
+// TestStackConfigNilStackIsSafe keeps the accessor usable from status paths
+// that may run before a stack exists.
+func TestStackConfigNilStackIsSafe(t *testing.T) {
+	var stack *protocols.Stack
+	if cfg := stack.Config(); cfg != nil {
+		t.Errorf("Config() on a nil stack = %v, want nil", cfg)
+	}
+}


### PR DESCRIPTION
## Summary

`simulationStatus` read `DeviceCount` from `Simulation.cfg`, captured once at session start and never
reassigned — the daemon has no replace-config-on-a-running-session API. Device mutations go through the
API layer's own state via `replaceConfig`, and the `ApplyConfig` hook that could have bridged them is
never wired in production (assigned only in tests; `TestRuntimeServicesApplyConfigNil` asserts it is nil
at runtime).

After deleting a device and reloading, `/api/v1/simulation` reported the start-time count while
`/runtime`, `/stats`, `/sessions`, `/config/devices` and `/sessions/{id}/devices` all reported the live
one. The Dashboard rendered **both numbers at once** — hero 57 beside a stat card reading 56 — and it
survived a page reload, because the hero and the Runtime sessions table both read the stale endpoint.

The running stack *does* track the live config (`ReloadConfig` → `initializeDevices` sets `s.config`
under `configMu`). This adds `Stack.Config()` as the honest accessor — nil-receiver safe, read under the
existing RWMutex — and has `simulationStatus` prefer it, falling back to the snapshot only when no stack
exists.

## Linked Issue

Fixes #1423

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Read-only accessor plus one status field; the previous behaviour remains as the fallback.

## Testing Evidence

```text
$ go test ./internal/protocols/ -run TestStackConfig      # BEFORE
stack.Config undefined (type *protocols.Stack has no field or method Config)
FAIL  [build failed]

$ go test ./internal/protocols/ -run TestStackConfig      # AFTER
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols  0.380s

$ go test ./internal/daemon/ ./internal/protocols/
ok  github.com/MustardSeedNetworks/niac-go/internal/daemon     10.222s
ok  github.com/MustardSeedNetworks/niac-go/internal/protocols   2.575s

$ golangci-lint run internal/protocols/... internal/daemon/...
0 issues.

$ make test
EXIT=0
```

Post-merge on CT304: delete a device, save & reload, and confirm all six endpoints agree.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched; this is a read path only.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
