### PR TITLE
fix(ui): derive About versions from the manifest and explain the disabled timeline button

### DIFF
--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -434,15 +434,16 @@
       "duration": "Duration (seconds)",
       "empty": "Add a timeline to make traffic and faults change automatically during the simulation.",
       "faultRate": "Rate (%)",
+      "faultType": "Fault",
       "faults": {
         "fcs_errors": "FCS errors",
         "high_utilization": "High utilization",
         "interface_errors": "Interface errors",
         "packet_discards": "Packet discards"
       },
-      "faultType": "Fault",
       "help": "Schedule realistic traffic and link conditions. The same timeline replays identically after every restart.",
       "interface": "Interface",
+      "needsInterface": "Add at least one interface to a device before scheduling behaviors — timelines target a device interface.",
       "phaseName": "Phase name",
       "phaseOffset": "Phase starts after (seconds)",
       "removeFault": "Remove fault",

--- a/internal/i18n/locales/en/pages.json
+++ b/internal/i18n/locales/en/pages.json
@@ -434,13 +434,13 @@
       "duration": "Duration (seconds)",
       "empty": "Add a timeline to make traffic and faults change automatically during the simulation.",
       "faultRate": "Rate (%)",
-      "faultType": "Fault",
       "faults": {
         "fcs_errors": "FCS errors",
         "high_utilization": "High utilization",
         "interface_errors": "Interface errors",
         "packet_discards": "Packet discards"
       },
+      "faultType": "Fault",
       "help": "Schedule realistic traffic and link conditions. The same timeline replays identically after every restart.",
       "interface": "Interface",
       "needsInterface": "Add at least one interface to a device before scheduling behaviors — timelines target a device interface.",

--- a/internal/i18n/locales/en/settings.json
+++ b/internal/i18n/locales/en/settings.json
@@ -7,7 +7,7 @@
     "legalTitle": "Legal",
     "linksTitle": "Links",
     "proprietaryNotice": "NIAC is proprietary software. Unauthorized copying, modification, or distribution is prohibited.",
-    "subtitle": "Network Injection & Analysis Console",
+    "subtitle": "Network In A Can",
     "version": "Version",
     "website": "Website"
   },

--- a/internal/i18n/locales/es/pages.json
+++ b/internal/i18n/locales/es/pages.json
@@ -238,6 +238,7 @@
       },
       "help": "Programa tráfico y condiciones de enlace realistas. El mismo cronograma se repite de forma idéntica después de cada reinicio.",
       "interface": "Interfaz",
+      "needsInterface": "Agregue al menos una interfaz a un dispositivo antes de programar comportamientos: las líneas de tiempo apuntan a una interfaz de dispositivo.",
       "phaseName": "Nombre de fase",
       "phaseOffset": "La fase comienza después de (segundos)",
       "removeFault": "Quitar falla",

--- a/internal/i18n/locales/es/settings.json
+++ b/internal/i18n/locales/es/settings.json
@@ -69,7 +69,7 @@
   },
   "about": {
     "applicationTitle": "Aplicación",
-    "subtitle": "Consola de inyección y análisis de red",
+    "subtitle": "Network In A Can",
     "legalTitle": "Legal",
     "copyright": "© {{year}} Mustard Seed Networks. Todos los derechos reservados.",
     "proprietaryNotice": "NIAC es software propietario. Se prohíbe la copia, modificación o distribución no autorizadas.",

--- a/ui/src/components/SettingsDrawer.tsx
+++ b/ui/src/components/SettingsDrawer.tsx
@@ -467,8 +467,8 @@ function AboutSection({ version }: AboutSectionProps): ReactElement {
           <div className="grid grid-cols-2 gap-compact pt-2 border-t border-surface-border">
             <InfoItem label={t('about.version')} value={version} />
             <InfoItem label={t('about.build')} value="Production" />
-            <InfoItem label="React" value="19.2" />
-            <InfoItem label="TypeScript" value="5.9" />
+            <InfoItem label="React" value={__REACT_VERSION__} />
+            <InfoItem label="TypeScript" value={__TYPESCRIPT_VERSION__} />
           </div>
         </div>
       </Section>

--- a/ui/src/components/wizard/DraftBehaviorComposer.tsx
+++ b/ui/src/components/wizard/DraftBehaviorComposer.tsx
@@ -162,6 +162,12 @@ export const DraftBehaviorComposer: FC<DraftBehaviorComposerProps> = ({
           variant="outline"
           leftIcon={<Plus className={iconSizes.md} />}
           disabled={busy || !firstDevice || !firstInterface}
+          // A timeline targets a device interface, so there is nothing to
+          // schedule until one exists. Without this the empty state told the
+          // user to click a permanently disabled button (D4).
+          title={
+            !firstDevice || !firstInterface ? t('newSimWizard.behaviors.needsInterface') : undefined
+          }
           onClick={addTimeline}
         >
           {t('newSimWizard.behaviors.addTimeline')}
@@ -174,6 +180,11 @@ export const DraftBehaviorComposer: FC<DraftBehaviorComposerProps> = ({
           <SmallText className="mt-tight text-text-muted">
             {t('newSimWizard.behaviors.empty')}
           </SmallText>
+          {(!firstDevice || !firstInterface) && (
+            <SmallText className="mt-tight block text-text-muted">
+              {t('newSimWizard.behaviors.needsInterface')}
+            </SmallText>
+          )}
         </div>
       )}
 
@@ -324,7 +335,7 @@ export const DraftBehaviorComposer: FC<DraftBehaviorComposerProps> = ({
         <Button
           tone="violet"
           leftIcon={<Save className={iconSizes.md} />}
-          disabled={busy || !valid}
+          disabled={busy || !valid || timelines.length === 0}
           loading={busy}
           data-testid="save-behaviors"
           onClick={() => void save()}

--- a/ui/src/shim.d.ts
+++ b/ui/src/shim.d.ts
@@ -12,3 +12,10 @@
 declare module "@fontsource-variable/manrope";
 declare module "@fontsource-variable/inter";
 declare module "@fontsource-variable/jetbrains-mono";
+
+/**
+ * Dependency versions injected by vite.config.ts from package.json, so the
+ * Settings > About panel cannot drift from what actually shipped (D17).
+ */
+declare const __REACT_VERSION__: string;
+declare const __TYPESCRIPT_VERSION__: string;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,7 +1,16 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, loadEnv, type PluginOption } from 'vite';
+
+const require = createRequire(import.meta.url);
+// Settings > About used to hard-code these and drifted two TypeScript majors
+// behind reality (D17). Read them from the manifest so they cannot go stale.
+const pkg = require('./package.json') as {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+};
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -9,6 +18,10 @@ export default defineConfig(({ mode }) => {
   const analyze = env.ANALYZE === 'true';
 
   return {
+    define: {
+      __REACT_VERSION__: JSON.stringify(pkg.dependencies.react),
+      __TYPESCRIPT_VERSION__: JSON.stringify(pkg.devDependencies.typescript),
+    },
     plugins: [
       react(),
       // FIX #181: Bundle analysis when ANALYZE=true


### PR DESCRIPTION
## Summary

**D17 — About misreported versions and the product name.** React and TypeScript were string literals:
`"19.2"` and `"5.9"`, against `package.json` pins of `19.2.8` and **`7.0.2`**. Two majors behind on
TypeScript, and it would keep drifting — worse because it sits beside a version row that *is* real build
metadata. `vite.config.ts` now injects both from the manifest at build time; verified in the built
bundle.

About was also the only place expanding NIAC as *"Network Injection & Analysis Console"*, while the help
content, the repo and `es/common.json` all say *"Network In A Can"*. Both locales updated.

**D4 — Behaviors pointed at a dead control.** The empty state said "add a timeline" beside a permanently
disabled **Add timeline** button, with nothing explaining why. A timeline targets a device interface, so
there is nothing to schedule until one exists; the precondition now appears in the empty state and on the
button's title. Confirmed both directions: a `basic-network` draft (0 `interfaces:`) disables it, a
generated Warehouse fleet (57) enables it.

**Save behaviors** was also enabled with zero timelines — `valid` is `timelines.every(...)` and
`[].every()` is `true`, so the primary action offered to save nothing. Now gated on ≥1 timeline.

## Linked Issue

Fixes #1435
Fixes #1436

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Copy, a build-time define, and one disabled-state condition.

## Testing Evidence

```text
$ make build && grep -o "19\.2\.8\|7\.0\.2" internal/api/ui/assets/*.js | sort -u
internal/api/ui/assets/index-CC9ui49K.js:19.2.8
internal/api/ui/assets/index-CC9ui49K.js:7.0.2

$ npx tsc --build --noEmit
(clean)

$ npx vitest run
 Test Files  90 passed (90)
      Tests  450 passed (450)

$ make test          # includes the i18n parity gate for the new key
EXIT=0
```

The new `needsInterface` key was added to both `en` and `es` so the i18n parity gate stays green.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched. The build-time define exposes only dependency version strings already public in
      `package.json`.
- [x] Dependencies are pinned and justified if changed. No dependency changes — this reads the existing pins.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
