### PR TITLE
fix(packets): stop the inspector reporting a zero arrival time and a phantom IPv4 layer

### DIFF
--- a/internal/api/sse/packet_observer.go
+++ b/internal/api/sse/packet_observer.go
@@ -118,8 +118,16 @@ func packetToWire(direction string, pkt *protocols.Packet) map[string]any {
 		truncated = true
 	}
 
+	// Only NewPacket and ParsePacket stamp a Timestamp; the protocol emitters
+	// build Packet literals directly and leave it zero. Stamp observation time
+	// here, as GopacketToWire does, so the wire never carries the zero value.
+	ts := pkt.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+
 	out := map[string]any{
-		"timestamp": pkt.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z"),
+		"timestamp": ts.UTC().Format("2006-01-02T15:04:05.000Z"),
 		"direction": direction,
 		"size":      pkt.Length,
 		"raw_data":  hex.EncodeToString(raw),

--- a/internal/api/sse/packet_observer_test.go
+++ b/internal/api/sse/packet_observer_test.go
@@ -1,6 +1,7 @@
 package sse
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -52,5 +53,40 @@ func TestGopacketToWireUsesStandaloneCaptureShape(t *testing.T) {
 	}
 	if wire["raw_data"] != "00112233445566778899aabb0800" {
 		t.Errorf("raw_data = %v", wire["raw_data"])
+	}
+}
+
+// TestPacketToWireNeverEmitsTheZeroTimestamp guards #1457.
+//
+// protocols.Packet carries a Timestamp, but only 3 of the 27 &Packet{...}
+// literals outside tests set it: NewPacket and ParsePacket stamp time.Now(),
+// while the protocol emitters build the struct directly and leave it zero.
+// packetToWire formatted it unconditionally, so the inspector showed every
+// frame arriving at "0001-01-01T00:00:00.000Z".
+//
+// The guard lives at the encoder because the encoder owns the wire contract —
+// the 24 emitter sites are not a boundary, and a 25th would regress silently.
+// Its documented cousin GopacketToWire already guards exactly this way.
+func TestPacketToWireNeverEmitsTheZeroTimestamp(t *testing.T) {
+	pkt := &protocols.Packet{Buffer: []byte{0xde, 0xad, 0xbe, 0xef}, Length: 4}
+	if !pkt.Timestamp.IsZero() {
+		t.Fatal("precondition: a bare Packet literal should carry the zero time")
+	}
+
+	got, _ := packetToWire("tx", pkt)["timestamp"].(string)
+	if strings.HasPrefix(got, "0001-01-01") {
+		t.Errorf("timestamp = %q, want an observation time, not the zero value", got)
+	}
+}
+
+// A packet that does carry a real timestamp must keep it — the guard fills a
+// gap, it does not overwrite recorded arrival times.
+func TestPacketToWirePreservesARealTimestamp(t *testing.T) {
+	when := time.Date(2026, 8, 23, 14, 30, 15, 0, time.UTC)
+	pkt := &protocols.Packet{Buffer: []byte{0x01}, Length: 1, Timestamp: when}
+
+	got, _ := packetToWire("rx", pkt)["timestamp"].(string)
+	if want := "2026-08-23T14:30:15.000Z"; got != want {
+		t.Errorf("timestamp = %q, want %q", got, want)
 	}
 }

--- a/ui/src/components/PacketList.tsx
+++ b/ui/src/components/PacketList.tsx
@@ -13,8 +13,8 @@ export interface Packet {
   id: string;
   timestamp: string;
   protocol: string;
-  sourceIp: string;
-  destIp: string;
+  sourceIp?: string;
+  destIp?: string;
   sourcePort?: number;
   destPort?: number;
   size: number;
@@ -71,10 +71,10 @@ const PacketRow = memo(
         <SmallText className="text-text-muted font-mono text-xs">{formattedTime}</SmallText>
       </div>
       <div className="mt-tight text-sm text-text-primary truncate">
-        {packet.sourceIp}
+        {packet.sourceIp ?? '\u2014'}
         {packet.sourcePort && `:${packet.sourcePort}`}
         <span className="text-text-muted mx-1">-&gt;</span>
-        {packet.destIp}
+        {packet.destIp ?? '\u2014'}
         {packet.destPort && `:${packet.destPort}`}
       </div>
       <SmallText className="text-text-muted truncate block">{packet.summary}</SmallText>

--- a/ui/src/pages/PacketInspectorPage.tsx
+++ b/ui/src/pages/PacketInspectorPage.tsx
@@ -44,6 +44,7 @@ import { H2, SmallText } from '../ui/Typography';
 import { getStreamFilter } from '../utils/conversations';
 import { buildProtocolLayers, computeHeaderBoundary } from '../utils/protocol-layers';
 import { PcapAnalyzerPage } from './PcapAnalyzerPage';
+import { packetFromStreamEvent } from './packets/packet-from-stream';
 
 /** Maximum number of packets to buffer */
 const MAX_PACKETS = 100;
@@ -160,44 +161,7 @@ export const PacketInspectorPage: FC = () => {
 
       const incoming = data.data;
 
-      // SSE payloads bypass the shared toCamelCase converter in client.ts,
-      // so fall back to snake_case keys when the camelCase key is missing.
-      const packet: Packet = {
-        id: generatePacketId(),
-        timestamp: (incoming.timestamp as string) || data.timestamp,
-        protocol: (incoming.protocol as string) || 'Unknown',
-        sourceIp: (incoming.sourceIp as string) || (incoming.source_ip as string) || 'Unknown',
-        destIp: (incoming.destIp as string) || (incoming.dest_ip as string) || 'Unknown',
-        sourcePort:
-          (incoming.sourcePort as number | undefined) ??
-          (incoming.source_port as number | undefined),
-        destPort:
-          (incoming.destPort as number | undefined) ?? (incoming.dest_port as number | undefined),
-        size: (incoming.size as number) || 0,
-        summary: (incoming.summary as string) || '',
-        rawData:
-          (incoming.rawData as string) ||
-          (incoming.raw_data as string) ||
-          (incoming.payload as string) ||
-          '',
-        headers: incoming.headers as Record<string, unknown> | undefined,
-        physicalVlan:
-          (incoming.physicalVlan as number | undefined) ??
-          (incoming.physical_vlan as number | undefined),
-        ingressNetwork:
-          (incoming.ingressNetwork as string | undefined) ??
-          (incoming.ingress_network as string | undefined),
-        routeDecision:
-          (incoming.routeDecision as string | undefined) ??
-          (incoming.route_decision as string | undefined),
-        hop: incoming.hop as string | undefined,
-        egressNetwork:
-          (incoming.egressNetwork as string | undefined) ??
-          (incoming.egress_network as string | undefined),
-        egressRejectionReason:
-          (incoming.egressRejectionReason as string | undefined) ??
-          (incoming.egress_rejection_reason as string | undefined),
-      };
+      const packet = packetFromStreamEvent(incoming, data.timestamp, generatePacketId());
 
       setPackets((prev) => {
         const updated = [...prev, packet];

--- a/ui/src/pages/packets/packet-from-stream.test.ts
+++ b/ui/src/pages/packets/packet-from-stream.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildProtocolLayers } from '../../utils/protocol-layers';
+import { packetFromStreamEvent } from './packet-from-stream';
+
+/**
+ * Guards #1458.
+ *
+ * A CDP frame is LLC-encapsulated and has no IP layer at all, yet the inspector
+ * rendered "Internet Protocol Version 4 (IPv4) / Source: Unknown / Destination:
+ * Unknown" under it on CT304. The mapping coerced absent addresses to the
+ * literal string 'Unknown' — a display placeholder leaking into the data model —
+ * and buildIpLayer's fallback branch tests truthiness, which 'Unknown' passes.
+ *
+ * These assert the mapping and the layer builder together, because neither half
+ * is wrong on its own: the bug only exists where the sentinel meets the branch.
+ */
+
+/** A CDP frame exactly as internal/api/sse/packet_observer.go emits it. */
+const cdpEvent = {
+  timestamp: '2026-08-23T14:30:15.000Z',
+  protocol: 'CDP',
+  size: 132,
+  raw_data: '01000ccccccc00000c4a080200760aaa',
+  headers: {
+    ethernet: {
+      srcMac: '00:00:0c:4a:08:02',
+      dstMac: '01:00:0c:cc:cc:cc',
+      etherType: 'LLC',
+    },
+  },
+};
+
+describe('packetFromStreamEvent', () => {
+  it('leaves addresses absent on a frame that has no IP layer', () => {
+    const packet = packetFromStreamEvent(cdpEvent, '2026-08-23T14:30:15.000Z', 'p1');
+
+    expect(packet.sourceIp, "'Unknown' is a display placeholder, not an address").toBeUndefined();
+    expect(packet.destIp).toBeUndefined();
+  });
+
+  it('does not fabricate an IPv4 layer for a CDP frame', () => {
+    const packet = packetFromStreamEvent(cdpEvent, '2026-08-23T14:30:15.000Z', 'p1');
+    const layers = buildProtocolLayers(packet.headers, packet);
+
+    expect(layers.map((l) => l.name)).not.toContain('Internet Protocol Version 4 (IPv4)');
+    expect(layers.map((l) => l.name)).toContain('Ethernet II');
+  });
+
+  it('still renders the IP layer when the frame really carries one', () => {
+    const packet = packetFromStreamEvent(
+      {
+        protocol: 'UDP',
+        size: 74,
+        source_ip: '10.44.10.5',
+        dest_ip: '10.44.10.1',
+        headers: { ethernet: { srcMac: 'aa:bb:cc:dd:ee:ff', dstMac: '11:22:33:44:55:66' } },
+      },
+      '2026-08-23T14:30:15.000Z',
+      'p2',
+    );
+    const layers = buildProtocolLayers(packet.headers, packet);
+
+    expect(packet.sourceIp).toBe('10.44.10.5');
+    const ip = layers.find((l) => l.name.startsWith('Internet Protocol'));
+    expect(ip?.fields.find((f) => f.name === 'Source')?.value).toBe('10.44.10.5');
+  });
+});

--- a/ui/src/pages/packets/packet-from-stream.ts
+++ b/ui/src/pages/packets/packet-from-stream.ts
@@ -1,0 +1,51 @@
+import type { Packet } from '../../components/PacketList';
+
+/**
+ * Map a live SSE packet payload onto the Packet shape the inspector renders.
+ *
+ * SSE payloads bypass the shared toCamelCase converter in client.ts, so every
+ * field falls back to its snake_case spelling.
+ */
+export function packetFromStreamEvent(
+  incoming: Record<string, unknown>,
+  fallbackTimestamp: string,
+  id: string,
+): Packet {
+  return {
+    id,
+    timestamp: (incoming.timestamp as string) || fallbackTimestamp,
+    protocol: (incoming.protocol as string) || 'Unknown',
+    // Absent, not 'Unknown': a frame with no IP layer has no address, and a
+    // display placeholder here made buildIpLayer fabricate an IPv4 layer for it.
+    sourceIp: (incoming.sourceIp as string) || (incoming.source_ip as string) || undefined,
+    destIp: (incoming.destIp as string) || (incoming.dest_ip as string) || undefined,
+    sourcePort:
+      (incoming.sourcePort as number | undefined) ?? (incoming.source_port as number | undefined),
+    destPort:
+      (incoming.destPort as number | undefined) ?? (incoming.dest_port as number | undefined),
+    size: (incoming.size as number) || 0,
+    summary: (incoming.summary as string) || '',
+    rawData:
+      (incoming.rawData as string) ||
+      (incoming.raw_data as string) ||
+      (incoming.payload as string) ||
+      '',
+    headers: incoming.headers as Record<string, unknown> | undefined,
+    physicalVlan:
+      (incoming.physicalVlan as number | undefined) ??
+      (incoming.physical_vlan as number | undefined),
+    ingressNetwork:
+      (incoming.ingressNetwork as string | undefined) ??
+      (incoming.ingress_network as string | undefined),
+    routeDecision:
+      (incoming.routeDecision as string | undefined) ??
+      (incoming.route_decision as string | undefined),
+    hop: incoming.hop as string | undefined,
+    egressNetwork:
+      (incoming.egressNetwork as string | undefined) ??
+      (incoming.egress_network as string | undefined),
+    egressRejectionReason:
+      (incoming.egressRejectionReason as string | undefined) ??
+      (incoming.egress_rejection_reason as string | undefined),
+  };
+}


### PR DESCRIPTION
## Summary

Two defects found driving the packet inspector live on CT304 after the D16 decode fix landed. Both are cases of the detail pane stating something untrue about the frame.

**Arrival time (#1457).** `protocols.Packet` carries a `Timestamp`, but only `NewPacket` and `ParsePacket` stamp it — the ~24 protocol-emitter sites build the struct directly and leave it zero, and `packetToWire` formatted it unconditionally. Every frame showed `0001-01-01T00:00:00.000Z`. The guard goes at the encoder, matching its documented cousin `GopacketToWire` twenty lines above: the encoder owns the wire contract, whereas a per-site fix across 24 emitters regresses silently the moment a 25th is added.

**Phantom IPv4 (#1458).** A CDP frame is LLC-encapsulated and has no IP layer, yet the tree rendered `Internet Protocol Version 4 (IPv4) / Source: Unknown / Destination: Unknown` beneath it. Two halves had to meet: the SSE mapping coerced absent addresses to the literal string `'Unknown'` — a display placeholder leaking into the data model — and `buildIpLayer`'s fallback branch tests truthiness, which the sentinel passes. The D16 fix guarded the *first* branch only. Addresses are now absent when the frame has none, and the list renders an em dash, which is honest: the frame has no address rather than an unknown one.

The SSE mapping moved out of the component into `packetFromStreamEvent` so the defect is testable end-to-end — payload to `Packet` to protocol layers — rather than only reachable by rendering the page. `PacketInspectorPage` drops from 670 to 645 lines as a side effect.

## Linked Issue

Closes #1457
Closes #1458

## Testing Evidence

Both guards were proven red against pre-fix code before the fix landed.

```
=== RED, #1457 ===
--- FAIL: TestPacketToWireNeverEmitsTheZeroTimestamp (0.00s)
    packet_observer_test.go:78: timestamp = "0001-01-01T00:00:00.000Z", want an
    observation time, not the zero value

=== RED, #1458 ===
FAIL src/pages/packets/packet-from-stream.test.ts > does not fabricate an IPv4 layer
AssertionError: expected [ 'Frame', 'Ethernet II', …(1) ] to not include
'Internet Protocol Version 4 (IPv4)'
FAIL ... > leaves addresses absent on a frame that has no IP layer
 Tests  2 failed | 1 passed (3)

=== GREEN, after the fix ===
ok  github.com/MustardSeedNetworks/niac-go/internal/api/sse  0.208s
 Test Files  93 passed (93)
      Tests  461 passed (461)

=== gates ===
golangci-lint run internal/api/sse/...   0 issues.
npx biome check (4 files)                No fixes applied.
npm run typecheck                        clean
pre-commit                               0 red flags
```

The third case in the new suite is the non-regression half: a frame that really carries addresses still renders its IP layer with the real values, and it passed before and after.

## Security and Release Checklist

- [x] No new external input is trusted — the encoder guard only substitutes observation time for an unset one
- [x] No new routes, auth surfaces, or persistent writes
- [x] No secrets, credentials, or customer-facing AI vocabulary
- [x] No suppressions added (`//nolint`, `biome-ignore`)
- [x] Behaviour change is limited to what the two issues describe