### PR TITLE
feat(daemon): let a native (untagged) session run alongside tagged ones

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -671,9 +671,19 @@ func (d *Daemon) startResourcesForRequest(
 	dryRun bool,
 	replacing bool,
 ) (simulationResources, error) {
+	// A trunk port carries a native VLAN, so NIAC models one for its own
+	// attachment too (D19). An access-mode session receives untagged frames, so
+	// it joins the shared trunk capture in the native slot (key 0) rather than
+	// opening a competing handle on the same interface. Direct mode is
+	// unisolated ownership of the whole interface and keeps its own capture.
 	if req.AttachmentMode == fabric.ModeTrunk {
 		return d.startTrunkSimulationResources(
 			req.Interface, req.AccessVLAN, cfg, compiled, dryRun, replacing,
+		)
+	}
+	if req.AttachmentMode == fabric.ModeAccess && !dryRun && d.trunks[req.Interface] != nil {
+		return d.startTrunkSimulationResources(
+			req.Interface, nativeVLANKey, cfg, compiled, dryRun, replacing,
 		)
 	}
 	return d.startSimulation(req.Interface, cfg, compiled, dryRun)

--- a/internal/daemon/native_session_test.go
+++ b/internal/daemon/native_session_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+)
+
+// D19: a real trunk port carries a native VLAN — untagged frames alongside
+// tagged ones. NIAC refused it: validateReplacement required *both* sessions to
+// be ModeTrunk, so an access/direct session and any other session on the same
+// interface was rejected outright. You could have N tagged scenarios, or one
+// untagged scenario, never both.
+//
+// fabric.Binding models only Mode + AccessVLAN, even though NIAC already models
+// a native VLAN for the devices it simulates (config.TrunkPort.NativeVLAN).
+// Untagged frames arriving on the trunk were counted and discarded
+// (trunkDrops.recordUntagged); the sweep saw drops.untagged = 67 on CT304.
+//
+// Owner-approved shape: demux key 0 is the native session — consistent with
+// config.UntaggedTag = 0 — at most one per interface, coexisting with N tagged.
+
+func nativeBinding() fabric.Binding {
+	return fabric.Binding{Interface: "eth0", Mode: fabric.ModeAccess}
+}
+
+func TestNativeSessionCoexistsWithTaggedSessions(t *testing.T) {
+	registry := newSessionRegistry()
+	registry.replace("tagged-200", &Simulation{Binding: trunkBinding(200)})
+	registry.replace("tagged-201", &Simulation{Binding: trunkBinding(201)})
+
+	if err := registry.validateReplacement("native", nativeBinding()); err != nil {
+		t.Fatalf("native session alongside tagged sessions = %v, want accepted", err)
+	}
+}
+
+func TestTaggedSessionCoexistsWithNativeSession(t *testing.T) {
+	registry := newSessionRegistry()
+	registry.replace("native", &Simulation{Binding: nativeBinding()})
+
+	if err := registry.validateReplacement("tagged-200", trunkBinding(200)); err != nil {
+		t.Fatalf("tagged session alongside a native session = %v, want accepted", err)
+	}
+}
+
+func TestSecondNativeSessionIsRejected(t *testing.T) {
+	registry := newSessionRegistry()
+	registry.replace("native", &Simulation{Binding: nativeBinding()})
+
+	err := registry.validateReplacement("native-2", nativeBinding())
+	if !errors.Is(err, ErrInterfaceInUse) {
+		t.Fatalf("second native session = %v, want ErrInterfaceInUse — a port has one native VLAN", err)
+	}
+}
+
+func TestDuplicateTaggedVLANStillRejected(t *testing.T) {
+	registry := newSessionRegistry()
+	registry.replace("tagged-200", &Simulation{Binding: trunkBinding(200)})
+
+	err := registry.validateReplacement("other", trunkBinding(200))
+	if !errors.Is(err, ErrPhysicalVLANInUse) {
+		t.Fatalf("duplicate VLAN = %v, want ErrPhysicalVLANInUse", err)
+	}
+}
+
+func TestReplacingTheSameSessionIsAllowed(t *testing.T) {
+	registry := newSessionRegistry()
+	registry.replace("native", &Simulation{Binding: nativeBinding()})
+
+	if err := registry.validateReplacement("native", nativeBinding()); err != nil {
+		t.Fatalf("restarting the same native session = %v, want accepted", err)
+	}
+}
+
+// TestUntaggedFramesReachTheNativeSession is the other half: the registry may
+// accept a native session, but the capture demux keyed only on a VLAN tag and
+// discarded untagged frames outright, so the session would receive nothing.
+func TestUntaggedFramesReachTheNativeSession(t *testing.T) {
+	capture := newTrunkCapture(&fakeTrunkPhysical{})
+
+	transport, err := capture.register(nativeVLANKey)
+	if err != nil {
+		t.Fatalf("register native session: %v", err)
+	}
+
+	// A plain untagged Ethernet frame: dst, src, ethertype, payload.
+	frame := []byte{
+		0x01, 0x80, 0xc2, 0x00, 0x00, 0x00,
+		0xd4, 0xc1, 0x9e, 0x23, 0x58, 0x5e,
+		0x08, 0x00,
+		0xde, 0xad, 0xbe, 0xef,
+	}
+
+	if !capture.dispatchFrame(frame) {
+		t.Fatal("untagged frame was dropped; the native session should have received it")
+	}
+
+	select {
+	case got := <-transport.rx:
+		if len(got) != len(frame) {
+			t.Errorf("delivered %d bytes, want %d", len(got), len(frame))
+		}
+	default:
+		t.Error("native session queue is empty")
+	}
+}
+
+// With no native session registered, untagged frames must still be dropped and
+// counted rather than delivered somewhere arbitrary.
+func TestUntaggedFramesStillDropWithoutANativeSession(t *testing.T) {
+	capture := newTrunkCapture(&fakeTrunkPhysical{})
+
+	frame := []byte{
+		0x01, 0x80, 0xc2, 0x00, 0x00, 0x00,
+		0xd4, 0xc1, 0x9e, 0x23, 0x58, 0x5e,
+		0x08, 0x00,
+	}
+
+	if capture.dispatchFrame(frame) {
+		t.Error("untagged frame was delivered with no native session registered")
+	}
+}

--- a/internal/daemon/session_registry.go
+++ b/internal/daemon/session_registry.go
@@ -30,12 +30,31 @@ func (r *sessionRegistry) validateReplacement(sessionID string, binding fabric.B
 	if sessionID == "" {
 		return ErrSessionIDRequired
 	}
+	// One interface carries N tagged (trunk) sessions plus at most one native
+	// session, exactly like a trunk port with a native VLAN. This used to
+	// require *both* sessions to be trunk, so a native scenario and a tagged one
+	// could never run together (D19).
+	//
+	// ModeAccess is the native case: an access port delivers frames untagged, so
+	// the session takes the demux's native slot. ModeDirect is not — it means
+	// unisolated ownership of the whole interface, so it still excludes
+	// everything else.
 	for id, active := range r.sessions {
 		if id == sessionID || active.Binding.Interface != binding.Interface {
 			continue
 		}
-		if active.Binding.Mode != fabric.ModeTrunk || binding.Mode != fabric.ModeTrunk {
+		if active.Binding.Mode == fabric.ModeDirect || binding.Mode == fabric.ModeDirect {
 			return fmt.Errorf("%w: %s", ErrInterfaceInUse, binding.Interface)
+		}
+		activeNative := active.Binding.Mode == fabric.ModeAccess
+		incomingNative := binding.Mode == fabric.ModeAccess
+
+		if activeNative && incomingNative {
+			return fmt.Errorf("%w: %s", ErrInterfaceInUse, binding.Interface)
+		}
+		if activeNative != incomingNative {
+			// One native, one tagged — different demux slots, no conflict.
+			continue
 		}
 		if active.Binding.AccessVLAN == binding.AccessVLAN {
 			return fmt.Errorf(

--- a/internal/daemon/trunk_capture.go
+++ b/internal/daemon/trunk_capture.go
@@ -42,6 +42,14 @@ var (
 	ErrTrunkCaptureFailed = errors.New("shared trunk capture has stopped")
 )
 
+// nativeVLANKey is the demux slot for the native (untagged) session.
+//
+// A real trunk port carries a native VLAN alongside its tagged ones, so NIAC
+// reserves key 0 for it — matching config.UntaggedTag, which already means
+// "the native VLAN" everywhere else. Valid 802.1Q tags are 1..4094, so 0 can
+// never collide with a tagged session (D19).
+const nativeVLANKey uint16 = 0
+
 type trunkPhysicalCapture interface {
 	StartCaptureContext(context.Context, func(gopacket.Packet)) error
 	SendPacket([]byte) error
@@ -152,16 +160,22 @@ func (c *trunkCapture) run(ctx context.Context) error {
 }
 
 func (c *trunkCapture) dispatchFrame(frame []byte) bool {
-	vlan, ok := frameVLAN(frame)
-	if !ok {
-		c.drops.recordUntagged()
-		return false
+	vlan, tagged := frameVLAN(frame)
+	if !tagged {
+		// Untagged frames belong to the native session, exactly as a trunk
+		// port's native VLAN works. Without one registered they are still
+		// dropped and counted rather than delivered somewhere arbitrary (D19).
+		vlan = nativeVLANKey
 	}
 	c.mu.RLock()
 	transport := c.sessions[vlan]
 	if transport == nil {
 		c.mu.RUnlock()
-		c.drops.recordUnapproved(vlan)
+		if !tagged {
+			c.drops.recordUntagged()
+		} else {
+			c.drops.recordUnapproved(vlan)
+		}
 		return false
 	}
 	select {
@@ -290,10 +304,20 @@ func (t *trunkSessionTransport) SendPacket(frame []byte) error {
 	if t.parent.failed.Load() {
 		return fmt.Errorf("%w on the interface serving VLAN %d", ErrTrunkCaptureFailed, t.vlan)
 	}
-	vlan, ok := frameVLAN(frame)
-	if !ok || vlan != t.vlan {
+	vlan, tagged := frameVLAN(frame)
+	if t.vlan == nativeVLANKey {
+		// The native session is the trunk's untagged VLAN: it must emit
+		// untagged frames, and must not smuggle a tag onto the wire (D19).
+		if tagged {
+			return fmt.Errorf("%w: the native session must send untagged", ErrTrunkEgressVLAN)
+		}
+
+		return t.parent.physical.SendPacket(frame)
+	}
+	if !tagged || vlan != t.vlan {
 		return fmt.Errorf("%w: expected VLAN %d", ErrTrunkEgressVLAN, t.vlan)
 	}
+
 	return t.parent.physical.SendPacket(frame)
 }
 


### PR DESCRIPTION
## Summary

A real trunk port carries a **native VLAN** — untagged frames alongside tagged ones. NIAC refused it.

`validateReplacement` required *both* sessions to be `ModeTrunk`, so any access or direct session
excluded every other session on the interface: you could have N tagged scenarios, **or** one untagged,
never both. Untagged frames arriving on the trunk were counted and discarded by `recordUntagged()` —
CT304 showed `drops.untagged = 67`.

NIAC already models a native VLAN for the devices it *simulates* (`config.TrunkPort.NativeVLAN`,
validated in the config validator). It now models one for its own attachment.

### Shape (owner-approved)

- **Demux key 0 is the native slot**, matching `config.UntaggedTag`, which already means "the native
  VLAN" everywhere else. Valid 802.1Q tags are 1..4094, so 0 cannot collide with a tagged session.
- Untagged frames route there when a native session is registered, and are **still dropped and counted**
  when none is — not delivered somewhere arbitrary.
- On egress the native session must send untagged and cannot smuggle a tag onto the wire.
- Still enforced: at most one native session per interface, one session per tagged VLAN.

### access ≠ direct

These are deliberately not treated the same. An **access** port delivers frames untagged, so an
access-mode session is the native case and joins the shared trunk capture. **Direct** means *unisolated
ownership of the whole interface*, so it still excludes everything else and keeps its own capture handle.
`TestSessionRegistryRejectsMixedOwnershipOnOneInterface` asserts exactly that and **passes unchanged** —
it caught this distinction when I had initially flattened the two.

## Linked Issue

Fixes #1426

## Type of Change

- [ ] Defect fix
- [x] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

Filed as a defect (#1426) because the owner's expectation is that this already works the way real
networking does; it is a capability change in the code.

## Risk

- [ ] Low
- [x] Medium
- [ ] High

Touches the session registry, the capture demux and the egress path — the wire behaviour of running
sessions. Mitigated by: tagged-session paths untouched (the `t.vlan != nativeVLANKey` branch is the
original code), direct mode unchanged, and untagged frames still dropped when no native session exists.
The whole daemon suite passes, including every pre-existing registry and trunk-capture test.

## Testing Evidence

The guard covers **both halves** — the registry accepting the combination, and the demux actually
delivering. That second half matters: the registry could say yes while the session received nothing.

```text
$ go test ./internal/daemon/ -run 'Native|Untagged|DuplicateTagged'   # BEFORE
internal/daemon/native_session_test.go:82:37: undefined: nativeVLANKey
FAIL  [build failed]      # there was no native slot to deliver to

$ go test ./internal/daemon/ -run 'Native|Untagged|DuplicateTagged'   # AFTER
ok  github.com/MustardSeedNetworks/niac-go/internal/daemon  0.884s

$ go test ./internal/daemon/          # whole package, incl. pre-existing tests
ok  github.com/MustardSeedNetworks/niac-go/internal/daemon  12.782s

$ golangci-lint run internal/daemon/...
0 issues.

$ make test
EXIT=0
```

Post-merge on CT304, the acceptance test from the issue: a native scenario plus ≥2 tagged scenarios
running together, each receiving its own traffic.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      No route changes. The attachment-policy gate is unchanged — a native session still needs an
      operator-approved policy for its interface and mode, so this widens concurrency, not authorisation.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc; the native-slot rationale is documented at the constant and both call sites.
