### PR TITLE
fix(fabric): return arrays, not null, from every preflight path

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -437,17 +437,21 @@ func loadValidSimulationConfig(
 // PreflightSimulation compiles a routed request without opening capture or changing runtime state.
 func (d *Daemon) PreflightSimulation(req api.SimulationRequest) (fabric.Report, error) {
 	if diagnostic := simulationInterfaceDiagnostic(req.Interface, e2eDryRunSimulation()); diagnostic != nil {
-		return fabric.Report{Diagnostics: []fabric.Diagnostic{*diagnostic}}, nil
+		report := fabric.NewReport()
+		report.Diagnostics = []fabric.Diagnostic{*diagnostic}
+		return report, nil
 	}
 	cfg, _, err := loadValidSimulationConfig(req, false)
 	if err != nil {
-		return fabric.Report{}, err
+		return fabric.NewReport(), err
 	}
 	if !usesRoutedFabric(cfg) {
 		if req.AttachmentMode == fabric.ModeTrunk {
 			return fabric.CompilePhysicalBinding(d.bindingFromRequest(req)), nil
 		}
-		return fabric.Report{Safe: true}, nil
+		report := fabric.NewReport()
+		report.Safe = true
+		return report, nil
 	}
 	return fabric.Compile(cfg, d.bindingFromRequest(req)), nil
 }

--- a/internal/daemon/preflight_report_shape_test.go
+++ b/internal/daemon/preflight_report_shape_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MustardSeedNetworks/niac-go/internal/api"
+	"github.com/MustardSeedNetworks/niac-go/internal/fabric"
+)
+
+func assertNoNullArrays(t *testing.T, report fabric.Report) {
+	t.Helper()
+	// The five collections the UI declares as non-nullable arrays. A nil Go
+	// slice marshals as null, and omitempty does not help.
+	nullArrayFields := []string{"networks", "interfaces", "routes", "dhcpScopes", "diagnostics"}
+	raw, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	for _, field := range nullArrayFields {
+		if strings.Contains(string(raw), `"`+field+`":null`) {
+			t.Errorf("%s marshalled as null; the UI types it as an array\n%s", field, raw)
+		}
+	}
+}
+
+// TestPreflightNonRoutedAccessModeReturnsArrays guards #1467.
+//
+// #1420 seeded Topology and Diagnostics in fabric.Compile and
+// CompilePhysicalBinding, but PreflightSimulation has literal returns that
+// reach neither. A config with no networks and no attachments in a non-trunk
+// mode — the wizard's Start-empty path in access mode — returns the zero
+// Report, whose slices are nil.
+//
+// Observed live on CT304: networks, interfaces, routes, dhcpScopes and
+// diagnostics all came back null on a 200 response.
+func TestPreflightNonRoutedAccessModeReturnsArrays(t *testing.T) {
+	t.Setenv(e2eDryRunEnv, "true")
+	d := &Daemon{}
+	req := api.SimulationRequest{
+		Interface: "eth0", Attachment: "tester", AttachmentMode: fabric.ModeAccess,
+		AccessVLAN: 210, ConfigData: `
+devices:
+  - name: new-device
+    type: host
+    mac: 02:00:00:00:00:01
+`,
+	}
+
+	report, err := d.PreflightSimulation(req)
+	if err != nil {
+		t.Fatalf("PreflightSimulation() error = %v", err)
+	}
+	if !report.Safe {
+		t.Fatalf("safe = false, diagnostics = %#v", report.Diagnostics)
+	}
+	assertNoNullArrays(t, report)
+}
+
+// The interface-diagnostic early return is the other literal that bypasses the
+// compiler's constructors.
+func TestPreflightInterfaceDiagnosticReturnsArrays(t *testing.T) {
+	d := &Daemon{}
+	req := api.SimulationRequest{
+		Interface: "definitely-not-a-real-interface",
+		ConfigData: `
+devices:
+  - name: new-device
+    type: host
+    mac: 02:00:00:00:00:01
+`,
+	}
+
+	report, err := d.PreflightSimulation(req)
+	if err != nil {
+		t.Fatalf("PreflightSimulation() error = %v", err)
+	}
+	assertNoNullArrays(t, report)
+}

--- a/internal/fabric/compiler.go
+++ b/internal/fabric/compiler.go
@@ -20,7 +20,7 @@ func Compile(cfg *config.Config, binding Binding) Report {
 		dhcpLeaseAddresses: make(map[netip.Addr]string),
 		// Seed the report's collections so a scenario that produces none of
 		// them still marshals as [] rather than null. (D6)
-		report: Report{Topology: NewTopology(), Diagnostics: []Diagnostic{}},
+		report: NewReport(),
 	}
 	compiler.compileBinding()
 	compiler.compileNetworks()
@@ -33,7 +33,7 @@ func Compile(cfg *config.Config, binding Binding) Report {
 func CompilePhysicalBinding(binding Binding) Report {
 	compiler := scenarioCompiler{
 		binding: binding,
-		report:  Report{Topology: NewTopology(), Diagnostics: []Diagnostic{}},
+		report:  NewReport(),
 	}
 	compiler.validateBindingMode()
 	compiler.report.Topology.Binding = CompiledBinding{

--- a/internal/fabric/types.go
+++ b/internal/fabric/types.go
@@ -161,3 +161,13 @@ type Report struct {
 	Topology    Topology     `json:"topology"`
 	Diagnostics []Diagnostic `json:"diagnostics"`
 }
+
+// NewReport returns a Report whose collections are empty rather than nil.
+//
+// The UI declares all five as non-nullable arrays, and a nil Go slice marshals
+// as null — omitempty does not help, the fields have to be initialised. Build
+// every Report through this so the wire contract holds by construction instead
+// of by each caller remembering (#1467).
+func NewReport() Report {
+	return Report{Topology: NewTopology(), Diagnostics: []Diagnostic{}}
+}


### PR DESCRIPTION
## Summary

#1420 (D6) seeded `Topology` and `Diagnostics` in `fabric.Compile` and `fabric.CompilePhysicalBinding` so the report's five collections marshal as `[]` rather than `null`, which is what the UI types them as. `Daemon.PreflightSimulation` has literal returns that reach neither constructor, so a config with no networks and no attachments in a non-trunk mode — the wizard's **Start empty** path in access mode — returned the zero `Report` with nil slices.

Observed live on CT304 running `19da728`, on a **200** response:

```json
{"safe": true,
 "topology": {"binding": {...}, "networks": null, "interfaces": null,
              "routes": null, "dhcpScopes": null},
 "diagnostics": null}
```

The wizard tolerated it only because #1420's UI half typed the fields as nullable and guarded the four reads. That tolerance is a client-side workaround for a server contract violation, not a fix — the API still owes arrays.

`fabric.NewReport()` now seeds both collections, and every construction site goes through it, so the contract holds by construction rather than by each caller remembering.

## Linked Issue

Closes #1467

## Testing Evidence

Both paths proven red against pre-fix code, reproducing the live response:

```
=== RED ===
--- FAIL: TestPreflightNonRoutedAccessModeReturnsArrays
    diagnostics marshalled as null; the UI types it as an array
    {"safe":true,"topology":{...,"networks":null,"interfaces":null,
     "routes":null,"dhcpScopes":null},"diagnostics":null}
--- FAIL: TestPreflightInterfaceDiagnosticReturnsArrays
    networks / interfaces / routes / dhcpScopes marshalled as null

=== GREEN ===
go test ./internal/daemon/ -run TestPreflight   ok
go test ./internal/fabric/                      ok
go test ./... -count=1                          all packages pass
golangci-lint run                               0 issues.
```

The second case covers the interface-diagnostic early return, the other literal that bypasses the constructors. Existing preflight tests, including `TestPreflightSimulationPreservesFlatScenarioWorkflow` which exercises the same non-routed access-mode path, pass unchanged.

## Security and Release Checklist

- [x] Serialization shape only — no change to what preflight decides, approves, or rejects
- [x] `Safe` and `Diagnostics` values are unchanged; only nil collections become empty
- [x] No new routes, auth surfaces, or persistent writes
- [x] No suppressions added (`//nolint`, `biome-ignore`)