### PR TITLE
fix(capture): require payload before a port names an application protocol

### DIFF
--- a/internal/api/capture/analyze.go
+++ b/internal/api/capture/analyze.go
@@ -317,7 +317,14 @@ func parseTCPLayer(packet gopacket.Packet, pkt *Packet) {
 		"window":  tcp.Window,
 	}
 
-	pkt.Protocol = getProtocolByPort(srcPort, dstPort, "TCP")
+	// A port number alone does not make a packet that protocol. The three-way
+	// handshake and bare ACKs on port 80 carry no application data, and both
+	// tcpdump and Wireshark show them as TCP, reserving the application name for
+	// segments that actually carry payload. Labelling them HTTP made a NIAC
+	// capture disagree with tcpdump on the first three rows of every conversation.
+	if len(tcp.Payload) > 0 {
+		pkt.Protocol = getProtocolByPort(srcPort, dstPort, "TCP")
+	}
 }
 
 // parseUDPLayer extracts UDP information from a packet.
@@ -345,7 +352,12 @@ func parseUDPLayer(packet gopacket.Packet, pkt *Packet) {
 		"length":  udp.Length,
 	}
 
-	pkt.Protocol = getProtocolByPort(srcPort, dstPort, "UDP")
+	// Same rule as TCP: the datagram has to carry something for its port to name
+	// an application protocol. A UDP datagram almost always does, so this is a
+	// consistency guard rather than a behaviour change.
+	if len(udp.Payload) > 0 {
+		pkt.Protocol = getProtocolByPort(srcPort, dstPort, "UDP")
+	}
 }
 
 // parseICMPLayer extracts ICMP information from a packet.

--- a/internal/api/capture/protocol_label_test.go
+++ b/internal/api/capture/protocol_label_test.go
@@ -1,0 +1,82 @@
+package capture
+
+import (
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+// buildTCPPacket assembles a real Ethernet/IPv4/TCP frame so the label is
+// derived the same way it is for a capture file, not from a hand-made struct.
+func buildTCPPacket(t *testing.T, srcPort, dstPort int, syn bool, payload []byte) gopacket.Packet {
+	t.Helper()
+
+	eth := &layers.Ethernet{
+		SrcMAC:       []byte{0x02, 0, 0, 0, 0, 1},
+		DstMAC:       []byte{0x02, 0, 0, 0, 0, 2},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version: 4, IHL: 5, TTL: 64, Protocol: layers.IPProtocolTCP,
+		SrcIP: []byte{10, 0, 0, 1}, DstIP: []byte{10, 0, 0, 2},
+	}
+	tcp := &layers.TCP{
+		SrcPort: layers.TCPPort(srcPort), DstPort: layers.TCPPort(dstPort),
+		SYN: syn, ACK: !syn, Seq: 1, Window: 1024,
+	}
+	if err := tcp.SetNetworkLayerForChecksum(ip); err != nil {
+		t.Fatalf("checksum layer: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	if err := gopacket.SerializeLayers(buf, opts, eth, ip, tcp, gopacket.Payload(payload)); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return gopacket.NewPacket(buf.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
+}
+
+func labelFor(t *testing.T, packet gopacket.Packet) string {
+	t.Helper()
+	pkt := &Packet{Headers: map[string]any{}}
+	parseTCPLayer(packet, pkt)
+	return pkt.Protocol
+}
+
+// TestBarePortsDoNotImplyAnApplicationProtocol guards the analyzer's PROTOCOL
+// column.
+//
+// parseTCPLayer applied getProtocolByPort unconditionally, so a three-way
+// handshake on port 80 — SYN, SYN-ACK, ACK, none of which carry a byte of
+// application data — was labelled HTTP. tcpdump and Wireshark both show TCP for
+// those and reserve the application name for segments that actually carry
+// payload, so anyone cross-checking a NIAC capture against tcpdump saw a
+// disagreement on the first three rows of every conversation.
+func TestBarePortsDoNotImplyAnApplicationProtocol(t *testing.T) {
+	tests := []struct {
+		name    string
+		srcPort int
+		dstPort int
+		syn     bool
+		payload []byte
+		want    string
+	}{
+		{"SYN to port 80", 44100, 80, true, nil, "TCP"},
+		{"bare ACK on port 80", 44100, 80, false, nil, "TCP"},
+		{"response ACK from port 80", 80, 44100, false, nil, "TCP"},
+		{"request with payload", 44100, 80, false, []byte("GET / HTTP/1.1\r\n\r\n"), "HTTP"},
+		{"response with payload", 80, 44100, false, []byte("HTTP/1.1 200 OK\r\n\r\n"), "HTTP"},
+		{"payload on an unknown port", 44100, 54321, false, []byte("hello"), "TCP"},
+		{"SSH with payload", 44100, 22, false, []byte("SSH-2.0-x"), "SSH"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := buildTCPPacket(t, tt.srcPort, tt.dstPort, tt.syn, tt.payload)
+			if got := labelFor(t, packet); got != tt.want {
+				t.Errorf("protocol = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The PCAP analyzer's PROTOCOL column named an application protocol from the port number alone, so the three-way handshake on port 80 — SYN, SYN-ACK, ACK, none of which carry a byte of application data — was labelled **HTTP**.

`tcpdump` and Wireshark both show **TCP** for those and reserve the application name for segments that actually carry payload. A NIAC capture therefore disagreed with tcpdump on the first three rows of every conversation, which is exactly where someone cross-checks.

`parseTCPLayer` now applies `getProtocolByPort` only when the segment has payload. `parseUDPLayer` gets the same guard for consistency — a datagram almost always carries something, so that half is not a behaviour change.

## Linked Issue

Closes #1506

## Testing Evidence

Guards proven red against pre-fix code, built from real serialized Ethernet/IPv4/TCP frames rather than hand-made structs so the label is derived the same way it is for a capture file:

```
=== RED ===
--- FAIL: TestBarePortsDoNotImplyAnApplicationProtocol/SYN_to_port_80
        protocol = "HTTP", want "TCP"
--- FAIL: TestBarePortsDoNotImplyAnApplicationProtocol/bare_ACK_on_port_80
        protocol = "HTTP", want "TCP"
--- FAIL: TestBarePortsDoNotImplyAnApplicationProtocol/response_ACK_from_port_80
        protocol = "HTTP", want "TCP"

=== GREEN ===
go test ./internal/api/capture/  ok
go test ./... -count=1           all packages pass
golangci-lint run ./internal/api/capture/...   0 issues.
```

Four of the seven cases are negative controls and passed before and after: a request and a response carrying payload still report `HTTP`, payload on an unrecognised port still reports `TCP`, and SSH with payload still reports `SSH`. The existing `TestGetProtocolByPort` table is untouched — the port map itself is unchanged, only when it is consulted.

Note on verification surface: `internal/api/capture` binds libpcap through cgo, so `GOOS=linux golangci-lint` cannot cross-lint it from macOS. The package carries no build-tagged files, so the native run is representative here, and CI is the Linux authority.

## Security and Release Checklist

- [x] Display labelling only — no change to what is captured, parsed, or stored
- [x] Packet headers, ports and payload handling are untouched
- [x] No new routes, auth surfaces, or persistent writes
- [x] No suppressions added (`//nolint`, `biome-ignore`)