### PR TITLE
fix(ui): make clipped help tabs and the topology export menu reachable

### DIFF
--- a/ui/e2e/reachability.spec.ts
+++ b/ui/e2e/reachability.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Mouse-reachability guards for Wave 6 (D1, D14).
+ *
+ * Both defects were controls that existed, were visible and were enabled — and
+ * could not be clicked, because something else painted on top or the container
+ * clipped them. Presence assertions pass against all of that; only geometry and
+ * hit-testing catch it.
+ */
+
+/** True when a click at the element's centre would actually reach it. */
+async function reachable(
+  page: import('@playwright/test').Page,
+  handle: import('@playwright/test').Locator,
+): Promise<boolean> {
+  return handle.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) return false;
+    // Off-screen entirely?
+    if (r.right <= 0 || r.bottom <= 0 || r.left >= innerWidth || r.top >= innerHeight) return false;
+    const hit = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+    return hit === el || el.contains(hit) || Boolean(hit && hit.contains(el));
+  });
+}
+
+test.describe('Help drawer tabs (D1)', () => {
+  test('all tabs are on-screen and clickable', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.locator('button[aria-label="Open help"]').last().click();
+
+    const tabs = page.getByRole('tab');
+    await expect(tabs.first()).toBeVisible({ timeout: 10000 });
+
+    const count = await tabs.count();
+    expect(count, 'help drawer should expose all of its tabs').toBeGreaterThanOrEqual(8);
+
+    for (let i = 0; i < count; i++) {
+      const tab = tabs.nth(i);
+      const label = (await tab.innerText()).trim() || `tab ${i}`;
+      expect(await reachable(page, tab), `tab "${label}" is not reachable by mouse`).toBe(true);
+    }
+  });
+
+  test('a clipped tab actually activates when clicked', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.locator('button[aria-label="Open help"]').last().click();
+
+    // FAQ is the last tab — the one that used to sit furthest outside the drawer.
+    const faq = page.getByRole('tab').last();
+    await faq.click();
+    await expect(faq).toHaveAttribute('aria-selected', 'true');
+  });
+});
+
+test.describe('Topology export menu (D14)', () => {
+  /**
+   * The export dropdown lives in the header Card; the graph lives in a sibling
+   * Card below it. Card's default variant sets `backdrop-blur-xl`, which makes
+   * each Card its own stacking context — so the dropdown's own `z-50` could not
+   * be compared against the graph Card at all, and the graph Card (later in the
+   * DOM) painted its whole layer over the menu's last item.
+   *
+   * This asserts the stacking relationship rather than clicking a menu item,
+   * because the E2E daemon runs with no simulation and the topology page has no
+   * graph data to open the menu against. The relationship is the invariant the
+   * fix establishes, and it holds with or without data.
+   */
+  test('the header card out-stacks the graph card', async ({ page }) => {
+    await page.goto('/topology');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByTestId('page-header-title')).toBeVisible({ timeout: 10000 });
+
+    const order = await page.evaluate(() => {
+      const cards = [...document.querySelectorAll('main [class*="backdrop-blur"]')];
+      if (cards.length < 2) return null;
+      const z = (el: Element) => {
+        const raw = getComputedStyle(el).zIndex;
+        return raw === 'auto' ? 0 : Number(raw);
+      };
+      // Header card is the first, the graph card follows it in the DOM.
+      return { header: z(cards[0]), graph: z(cards[cards.length - 1]) };
+    });
+
+    expect(order, 'expected a header card and a graph card on the topology page').not.toBeNull();
+    expect(
+      order?.header,
+      'header card must paint above the graph card, or the export menu is swallowed',
+    ).toBeGreaterThan(order?.graph ?? 0);
+  });
+});

--- a/ui/src/components/HelpDrawer.tsx
+++ b/ui/src/components/HelpDrawer.tsx
@@ -180,7 +180,14 @@ export function HelpDrawer({ isOpen, onClose, section }: HelpDrawerProps): React
 
             {/* Tab Navigation */}
             <div className="border-b border-surface-border px-cell">
-              <nav className="flex gap-tight -mb-px">
+              {/*
+                Wraps rather than clipping. The strip is ~851px of tabs inside a
+                fixed-width drawer (~455px of content), so a non-wrapping row with
+                overflow-x: visible left Commands / Glossary / Shortcuts / FAQ
+                unreachable by mouse at every viewport width — widening the window
+                does not help, because the drawer width is fixed (D1).
+              */}
+              <div className="flex flex-wrap gap-tight -mb-px" role="tablist">
                 {TABS.map((tab) => (
                   <button
                     key={tab.id}
@@ -200,7 +207,7 @@ export function HelpDrawer({ isOpen, onClose, section }: HelpDrawerProps): React
                     <span>{tab.label}</span>
                   </button>
                 ))}
-              </nav>
+              </div>
             </div>
           </div>
 

--- a/ui/src/pages/TopologyPage.tsx
+++ b/ui/src/pages/TopologyPage.tsx
@@ -45,6 +45,7 @@ import {
   useTopologyExport,
   writeSavedLayoutMode,
 } from './topology';
+import { reframeAfterPaint } from './topology/reframe';
 import { TrunkEdge } from './topology/TrunkEdge';
 
 /**
@@ -349,10 +350,7 @@ export const TopologyPage: FC = () => {
     setNodes([]);
     setEdges([]);
     setResetCounter((n) => n + 1);
-    // Re-frame the canvas after the fresh layout settles.
-    window.setTimeout(() => {
-      rfInstance.current?.fitView({ padding: 0.2, duration: 400 });
-    }, 150);
+    reframeAfterPaint(() => rfInstance.current?.fitView({ padding: 0.2, duration: 400 }));
   }, [setNodes, setEdges, layoutPersistence]);
 
   // The set of unique device types currently in the graph — drives the
@@ -452,10 +450,10 @@ export const TopologyPage: FC = () => {
     lastDeviceSetSig.current = sig;
     // Defer one tick so layoutNodes has populated the new positions
     // before fitView measures them.
-    const t = window.setTimeout(() => {
-      rfInstance.current?.fitView({ padding: 0.2, duration: 400 });
-    }, 50);
-    return () => window.clearTimeout(t);
+    const cancelReframe = reframeAfterPaint(() =>
+      rfInstance.current?.fitView({ padding: 0.2, duration: 400 }),
+    );
+    return cancelReframe;
   }, [devices]);
 
   const {
@@ -491,9 +489,7 @@ export const TopologyPage: FC = () => {
         // refit (better than freezing on a transient network blip).
       })
       .finally(() => {
-        window.requestAnimationFrame(() => {
-          rfInstance.current?.fitView({ padding: 0.2, duration: 300 });
-        });
+        reframeAfterPaint(() => rfInstance.current?.fitView({ padding: 0.2, duration: 300 }));
       });
   }, [refetchTopology, refetchDevices, refetchNeighbors]);
 
@@ -502,7 +498,7 @@ export const TopologyPage: FC = () => {
   return (
     <div className="stack-xl">
       {/* Header Card */}
-      <Card className="border-surface-border bg-bg-surface/70">
+      <Card className="relative z-20 border-surface-border bg-bg-surface/70">
         <CardContent>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-comfortable">
             <div className="flex items-center gap-default">
@@ -718,7 +714,7 @@ export const TopologyPage: FC = () => {
           ≈ 240 px on this layout). Gives much more room for the graph
           on standard 1080p+ displays. */}
       {view === 'graph' && (
-        <Card className="border-surface-border bg-bg-surface/70 overflow-hidden">
+        <Card className="relative z-0 border-surface-border bg-bg-surface/70 overflow-hidden">
           <div className="h-[calc(100vh-260px)] min-h-[520px] relative">
             {loading ? (
               <div className="absolute inset-0 flex-center">

--- a/ui/src/pages/topology/ActionsMenu.tsx
+++ b/ui/src/pages/topology/ActionsMenu.tsx
@@ -52,7 +52,12 @@ export const ActionsMenu: FC<{
   };
 
   return (
-    <div className="relative" data-topology-actions>
+    // z-50 here, not just on the dropdown: Card's default variant sets
+    // backdrop-blur-xl, which creates a stacking context, so the dropdown's own
+    // z-50 could not be compared against the sibling graph Card. The graph Card
+    // is later in the DOM and painted its whole layer over the menu's last item
+    // (D14). Raising this wrapper puts the header card's context on top.
+    <div className="relative z-50" data-topology-actions>
       <Button
         variant="ghost"
         size="sm"

--- a/ui/src/pages/topology/reframe.ts
+++ b/ui/src/pages/topology/reframe.ts
@@ -1,0 +1,20 @@
+/**
+ * Re-frame the React Flow canvas after React has committed a new layout.
+ *
+ * A fixed setTimeout races the dagre pass on a large graph: fitView measures
+ * stale node geometry and the canvas lands at a wrong zoom with almost nothing
+ * in view (D15). Two nested animation frames guarantee a committed paint first.
+ *
+ * Returns a cancel function so effects can clean up on unmount.
+ */
+export function reframeAfterPaint(fit: () => void): () => void {
+  let inner = 0;
+  const outer = window.requestAnimationFrame(() => {
+    inner = window.requestAnimationFrame(fit);
+  });
+
+  return () => {
+    window.cancelAnimationFrame(outer);
+    window.cancelAnimationFrame(inner);
+  };
+}


### PR DESCRIPTION
## Summary

Three layout defects where the control existed, was visible and was enabled — and could not be clicked.

**D1 — four help tabs unreachable.** The tab strip was a non-wrapping flex row with `overflow-x: visible`
inside a fixed-width drawer: ~851px of tabs in ~455px of content, leaving Commands / Glossary /
Shortcuts / FAQ off the end at **every** viewport width (widening the window does not help — the drawer
width is fixed). Four tabs of authored help shipped unreachable by mouse. The strip now wraps and
carries `role="tablist"` on a `div` (a `<nav>` may not host that role).

**D14 — GraphML export unclickable.** The dropdown already had `z-50`, but `Card`'s default variant sets
`backdrop-blur-xl`, which makes every Card its own **stacking context** — so the menu's z-index could not
be compared against the sibling graph Card at all. The graph Card is later in the DOM and painted its
whole layer over the menu's last item. Fixed by ordering the two cards explicitly, rather than raising
the menu inside a context it cannot escape.

**D15 — topology never fits the viewport.** `handleResetLayout` re-framed on a fixed 150ms timer, which
races the dagre pass: `fitView` measured stale geometry and left the canvas at `scale(0.2)` with 1 of 56
nodes visible. Both call sites now wait for the committed paint. `handleRefresh` already used this
pattern and its comment documents exactly this failure — reset was simply never migrated.

The three call sites were duplicating the same rAF dance, so the helper moved to
`pages/topology/reframe.ts` alongside the module's other helpers. That also brings `TopologyPage.tsx`
back **under** its size baseline (856 vs 865) instead of raising it.

## Linked Issue

Fixes #1432
Fixes #1433
Fixes #1434

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

CSS ordering, a wrapping class, and swapping two timers for animation frames.

## Testing Evidence

These guards **hit-test**. Presence, visibility and enabled-ness were all true while the controls were
unclickable, so any assertion short of geometry passes against the broken code.

```text
$ npx playwright test e2e/reachability.spec.ts    # BEFORE
Error: tab "Commands" is not reachable by mouse
  2 failed
  1 passed

$ npx playwright test e2e/reachability.spec.ts    # AFTER
  6 passed (3.5s)

$ npx playwright test e2e/reachability.spec.ts e2e/topology-device-node.spec.ts e2e/help-drawer.spec.ts
  12 passed (7.9s)

$ npx vitest run
 Test Files  90 passed (90)
      Tests  449 passed (449)

$ make test
EXIT=0
```

The export guard asserts the **stacking relationship** rather than clicking a menu item: the E2E daemon
runs without a simulation, so the topology page has no graph data to open the menu against. The
relationship is the invariant the fix establishes, and it holds with or without data. Post-merge on
CT304 I will click all four export items with a real mouse.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched — presentation only.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
