### PR TITLE
fix(ui): show the preflight details the server sends

### DIFF
--- a/ui/src/components/wizard/PreflightStep.test.tsx
+++ b/ui/src/components/wizard/PreflightStep.test.tsx
@@ -1,180 +1,64 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiError } from '../../api/errors';
 import '../../i18n';
-import type { SimulationPreflightReport } from '../../api/fabric-types';
 import { PreflightStep } from './PreflightStep';
 
 const preflightSimulation = vi.fn();
-
 vi.mock('../../api/client', () => ({
   preflightSimulation: (payload: unknown) => preflightSimulation(payload),
 }));
 
-const safeReport: SimulationPreflightReport = {
-  safe: true,
-  topology: {
-    binding: {
-      attachment: 'tester',
-      interface: 'eth0',
-      mode: 'access',
-      physicalVlan: 200,
-      network: 'lab-access',
-      wireTagged: false,
-    },
-    networks: [],
-    interfaces: [],
-    routes: [],
-    dhcpScopes: [],
-  },
-  diagnostics: [],
-};
+/**
+ * Guards #1472.
+ *
+ * #1461 made the server enumerate its validation errors, and it does — on
+ * CT304 a failing preflight returns one detail per error, each with the field
+ * path that names the offending device. PreflightStep narrowed the rejection to
+ * `Error` and kept only `message`, so the one screen whose job is diagnosis
+ * showed a bare "Simulation preflight failed".
+ *
+ * #1429 (D3) threaded details through the *toast* path; the wizard renders this
+ * failure as an inline banner and never reaches that code.
+ */
+const request = { interface: 'eth0', configData: 'devices: []\n' } as never;
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  preflightSimulation.mockResolvedValue(safeReport);
-});
-
-describe('PreflightStep', () => {
-  // D6: a Go nil slice marshals as `null`, not `[]`. The success branch read
-  // `topology.networks.length`, so a preflight that PASSED crashed the wizard
-  // into an error boundary. Both pre-existing fixtures used `[]`, which is
-  // exactly why this shipped — this one reproduces the wire shape the daemon
-  // actually sent for a config with no networks.
-  it('renders a safe report whose collections came back null', async () => {
+describe('PreflightStep validation failures', () => {
+  it('lists every detail the server sent, with its field', async () => {
     const user = userEvent.setup();
-    preflightSimulation.mockResolvedValue({
-      safe: true,
-      topology: {
-        binding: {
-          attachment: 'cyberscope',
-          interface: 'eth0',
-          mode: 'trunk',
-          physicalVlan: 299,
-          network: '',
-          wireTagged: true,
+    preflightSimulation.mockRejectedValue(
+      new ApiError('Simulation preflight failed', 400, 'preflight_failed', [
+        {
+          field: 'devices[0].snmp_agent.community',
+          issue: 'SNMPv1/v2c requires an explicit community',
         },
-        networks: null,
-        interfaces: null,
-        routes: null,
-        dhcpScopes: null,
-      },
-      diagnostics: null,
-    });
+        {
+          field: 'devices[1].snmp_agent.community',
+          issue: 'SNMPv1/v2c requires an explicit community',
+        },
+      ]),
+    );
 
-    render(<PreflightStep request={{ interface: 'eth0' }} onStart={vi.fn()} />);
+    render(<PreflightStep request={request} onStart={vi.fn()} />);
     await user.click(screen.getByTestId('wizard-preflight-check'));
 
-    // Must reach the success state rather than throwing on `.length`.
-    await waitFor(() => {
-      expect(screen.getByTestId('wizard-preflight-start')).toBeEnabled();
-    });
+    expect(await screen.findAllByText(/SNMPv1\/v2c requires an explicit community/)).toHaveLength(
+      2,
+    );
+    expect(screen.getByText(/devices\[0\]\.snmp_agent\.community/)).toBeInTheDocument();
+    expect(screen.getByText(/devices\[1\]\.snmp_agent\.community/)).toBeInTheDocument();
   });
 
-  it('checks access mode with VLAN 200 by default and starts only after a safe report', async () => {
+  it('still shows the message when the server sent no details', async () => {
     const user = userEvent.setup();
-    const onStart = vi.fn();
-    render(
-      <PreflightStep
-        request={{ interface: 'eth0', configData: 'devices: []\n' }}
-        onStart={onStart}
-      />,
+    preflightSimulation.mockRejectedValue(
+      new ApiError('Simulation preflight failed', 400, 'preflight_failed', []),
     );
 
-    expect(screen.getByTestId('wizard-preflight-start')).toBeDisabled();
+    render(<PreflightStep request={request} onStart={vi.fn()} />);
     await user.click(screen.getByTestId('wizard-preflight-check'));
 
-    await waitFor(() => expect(preflightSimulation).toHaveBeenCalledTimes(1));
-    expect(preflightSimulation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        interface: 'eth0',
-        attachment: 'tester',
-        attachmentMode: 'access',
-        accessVlan: 200,
-      }),
-    );
-    expect(screen.getByTestId('wizard-preflight-start')).not.toBeDisabled();
-
-    await user.click(screen.getByTestId('wizard-preflight-start'));
-    expect(onStart).toHaveBeenCalledWith(expect.objectContaining({ accessVlan: 200 }));
-  });
-
-  it('submits direct mode without browser-owned isolation authorization', async () => {
-    const user = userEvent.setup();
-    preflightSimulation.mockResolvedValue({
-      ...safeReport,
-      safe: false,
-      diagnostics: [{ code: 'unknown_attachment', field: 'attachment', message: 'not found' }],
-    });
-    render(<PreflightStep request={{ interface: 'eth0' }} onStart={vi.fn()} />);
-
-    await user.selectOptions(screen.getByTestId('wizard-attachment-mode'), 'direct');
-    expect(screen.queryByTestId('wizard-access-vlan')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('wizard-dedicated-interface')).not.toBeInTheDocument();
-    expect(screen.getByTestId('wizard-preflight-check')).not.toBeDisabled();
-    await user.click(screen.getByTestId('wizard-preflight-check'));
-
-    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('not found'));
-    expect(screen.getByRole('alert')).toHaveTextContent('Unsafe physical attachment');
-    expect(preflightSimulation).toHaveBeenCalledWith(
-      expect.objectContaining({ attachmentMode: 'direct' }),
-    );
-    expect(preflightSimulation.mock.calls[0]?.[0]).not.toHaveProperty('accessVlan');
-    expect(preflightSimulation.mock.calls[0]?.[0]).not.toHaveProperty('dedicated');
-    expect(screen.getByTestId('wizard-preflight-start')).toBeDisabled();
-  });
-
-  it('submits a stable session ID and physical VLAN for trunk mode', async () => {
-    const user = userEvent.setup();
-    const onStart = vi.fn();
-    preflightSimulation.mockResolvedValue({
-      ...safeReport,
-      topology: {
-        ...safeReport.topology,
-        binding: { ...safeReport.topology.binding, mode: 'trunk', wireTagged: true },
-      },
-    });
-    render(<PreflightStep request={{ interface: 'eth0' }} onStart={onStart} />);
-
-    await user.selectOptions(screen.getByTestId('wizard-attachment-mode'), 'trunk');
-    await user.clear(screen.getByTestId('wizard-session-id'));
-    await user.type(screen.getByTestId('wizard-session-id'), 'hospital');
-    await user.click(screen.getByTestId('wizard-preflight-check'));
-
-    await waitFor(() => expect(screen.getByTestId('wizard-preflight-start')).not.toBeDisabled());
-    expect(preflightSimulation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attachmentMode: 'trunk',
-        sessionId: 'hospital',
-        accessVlan: 200,
-      }),
-    );
-    await user.click(screen.getByTestId('wizard-preflight-start'));
-    expect(onStart).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'hospital' }));
-  });
-
-  it('does not approve a changed payload when an older preflight resolves late', async () => {
-    const user = userEvent.setup();
-    let resolveFirst: (report: SimulationPreflightReport) => void = () => undefined;
-    preflightSimulation.mockReturnValueOnce(
-      new Promise<SimulationPreflightReport>((resolve) => {
-        resolveFirst = resolve;
-      }),
-    );
-    const onStart = vi.fn();
-    render(<PreflightStep request={{ interface: 'eth0' }} onStart={onStart} />);
-
-    await user.click(screen.getByTestId('wizard-preflight-check'));
-    await user.clear(screen.getByTestId('wizard-access-vlan'));
-    await user.type(screen.getByTestId('wizard-access-vlan'), '2');
-    resolveFirst(safeReport);
-
-    await waitFor(() => expect(preflightSimulation).toHaveBeenCalledTimes(1));
-    expect(screen.getByTestId('wizard-preflight-start')).toBeDisabled();
-    await user.click(screen.getByTestId('wizard-preflight-check'));
-    await waitFor(() => expect(screen.getByTestId('wizard-preflight-start')).not.toBeDisabled());
-    await user.click(screen.getByTestId('wizard-preflight-start'));
-
-    expect(onStart).toHaveBeenCalledWith(expect.objectContaining({ accessVlan: 2 }));
+    expect(await screen.findByText('Simulation preflight failed')).toBeInTheDocument();
   });
 });

--- a/ui/src/components/wizard/PreflightStep.tsx
+++ b/ui/src/components/wizard/PreflightStep.tsx
@@ -1,6 +1,7 @@
 import { type FC, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { preflightSimulation } from '../../api/client';
+import { type ApiErrorDetail, isApiError } from '../../api/errors';
 import type { SimulationPreflightReport, SimulationPreflightRequest } from '../../api/fabric-types';
 import type { SimulationRequest } from '../../api/types';
 import { Button } from '../../ui/Button';
@@ -26,6 +27,10 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
   const [report, setReport] = useState<SimulationPreflightReport | null>(null);
   const [approvedPayload, setApprovedPayload] = useState<SimulationPreflightRequest | null>(null);
   const [error, setError] = useState('');
+  // The server enumerates validation failures one per offending field (#1461);
+  // keeping only err.message threw that diagnosis away on the one screen whose
+  // job is to show it (#1472).
+  const [errorDetails, setErrorDetails] = useState<readonly ApiErrorDetail[]>([]);
   const [checking, setChecking] = useState(false);
   const requestSequence = useRef(0);
 
@@ -51,6 +56,7 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
     const checkedPayload = payload;
     setChecking(true);
     setError('');
+    setErrorDetails([]);
     try {
       const result = await preflightSimulation(checkedPayload);
       if (requestSequence.current !== sequence) return;
@@ -61,6 +67,7 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
       setReport(null);
       setApprovedPayload(null);
       setError(err instanceof Error ? err.message : t('newSimWizard.preflight.requestError'));
+      setErrorDetails(isApiError(err) ? err.details : []);
     } finally {
       if (requestSequence.current === sequence) setChecking(false);
     }
@@ -134,9 +141,18 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
           </label>
         )}
         {error && (
-          <SmallText className="text-status-error" role="alert">
-            {error}
-          </SmallText>
+          <div className="text-status-error" role="alert">
+            <SmallText className="text-status-error">{error}</SmallText>
+            {errorDetails.length > 0 && (
+              <ul className="mt-tight list-disc pl-5 text-sm text-status-error">
+                {errorDetails.map((detail) => (
+                  <li key={`${detail.field ?? ''}-${detail.issue}`}>
+                    {detail.field ? `${detail.field}: ${detail.issue}` : detail.issue}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         )}
         {report?.safe && (
           <div


### PR DESCRIPTION
## Summary

#1461 made preflight enumerate its validation failures one per offending field, and it does. On CT304 running `0.94.60`, a failing preflight returns:

```json
{"error":"preflight_failed","message":"Simulation preflight failed",
 "details":[
  {"field":"devices[0].snmp_agent.community","issue":"SNMPv1/v2c requires an explicit community"},
  {"field":"devices[1].snmp_agent.community","issue":"SNMPv1/v2c requires an explicit community"}]}
```

The wizard showed only `Simulation preflight failed`. `PreflightStep` narrowed the rejection to `Error` and kept just `message`, so the diagnosis travelled the whole way over the wire and was discarded by the one screen whose job is to show it.

`ApiError` already carries `details` with `field`, `issue`, `line` and `column`, and `isApiError()` already exists. The step now holds them alongside the message and renders them in the same list markup it already uses for unsafe-report diagnostics.

## Relationship to #1429 (D3)

D3 threaded `details[]` through `format.ts` → `useErrorToast` → `ui-store` → `ToastContainer`, which is the **toast** path. The wizard renders a preflight failure as an inline banner and never reaches that code — which is why the earlier fix did not cover it.

## Linked Issue

Closes #1472

## Testing Evidence

Proven red against pre-fix code:

```
=== RED ===
FAIL src/components/wizard/PreflightStep.test.tsx > lists every detail the server sent, with its field
 Tests  1 failed | 1 passed (2)

=== GREEN ===
 Test Files  94 passed (94)
      Tests  461 passed (461)
npm run typecheck   clean
npx biome check     No fixes applied.
```

The second case is the negative control: an `ApiError` with no details still shows the plain message, and it passed before and after. Test collection was checked rather than assumed — 94 test files on disk, 94 collected by `vitest list --filesOnly`, including this one.

## Security and Release Checklist

- [x] Renders only the validator's field path and message — no config values or user data are surfaced
- [x] Details come from the server's own structured error, not from client-side inference
- [x] No new routes, auth surfaces, or persistent writes
- [x] No suppressions added (`//nolint`, `biome-ignore`)