### PR TITLE
fix(i18n): assert exact pins instead of a hardcoded version target

### DIFF
--- a/scripts/i18n/validate.sh
+++ b/scripts/i18n/validate.sh
@@ -422,29 +422,33 @@ check_key_usage() {
 # Check: locked package versions (matches I18N_CONVENTIONS.md)
 # -----------------------------------------------------------------------------
 check_locked_versions() {
-  section "i18n package versions (pinned exact, per CLAUDE.md)"
+  section "i18n package versions (pinned exact)"
   local pkg="${UI_SRC_DIR%/src}/package.json"
   [ ! -f "$pkg" ] && { warn "package.json not found at $pkg; skipping"; return; }
   local issues=0
-  # POSIX-compatible parallel arrays (no `declare -A` — macOS bash 3.x).
+  # Exact pins only — deliberately no hardcoded target version here.
+  #
+  # Under always-latest, Renovate moves these packages and any literal written
+  # into this script rots on the very next bump: the gate then demands a
+  # downgrade, which is how all three repos ended up asserting a version older
+  # than the one they shipped. The version itself is Renovate's call. What a
+  # single repo *can* verify locally is that nobody reintroduced a range —
+  # a `^` here is what would let the three repos drift apart between installs.
   local names=(i18next react-i18next i18next-browser-languagedetector)
-  local wants=(26.3.6 17.0.11 8.2.1)
-  local i=0
-  while [ "$i" -lt "${#names[@]}" ]; do
-    local name="${names[$i]}"
-    local want="${wants[$i]}"
-    local actual
+  local name actual
+  for name in "${names[@]}"; do
     actual=$(jq -r --arg n "$name" '.dependencies[$n] // .devDependencies[$n] // empty' "$pkg")
     if [ -z "$actual" ]; then
       warn "$name not installed in $pkg"
-    elif [ "$actual" != "$want" ]; then
-      ratchet_fail "$name pinned to $actual but lockstep target is $want"
-      annotate "$pkg" "$name should be pinned to $want (CLAUDE.md always-latest + I18N_CONVENTIONS.md)"
+      continue
+    fi
+    if ! printf '%s' "$actual" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+      fail "$name pinned as '$actual' — must be an exact version, not a range"
+      annotate "$pkg" "$name must be pinned exactly (no ^, ~ or range); got '$actual'"
       issues=$((issues + 1))
     fi
-    i=$((i + 1))
   done
-  [ "$issues" -eq 0 ] && ok "all i18n packages on locked versions"
+  [ "$issues" -eq 0 ] && ok "all i18n packages pinned exact"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`scripts/i18n/validate.sh` asserted the i18n lockstep target as a hardcoded
literal (`wants=(26.3.6 17.0.11 8.2.1)`). Renovate never updates that literal, so on the
first bump after it was written the gate started demanding a **downgrade** —
this repo ships i18next 26.4.0 / react-i18next 17.0.12 and the check asked for
older. All three fleet repos were in that state simultaneously.

Cross-repo lockstep is intact; only the assertion rotted. Bumping the literal
would restore correctness for exactly one Renovate cycle.

This drops the literal and asserts the invariant a single repo can actually
verify: **exact pin, no range**. A `^` is what would let the three repos drift
apart between installs; the version itself is Renovate's call under
always-latest. Uses `fail` rather than `ratchet_fail` — every repo already
complies, so there is no catch-up to ratchet and this is a real gate.

## Linked Issue

Closes #1514

Fleet tracking issue: MustardSeedNetworks/stem#748

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Testing Evidence

Gate passes on the real tree (the false downgrade demand is gone):

```text
$ ./scripts/i18n/validate.sh --ratchet
=== i18n package versions (pinned exact) ===
✓ all i18n packages pinned exact
```

And the new check actually catches what it claims to. Injecting a caret range,
then restoring:

```text
$ # ui/package.json: "i18next": "^26.4.0"
$ ./scripts/i18n/validate.sh --ratchet
=== i18n package versions (pinned exact) ===
✘ i18next pinned as '^26.4.0' — must be an exact version, not a range
::error file=ui/package.json::i18next must be pinned exactly (no ^, ~ or range); got '^26.4.0'
$ echo $?
1
```

Note the exit 1 is **under `--ratchet`** — this check is deliberately not
demoted. `shellcheck -S warning scripts/i18n/validate.sh` is clean.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. — CI script only, no product code.
- [x] Dependencies are pinned and justified if changed. — no dependency changed; this tightens how pins are enforced.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.
