### PR TITLE
fix(i18n): semgrep for the fallback rules, and drop --ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,6 +669,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # The t()-fallback rules are semgrep rules, not grep — every text-based
+      # version had a blind spot. Pinned exact, per the dependency policy; the
+      # fleet SAST job pins its own copy separately.
+      - name: Install semgrep
+        run: pipx install semgrep==1.168.0
+
       - uses: ./.github/actions/setup-node
 
       - name: Install frontend dependencies
@@ -685,7 +691,7 @@ jobs:
         # cleanup brings both counts to zero across seed/stem/niac.
         # See scripts/i18n/README.md and
         # msn-docs-internal/05-Engineering/I18N_CONVENTIONS.md.
-        run: ./scripts/i18n/validate.sh --ratchet
+        run: ./scripts/i18n/validate.sh
 
   # ===========================================================================
   # Documentation Checks

--- a/scripts/i18n/check-keys.py
+++ b/scripts/i18n/check-keys.py
@@ -72,6 +72,34 @@ def normalize_plural(key: str) -> str:
     return key
 
 
+GO_T_CALL = re.compile(r"""\.T\(\s*"((?:errors|[a-z][\w]*)\.[\w.]+)"\s*[,)]""")
+
+
+def extract_go_keys() -> set[tuple[str, str]]:
+    """Return {(namespace, key)} for every localizer.T("ns.key") in Go source.
+
+    internal/i18n/locales is embedded by the Go backend as well as bundled by
+    the UI, so scanning only ui/src reports every backend-only string as an
+    unused key. seed alone has 207 localizer.T call sites; errors.settings.conflict
+    is reported unused while handlers_settings.go depends on it.
+
+    Go addresses keys as "namespace.rest", flattened, rather than "ns:rest".
+    """
+    hits: set[tuple[str, str]] = set()
+    for path in ROOT.rglob("*.go"):
+        if "/vendor/" in str(path):
+            continue
+        try:
+            text = path.read_text()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for m in GO_T_CALL.finditer(text):
+            ns, _, rest = m.group(1).partition(".")
+            if rest:
+                hits.add((ns, rest))
+    return hits
+
+
 def extract_t_calls() -> set[tuple[str, str, int, str]]:
     """Walk ui/src/**/*.{ts,tsx} and yield (file, line, key) tuples for
     every t('…') call. Returns a set of (namespace, key, line, file).
@@ -86,15 +114,19 @@ def extract_t_calls() -> set[tuple[str, str, int, str]]:
     #   const { t } = useTranslation('common');           → alias 't' -> 'common'
     #   const { t: tDevices } = useTranslation('devices'); → 'tDevices' -> 'devices'
     USE_TRANSLATION = re.compile(
-        r"""const\s*\{\s*t(?:\s*:\s*([A-Za-z]+))?\s*[,}].*?useTranslation\s*\(\s*['"]([a-z]+)['"]""",
+        r"""const\s*\{\s*t(?:\s*:\s*([A-Za-z]+))?\s*[,}]"""
+        r"""(?:(?!useTranslation).)*?useTranslation\s*\(\s*(\[[^\]]*\]|['"][a-z]+['"])""",
         re.DOTALL,
     )
+    NS_LITERAL = re.compile(r"""['"]([a-z]+)['"]""")
     # Tighter T_CALL that captures the alias function name (group 1)
     # plus the literal key (group 2).
     T_CALL_LOCAL = re.compile(
         r"""\b(t(?:[A-Z][A-Za-z]*)?)\s*\(\s*['"`]([a-zA-Z][\w-]*[.:][\w.:-]+)['"`]""",
         re.MULTILINE,
     )
+
+    all_namespaces = set(load_locale_keys().keys())
 
     hits: set[tuple[str, str, int, str]] = set()
     for path in UI_SRC.rglob("*.ts*"):
@@ -116,12 +148,28 @@ def extract_t_calls() -> set[tuple[str, str, int, str]]:
         alias_to_namespaces: dict[str, set[str]] = {}
         for m in USE_TRANSLATION.finditer(text):
             alias = m.group(1) or "t"
-            ns = m.group(2)
-            alias_to_namespaces.setdefault(alias, set()).add(ns)
+            # i18next treats the first array entry as the default namespace,
+            # but a bare key may resolve against any of them, and the lookup
+            # below already tries every candidate. The array form used to
+            # match nothing at all, so every bare key in such a file fell
+            # through to the global default namespace.
+            for ns in NS_LITERAL.findall(m.group(2)):
+                alias_to_namespaces.setdefault(alias, set()).add(ns)
         if "t" not in alias_to_namespaces:
-            # Default: bare `t(` outside any useTranslation call falls back
-            # to common, mirroring i18next's defaultNamespace.
-            alias_to_namespaces["t"] = {"common"}
+            if "useTranslation" in text:
+                # The file binds a namespace somewhere this regex did not
+                # attribute to the bare alias; common is i18next's default.
+                alias_to_namespaces["t"] = {"common"}
+            else:
+                # No useTranslation in the file at all: `t` arrived as a prop
+                # or a parameter, and its namespace is genuinely unknowable
+                # without following the caller. Asserting "common" here is how
+                # PathDiscoveryTimeline's keys were reported missing from
+                # common.json while sitting in cards.json. Verify the key
+                # exists *somewhere* instead of pinning a namespace we cannot
+                # know — that still catches typos and deletions, and invents
+                # no false positives.
+                alias_to_namespaces["t"] = set(all_namespaces)
 
         rel = path.relative_to(ROOT)
 
@@ -219,10 +267,14 @@ def main() -> int:
 
     all_prefixes = tuple(BUILTIN_DYNAMIC_PREFIXES + repo_prefixes)
 
+    go_keys = extract_go_keys()
+
     unused: list[tuple[str, str]] = []
     for ns, keys in locale.items():
         for k in keys:
             if k in used_keys.get(ns, set()):
+                continue
+            if (ns, k) in go_keys:
                 continue
             # Match either `key.path` or `<namespace>:key.path`
             qualified = f"{ns}:{k}"
@@ -231,16 +283,13 @@ def main() -> int:
             unused.append((ns, k))
 
     # Report.
-    ratchet = "--ratchet" in sys.argv
     code = 0
     if missing:
-        level = "warning" if ratchet else "error"
-        print(f"::{level}::{len(missing)} t() call(s) reference keys missing from EN locale:")
+        print(f"::error::{len(missing)} t() call(s) reference keys missing from EN locale:")
         for ns, key, line, file in sorted(missing)[:30]:
             print(f"  {file}:{line}: t('{ns}:{key}') — not in {ns}.json")
         if len(missing) > 30:
             print(f"  … and {len(missing) - 30} more")
-        if not ratchet:
             code = 1
     else:
         print("✓ every t() call has a matching EN locale key")
@@ -252,15 +301,11 @@ def main() -> int:
         # PR time. To allow a genuinely dynamic-lookup key that the
         # static analyzer can't see, add a prefix entry to
         # dynamic-prefixes.txt with a one-line WHY comment.
-        # --ratchet downgrades to warn for callers that want to defer
-        # cleanup; the validator passes --ratchet through.
-        level = "warning" if ratchet else "error"
-        print(f"::{level}::{len(unused)} EN locale key(s) not referenced by any t() call:")
+        print(f"::error::{len(unused)} EN locale key(s) not referenced by any t() call:")
         for ns, key in sorted(unused)[:30]:
             print(f"  {ns}.json: {key}")
         if len(unused) > 30:
             print(f"  … and {len(unused) - 30} more")
-        if not ratchet:
             code = 1
     else:
         print("✓ every EN locale key is referenced by at least one t() call")

--- a/scripts/i18n/semgrep-i18n.py
+++ b/scripts/i18n/semgrep-i18n.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run the structural i18n rules and report findings as GitHub annotations.
+
+Kept as a file rather than inline in validate.sh: the reporting needs quoting
+that does not survive being nested inside a shell function, and having it here
+means it can be run and tested directly.
+
+Exit status is 1 if anything is found, 0 otherwise, and 0 with a notice when
+semgrep is not installed — CI installs it; a laptop without it should not fail
+the whole gate.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RULES = ROOT / "scripts" / "i18n" / "semgrep-i18n.yml"
+UI_SRC = ROOT / "ui" / "src"
+
+
+def main() -> int:
+    if shutil.which("semgrep") is None:
+        print("semgrep not installed; skipping structural i18n rules")
+        return 0
+    if not RULES.is_file():
+        print(f"missing rules file: {RULES}")
+        return 1
+
+    proc = subprocess.run(
+        ["semgrep", "--config", str(RULES), "--metrics=off", "--json", str(UI_SRC)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        results = json.loads(proc.stdout).get("results", [])
+    except json.JSONDecodeError:
+        print("semgrep produced no parseable output:")
+        print(proc.stderr.strip()[:2000])
+        return 1
+
+    if not results:
+        return 0
+
+    print(f"::error::{len(results)} banned t() fallback pattern(s):")
+    for r in sorted(results, key=lambda x: (x["path"], x["start"]["line"])):
+        rule = r["check_id"].rsplit(".", 1)[-1]
+        line = r["start"]["line"]
+        try:
+            path = str(Path(r["path"]).resolve().relative_to(ROOT))
+        except ValueError:
+            path = r["path"]
+        # semgrep's extra.lines can report a propagated definition rather than
+        # the call site, which reads as the wrong code. Quote the file.
+        try:
+            src = (ROOT / path).read_text().split("\n")[line - 1]
+        except (OSError, IndexError):
+            src = ""
+        snippet = " ".join(src.split())[:100]
+        print(f"  {path}:{line}: {rule}: {snippet}")
+        print(f"::error file={path},line={line}::{rule} — put the copy in a locale file")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/i18n/semgrep-i18n.yml
+++ b/scripts/i18n/semgrep-i18n.yml
@@ -1,0 +1,44 @@
+# Structural i18n rules, run by scripts/i18n/validate.sh.
+#
+# These replace hand-written regex. Every text-based attempt at this check has
+# had a blind spot: the original grep could not see the multiline t(\n 'key',\n
+# 'fallback',\n) form (10 sites), nor a fallback whose quote style it did not
+# own. A Python rewrite fixed those and still missed fallbacks passed as
+# *variables* — RoleChip and RoleGuard held English copy in
+# confirmTitleDefault/confirmMessageDefault consts and handed them to t().
+#
+# Semgrep parses TypeScript rather than scanning lines, and does constant
+# propagation, so it sees all of those. Semgrep is already a fleet CI tool.
+rules:
+  - id: i18n-fallback-string-arg
+    languages: [typescript]
+    severity: ERROR
+    message: >-
+      Banned t('key', 'fallback'). i18next returns the locale value whenever the
+      key resolves, so the fallback never renders. It hides a missing key, and
+      the extra argument matches i18next's loose defaultValue overload, which
+      switches off the typed key union at this call site.
+    patterns:
+      - pattern-either:
+          - pattern: '$T($KEY, "...")'
+          - pattern: '$T($KEY, "...", $OPTS)'
+      - metavariable-regex:
+          metavariable: $T
+          regex: ^t([A-Z][A-Za-z]*)?$
+
+  - id: i18n-fallback-default-value
+    languages: [typescript]
+    severity: ERROR
+    message: >-
+      Banned defaultValue fallback. Put the copy in the locale file. An *empty*
+      defaultValue is allowed and deliberately not matched here - it is an
+      opt-in probe (a page has an eyebrow when its namespace declares one) and
+      cannot mask missing copy, because it renders nothing.
+    patterns:
+      - pattern: '$T($KEY, {..., defaultValue: "$V", ...})'
+      - metavariable-regex:
+          metavariable: $T
+          regex: ^t([A-Z][A-Za-z]*)?$
+      - metavariable-regex:
+          metavariable: $V
+          regex: ^.+$

--- a/scripts/i18n/validate.sh
+++ b/scripts/i18n/validate.sh
@@ -151,34 +151,21 @@ check_no_empty_values() {
 # Check: no fallback patterns (t('key', 'English fallback'))
 # -----------------------------------------------------------------------------
 check_no_fallback_patterns() {
-  section "No t('key', 'fallback') patterns in $UI_SRC_DIR"
+  section "Structural i18n (t() fallbacks)"
   [ ! -d "$UI_SRC_DIR" ] && { warn "UI_SRC_DIR=$UI_SRC_DIR does not exist; skipping"; return; }
 
-  # Match t('key', '...something...') with single OR double quotes for both
-  # arguments. Ignore: t(key) [single arg], t('key', { interpolation }) [object].
-  # The interpolation form starts with { not a quote.
-  # Word-boundary `\bt\(` so identifiers ending in `t` (e.g.
-  # headers.set('Accept', 'application/json')) don't false-match.
-  local hits
-  hits=$(grep -rnE "\\bt\\(\\s*['\"][^'\"]+['\"]\\s*,\\s*['\"]" "$UI_SRC_DIR" \
-    --include='*.ts' --include='*.tsx' 2>/dev/null \
-    | grep -v "// allow-fallback") || true
-
-  if [ -n "$hits" ]; then
-    local count
-    count=$(echo "$hits" | wc -l | tr -d ' ')
-    ratchet_fail "$count fallback pattern(s) t('key', 'string') — banned per I18N_CONVENTIONS:"
-    echo "$hits" | sed 's/^/      /'
-    while IFS= read -r line; do
-      local file
-      file=$(echo "$line" | cut -d: -f1)
-      local lineno
-      lineno=$(echo "$line" | cut -d: -f2)
-      annotate "$file" "line $lineno: fallback pattern banned — add key to locale file instead"
-    done <<<"$hits"
-  else
-    ok "no fallback patterns"
+  # Was a grep. TypeScript is not line-oriented and the grep missed the
+  # multiline call form, a fallback quoted with the other delimiter, and
+  # English copy assigned to a const and passed as the argument. Semgrep
+  # parses TS and propagates constants, so it sees all three.
+  local out
+  if ! out=$(python3 scripts/i18n/semgrep-i18n.py 2>&1); then
+    fail "banned t() fallback patterns:"
+    echo "$out" | sed 's/^/      /' | head -40
+    return
   fi
+  [ -n "$out" ] && warn "$out"
+  ok "no t() fallback patterns"
 }
 
 # -----------------------------------------------------------------------------
@@ -396,14 +383,8 @@ check_key_usage() {
     warn "python3 not found; skipping check-keys.py"
     return
   fi
-  # Propagate --ratchet so newly-added repos can absorb check-keys.py
-  # without an immediate cleanup burden. Use a plain string instead of
-  # an array because bash 3.2 (macOS default) errors on `${empty[@]}`
-  # under `set -u`.
-  local extra=""
-  [ "$RATCHET" -eq 1 ] && extra="--ratchet"
   local out
-  if ! out=$(python3 "$script" $extra 2>&1); then
+  if ! out=$(python3 "$script" 2>&1); then
     fail "check-keys.py found t() calls referencing missing keys:"
     echo "$out" | head -40 | sed 's/^/      /'
     return
@@ -415,7 +396,7 @@ check_key_usage() {
     wcount=$(echo "$out" | grep -c "^  [^✓]" || echo 0)
     warn "$wcount unused EN locale key(s) (informational; not failing — too noisy until catch-up)"
   fi
-  ok "every t() call resolves to an EN locale key (or all errors demoted under --ratchet)"
+  ok "every t() call resolves to an EN locale key"
 }
 
 # -----------------------------------------------------------------------------
@@ -455,12 +436,10 @@ check_locked_versions() {
 # Main
 # -----------------------------------------------------------------------------
 QUICK=0
-RATCHET=0
 ONLY_CHECK=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --quick)   QUICK=1; shift ;;
-    --ratchet) RATCHET=1; shift ;;
     --check)   ONLY_CHECK="$2"; shift 2 ;;
     --help|-h)
       sed -n '2,30p' "$0"
@@ -469,15 +448,6 @@ while [ $# -gt 0 ]; do
     *) echo "Unknown arg: $1"; exit 2 ;;
   esac
 done
-
-# Helper used by the two ratchet-eligible checks to downgrade fail → warn.
-ratchet_fail() {
-  if [ "$RATCHET" -eq 1 ]; then
-    warn "$1"
-  else
-    fail "$1"
-  fi
-}
 
 run_check() {
   local fn="$1"


### PR DESCRIPTION
## Summary

Ports MustardSeedNetworks/stem#767 and #764. Three changes, each removing a way
the gate could report success it had not earned.

### 1. The fallback check was a grep

TypeScript is not line-oriented. Every text-based version of this check has had
a blind spot:

| attempt | missed |
|---|---|
| `grep -rnE` | the multiline call form; a fallback quoted with the other delimiter |
| a Python rewrite | fallbacks passed as **variables** |
| semgrep | — |

Semgrep parses TS and propagates constants, so it sees all three. It is
**already a fleet CI tool**, not a new dependency, and its counts agreed
*exactly* with a hand regex pass on seed (373 + 34 = 407) — the same check plus
a class regex cannot express.

**niac is clean under it today.** This is a guard for what lands next, not a
cleanup.

### 2. `--ratchet` is gone

It demoted failures to annotations, so the job exited `OK with N warning(s)` and
went green. That is how a stale version-lockstep assertion sat wrong in all
three repos unnoticed. niac already passes unflagged, so removing it costs
nothing here and closes the hole.

### 3. `check-keys.py` converges on seed's copy

Three sources of false positives, fixed:

- `useTranslation(['a','b'])` matched nothing, so bare keys fell through to the
  global default namespace.
- A file with **no** `useTranslation` uses a `t` that arrived as a prop, whose
  namespace is unknowable without following the caller. Assuming `common`
  invents failures. It now checks the key exists somewhere instead.
- `internal/i18n/locales` is embedded by the Go backend as well as the UI, but
  only `ui/src` was scanned. niac has no `localizer.T` call sites today —
  keeping the three scripts identical is the point.

## Linked Issue

Closes #1519

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [x] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

No product code changes. The gate is green unflagged before and after.

## Testing Evidence

```text
$ ./scripts/i18n/validate.sh          # no --ratchet
✓ all keys present in all locales
✓ no empty values
✓ no t() fallback patterns
✓ no banned vocabulary
✓ all glossary terms preserved in secondary locales
✓ interpolation vars match across locales
✓ all plural keys complete
✓ every t() call resolves to an EN locale key
✓ all i18n packages pinned exact
$ echo $?
0

$ python3 scripts/i18n/check-keys.py
✓ every t() call has a matching EN locale key
✓ every EN locale key is referenced by at least one t() call

$ actionlint -ignore 'SC2129' .github/workflows/ci.yml   # clean
```

## Deliberately not in this PR

The hardcoded-English check is still the old **warn-only** grep. Replacing it
with stem's `check-source.py` surfaces **35 real strings** in niac —
`ErrorBoundary` alone has 7, and the walk analyzer/validator pages another 7.
That is its own change; filed separately so this PR stays reviewable.

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. — CI tooling only.
- [x] Dependencies are pinned and justified if changed. — semgrep pinned exact; already a fleet tool.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed.
