### PR TITLE
fix(ui): enable Behaviors from any device that has an interface

### DIFF
--- a/ui/src/components/wizard/DraftBehaviorComposer.test.tsx
+++ b/ui/src/components/wizard/DraftBehaviorComposer.test.tsx
@@ -72,3 +72,84 @@ describe('DraftBehaviorComposer', () => {
     expect(onDraftUpdate).toHaveBeenCalledWith(updated);
   });
 });
+
+/**
+ * Guards #1491.
+ *
+ * The gate asked whether the *first* device has an interface, not whether any
+ * device does. The Start-empty seed puts `new-device` — a host with no
+ * interfaces — at position 0, so on CT304 the step stayed disabled after two
+ * switches with four interfaces each had been added and one of those interfaces
+ * was already carrying a link the wizard itself created.
+ *
+ * The same two values seed the default phase's traffic entry, so the timeline
+ * must also target the device that actually has the interface.
+ */
+const draftWithInterfacelessFirstDevice: ScenarioDraft = {
+  ...draft,
+  content: `
+devices:
+  - name: new-device
+    type: host
+    mac: "02:00:00:00:00:01"
+  - name: UITEST-SW-A
+    type: switch
+    interfaces:
+      - name: Ethernet1/1
+        type: ethernet
+        speed: 1000000000
+`,
+};
+
+describe('DraftBehaviorComposer with an interfaceless first device', () => {
+  beforeEach(() => replaceScenarioDraftBehaviors.mockReset());
+
+  it('enables the step using a later device that has interfaces', async () => {
+    render(
+      <DraftBehaviorComposer
+        draft={draftWithInterfacelessFirstDevice}
+        onDraftUpdate={vi.fn()}
+        onBusyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Add timeline' })).toBeEnabled();
+  });
+
+  it('seeds the default phase with the device that has the interface', async () => {
+    const user = userEvent.setup();
+    replaceScenarioDraftBehaviors.mockResolvedValue({
+      ...draftWithInterfacelessFirstDevice,
+      revision: 'revision-2',
+    });
+
+    render(
+      <DraftBehaviorComposer
+        draft={draftWithInterfacelessFirstDevice}
+        onDraftUpdate={vi.fn()}
+        onBusyChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add timeline' }));
+    await user.click(screen.getByTestId('save-behaviors'));
+
+    await waitFor(() => expect(replaceScenarioDraftBehaviors).toHaveBeenCalledTimes(1));
+    const timelines = replaceScenarioDraftBehaviors.mock.calls[0]?.[2];
+    expect(timelines?.[0]?.phases[0]?.traffic).toEqual([
+      { device: 'UITEST-SW-A', interface: 'Ethernet1/1', utilization: 75 },
+    ]);
+  });
+
+  it('stays disabled when no device has an interface', () => {
+    render(
+      <DraftBehaviorComposer
+        draft={{ ...draft, content: 'devices:\n  - name: new-device\n    type: host\n' }}
+        onDraftUpdate={vi.fn()}
+        onBusyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Add timeline' })).toBeDisabled();
+  });
+});

--- a/ui/src/components/wizard/DraftBehaviorComposer.tsx
+++ b/ui/src/components/wizard/DraftBehaviorComposer.tsx
@@ -49,8 +49,16 @@ export const DraftBehaviorComposer: FC<DraftBehaviorComposerProps> = ({
     value: device.name,
     label: device.name,
   }));
-  const firstDevice = deviceOptions[0]?.value ?? '';
-  const firstInterface = topology.interfaces[firstDevice]?.[0]?.name ?? '';
+  // The first device is not necessarily a usable one: the Start-empty seed puts
+  // an interfaceless host at position 0, which left this step permanently
+  // disabled however many switches were added afterwards (#1491). Seed from the
+  // first device that actually has an interface, since that is what a timeline
+  // targets.
+  const seedDevice = topology.devices.find(
+    (device) => (topology.interfaces[device.name] ?? []).length > 0,
+  );
+  const firstDevice = seedDevice?.name ?? '';
+  const firstInterface = firstDevice ? (topology.interfaces[firstDevice]?.[0]?.name ?? '') : '';
   const interfaceOptions = (device: string) =>
     (topology.interfaces[device] ?? []).map((iface) => ({ value: iface.name, label: iface.name }));
 


### PR DESCRIPTION
## Summary

The New Simulation wizard's **Behaviors** step stayed disabled even when the draft had devices with interfaces. Driven live on CT304:

1. Start empty → Next — draft seeded with `new-device`, a host with no `interfaces:`
2. Add `UITEST-SW-A` (access profile → 4 × Ethernet)
3. Add `UITEST-SW-B` (4 × Ethernet)
4. Drag SW-A → SW-B and connect `Ethernet1/1` to `Ethernet1/1` — succeeded, edge created
5. Behaviors → **"Add timeline" still disabled**, explaining `Add at least one interface to a device before scheduling behaviors`

Two devices with four interfaces each were present, and one of those interfaces was already carrying a link the wizard itself had just created.

## Root cause

`DraftBehaviorComposer.tsx:52-53` asked whether the **first** device has an interface, not whether **any** device does:

```ts
const firstDevice = deviceOptions[0]?.value ?? '';
const firstInterface = topology.interfaces[firstDevice]?.[0]?.name ?? '';
```

The Start-empty seed puts an interfaceless host at position 0, so the gate was permanently false for every draft built that way.

The same two values seed the default phase's traffic entry, so even once enabled the phase could target a device with no interface to carry it. Both now come from the first device that actually has one.

## Relationship to #1435 (D4)

D4 fixed the *message*: the empty state used to point at a permanently disabled button without saying why. The explanation it added is accurate about the rule — but the rule itself was wrong, so the message ended up confidently explaining a condition the draft had already satisfied.

## Linked Issue

Closes #1491

## Testing Evidence

Guards proven red against pre-fix code:

```
=== RED ===
FAIL > enables the step using a later device that has interfaces
FAIL > seeds the default phase with the device that has the interface
 Tests  2 failed | 2 passed (4)

=== GREEN ===
 Tests  474 passed
npm run typecheck   clean
npx biome check     No fixes applied.
```

Two controls passed before and after: the existing single-device timeline test is unchanged, and a new case asserts the button stays **disabled** when no device has an interface, so the gate was loosened only where it was wrong.

## Security and Release Checklist

- [x] Selection logic only — no change to what a saved timeline may contain or to the persisted schema
- [x] The step is still gated when genuinely nothing can carry traffic
- [x] No new routes, auth surfaces, or persistent writes
- [x] No suppressions added (`//nolint`, `biome-ignore`)