### PR TITLE
fix(sse): decode tagged L2 control frames instead of reporting Unknown

### DIFF
--- a/internal/api/sse/packet_decode_test.go
+++ b/internal/api/sse/packet_decode_test.go
@@ -1,0 +1,95 @@
+package sse
+
+import "testing"
+
+// A real 802.1Q-tagged RSTP BPDU captured from NIAC's own trunk on CT304.
+// This is the exact frame shape the Packets page reported as
+// "Unknown  Unknown->Unknown" while rendering its bytes correctly (D16).
+//
+//	01 80 c2 00 00 00  dst — IEEE 802.1D bridge group
+//	d4 c1 9e 23 58 5e  src
+//	81 00 01 2b        802.1Q tag, VLAN 0x12b = 299
+//	00 27              LLC length 39 (not an EtherType)
+//	42 42 03           LLC DSAP/SSAP 0x42, control 0x03 → STP
+func taggedBPDU() []byte {
+	return []byte{
+		0x01, 0x80, 0xc2, 0x00, 0x00, 0x00,
+		0xd4, 0xc1, 0x9e, 0x23, 0x58, 0x5e,
+		0x81, 0x00, 0x01, 0x2b,
+		0x00, 0x27,
+		0x42, 0x42, 0x03,
+		0x00, 0x00, 0x02, 0x02, 0x7e,
+		0x00, 0x00, 0xd4, 0xc1, 0x9e, 0x23, 0x58, 0x43,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0xd4, 0xc1, 0x9e, 0x23, 0x58, 0x43,
+		0x80, 0x81, 0x00, 0x00, 0x14, 0x00, 0x02, 0x00, 0x0f, 0x00,
+	}
+}
+
+func TestEnrichWithLayersDecodesTaggedBPDU(t *testing.T) {
+	out := map[string]any{"protocol": "Unknown", "summary": ""}
+	enrichWithLayers(out, taggedBPDU())
+
+	if got := out["protocol"]; got != "STP" {
+		t.Errorf("protocol = %v, want STP — a tagged BPDU is not Unknown", got)
+	}
+	if got := out["vlan_tag"]; got != uint16(299) {
+		t.Errorf("vlan_tag = %v, want 299", got)
+	}
+	if got := out["src_mac"]; got != "d4:c1:9e:23:58:5e" {
+		t.Errorf("src_mac = %v, want d4:c1:9e:23:58:5e", got)
+	}
+	if got := out["dst_mac"]; got != "01:80:c2:00:00:00" {
+		t.Errorf("dst_mac = %v, want 01:80:c2:00:00:00", got)
+	}
+}
+
+// The UI builds its layer tree from a nested `headers` map. Emitting only flat
+// keys meant it never found an ethernet layer and printed "(not parsed)" for
+// the MACs of every packet.
+func TestEnrichWithLayersEmitsNestedHeaders(t *testing.T) {
+	out := map[string]any{"protocol": "Unknown", "summary": ""}
+	enrichWithLayers(out, taggedBPDU())
+
+	headers, ok := out["headers"].(map[string]any)
+	if !ok {
+		t.Fatal("no headers map emitted; the UI reads headers.ethernet")
+	}
+	eth, ok := headers["ethernet"].(map[string]any)
+	if !ok {
+		t.Fatal("headers.ethernet missing")
+	}
+	if eth["srcMac"] != "d4:c1:9e:23:58:5e" {
+		t.Errorf("headers.ethernet.srcMac = %v", eth["srcMac"])
+	}
+	if _, hasIP := headers["ipv4"]; hasIP {
+		t.Error("an STP BPDU must not report an IPv4 layer")
+	}
+}
+
+// An IP packet must still classify as before — the L2 pass runs last and only
+// fills a protocol still marked Unknown.
+func TestEnrichWithLayersStillClassifiesIPv4(t *testing.T) {
+	frame := []byte{
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+		0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+		0x08, 0x00,
+		0x45, 0x00, 0x00, 0x1c, 0x00, 0x01, 0x00, 0x00, 0x40, 0x01, 0x00, 0x00,
+		0x0a, 0x00, 0x00, 0x01,
+		0x0a, 0x00, 0x00, 0x02,
+		0x08, 0x00, 0xf7, 0xff, 0x00, 0x01, 0x00, 0x01,
+	}
+	out := map[string]any{"protocol": "Unknown", "summary": ""}
+	enrichWithLayers(out, frame)
+
+	if got := out["protocol"]; got != "ICMP" {
+		t.Errorf("protocol = %v, want ICMP", got)
+	}
+	if got := out["source_ip"]; got != "10.0.0.1" {
+		t.Errorf("source_ip = %v, want 10.0.0.1", got)
+	}
+	headers, _ := out["headers"].(map[string]any)
+	if _, hasIP := headers["ipv4"]; !hasIP {
+		t.Error("headers.ipv4 missing for an IPv4 packet")
+	}
+}

--- a/internal/api/sse/packet_observer.go
+++ b/internal/api/sse/packet_observer.go
@@ -39,6 +39,16 @@ const maxRawPacketBytes = 256
 // ipv4Len is the byte length of an IPv4 protocol address.
 const ipv4Len = 4
 
+// dot1qLLCMinPayload is a length field plus a minimal LLC header.
+const dot1qLLCMinPayload = 5
+
+// minEtherType is the first value that is an EtherType rather than a length.
+const minEtherType = 0x0600
+
+// headerLayerHint pre-sizes the per-packet headers map: ethernet, dot1q and one
+// network layer covers almost every frame NIAC sees.
+const headerLayerHint = 4
+
 // NewPacketObserver returns a protocols.PacketObserver that forwards each
 // observed packet onto the hub's packets stream. Used to wire the SSE bridge
 // into a protocol stack from the api layer without exposing hub internals.
@@ -145,24 +155,104 @@ func enrichWithLayers(out map[string]any, buf []byte) {
 	}
 	packet := gopacket.NewPacket(buf, layers.LayerTypeEthernet, gopacket.NoCopy)
 
+	// The Packet Inspector builds its layer tree from a nested `headers` map.
+	// Emitting only flat keys meant it never found an ethernet layer and showed
+	// "(not parsed)" for the MACs of every packet, not just the odd ones (D16).
+	headers := make(map[string]any, headerLayerHint)
+
 	if ethLayer := packet.Layer(layers.LayerTypeEthernet); ethLayer != nil {
 		if eth, ok := ethLayer.(*layers.Ethernet); ok {
 			out["src_mac"] = eth.SrcMAC.String()
 			out["dst_mac"] = eth.DstMAC.String()
+			headers["ethernet"] = map[string]any{
+				"srcMac":    eth.SrcMAC.String(),
+				"dstMac":    eth.DstMAC.String(),
+				"etherType": eth.EthernetType.String(),
+			}
 		}
 	}
 
-	enrichNetworkLayer(out, packet)
+	enrichVLAN(out, headers, packet)
+	enrichNetworkLayer(out, headers, packet)
 	enrichTransportLayer(out, packet)
+	enrichLinkLayer(out, packet)
+
+	if len(headers) > 0 {
+		out["headers"] = headers
+	}
+}
+
+// enrichVLAN records an 802.1Q tag when the frame carries one.
+func enrichVLAN(out map[string]any, headers map[string]any, packet gopacket.Packet) {
+	l := packet.Layer(layers.LayerTypeDot1Q)
+	if l == nil {
+		return
+	}
+	dot1q, ok := l.(*layers.Dot1Q)
+	if !ok {
+		return
+	}
+	out["vlan_tag"] = dot1q.VLANIdentifier
+	headers["dot1q"] = map[string]any{
+		"vlanId":   dot1q.VLANIdentifier,
+		"priority": dot1q.Priority,
+	}
+}
+
+// enrichLinkLayer names the L2 control protocols NIAC itself emits.
+//
+// Nothing here was decoded before: enrichNetworkLayer and
+// enrichTransportLayer only ever tested IPv4/IPv6/ARP and TCP/UDP/ICMP, so a
+// tagged STP BPDU — exactly what NIAC puts on a trunk — fell through every
+// branch and kept the "Unknown" default. gopacket's chain for one of these is
+// Ethernet → Dot1Q → LLC → STP, and none of those four layer types was ever
+// queried (D16).
+//
+// Runs last and only fills a protocol still marked Unknown, so it can never
+// override a real L3/L4 classification.
+func enrichLinkLayer(out map[string]any, packet gopacket.Packet) {
+	if out["protocol"] != "Unknown" {
+		return
+	}
+	// gopacket cannot chain past Dot1Q into LLC: Dot1Q.NextLayerType() hands its
+	// inner value to EthernetType.LayerType(), and unlike the Ethernet decoder
+	// that mapping has no "< 0x0600 means a length, so this is LLC" branch. A
+	// tagged LLC frame therefore decodes as Dot1Q → Payload and every layer
+	// lookup below misses. Re-decode the tag's payload as LLC by hand.
+	if inner := taggedLLCProtocol(packet); inner != "" {
+		out["protocol"] = inner
+		if inner == "STP" {
+			out["summary"] = "Spanning Tree BPDU"
+		}
+
+		return
+	}
+
+	switch {
+	case packet.Layer(layers.LayerTypeSTP) != nil:
+		out["protocol"] = "STP"
+		out["summary"] = "Spanning Tree BPDU"
+	case packet.Layer(layers.LayerTypeCiscoDiscovery) != nil:
+		out["protocol"] = "CDP"
+	case packet.Layer(layers.LayerTypeLinkLayerDiscovery) != nil:
+		out["protocol"] = "LLDP"
+	case packet.Layer(layers.LayerTypeSNAP) != nil:
+		out["protocol"] = "SNAP"
+	case packet.Layer(layers.LayerTypeLLC) != nil:
+		out["protocol"] = "LLC"
+	}
 }
 
 // enrichNetworkLayer sets source/dest IP and the L3 protocol label.
-func enrichNetworkLayer(out map[string]any, packet gopacket.Packet) {
+func enrichNetworkLayer(out map[string]any, headers map[string]any, packet gopacket.Packet) {
 	if l := packet.Layer(layers.LayerTypeIPv4); l != nil {
 		if ip, ok := l.(*layers.IPv4); ok {
 			out["source_ip"] = ip.SrcIP.String()
 			out["dest_ip"] = ip.DstIP.String()
 			out["protocol"] = "IPv4"
+			headers["ipv4"] = map[string]any{
+				"src": ip.SrcIP.String(), "dst": ip.DstIP.String(), "ttl": ip.TTL,
+			}
 		}
 		return
 	}
@@ -171,6 +261,9 @@ func enrichNetworkLayer(out map[string]any, packet gopacket.Packet) {
 			out["source_ip"] = ip.SrcIP.String()
 			out["dest_ip"] = ip.DstIP.String()
 			out["protocol"] = "IPv6"
+			headers["ipv6"] = map[string]any{
+				"src": ip.SrcIP.String(), "dst": ip.DstIP.String(),
+			}
 		}
 		return
 	}
@@ -222,6 +315,47 @@ func enrichTransportLayer(out map[string]any, packet gopacket.Packet) {
 	if packet.Layer(layers.LayerTypeICMPv6) != nil {
 		out["protocol"] = "ICMPv6"
 	}
+}
+
+// taggedLLCProtocol names the control protocol inside an 802.1Q tag, or "" if
+// the frame is not tagged LLC.
+func taggedLLCProtocol(packet gopacket.Packet) string {
+	l := packet.Layer(layers.LayerTypeDot1Q)
+	if l == nil {
+		return ""
+	}
+	dot1q, ok := l.(*layers.Dot1Q)
+	if !ok {
+		return ""
+	}
+
+	return decodeTaggedLLC(uint16(dot1q.Type), l.LayerPayload())
+}
+
+// decodeTaggedLLC decodes an 802.1Q tag's payload as LLC and names the control
+// protocol it carries. Returns "" when the tag does not carry LLC.
+//
+// innerType is the Dot1Q header's own type field, which holds a *length* rather
+// than an EtherType when it is below 0x0600 — that is what marks the payload as
+// LLC. gopacket already consumed those two bytes, so payload starts at the LLC
+// header itself.
+func decodeTaggedLLC(innerType uint16, payload []byte) string {
+	if innerType >= minEtherType || len(payload) < dot1qLLCMinPayload {
+		return ""
+	}
+	inner := gopacket.NewPacket(payload, layers.LayerTypeLLC, gopacket.NoCopy)
+	switch {
+	case inner.Layer(layers.LayerTypeSTP) != nil:
+		return "STP"
+	case inner.Layer(layers.LayerTypeCiscoDiscovery) != nil:
+		return "CDP"
+	case inner.Layer(layers.LayerTypeSNAP) != nil:
+		return "SNAP"
+	case inner.Layer(layers.LayerTypeLLC) != nil:
+		return "LLC"
+	}
+
+	return ""
 }
 
 // ipv4String formats a 4-byte IPv4 address as dotted-quad. Avoids a

--- a/ui/src/utils/protocol-layers.ts
+++ b/ui/src/utils/protocol-layers.ts
@@ -121,7 +121,12 @@ function buildIpLayer(
   const ipv6 = headers?.ipv6 as Record<string, unknown> | undefined;
   const ip = ipv4 ?? ipv6 ?? (headers?.ip as Record<string, unknown> | undefined);
 
-  if (ip) {
+  // Only render an IP layer when the packet actually has one. This used to fall
+  // back to packet.sourceIp, which PacketInspectorPage defaults to the literal
+  // "Unknown" — so an STP BPDU, which has no IP layer at all, was shown as
+  // "Internet Protocol Version 4 (IPv4) / Source: Unknown" (D16).
+  const hasAddresses = Boolean(ip?.src ?? ip?.dst);
+  if (ip && hasAddresses) {
     const version = ipv6 ? 'IPv6' : 'IPv4';
     return {
       name: `Internet Protocol Version ${ipv6 ? '6' : '4'} (${version})`,


### PR DESCRIPTION
## Summary

The Packets page showed every frame as `Unknown  Unknown->Unknown` while rendering its bytes correctly.
Three separate faults.

**1. No L2 awareness.** `enrichNetworkLayer` and `enrichTransportLayer` only ever tested IPv4/IPv6/ARP
and TCP/UDP/ICMP — grepping the observer for `Dot1Q`, `LLC` or `SNAP` returned nothing. A tagged STP
BPDU, exactly what NIAC puts on a trunk, fell through every branch and kept the `"Unknown"` default.

gopacket alone is not enough here. It **cannot chain past Dot1Q into LLC**: `Dot1Q.NextLayerType()` hands
its inner value to `EthernetType.LayerType()`, and unlike the Ethernet decoder that mapping has no
*"< 0x0600 means a length, so this is LLC"* branch. A tagged LLC frame decodes as `Dot1Q → Payload` and
every layer lookup misses. The tag's payload is now re-decoded as LLC by hand. Same blind spot already
fixed on the seed side — and the offset matters: gopacket consumes the length field into `Dot1Q.Type`, so
the payload starts at the LLC header itself. I confirmed that against the real frame rather than assuming.

**2. Shape mismatch.** The observer emitted flat keys (`src_mac`, `source_ip`, …) while the UI builds its
layer tree from a nested `headers` map. It never found an ethernet layer, so MACs read "(not parsed)" for
**every** packet, not just the odd ones. The observer now emits `headers.ethernet / dot1q / ipv4 / ipv6`
in camelCase per ADR-0007, alongside the existing flat keys.

**3. Phantom IP layer.** `buildIpLayer` fell back to `packet.sourceIp`, which `PacketInspectorPage`
defaults to the literal `"Unknown"` — so a frame with no IP layer at all rendered as *"Internet Protocol
Version 4 (IPv4) / Source: Unknown"*. It now renders only when real addresses are present. Note the
`"Unknown"` literal is **client-side**; the server simply omits the keys. The original sweep report had
this backwards.

The L2 pass runs last and only fills a protocol still marked `Unknown`, so it can never override a real
L3/L4 classification.

## Linked Issue

Fixes #1427

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Observability only — this changes how frames are *described*, never how they are sent or routed. Existing
flat keys are still emitted, so nothing that read them breaks.

## Testing Evidence

The guard decodes a **real tagged RSTP BPDU captured from NIAC's own trunk on CT304**, and separately
asserts an IPv4 packet still classifies as before.

```text
$ go test ./internal/api/sse/ -run TestEnrichWithLayers    # BEFORE
--- FAIL: TestEnrichWithLayersDecodesTaggedBPDU
    protocol = Unknown, want STP — a tagged BPDU is not Unknown

$ go test ./internal/api/sse/                              # AFTER
ok  github.com/MustardSeedNetworks/niac-go/internal/api/sse  0.619s

$ golangci-lint run internal/api/sse/...
0 issues.

$ npx vitest run
 Test Files  91 passed (91)
      Tests  456 passed (456)

$ make test
EXIT=0
```

Post-merge on CT304: confirm the live capture reports STP with real MACs and no IP layer.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched.
      None touched. Decoding is bounded — the LLC re-decode requires a length-typed Dot1Q and a minimum
      payload, and the raw-bytes cap is unchanged.
- [x] Dependencies are pinned and justified if changed. No dependency changes.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. Covered by the
      remediation plan doc; the gopacket blind spot is documented at the decode site.
