### PR TITLE
fix(ui): read the protocols the device API already returns

### DIFF
--- a/ui/src/api/device-config-types.ts
+++ b/ui/src/api/device-config-types.ts
@@ -95,6 +95,13 @@ export interface Device {
   mapToIp?: string;
   interfaces?: string[];
   interfaceDetails?: DeviceInterface[];
+  /**
+   * Protocols this device speaks, as computed by the server. Present on both
+   * the list summary and the detail response. The UI used to re-derive this
+   * from the sub-objects below, which the *summary* response omits — so every
+   * device rendered as "No protocols" (D9). Read this field.
+   */
+  protocols?: string[];
   snmpAgent?: SNMPAgent;
   lldp?: LLDPConfig;
   cdp?: CDPConfig;

--- a/ui/src/components/device-list/deviceFilters.test.ts
+++ b/ui/src/components/device-list/deviceFilters.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Device Library filtering — regression guard for D9.
+ *
+ * `getDeviceProtocols` re-derived the protocol list by probing per-protocol
+ * sub-objects (`snmpAgent`, `lldp`, `cdp`, …). `GET /api/v1/config/devices`
+ * returns a *summary* shape that carries none of them — the union of keys
+ * across all 75 devices in a real response is:
+ *
+ *   hostname · interfaceDetails · interfaces · ips · mac · protocols · type · vlan
+ *
+ * so every predicate was `Boolean(undefined)`, the column read "No protocols"
+ * for every device, the CSV export shipped an empty column, and the protocol
+ * dropdown — built from the protocols found across devices — rendered with a
+ * single option and could never match.
+ *
+ * The server had already done the work: it sends `protocols: [...]`.
+ *
+ * These fixtures deliberately use the **summary** shape. A fixture with
+ * `snmpAgent` populated would pass against the broken code, which is exactly
+ * why this shipped with no test at all.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Device } from '../../api/types';
+import { getDeviceProtocols, matchesProtocolFilter } from './deviceFilters';
+
+/** What the list endpoint actually returns — no protocol sub-objects. */
+const summaryDevice = {
+  hostname: 'LAB-EDGE-R1',
+  type: 'router',
+  mac: '00:00:0c:00:01:01',
+  ips: ['10.254.200.1', '203.0.113.1'],
+  interfaces: ['TenGigabitEthernet0/0/0'],
+  protocols: ['SNMP', 'DHCP', 'DNS', 'LLDP', 'CDP'],
+  vlan: 200,
+} as unknown as Device;
+
+const noProtocols = {
+  hostname: 'BARE-HOST-01',
+  type: 'host',
+  mac: '00:00:0c:00:02:01',
+  ips: ['10.254.200.50'],
+  protocols: [],
+} as unknown as Device;
+
+describe('getDeviceProtocols', () => {
+  it('reads the protocols the list endpoint already provides', () => {
+    expect(getDeviceProtocols(summaryDevice)).toEqual(['SNMP', 'DHCP', 'DNS', 'LLDP', 'CDP']);
+  });
+
+  it('returns an empty list for a device that speaks nothing', () => {
+    expect(getDeviceProtocols(noProtocols)).toEqual([]);
+  });
+
+  it('does not fall over when the field is missing entirely', () => {
+    const legacy = { hostname: 'X', type: 'host', mac: '00:00:00:00:00:01' } as unknown as Device;
+    expect(getDeviceProtocols(legacy)).toEqual([]);
+  });
+});
+
+describe('matchesProtocolFilter', () => {
+  it('matches a device that speaks the selected protocol', () => {
+    expect(matchesProtocolFilter(summaryDevice, 'LLDP')).toBe(true);
+  });
+
+  it('rejects a device that does not', () => {
+    expect(matchesProtocolFilter(summaryDevice, 'FTP')).toBe(false);
+    expect(matchesProtocolFilter(noProtocols, 'SNMP')).toBe(false);
+  });
+
+  it('passes everything through when no protocol is selected', () => {
+    expect(matchesProtocolFilter(noProtocols, 'all')).toBe(true);
+  });
+});

--- a/ui/src/components/device-list/deviceFilters.ts
+++ b/ui/src/components/device-list/deviceFilters.ts
@@ -1,35 +1,21 @@
 import type { Device } from '../../api/types';
 
-export const PROTOCOL_RULES = [
-  { label: 'SNMP', isEnabled: (device: Device) => Boolean(device.snmpAgent) },
-  {
-    label: 'LLDP',
-    isEnabled: (device: Device) => Boolean(device.lldp?.enabled),
-  },
-  { label: 'CDP', isEnabled: (device: Device) => Boolean(device.cdp?.enabled) },
-  { label: 'STP', isEnabled: (device: Device) => Boolean(device.stp?.enabled) },
-  { label: 'DHCP', isEnabled: (device: Device) => Boolean(device.dhcp) },
-  { label: 'DNS', isEnabled: (device: Device) => Boolean(device.dns) },
-  {
-    label: 'HTTP',
-    isEnabled: (device: Device) => Boolean(device.http?.enabled),
-  },
-  { label: 'FTP', isEnabled: (device: Device) => Boolean(device.ftp?.enabled) },
-  {
-    label: 'NetBIOS',
-    isEnabled: (device: Device) => Boolean(device.netbios?.enabled),
-  },
-] as const;
-
-export const getDeviceProtocols = (device: Device): string[] => {
-  const protos: string[] = [];
-  for (const rule of PROTOCOL_RULES) {
-    if (rule.isEnabled(device)) {
-      protos.push(rule.label);
-    }
-  }
-  return protos;
-};
+/**
+ * Protocols a device speaks, as reported by the API.
+ *
+ * This used to re-derive the list by probing per-protocol sub-objects
+ * (`snmpAgent`, `lldp`, …), but `GET /api/v1/config/devices` returns a summary
+ * shape that carries none of them — the union of keys across a real response is
+ * hostname · interfaceDetails · interfaces · ips · mac · protocols · type · vlan.
+ * Every predicate was therefore `Boolean(undefined)`: the column read "No
+ * protocols" for every device, the CSV export shipped an empty column, and the
+ * filter dropdown had a single option and could never match (D9).
+ *
+ * The server already computes this. Order is the server's; it is meaningful and
+ * consistent across devices, so it is not re-sorted here.
+ */
+export const getDeviceProtocols = (device: Device): string[] =>
+  Array.isArray(device.protocols) ? device.protocols : [];
 
 export const matchesSearchQuery = (device: Device, query: string): boolean => {
   const normalized = query.trim().toLowerCase();
@@ -49,6 +35,8 @@ export const matchesProtocolFilter = (device: Device, filter: string): boolean =
   if (filter === 'all') {
     return true;
   }
-  const rule = PROTOCOL_RULES.find((entry) => entry.label === filter);
-  return rule ? rule.isEnabled(device) : false;
+
+  return getDeviceProtocols(device).some(
+    (protocol) => protocol.toUpperCase() === filter.toUpperCase(),
+  );
 };

--- a/ui/src/components/device-list/useDeviceListState.ts
+++ b/ui/src/components/device-list/useDeviceListState.ts
@@ -13,12 +13,7 @@ import { useApiResource } from '../../hooks/useApiResource';
 import { getErrorMessage } from '../../utils/format';
 import { safeGetItem, safeSetItem } from '../../utils/storage';
 import type { StatusMessage } from './DeviceStatusMessage';
-import {
-  getDeviceProtocols,
-  matchesProtocolFilter,
-  matchesSearchQuery,
-  PROTOCOL_RULES,
-} from './deviceFilters';
+import { getDeviceProtocols, matchesProtocolFilter, matchesSearchQuery } from './deviceFilters';
 
 export interface UseDeviceListStateReturn {
   // Data
@@ -124,14 +119,14 @@ export const useDeviceListState = (): UseDeviceListStateReturn => {
     return Array.from(types);
   }, [devices]);
 
-  // Get unique protocols for filter
+  // Protocol filter options, from what the devices actually report. Built by
+  // probing sub-objects the list response does not carry, this always produced
+  // an empty dropdown (D9).
   const protocols = useMemo(() => {
     const protos = new Set<string>();
-    for (const d of devices) {
-      for (const rule of PROTOCOL_RULES) {
-        if (rule.isEnabled(d)) {
-          protos.add(rule.label);
-        }
+    for (const device of devices) {
+      for (const protocol of getDeviceProtocols(device)) {
+        protos.add(protocol);
       }
     }
     return Array.from(protos).sort();


### PR DESCRIPTION
## Summary

`getDeviceProtocols` re-derived the protocol list by probing per-protocol sub-objects (`snmpAgent`,
`lldp`, `cdp`, `stp`, `dhcp`, `dns`, `http`, `ftp`, `netbios`). `GET /api/v1/config/devices` returns a
**summary** shape that carries none of them — the union of keys across all 75 devices in a real response
is `hostname · interfaceDetails · interfaces · ips · mac · protocols · type · vlan`. `handleDeviceList`
only includes the sub-objects when `?details=true`, which `fetchConfigDevices` never sends.

So every predicate was `Boolean(undefined)`:

- the Protocols column read **"No protocols"** for all 75 devices, in both table and card view
- the CSV export shipped an empty `protocols` column
- the filter dropdown — built from the protocols found across devices — rendered with **one** option and
  could never match

Segments, which reads the field directly, showed the protocols correctly all along.

The server already computes this and sends `protocols: [...]`. Read it. The `Device` type now declares
the field so the compiler knows it exists. Order is the server's — meaningful and consistent across
devices — so it is not re-sorted.

## Linked Issue

Fixes #1424

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Net removal: nine predicates and a rules table replaced by reading one field.

## Testing Evidence

**No test existed for this module at all.** The fixtures deliberately use the summary shape — one with
`snmpAgent` populated would pass against the broken code, which is exactly how this shipped.

```text
$ npx vitest run src/components/device-list/deviceFilters.test.ts   # BEFORE
  × reads the protocols the list endpoint already provides
  × matches a device that speaks the selected protocol
AssertionError: expected [] to deeply equal [ 'SNMP', 'DHCP', 'DNS', 'LLDP', 'CDP' ]
AssertionError: expected false to be true
      Tests  2 failed | 4 passed (6)

$ npx vitest run                                                     # AFTER
 Test Files  91 passed (91)
      Tests  456 passed (456)

$ npx tsc --build --noEmit
(clean)

$ make test
EXIT=0
```

Post-merge on CT304: confirm the column populates, the dropdown offers real protocols and filters, and
the CSV export carries them.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched — read path only.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
