### PR TITLE
fix(ui): let Escape reach the focus trap so modals actually close

### DIFF
--- a/ui/src/ui/Modal.escape.test.tsx
+++ b/ui/src/ui/Modal.escape.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmModal } from './ConfirmModal';
+import { Modal } from './Modal';
+
+/**
+ * Guards #1465.
+ *
+ * Modal wired an onKeyDown that called stopPropagation() on Escape, "to prevent
+ * escape from bubbling if handled by the focus-trap hook". But useFocusTrap
+ * listens on `document`, and React dispatches synthetic events from its root
+ * container — below document — so that call stopped the native event before the
+ * very handler it claimed to defer to could ever see it.
+ *
+ * The trap auto-focuses inside the dialog and keeps focus there, so the keypress
+ * always originated inside the modal and Escape was always swallowed. Measured
+ * on CT304: pressing Escape inside the dialog reached a document listener zero
+ * times, while dispatching directly at document closed the dialog.
+ *
+ * These press Escape on a control *inside* the dialog, which is the only way it
+ * happens in real use.
+ */
+describe('Modal Escape handling', () => {
+  it('closes when Escape is pressed on a control inside the dialog', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Modal isOpen onClose={onClose} title="Danger">
+        <button type="button">Inside</button>
+      </Modal>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Inside' }));
+    await user.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves Escape inert when closeOnEscape is off', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Modal isOpen onClose={onClose} closeOnEscape={false} title="Danger">
+        <button type="button">Inside</button>
+      </Modal>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Inside' }));
+    await user.keyboard('{Escape}');
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('cancels a ConfirmModal on Escape, the real CT304 case', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+
+    render(
+      <ConfirmModal
+        isOpen
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        title="Stop simulation?"
+        message="Are you sure?"
+        confirmLabel="Stop"
+      />,
+    );
+
+    // Focus without clicking: clicking Cancel would call onCancel by itself and
+    // the test would pass whether or not Escape works.
+    screen.getByRole('button', { name: 'Stop' }).focus();
+    await user.keyboard('{Escape}');
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/ui/Modal.tsx
+++ b/ui/src/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react';
-import { type FC, type KeyboardEvent, type ReactNode, useEffect } from 'react';
+import { type FC, type ReactNode, useEffect } from 'react';
 import { iconSizes } from '../constants/sizes';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
@@ -56,13 +56,6 @@ export const Modal: FC<ModalProps> = ({
     return null;
   }
 
-  const handleContentKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    // Prevent escape from bubbling if handled by the focus-trap hook
-    if (e.key === 'Escape') {
-      e.stopPropagation();
-    }
-  };
-
   return (
     <div className="fixed inset-0 z-50 flex-center">
       {closeOnBackdropClick ? (
@@ -81,7 +74,6 @@ export const Modal: FC<ModalProps> = ({
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'modal-title' : undefined}
-        onKeyDown={handleContentKeyDown}
       >
         {(title || showCloseButton) && (
           <div className="flex-between px-6 py-4 border-b border-surface-border">


### PR DESCRIPTION
## Summary

No modal in the app closed on Escape. Found driving the "Stop simulation?" confirm dialog live on CT304.

`Modal` wired an `onKeyDown` on the dialog container:

```tsx
// Prevent escape from bubbling if handled by the focus-trap hook
if (e.key === 'Escape') { e.stopPropagation(); }
```

but `useFocusTrap` registers its handler on **`document`**, and React dispatches synthetic events from its root container — below `document`. That call stopped the native event before the very handler it claimed to defer to could ever see it. Because the trap auto-focuses inside the dialog and keeps focus there, the keypress always originated inside the modal, so Escape was always swallowed.

The fix is to delete the handler: `useFocusTrap` already calls `preventDefault()` and `stopPropagation()` itself when it handles Escape, so nothing else needs to suppress the event.

## Relationship to #1436 (D18)

D18 fixed a genuine second cause — `onEscape` sat in the effect's dependency list, so the trap tore down and re-armed on every parent render and the teardown's `restoreFocus()` yanked focus out of the dialog. That fix is correct and stays. It was necessary but not sufficient: this `stopPropagation` was never removed, so Escape remained dead and the D18 verification pass caught it.

## Linked Issue

Closes #1465

## Testing Evidence

Measured live on CT304 with the confirm dialog open, which is what identified the propagation as the culprit rather than the trap:

```
escape pressed from inside the dialog   -> document listener saw it 0 times, dialog stays open
escape dispatched directly at document  -> dialog closes (1 -> 0)
escape pressed from a button appended outside the React root -> dialog closes
```

Guards proven red against pre-fix code, pressing Escape on a control *inside* the dialog since that is the only way it happens in real use:

```
=== RED ===
FAIL src/ui/Modal.escape.test.tsx > closes when Escape is pressed on a control inside the dialog
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
FAIL src/ui/Modal.escape.test.tsx > cancels a ConfirmModal on Escape, the real CT304 case
 Tests  2 failed | 1 passed (3)

=== GREEN ===
 Test Files  94 passed (94)
      Tests  464 passed (464)
npm run typecheck   clean
npx biome check     No fixes applied.
pre-commit          ALL PRE-COMMIT CHECKS PASSED
```

The third case focuses the confirm button rather than clicking Cancel: an earlier draft clicked Cancel and passed whether or not Escape worked, so it was rewritten to fail for the right reason. The `closeOnEscape={false}` case is the negative control and passed before and after.

## Security and Release Checklist

- [x] No change to what any dialog does on confirm — only to how it is dismissed
- [x] Escape now cancels rather than confirms; destructive confirms still require an explicit click
- [x] No new routes, auth surfaces, or persistent writes
- [x] No suppressions added (`//nolint`, `biome-ignore`)