### PR TITLE
fix(ui): render server error details wherever an error is shown inline

### DIFF
--- a/ui/src/components/walk/WalkProfileCreator.test.tsx
+++ b/ui/src/components/walk/WalkProfileCreator.test.tsx
@@ -122,3 +122,40 @@ describe('WalkProfileCreator', () => {
     await waitFor(() => expect(screen.getByTestId('walk-profile-username')).toHaveValue(''));
   });
 });
+
+/**
+ * Guards #1499.
+ *
+ * #1488 made the server say why a capture failed, and on the released 0.94.66
+ * it does — the response carried "no response from the target: it did not
+ * answer, or the community or SNMPv3 credentials are wrong" while the screen
+ * showed only "SNMP walk capture failed". setError kept err.message and dropped
+ * ApiError.details.
+ */
+describe('WalkProfileCreator capture failures', () => {
+  beforeEach(() => {
+    captureWalkProfile.mockReset();
+  });
+
+  it('shows the server detail alongside the message', async () => {
+    const { ApiError } = await import('../../api/errors');
+    captureWalkProfile.mockRejectedValue(
+      new ApiError('SNMP walk capture failed', 502, 'walk_capture_failed', [
+        { issue: 'no response from the target: it did not answer, or the community is wrong' },
+      ]),
+    );
+    render(<WalkProfileCreator />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Capture from device' }));
+    fireEvent.change(screen.getByLabelText('Target IP address'), {
+      target: { value: '10.44.99.250' },
+    });
+    fireEvent.change(screen.getByTestId('walk-profile-community'), {
+      target: { value: 'not-a-real-community' },
+    });
+    fireEvent.click(screen.getByTestId('walk-profile-capture'));
+
+    expect(await screen.findByText('SNMP walk capture failed')).toBeInTheDocument();
+    expect(await screen.findByText(/no response from the target/)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/walk/WalkProfileCreator.tsx
+++ b/ui/src/components/walk/WalkProfileCreator.tsx
@@ -1,5 +1,6 @@
 import { type FC, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { type ApiErrorDetail, isApiError } from '../../api/errors';
 import {
   captureWalkProfile,
   createCapturedProfile,
@@ -7,6 +8,7 @@ import {
   type WalkCaptureCredentials,
   type WalkProfileReview,
 } from '../../api/walk-profile-client';
+import { ApiErrorMessage } from '../../ui/ApiErrorMessage';
 import { Card, CardContent } from '../../ui/Card';
 import { WalkProfileReviewForm } from './WalkProfileReviewForm';
 import { WalkProfileSource } from './WalkProfileSource';
@@ -40,6 +42,9 @@ export const WalkProfileCreator: FC = () => {
   const [review, setReview] = useState<WalkProfileReview | null>(null);
   const [busy, setBusy] = useState<'idle' | 'reading' | 'capturing' | 'creating'>('idle');
   const [error, setError] = useState<string | null>(null);
+  // The server enumerates why a capture failed (#1488); keeping only
+  // err.message discarded it at the last step (#1499).
+  const [errorDetails, setErrorDetails] = useState<readonly ApiErrorDetail[]>([]);
   const [createdRole, setCreatedRole] = useState<string | null>(null);
   const controller = useRef<AbortController | null>(null);
   const fileInput = useRef<HTMLInputElement | null>(null);
@@ -48,6 +53,7 @@ export const WalkProfileCreator: FC = () => {
     setReview(null);
     setCreatedRole(null);
     setError(null);
+    setErrorDetails([]);
   };
 
   const runImport = async () => {
@@ -58,6 +64,7 @@ export const WalkProfileCreator: FC = () => {
     }
     setBusy('reading');
     setError(null);
+    setErrorDetails([]);
     setCreatedRole(null);
     controller.current = new AbortController();
     try {
@@ -69,7 +76,10 @@ export const WalkProfileCreator: FC = () => {
         ),
       );
     } catch (caught) {
-      if ((caught as Error).name !== 'AbortError') setError((caught as Error).message);
+      if ((caught as Error).name !== 'AbortError') {
+        setError((caught as Error).message);
+        setErrorDetails(isApiError(caught) ? caught.details : []);
+      }
     } finally {
       controller.current = null;
       setFile(null);
@@ -81,6 +91,7 @@ export const WalkProfileCreator: FC = () => {
   const runCapture = async () => {
     setBusy('capturing');
     setError(null);
+    setErrorDetails([]);
     setCreatedRole(null);
     controller.current = new AbortController();
     try {
@@ -88,7 +99,10 @@ export const WalkProfileCreator: FC = () => {
         await captureWalkProfile(walkFilename(captureName), capture, controller.current.signal),
       );
     } catch (caught) {
-      if ((caught as Error).name !== 'AbortError') setError((caught as Error).message);
+      if ((caught as Error).name !== 'AbortError') {
+        setError((caught as Error).message);
+        setErrorDetails(isApiError(caught) ? caught.details : []);
+      }
     } finally {
       controller.current = null;
       setCapture((current) => ({
@@ -106,6 +120,7 @@ export const WalkProfileCreator: FC = () => {
     if (!review) return;
     setBusy('creating');
     setError(null);
+    setErrorDetails([]);
     try {
       const created = await createCapturedProfile({
         role: review.profile.role,
@@ -148,11 +163,7 @@ export const WalkProfileCreator: FC = () => {
           runCapture={runCapture}
           cancel={() => controller.current?.abort()}
         />
-        {error && (
-          <p role="alert" className="text-sm text-status-error">
-            {error}
-          </p>
-        )}
+        {error && <ApiErrorMessage message={error} details={errorDetails} />}
         {createdRole && (
           <p role="status" className="text-sm text-status-success">
             {t('walkAnalyzer.profile.created', { role: createdRole })}

--- a/ui/src/components/wizard/PreflightStep.tsx
+++ b/ui/src/components/wizard/PreflightStep.tsx
@@ -4,6 +4,7 @@ import { preflightSimulation } from '../../api/client';
 import { type ApiErrorDetail, isApiError } from '../../api/errors';
 import type { SimulationPreflightReport, SimulationPreflightRequest } from '../../api/fabric-types';
 import type { SimulationRequest } from '../../api/types';
+import { ApiErrorMessage } from '../../ui/ApiErrorMessage';
 import { Button } from '../../ui/Button';
 import { Card, CardContent } from '../../ui/Card';
 import { H2, SmallText } from '../../ui/Typography';
@@ -140,20 +141,7 @@ export const PreflightStep: FC<PreflightStepProps> = ({ request, onStart, starti
             />
           </label>
         )}
-        {error && (
-          <div className="text-status-error" role="alert">
-            <SmallText className="text-status-error">{error}</SmallText>
-            {errorDetails.length > 0 && (
-              <ul className="mt-tight list-disc pl-5 text-sm text-status-error">
-                {errorDetails.map((detail) => (
-                  <li key={`${detail.field ?? ''}-${detail.issue}`}>
-                    {detail.field ? `${detail.field}: ${detail.issue}` : detail.issue}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )}
+        {error && <ApiErrorMessage message={error} details={errorDetails} />}
         {report?.safe && (
           <div
             className="rounded-lg border border-status-success/40 bg-status-success/10 pad-sm"

--- a/ui/src/ui/ApiErrorMessage.test.tsx
+++ b/ui/src/ui/ApiErrorMessage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ApiErrorMessage } from './ApiErrorMessage';
+
+/**
+ * Guards #1499.
+ *
+ * The API enumerates its failures one per offending field — preflight
+ * validation (#1461), walk capture (#1488) — and each inline surface kept only
+ * `err.message`, so the diagnosis travelled the whole way over the wire and
+ * died at the last step. On the released 0.94.66 the walk-capture response
+ * carried "no response from the target: it did not answer, or the community or
+ * SNMPv3 credentials are wrong" while the screen said only "SNMP walk capture
+ * failed".
+ */
+describe('ApiErrorMessage', () => {
+  it('lists every detail beneath the message', () => {
+    render(
+      <ApiErrorMessage
+        message="Simulation preflight failed"
+        details={[
+          {
+            field: 'devices[0].snmp_agent.community',
+            issue: 'SNMPv1/v2c requires an explicit community',
+          },
+          {
+            field: 'devices[1].snmp_agent.community',
+            issue: 'SNMPv1/v2c requires an explicit community',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Simulation preflight failed')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText(/devices\[0\]\.snmp_agent\.community/)).toBeInTheDocument();
+  });
+
+  it('renders a detail with no field as its bare issue', () => {
+    render(
+      <ApiErrorMessage
+        message="SNMP walk capture failed"
+        details={[{ issue: 'no response from the target' }]}
+      />,
+    );
+
+    expect(screen.getByText('no response from the target')).toBeInTheDocument();
+  });
+
+  it('shows just the message when the server sent no details', () => {
+    render(<ApiErrorMessage message="Something went wrong" />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.queryByRole('listitem')).toBeNull();
+  });
+
+  it('is announced as an alert', () => {
+    render(<ApiErrorMessage message="Failed" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/ui/src/ui/ApiErrorMessage.tsx
+++ b/ui/src/ui/ApiErrorMessage.tsx
@@ -1,0 +1,33 @@
+import type { FC } from 'react';
+import type { ApiErrorDetail } from '../api/errors';
+import { SmallText } from './Typography';
+
+interface ApiErrorMessageProps {
+  message: string;
+  /** Structured per-field detail the server sent, when it sent any. */
+  details?: readonly ApiErrorDetail[];
+}
+
+/**
+ * Inline error text plus whatever the server said about *why*.
+ *
+ * The API enumerates its failures one per offending field — preflight
+ * validation (#1461), walk capture (#1488) — and each inline surface used to
+ * keep only `err.message` and throw the rest away, so the diagnosis travelled
+ * the whole way over the wire and died at the last step (#1472, #1499). One
+ * component so the next inline error surface renders the detail for free.
+ */
+export const ApiErrorMessage: FC<ApiErrorMessageProps> = ({ message, details = [] }) => (
+  <div className="text-status-error" role="alert">
+    <SmallText className="text-status-error">{message}</SmallText>
+    {details.length > 0 && (
+      <ul className="mt-tight list-disc pl-5 text-sm text-status-error">
+        {details.map((detail) => (
+          <li key={`${detail.field ?? ''}-${detail.issue}`}>
+            {detail.field ? `${detail.field}: ${detail.issue}` : detail.issue}
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+);


### PR DESCRIPTION
## Summary

#1488 made the server say *why* a walk capture failed, and on the released `0.94.66` it does:

```json
{"error":"walk_capture_failed","message":"SNMP walk capture failed",
 "details":[{"issue":"no response from the target: it did not answer, or the community or SNMPv3 credentials are wrong"}]}
```

The Walk Analyzer showed only `SNMP walk capture failed`. `WalkProfileCreator` narrowed the rejection to `Error` and kept only `message`.

This is the third place with the same shape — #1429 threaded details through the **toast** path, #1472 fixed the **New Simulation wizard's** inline banner, and this is the **Walk Analyzer's**. Rather than patch a third copy, both inline sites now render one `ApiErrorMessage` component, so the next inline error surface gets the detail for free instead of repeating the omission.

## Linked Issue

Closes #1499

## Testing Evidence

The behavioural red is the live `0.94.66` observation above. The component guard was confirmed to actually guard by reverting the source fix and re-running:

```
=== fix reverted ===
× shows the server detail alongside the message
TestingLibraryElementError: Unable to find an element with the text:
/no response from the target/

=== fix restored ===
 Tests  4 passed (4)
```

Full gates:

```
 Test Files 99 passed · Tests 492 passed
npm run typecheck   clean
npx biome check     No fixes applied.
```

`ApiErrorMessage` carries its own cases: details with a field render as `field: issue`, a detail without one renders bare, no details renders just the message, and the block is announced as an `alert`. The preflight step's existing behaviour is preserved by construction — it now renders the same component with the same props it was building inline.

## Security and Release Checklist

- [x] Renders only what the server already returned — no client-side inference, no new data exposed
- [x] The capture form still clears the community after a request, including the failure path
- [x] No new routes, auth surfaces, or persistent writes
- [x] No suppressions added (`//nolint`, `biome-ignore`)