### PR TITLE
fix(config): make wizard drafts startable and preflight failures legible

### DIFF
--- a/cmd/niac/cmd_daemon.go
+++ b/cmd/niac/cmd_daemon.go
@@ -163,20 +163,60 @@ func resolveDaemonAPIToken(o *daemonOptions) string {
 
 func parseAttachmentPolicies(values []string) ([]fabric.PhysicalAttachmentPolicy, error) {
 	policies := make([]fabric.PhysicalAttachmentPolicy, 0, len(values))
-	seenInterfaces := make(map[string]struct{}, len(values))
+	// One interface carries N tagged sessions plus at most one native session,
+	// exactly as the session registry models a trunk port with a native VLAN
+	// (#1426), so it needs one policy per mode rather than one policy outright
+	// (#1463). Direct is the exception: it is unisolated ownership of the whole
+	// interface, so it cannot share one.
+	seenModes := make(map[string]map[fabric.AttachmentMode]struct{}, len(values))
 	for _, value := range values {
 		policy, err := parseAttachmentPolicy(value)
 		if err != nil {
 			return nil, err
 		}
-		if _, duplicate := seenInterfaces[policy.Interface]; duplicate {
-			return nil, fmt.Errorf("duplicate interface in attachment policy %q", value)
+		modes := seenModes[policy.Interface]
+		if modes == nil {
+			modes = make(map[fabric.AttachmentMode]struct{}, attachmentModesPerInterface)
+			seenModes[policy.Interface] = modes
 		}
-		seenInterfaces[policy.Interface] = struct{}{}
+		if _, duplicate := modes[policy.Mode]; duplicate {
+			return nil, fmt.Errorf(
+				"duplicate %s policy for interface %q in attachment policy %q",
+				policy.Mode, policy.Interface, value,
+			)
+		}
+		if exclusiveErr := checkDirectExclusive(policy, modes, value); exclusiveErr != nil {
+			return nil, exclusiveErr
+		}
+		modes[policy.Mode] = struct{}{}
 		policies = append(policies, policy)
 	}
 	return policies, nil
 }
+
+// checkDirectExclusive rejects a direct policy sharing an interface with any
+// other mode, in either order.
+func checkDirectExclusive(
+	policy fabric.PhysicalAttachmentPolicy,
+	modes map[fabric.AttachmentMode]struct{},
+	value string,
+) error {
+	_, hasDirect := modes[fabric.ModeDirect]
+	if !hasDirect && policy.Mode != fabric.ModeDirect {
+		return nil
+	}
+	if hasDirect || len(modes) > 0 {
+		return fmt.Errorf(
+			"interface %q cannot combine direct with another attachment mode (%q)",
+			policy.Interface, value,
+		)
+	}
+	return nil
+}
+
+// attachmentModesPerInterface is the most modes one interface can hold: a
+// trunk policy for the tagged sessions plus an access policy for the native one.
+const attachmentModesPerInterface = 2
 
 const attachmentPolicySyntax = "expected INTERFACE=direct, INTERFACE=access:VLAN, or INTERFACE=trunk:VLAN,..."
 

--- a/cmd/niac/daemon_test.go
+++ b/cmd/niac/daemon_test.go
@@ -87,9 +87,12 @@ func TestParseAttachmentPoliciesRejectsInvalidValues(t *testing.T) {
 		{name: "whitespace", value: []string{" eth0=direct"}, match: "expected INTERFACE"},
 		{name: "duplicate", value: []string{"eth0=direct", "eth0=direct"}, match: "duplicate"},
 		{
-			name:  "duplicate interface",
+			// Still rejected, but as a direct-exclusivity violation rather than a
+			// bare duplicate interface: one interface may now hold a trunk and an
+			// access policy together (#1463), just never direct with anything.
+			name:  "direct combined with trunk",
 			value: []string{"eth0=direct", "eth0=trunk:200"},
-			match: "duplicate interface",
+			match: "cannot combine direct",
 		},
 	}
 
@@ -118,5 +121,81 @@ func TestDaemonOptionsStruct(t *testing.T) {
 	}
 	if opts.storagePath != "/custom/path.db" {
 		t.Errorf("storagePath = %q, want %q", opts.storagePath, "/custom/path.db")
+	}
+}
+
+// TestParseAttachmentPoliciesAllowsNativeAlongsideTrunk guards #1463.
+//
+// #1426 taught the session registry that one interface carries N tagged
+// sessions plus at most one native session — a trunk port with a native VLAN.
+// The policy parser still rejected any repeat of an interface, so the operator
+// could not approve both bindings and the capability was unreachable: CT304
+// runs six tagged scenarios and refuses a seventh in access mode on policy
+// grounds, not registry grounds.
+func TestParseAttachmentPoliciesAllowsNativeAlongsideTrunk(t *testing.T) {
+	got, err := parseAttachmentPolicies([]string{
+		"eth0=trunk:200,201",
+		"eth0=access:210",
+	})
+	if err != nil {
+		t.Fatalf("native alongside trunk on one interface = %v, want accepted", err)
+	}
+
+	want := []fabric.PhysicalAttachmentPolicy{
+		{Interface: "eth0", Mode: fabric.ModeTrunk, AllowedVLANs: []uint16{200, 201}},
+		{Interface: "eth0", Mode: fabric.ModeAccess, AccessVLAN: 210},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseAttachmentPolicies() = %#v, want %#v", got, want)
+	}
+}
+
+// Both bindings must actually be approved by the resulting policy set.
+func TestNativeAndTaggedBindingsAreBothApproved(t *testing.T) {
+	policies, err := parseAttachmentPolicies([]string{"eth0=trunk:200,201", "eth0=access:210"})
+	if err != nil {
+		t.Fatalf("parseAttachmentPolicies() error = %v", err)
+	}
+
+	approves := func(binding fabric.Binding) bool {
+		for _, policy := range policies {
+			if policy.Approves(binding) {
+				return true
+			}
+		}
+		return false
+	}
+
+	tagged := fabric.Binding{Interface: "eth0", Mode: fabric.ModeTrunk, AccessVLAN: 201}
+	native := fabric.Binding{Interface: "eth0", Mode: fabric.ModeAccess, AccessVLAN: 210}
+	if !approves(tagged) {
+		t.Error("tagged binding on eth0 VLAN 201 was not approved")
+	}
+	if !approves(native) {
+		t.Error("native binding on eth0 access VLAN 210 was not approved")
+	}
+}
+
+// Direct means unisolated ownership of the whole interface, so it still cannot
+// share one with anything else.
+func TestParseAttachmentPoliciesKeepsDirectExclusive(t *testing.T) {
+	for _, values := range [][]string{
+		{"eth0=direct", "eth0=trunk:200"},
+		{"eth0=trunk:200", "eth0=direct"},
+		{"eth0=direct", "eth0=access:210"},
+	} {
+		if _, err := parseAttachmentPolicies(values); err == nil {
+			t.Errorf("parseAttachmentPolicies(%v) = nil error, want direct to stay exclusive", values)
+		}
+	}
+}
+
+// A repeated mode on one interface is still an operator mistake.
+func TestParseAttachmentPoliciesRejectsRepeatedMode(t *testing.T) {
+	if _, err := parseAttachmentPolicies([]string{"eth0=access:210", "eth0=access:211"}); err == nil {
+		t.Error("two access policies on one interface = nil error, want a duplicate error")
+	}
+	if _, err := parseAttachmentPolicies([]string{"eth0=trunk:200", "eth0=trunk:201"}); err == nil {
+		t.Error("two trunk policies on one interface = nil error, want a duplicate error")
 	}
 }

--- a/internal/api/handlers_simulation.go
+++ b/internal/api/handlers_simulation.go
@@ -152,6 +152,13 @@ func preflightErrorDetails(err error) []ErrorDetail {
 	if err == nil {
 		return nil
 	}
+	// A validation failure carries a structured error per finding, complete with
+	// the offending field path. ListError.Error() collapses those to a bare
+	// count once there is more than one, so unwrap before falling back to text.
+	var listErr *config.ListError
+	if errors.As(err, &listErr) && len(listErr.Errors) > 0 {
+		return validationErrorDetails(listErr)
+	}
 	raw := strings.NewReplacer("\n", "; ").Replace(err.Error())
 	var details []ErrorDetail
 	for part := range strings.SplitSeq(raw, "; ") {
@@ -163,6 +170,22 @@ func preflightErrorDetails(err error) []ErrorDetail {
 	}
 	if len(details) == 0 {
 		return nil
+	}
+
+	return details
+}
+
+// validationErrorDetails maps each semantic-validation finding onto a detail,
+// keeping the field path and source position the validator recorded.
+func validationErrorDetails(listErr *config.ListError) []ErrorDetail {
+	details := make([]ErrorDetail, 0, len(listErr.Errors))
+	for _, e := range listErr.Errors {
+		details = append(details, ErrorDetail{
+			Field:  e.Field,
+			Issue:  e.Message,
+			Line:   e.Line,
+			Column: e.Column,
+		})
 	}
 
 	return details

--- a/internal/api/preflight_details_test.go
+++ b/internal/api/preflight_details_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/config"
+)
+
+// TestPreflightErrorDetailsEnumeratesValidationErrors guards #1461.
+//
+// config.ListError.Error() deliberately collapses to "N configuration errors
+// found" once there is more than one — fine for a single-line CLI string, but
+// preflight consumed only that string and threw away ListError.Errors, which
+// carries a structured *config.Error per finding with the field path on it.
+//
+// The operator saw "Simulation preflight failed" and nothing else; diagnosing
+// the two real errors meant reproducing the config offline and running the
+// validator by hand.
+func TestPreflightErrorDetailsEnumeratesValidationErrors(t *testing.T) {
+	listErr := &config.ListError{}
+	listErr.Add(config.NewConfigError(
+		"draft.yaml", "devices[0].snmp_agent.community", "SNMPv1/v2c requires an explicit community"))
+	listErr.Add(config.NewConfigError(
+		"draft.yaml", "devices[1].snmp_agent.community", "SNMPv1/v2c requires an explicit community"))
+
+	// Preflight wraps the validator's error before it reaches the handler.
+	wrapped := fmt.Errorf("simulation configuration failed semantic validation: %w", listErr)
+
+	details := preflightErrorDetails(wrapped)
+
+	if len(details) != 2 {
+		t.Fatalf("got %d details, want one per validation error: %+v", len(details), details)
+	}
+	for i, want := range []string{"devices[0].snmp_agent.community", "devices[1].snmp_agent.community"} {
+		if details[i].Field != want {
+			t.Errorf("details[%d].Field = %q, want %q", i, details[i].Field, want)
+		}
+		if details[i].Issue != "SNMPv1/v2c requires an explicit community" {
+			t.Errorf("details[%d].Issue = %q, want the underlying message", i, details[i].Issue)
+		}
+	}
+}
+
+// Errors that are not validation lists keep the existing "; "-splitting
+// behaviour, which several non-validation preflight failures rely on.
+func TestPreflightErrorDetailsStillSplitsPlainErrors(t *testing.T) {
+	details := preflightErrorDetails(errors.New("first problem; second problem"))
+
+	if len(details) != 2 {
+		t.Fatalf("got %d details, want 2: %+v", len(details), details)
+	}
+	if details[0].Issue != "first problem" || details[1].Issue != "second problem" {
+		t.Errorf("unexpected split: %+v", details)
+	}
+}

--- a/internal/config/yaml_marshal_protocols.go
+++ b/internal/config/yaml_marshal_protocols.go
@@ -19,7 +19,13 @@ func ttlToYAML(cfg *TTLConfig) *converter.TTLConfig {
 }
 
 func snmpToYAML(cfg *SNMPConfig) *converter.SnmpAgent {
-	if cfg == nil {
+	// Device.SNMPConfig is a value field, so callers hand this a pointer that is
+	// never nil — unlike every sibling protocol config, which is a pointer and
+	// can simply be absent (#1462). Treat the entirely-unset struct as absent
+	// here, or every saved device grows an `snmp_agent: {}` block that the
+	// loader then reads back as "SNMP configured" and the validator rejects for
+	// having no community (#1460).
+	if cfg == nil || cfg.unset() {
 		return nil
 	}
 	out := &converter.SnmpAgent{
@@ -258,4 +264,14 @@ func reflectorToYAML(cfg *ReflectorConfig) *converter.ReflectorConfig {
 	}
 	out := converter.ReflectorConfig(*cfg)
 	return &out
+}
+
+// unset reports whether the config carries no SNMP settings at all, so
+// marshalling can omit the block entirely and keep the round trip faithful.
+func (c *SNMPConfig) unset() bool {
+	return c.Enabled == nil && c.Community == "" && c.SysName == "" && c.SysDescr == "" &&
+		c.SysContact == "" && c.SysLocation == "" && c.WalkFile == "" &&
+		len(c.WalkFiles) == 0 && len(c.AddMibs) == 0 && len(c.CommunityIncludes) == 0 &&
+		len(c.AccessList) == 0 && c.SnmpAddr == nil &&
+		c.Dot1DFdbTable == nil && c.Dot1QFdbTable == nil && c.Traps == nil
 }

--- a/internal/config/yaml_snmp_roundtrip_test.go
+++ b/internal/config/yaml_snmp_roundtrip_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// The New Simulation wizard's Start-empty seed, verbatim from
+// ui/src/pages/NewSimulationWizardPage.tsx.
+const wizardStartEmptyYAML = `devices:
+  - name: new-device
+    type: host
+    mac: 02:00:00:00:00:01
+`
+
+// TestStartEmptyDraftSurvivesTheSaveReloadRoundTrip guards #1460.
+//
+// Device.SNMPConfig is a value field, so yaml.go's snmpToYAML(&device.SNMPConfig)
+// is handed a pointer that is never nil and its cfg == nil guard can never fire.
+// Every device was marshalled with a non-nil &converter.SnmpAgent{}, which
+// `omitempty` does not omit, so every saved config gained `snmp_agent: {}`.
+//
+// On reload the present key makes SNMP count as configured, and
+// validateSNMPCommunity then demands a community nobody asked for — so a draft
+// the wizard itself produced could not pass its own preflight.
+//
+// This asserts the round trip rather than the marshal output alone, because the
+// defect only bites on the second load: the first parse is clean.
+func TestStartEmptyDraftSurvivesTheSaveReloadRoundTrip(t *testing.T) {
+	cfg, err := LoadYAMLBytes([]byte(wizardStartEmptyYAML))
+	if err != nil {
+		t.Fatalf("load the wizard seed: %v", err)
+	}
+
+	saved, err := MarshalConfigYAML(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(saved), "snmp_agent") {
+		t.Errorf("saved config grew an snmp_agent block the source never had:\n%s", saved)
+	}
+
+	reloaded, err := LoadYAMLBytes(saved)
+	if err != nil {
+		t.Fatalf("reload the saved config: %v", err)
+	}
+
+	if verr := NewValidator("draft.yaml").Validate(reloaded); verr != nil && len(verr.Errors) > 0 {
+		for _, e := range verr.Errors {
+			t.Errorf("round-tripped draft fails validation: %s", e.Error())
+		}
+	}
+}
+
+// A device that really does configure SNMP must still marshal its block — the
+// omission is for the entirely-unset case only.
+func TestConfiguredSNMPStillMarshals(t *testing.T) {
+	cfg, err := LoadYAMLBytes([]byte(`devices:
+  - name: sw-1
+    type: switch
+    mac: 02:00:00:00:00:02
+    snmp_agent:
+      community: public
+      sysname: sw-1
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	saved, err := MarshalConfigYAML(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{"snmp_agent", "community: public"} {
+		if !strings.Contains(string(saved), want) {
+			t.Errorf("saved config lost %q:\n%s", want, saved)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Three defects found driving the New Simulation wizard live on CT304. Together they meant the **Start empty** path could not produce a runnable simulation, and the operator could not see why.

**Every saved config gained an `snmp_agent` block (#1460).** `Device.SNMPConfig` is a *value* field, so `yaml.go`'s `snmpToYAML(&device.SNMPConfig)` is handed a pointer that is never nil and its `cfg == nil` guard can never fire. Every device was marshalled with a non-nil `&converter.SnmpAgent{}`, which `omitempty` does not omit. On reload the present key makes SNMP count as configured, so the validator demanded a community nobody asked for — and the wizard's own draft failed its own preflight. SNMP is the only protocol config on `Device` that is value-typed; every sibling is a pointer and round-trips correctly. `snmpToYAML` now treats an entirely unset config as absent. Making the field a pointer is the deeper alignment and is filed separately as #1462 rather than ridden along here.

**Preflight named no errors (#1461).** `config.ListError.Error()` collapses to `"N configuration errors found"` past one error, and the handler consumed only that string while `ListError.Errors` carried a structured error per finding *with its field path*. Diagnosing the two errors above required reproducing the config offline and running the validator by hand. The handler now unwraps the list and emits one detail per error; non-validation errors keep the existing `"; "`-splitting, and the `Error()` formats are untouched since CLI output depends on them.

**Native scenarios could never be policy-approved (#1463).** #1426 taught the session registry that one interface carries N tagged sessions plus one native session — a trunk port with a native VLAN. But `parseAttachmentPolicies` rejected any repeat of an interface, so `eth0=trunk:...` and `eth0=access:...` could not coexist and the capability was unreachable in practice. CT304 runs six tagged scenarios and refuses a seventh in access mode on policy grounds, not registry grounds. Policies are now one per `(interface, mode)`, with `direct` still exclusive since it owns the whole interface.

## Linked Issue

Closes #1460
Closes #1461
Closes #1463

## Testing Evidence

Each guard was proven red against pre-fix code before its fix landed.

```
=== RED, #1460 ===
--- FAIL: TestStartEmptyDraftSurvivesTheSaveReloadRoundTrip
    saved config grew an snmp_agent block the source never had:
        devices:
            - name: new-device
              type: host
              mac: "02:00:00:00:00:01"
              snmp_agent: {}
    round-tripped draft fails validation: draft.yaml: SNMPv1/v2c requires an explicit community

=== RED, #1461 ===
--- FAIL: TestPreflightErrorDetailsEnumeratesValidationErrors
    got 1 details, want one per validation error:
    [{Field: Issue:simulation configuration failed semantic validation: 2 configuration errors found}]

=== RED, #1463 ===
--- FAIL: TestParseAttachmentPoliciesAllowsNativeAlongsideTrunk
    native alongside trunk on one interface = duplicate interface in attachment
    policy "eth0=access:210", want accepted
--- FAIL: TestNativeAndTaggedBindingsAreBothApproved

=== GREEN ===
go test ./... -count=1        all packages pass
golangci-lint run             0 issues.
pre-commit                    ALL PRE-COMMIT CHECKS PASSED
```

The live symptom that started this, from CT304:

```
POST /api/v1/simulation/preflight -> 400
{"error":"preflight_failed","details":[{"issue":"simulation configuration failed
 semantic validation: 2 configuration errors found"}]}
```

One pre-existing case in `TestParseAttachmentPoliciesRejectsInvalidValues` changed its expected *message* only — `eth0=direct` plus `eth0=trunk:200` is still rejected, now as a direct-exclusivity violation rather than a bare duplicate interface. Non-regression halves are included throughout: a device that really configures SNMP still marshals its block, plain errors still split on `"; "`, and repeated modes on one interface are still rejected.

## Security and Release Checklist

- [x] `direct` attachment mode remains exclusive — the policy relaxation cannot grant unisolated interface ownership alongside another session
- [x] No default credentials introduced: the fix omits an unset SNMP block rather than defaulting a community, so the validator's explicit-community requirement still holds
- [x] Preflight details expose validator field paths and messages only, no config values
- [x] No new routes, auth surfaces, or persistent writes
- [x] No suppressions added (`//nolint`, `biome-ignore`)