### PR TITLE
fix(api): group the segments view by per-device VLAN

### DIFF
--- a/internal/api/handlers_segments.go
+++ b/internal/api/handlers_segments.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/MustardSeedNetworks/niac-go/internal/config"
 )
@@ -15,12 +16,7 @@ type segmentResponse struct {
 	Devices  []map[string]any `json:"devices"`
 }
 
-// handleSegments enumerates the multi-VLAN segments the current config
-// describes, grouping devices by VLAN tag. It reads config, not the stack: the
-// runtime segmentTables demux is unexported and Stack.AllDevices() flattens the
-// grouping away, so config.NormalizedSegments() is the only accurate,
-// already-grouped, cross-package source. A config with no `segments:` still
-// reports one untagged segment, so the wire shape is uniform.
+// handleSegments enumerates the VLAN segments the current config describes.
 // Route: GET /api/v1/segments.
 func (s *Server) handleSegments(w http.ResponseWriter, _ *http.Request) {
 	cfg := s.currentConfig()
@@ -32,10 +28,63 @@ func (s *Server) handleSegments(w http.ResponseWriter, _ *http.Request) {
 	s.writeJSON(w, buildSegmentResponses(cfg))
 }
 
-// buildSegmentResponses projects a config's normalized segments. Shared with
-// the session-scoped segments endpoint so both render segments identically.
+// buildSegmentResponses groups the config's devices by VLAN for display.
+//
+// An explicit `segments:` block is authoritative — that is the engine's own
+// multi-VLAN binding (ADR 0008) and NormalizedSegments() is the right source
+// for it. None of the shipped scenario packs use one, though: they carry VLAN
+// membership per device instead. Falling straight through to
+// NormalizedSegments() therefore took its "bare devices = one untagged segment"
+// compatibility branch 100% of the time, and a config the daemon knows is split
+// {200:40, 210:7, 240:6, None:3} rendered as a single "Untagged" bucket (D12).
+//
+// Deliberately NOT fixed by changing NormalizedSegments(): that drives
+// Stack.initializeSegments, which builds a VLAN-tagged DeviceTable per segment.
+// Re-grouping there would change which frames are emitted tagged — a traffic
+// change, not a display fix. This groups for the view only; the engine's
+// segment model is untouched.
+//
+// Tag 0 (config.UntaggedTag) stays a real bucket for genuinely untagged
+// devices rather than a catch-all, so a mixed config reports both.
 func buildSegmentResponses(cfg *config.Config) []segmentResponse {
-	segments := cfg.NormalizedSegments()
+	if len(cfg.Segments) > 0 {
+		return segmentResponsesFrom(cfg.NormalizedSegments())
+	}
+
+	return segmentResponsesFrom(segmentsByDeviceVLAN(cfg.Devices))
+}
+
+// segmentsByDeviceVLAN groups a flat device list by each device's VLAN
+// membership, ordered untagged-first then ascending by tag so the view is
+// stable across requests.
+func segmentsByDeviceVLAN(devices []config.Device) []config.Segment {
+	if len(devices) == 0 {
+		return nil
+	}
+
+	byTag := make(map[int][]config.Device)
+	for i := range devices {
+		tag := devices[i].VLAN
+		byTag[tag] = append(byTag[tag], devices[i])
+	}
+
+	tags := make([]int, 0, len(byTag))
+	for tag := range byTag {
+		tags = append(tags, tag)
+	}
+	slices.Sort(tags)
+
+	segments := make([]config.Segment, 0, len(tags))
+	for _, tag := range tags {
+		segments = append(segments, config.Segment{Tag: tag, Devices: byTag[tag]})
+	}
+
+	return segments
+}
+
+// segmentResponsesFrom projects segments onto the wire shape. Shared with the
+// session-scoped segments endpoint so both render identically.
+func segmentResponsesFrom(segments []config.Segment) []segmentResponse {
 	out := make([]segmentResponse, 0, len(segments))
 	for i := range segments {
 		seg := &segments[i]

--- a/internal/api/handlers_segments_test.go
+++ b/internal/api/handlers_segments_test.go
@@ -78,6 +78,68 @@ func TestHandleSegmentsFlatConfigIsUntagged(t *testing.T) {
 	}
 }
 
+// TestHandleSegmentsGroupsFlatConfigByDeviceVLAN guards D12.
+//
+// None of the shipped scenario packs use an explicit `segments:` block; they
+// carry VLAN membership per device. The handler used to fall straight through
+// to NormalizedSegments(), whose "bare devices = one untagged segment"
+// compatibility branch was therefore taken 100% of the time — a config the
+// daemon reports as {200:40, 210:7, 240:6, None:3} rendered as a single
+// "Untagged" bucket on a page whose entire purpose is per-VLAN grouping.
+//
+// Tag 0 stays a real bucket for genuinely untagged devices, so a mixed config
+// reports both rather than one swallowing the other.
+func TestHandleSegmentsGroupsFlatConfigByDeviceVLAN(t *testing.T) {
+	server, _ := newTestServer(t)
+	server.cfg.Config = &config.Config{
+		Devices: []config.Device{
+			{Name: "mgmt-1", Type: "switch", VLAN: 200},
+			{Name: "mgmt-2", Type: "switch", VLAN: 200},
+			{Name: "data-1", Type: "host", VLAN: 210},
+			{Name: "native-1", Type: "router"}, // genuinely untagged
+		},
+	}
+
+	segs := decodeSegments(t, server)
+	if len(segs) != 3 {
+		t.Fatalf("segments = %d, want 3 (untagged, 200, 210): %+v", len(segs), segs)
+	}
+
+	// Untagged first, then ascending by tag, so the view is stable.
+	if segs[0].VLANTag != config.UntaggedTag || !segs[0].Untagged {
+		t.Errorf("segs[0] = %+v, want the untagged bucket", segs[0])
+	}
+	if len(segs[0].Devices) != 1 {
+		t.Errorf("untagged devices = %d, want 1", len(segs[0].Devices))
+	}
+	if segs[1].VLANTag != 200 || len(segs[1].Devices) != 2 {
+		t.Errorf("segs[1] = tag %d with %d devices, want tag 200 with 2", segs[1].VLANTag, len(segs[1].Devices))
+	}
+	if segs[2].VLANTag != 210 || len(segs[2].Devices) != 1 {
+		t.Errorf("segs[2] = tag %d with %d devices, want tag 210 with 1", segs[2].VLANTag, len(segs[2].Devices))
+	}
+	if segs[1].Untagged || segs[2].Untagged {
+		t.Error("tagged segments must not be marked untagged")
+	}
+}
+
+// TestHandleSegmentsExplicitBlockWins keeps the engine's own binding
+// authoritative: a config that declares `segments:` is grouped by that, not
+// re-derived from per-device VLAN.
+func TestHandleSegmentsExplicitBlockWins(t *testing.T) {
+	server, _ := newTestServer(t)
+	server.cfg.Config = &config.Config{
+		Segments: []config.Segment{
+			{Tag: 300, Devices: []config.Device{{Name: "a", Type: "router", VLAN: 999}}},
+		},
+	}
+
+	segs := decodeSegments(t, server)
+	if len(segs) != 1 || segs[0].VLANTag != 300 {
+		t.Fatalf("segments = %+v, want a single tag-300 segment from the explicit block", segs)
+	}
+}
+
 func TestHandleSegmentsNilConfig(t *testing.T) {
 	server, _ := newTestServer(t)
 	server.cfg.Config = nil


### PR DESCRIPTION
## Summary

None of the shipped scenario packs use an explicit `segments:` block — they carry VLAN membership per
device. `handleSegments` fell straight through to `NormalizedSegments()`, so its *"bare devices = one
untagged segment"* compatibility branch was taken **100% of the time**: a config the daemon reports as
`{200:40, 210:7, 240:6, None:3}` rendered as a single "Untagged" bucket, on a page whose entire purpose
is per-VLAN grouping.

### Why not fix `NormalizedSegments()`

That was the plan's first instinct, and reading the callers ruled it out. `NormalizedSegments()` also
drives `Stack.initializeSegments`, which builds a **VLAN-tagged `DeviceTable` per segment** and registers
devices into it. Re-grouping there would change which frames are emitted tagged — a traffic change, not a
display fix, and it would alter what the demo packs put on the wire.

The grouping now happens in the view layer; the engine's segment model is untouched. An explicit
`segments:` block still wins, because that is the engine's own binding (ADR 0008) and authoritative when
present.

Per the owner's rule — *"multiple scenarios each on their own tag, or an untagged scenario, or tagged as
well — either should work"* — tag 0 stays a **real** bucket for genuinely untagged devices rather than a
catch-all, so a mixed config reports both. Ordering is untagged-first then ascending, so the view is
stable across requests.

## Linked Issue

Fixes #1425

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Scoped to the segments read path. The engine's segment handling — and therefore emitted traffic — is
byte-for-byte unchanged, which was the whole point of fixing it here.

## Testing Evidence

```text
$ go test ./internal/api/ -run TestHandleSegments        # BEFORE
--- FAIL: TestHandleSegmentsGroupsFlatConfigByDeviceVLAN
    segments = 1, want 3 (untagged, 200, 210):
    [{VLANTag:0 Untagged:true Devices:[mgmt-1 mgmt-2 data-1 native-1]}]

$ go test ./internal/api/ -run TestHandleSegments        # AFTER
ok  github.com/MustardSeedNetworks/niac-go/internal/api  0.745s

$ go test ./internal/config/ -run TestNormalizedSegments
ok  github.com/MustardSeedNetworks/niac-go/internal/config  0.241s

$ golangci-lint run internal/api/...
0 issues.

$ make test
EXIT=0
```

**Both pre-existing tests pass unchanged** — `TestNormalizedSegmentsBackwardCompat` and
`TestHandleSegmentsFlatConfigIsUntagged`. The plan predicted these would need rewriting; fixing the view
layer instead of the engine made that unnecessary, and they remain correct assertions about their own
layers.

Post-merge on CT304: confirm the Segments page shows per-VLAN groups for a shipped pack.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched — read path only, same response shape.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc.
