### PR TITLE
ci: compile the darwin build on a macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,40 @@ jobs:
           flags: backend
           fail_ci_if_error: false
 
+  # ===========================================================================
+  # Backend (macOS)
+  # ===========================================================================
+  # niac ships a darwin build (goreleaser `niac-darwin`, CGO_ENABLED=1), but
+  # every CI job runs on ubuntu, so `internal/truststore/truststore_darwin.go`
+  # and the darwin half of the library lock/sync pair were never compiled — a
+  # break in them would surface at release time, not here. Cross-compiling from
+  # ubuntu cannot stand in: gopacket/pcap needs cgo, so `GOOS=darwin go build`
+  # fails on the pure-Go builder. macOS ships libpcap, so this needs no apt step.
+  backend-darwin:
+    name: Backend (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.schema == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.https == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      # truststore is the only package with darwin-specific logic and it has
+      # tests, so this both links the darwin build and exercises it.
+      - name: Test
+        run: go test -race ./internal/truststore/...
+
   race:
     name: Backend (race detector)
     runs-on: ubuntu-latest
@@ -1001,6 +1035,7 @@ jobs:
     needs:
       - changes
       - backend
+      - backend-darwin
       - race
       - frontend
       - security


### PR DESCRIPTION
## Summary

niac ships a darwin binary (goreleaser `niac-darwin`, `goos: [darwin]`, `CGO_ENABLED=1`), but every job in `ci.yml` runs on `ubuntu-latest` — so `internal/truststore/truststore_darwin.go` and the darwin half of the library lock/sync pair were **never compiled by CI**. A break in them shows green checks and surfaces at release time.

Adds a `Backend (macOS)` job on `macos-latest` (build, vet, and `go test -race ./internal/truststore/...`), wired into the `CI Complete` aggregate so branch protection gates on it.

Cross-compiling from ubuntu cannot substitute — `gopacket/pcap` needs cgo, so `GOOS=darwin go build ./...` fails on the pure-Go builder:

```
# github.com/gopacket/gopacket/pcap
pcap.go:30:22: undefined: pcapErrorNotActivated
```

A native runner is the only thing that covers it. macOS ships libpcap, so unlike the ubuntu backend job this needs no apt step. `truststore` is the only package with darwin-specific logic and it has tests, so the job both **links** the darwin build and **exercises** it.

Same class of gap fixed in `foundation` (MustardSeedNetworks/foundation#7), where the CoreWLAN cgo path was never built by CI.

## Linked Issue

Fixes #1520

## Testing Evidence

All three job commands run natively on macOS 26 / Go 1.27.0 darwin/arm64:

```
$ go build ./...
# github.com/MustardSeedNetworks/niac-go/cmd/niac
ld: warning: ignoring duplicate libraries: '-lpcap'
exit=0

$ go vet ./...
exit=0

$ go test -race ./internal/truststore/...
ok  	github.com/MustardSeedNetworks/niac-go/internal/truststore	1.272s
```

Cross-compile confirmed non-viable, and windows confirmed still building:

```
$ GOOS=darwin GOARCH=amd64 go build ./...   -> BUILD FAILED (cgo/pcap)
$ GOOS=windows GOARCH=amd64 go build ./...  -> build OK
$ GOOS=windows GOARCH=arm64 go build ./...  -> build OK
```

Workflow lint:

```
$ actionlint -ignore 'SC2129'
(exit 0, no output)
```

The `ld: warning: ignoring duplicate libraries: '-lpcap'` line is a benign Xcode linker warning, not an error (exit 0) — and it is precisely the kind of darwin-only signal no ubuntu job can surface.

## Security and Release Checklist

- No product code changed — CI configuration only.
- New checkout step sets `persist-credentials: false`. Note the other checkouts in this workflow do not; zizmor reports 11 pre-existing medium `artipacked` findings (0 high, so the gate still passes). Not bundled here — worth a separate sweep.
- No new secrets, permissions, or third-party actions: the job reuses the existing pinned `actions/checkout` SHA and the local `./.github/actions/setup-go` composite.
- No release/versioning impact; the darwin artifact itself is unchanged, only now built in CI as well.

## Follow-up not in this PR

Windows is also a release target and likewise never compiled by CI. Unlike darwin, `GOOS=windows go build ./...` **does** work from ubuntu (gopacket/pcap uses runtime DLL loading there, no cgo) and currently passes — a cheap one-step guard, tracked separately rather than bundled here.