### PR TITLE
fix: surface the reasons the API already knows

### DIFF
--- a/internal/api/handlers_client_errors.go
+++ b/internal/api/handlers_client_errors.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"net/http"
+)
+
+// maxClientErrorBatch bounds one flush from the browser's error reporter.
+// The reporter batches at MAX_BATCH_SIZE = 10; the ceiling here is slack for
+// that, not a contract.
+const maxClientErrorBatch = 32
+
+// clientErrorReport is one captured front-end error.
+type clientErrorReport struct {
+	Message   string `json:"message"`
+	Stack     string `json:"stack,omitempty"`
+	Context   string `json:"context"`
+	Timestamp int64  `json:"timestamp"`
+	URL       string `json:"url"`
+}
+
+type clientErrorBatch struct {
+	Errors []clientErrorReport `json:"errors"`
+}
+
+// handleClientErrors records front-end errors reported by the browser.
+//
+// The UI has always POSTed here (ui/src/utils/error-reporter.ts), but the route
+// was never implemented, so every flush 404'd. The reporter's `.catch()` could
+// not soften that either — a 404 is a resolved fetch, not a rejection — so the
+// only visible effect was a second console error, and no client-side error has
+// ever reached the server (D7).
+//
+// Reports are logged, not stored: they are diagnostic breadcrumbs for an
+// operator reading the daemon log, and persisting attacker-influenced strings
+// would be a liability without any consumer for them.
+func (s *Server) handleClientErrors(w http.ResponseWriter, r *http.Request) {
+	var batch clientErrorBatch
+	if !decodeJSONStrict(w, r, &batch, MaxRequestBodySize) {
+		return
+	}
+
+	if len(batch.Errors) > maxClientErrorBatch {
+		writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"too many errors in one batch", nil)
+
+		return
+	}
+
+	for i := range batch.Errors {
+		report := &batch.Errors[i]
+		s.logger.WarnContext(r.Context(), "[UI] client error",
+			"message", report.Message,
+			"context", report.Context,
+			"url", report.URL,
+			"stack", report.Stack,
+		)
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/handlers_client_errors_test.go
+++ b/internal/api/handlers_client_errors_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleClientErrorsAcceptsReporterPayload guards D7.
+//
+// ui/src/utils/error-reporter.ts has always POSTed batches to
+// /api/v1/client-errors, but the route was never registered — every flush
+// returned 404, and the reporter's .catch() could not soften it because a 404
+// is a resolved fetch rather than a rejection. No client-side error had ever
+// reached the server, including the wizard crash the sweep found.
+//
+// The body here is the reporter's real shape, not a Go struct literal: the
+// whole failure mode was a route/contract mismatch, which a struct-built
+// fixture cannot express.
+func TestHandleClientErrorsAcceptsReporterPayload(t *testing.T) {
+	server := &Server{logger: slog.Default()}
+
+	body := `{"errors":[{"message":"Cannot read properties of null (reading 'length')",` +
+		`"stack":"at PreflightStep","context":"react-error-boundary",` +
+		`"timestamp":1755830000000,"url":"http://127.0.0.1:8445/new-simulation"}]}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/client-errors", strings.NewReader(body))
+	server.handleClientErrors(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+}
+
+func TestHandleClientErrorsRejectsOversizedBatch(t *testing.T) {
+	server := &Server{logger: slog.Default()}
+
+	entries := make([]string, 0, maxClientErrorBatch+1)
+	for range maxClientErrorBatch + 1 {
+		entries = append(entries, `{"message":"boom","context":"x","timestamp":1,"url":"u"}`)
+	}
+	body := `{"errors":[` + strings.Join(entries, ",") + `]}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/client-errors", strings.NewReader(body))
+	server.handleClientErrors(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
@@ -127,17 +128,44 @@ func (s *Server) handleSimulationPreflight(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		s.logger.ErrorContext(r.Context(), "[API] Simulation preflight failed", "error", err)
+		// Return what went wrong, not just that something did. The daemon
+		// already knows ("SNMPv1/v2c requires an explicit community"), and the
+		// CLI prints it; collapsing it to a fixed string left the one button
+		// whose whole job is diagnosis unable to diagnose anything (D5).
 		writeError(
 			w,
 			r,
 			http.StatusBadRequest,
 			"preflight_failed",
 			"Simulation preflight failed",
-			nil,
+			preflightErrorDetails(err),
 		)
 		return
 	}
 	s.writeJSON(w, report)
+}
+
+// preflightErrorDetails turns a preflight error into per-issue details so the
+// client can show the operator what to fix. Semantic validation aggregates its
+// findings into one error separated by newlines or "; ", so split on both.
+func preflightErrorDetails(err error) []ErrorDetail {
+	if err == nil {
+		return nil
+	}
+	raw := strings.NewReplacer("\n", "; ").Replace(err.Error())
+	var details []ErrorDetail
+	for part := range strings.SplitSeq(raw, "; ") {
+		issue := strings.TrimSpace(part)
+		if issue == "" {
+			continue
+		}
+		details = append(details, ErrorDetail{Issue: issue})
+	}
+	if len(details) == 0 {
+		return nil
+	}
+
+	return details
 }
 
 // handleSimulationStart processes POST requests to start a simulation.

--- a/internal/api/handlers_simulation_details_test.go
+++ b/internal/api/handlers_simulation_details_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPreflightErrorDetails guards D5.
+//
+// The preflight handler collapsed every failure into the fixed string
+// "Simulation preflight failed" and passed nil details, so the one button whose
+// job is diagnosis reported nothing. The daemon knew the cause all along — the
+// same binary's CLI prints "SNMPv1/v2c requires an explicit community" for the
+// identical config — and the log line carried only a count.
+func TestPreflightErrorDetails(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "aggregated semantic validation errors are split per issue",
+			err: errors.New("simulation configuration failed semantic validation: " +
+				"SNMPv1/v2c requires an explicit community; SNMPv1/v2c requires an explicit community"),
+			want: []string{
+				"simulation configuration failed semantic validation: SNMPv1/v2c requires an explicit community",
+				"SNMPv1/v2c requires an explicit community",
+			},
+		},
+		{
+			name: "newline separated issues are split too",
+			err:  errors.New("first problem\nsecond problem"),
+			want: []string{"first problem", "second problem"},
+		},
+		{
+			name: "a single error still yields one detail",
+			err:  errors.New("unknown attachment"),
+			want: []string{"unknown attachment"},
+		},
+		{
+			name: "nil error yields no details",
+			err:  nil,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := preflightErrorDetails(tt.err)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d details, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i].Issue != tt.want[i] {
+					t.Errorf("detail[%d] = %q, want %q", i, got[i].Issue, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -358,6 +358,14 @@ func (s *Server) registerTopologyReadOnlyRoutes(mux *http.ServeMux) {
 		},
 		{path: "/api/v1/segments", handler: s.handleSegments, methods: []string{http.MethodGet}},
 		{
+			path:         "/api/v1/client-errors",
+			handler:      s.handleClientErrors,
+			methods:      []string{http.MethodPost},
+			maxBodyBytes: MaxRequestBodySize,
+			rl:           rlWrite,
+			csrf:         true,
+		},
+		{
 			path:    "/api/v1/errors",
 			handler: s.handleErrors,
 			methods: []string{

--- a/ui/src/hooks/useErrorToast.ts
+++ b/ui/src/hooks/useErrorToast.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isApiError } from '../api/errors';
 import { useUIStore } from '../stores/ui-store';
 import { getErrorMessage } from '../utils/format';
 
@@ -19,10 +20,21 @@ export function useErrorToast() {
 
   return useCallback(
     (err: unknown, title?: string) => {
+      // Surface the server's details[] rather than only the generic message.
+      // The API says exactly what is wrong ("line 65: field enabled not found
+      // in type converter.DhcpServer"); dropping it left users with nothing to
+      // act on (D3).
+      const details = isApiError(err)
+        ? err.details.map((detail) =>
+            detail.line ? `line ${detail.line}: ${detail.issue}` : detail.issue,
+          )
+        : undefined;
+
       addNotification({
         type: 'error',
         title: title ?? t('toast.requestFailedTitle'),
         message: getErrorMessage(err),
+        details: details && details.length > 0 ? details : undefined,
       });
     },
     [addNotification, t],

--- a/ui/src/stores/ui-store.ts
+++ b/ui/src/stores/ui-store.ts
@@ -76,6 +76,13 @@ export interface Notification {
   type: 'success' | 'error' | 'warning' | 'info';
   title: string;
   message?: string;
+  /**
+   * Structured detail lines from the API's `details[]`. The server already
+   * says things like "line 65: field enabled not found in type
+   * converter.DhcpServer"; before D3 the toast showed only the generic
+   * `message` and threw these away, which made the wizard a dead end.
+   */
+  details?: string[];
   timestamp: number;
   duration?: number;
 }

--- a/ui/src/ui/ToastContainer.tsx
+++ b/ui/src/ui/ToastContainer.tsx
@@ -41,6 +41,13 @@ const Toast: FC<{ notification: Notification }> = ({ notification }) => {
         {notification.message && (
           <p className="text-sm opacity-80 mt-0.5">{notification.message}</p>
         )}
+        {notification.details && notification.details.length > 0 && (
+          <ul className="mt-tight list-disc pl-4 text-xs opacity-80">
+            {notification.details.map((detail) => (
+              <li key={detail}>{detail}</li>
+            ))}
+          </ul>
+        )}
       </div>
       <button
         type="button"


### PR DESCRIPTION
## Summary

Three defects that all amounted to throwing away a diagnosis the system already had.

**D3 — toasts discarded `details[]`.** `ApiError` already carried them (`parseApiError` attaches them,
and five pages read them bespoke), but the shared toast path never did: `getErrorMessage` returns
`err.message` only, `useErrorToast` never touched `.details`, `Notification` had no field, and
`ToastContainer` had nowhere to render them. So the wizard showed *"Request failed / Configuration
validation failed"* while the server had said *"line 65: field enabled not found in type
converter.DhcpServer"*. Wired through all four layers.

**D5 — preflight reported nothing on the error path.** The handler collapsed every failure into a fixed
string and passed `nil` details, so the one button whose job is diagnosis diagnosed nothing. The daemon
knew the cause — the same binary's CLI prints *"SNMPv1/v2c requires an explicit community"* for the
identical config — and the log line carried only a count. Aggregated validation errors are now split per
issue and returned. Scope is the **error** path only; `safe:true` and `safe:false` both reported
correctly already.

**D7 — client error telemetry had never worked.** The UI has always POSTed to `/api/v1/client-errors`,
but the route was never registered, so every flush 404'd. The reporter's `.catch()` could not soften
that — a 404 is a resolved fetch, not a rejection — so the only visible effect was a second console
error. The file is headed *"FIX #190: No client-side error logging"*; that fix was incomplete, and no
client error had ever reached the server, **including the wizard crash this programme found**.
Implemented as a logging endpoint: these are diagnostic breadcrumbs for an operator reading the daemon
log, and persisting attacker-influenced strings with no consumer would be a liability.

## Linked Issue

Fixes #1429
Fixes #1430
Fixes #1431

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Additive: one new POST route, one optional notification field, and error detail that was previously
discarded. No existing behaviour changes shape.

## Testing Evidence

```text
$ go test ./internal/api/ -run 'TestPreflightErrorDetails|TestHandleClientErrors'
ok  github.com/MustardSeedNetworks/niac-go/internal/api  0.812s

$ golangci-lint run internal/api/...
0 issues.

$ npx vitest run
 Test Files  90 passed (90)
      Tests  450 passed (450)

$ make test
EXIT=0
```

The client-errors guard posts the **reporter's real payload** rather than a Go struct literal — the
failure mode was a route/contract mismatch, which a struct-built fixture cannot express.

Post-merge on CT304: trigger a validation failure in the wizard and confirm the line/field reaches the
toast.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      The new POST route is registered with the same `rlWrite` rate limit and `csrf: true` as its
      neighbours, decodes strictly, and bounds the batch size. Reports are logged, never persisted or
      echoed back.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
