### PR TITLE
fix(i18n): fail the key gate on any finding, and see <Trans> keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,10 +685,14 @@ jobs:
         working-directory: ui
         run: npm run i18n:lint && npm run i18n:check && npm run i18n:test
 
+      # The gate itself needs a gate: check-keys.py printed `::error::`
+      # annotations while returning 0 for any finding count at or below 30,
+      # and an annotation does not fail a job. Runs before the validator so a
+      # broken checker is reported as a broken checker.
+      - name: Self-test the i18n key checker
+        run: python3 scripts/i18n/test-check-keys.py
+
       - name: Validate i18n (parity, glossary, banned vocab, etc.)
-        # --ratchet demotes the pre-existing-debt checks (no-fallback-patterns
-        # and locked-versions) from fail to warn. Drop --ratchet once Phase 3
-        # cleanup brings both counts to zero across seed/stem/niac.
         # See scripts/i18n/README.md and
         # msn-docs-internal/05-Engineering/I18N_CONVENTIONS.md.
         run: ./scripts/i18n/validate.sh

--- a/scripts/i18n/check-keys.py
+++ b/scripts/i18n/check-keys.py
@@ -125,6 +125,16 @@ def extract_t_calls() -> set[tuple[str, str, int, str]]:
         r"""\b(t(?:[A-Z][A-Za-z]*)?)\s*\(\s*['"`]([a-zA-Z][\w-]*[.:][\w.:-]+)['"`]""",
         re.MULTILINE,
     )
+    # <Trans i18nKey="…"> references a key exactly as t('…') does, and this
+    # checker only ever scanned t() calls — so a key rendered solely through
+    # <Trans> read as unreferenced. <Trans> is the required form for copy that
+    # wraps an inline component, so the blind spot covered exactly the strings
+    # most likely to be rich text. Covering it here also catches a <Trans>
+    # pointing at a key that does not exist, which nothing checked before.
+    TRANS_I18NKEY = re.compile(
+        r"""\bi18nKey\s*=\s*\{?\s*['"`]([a-zA-Z][\w-]*[.:][\w.:-]+)['"`]""",
+        re.MULTILINE,
+    )
 
     all_namespaces = set(load_locale_keys().keys())
 
@@ -186,6 +196,18 @@ def extract_t_calls() -> set[tuple[str, str, int, str]]:
                 # call as "found" if the key exists in any of them.
                 candidates = alias_to_namespaces.get(alias, {"common"})
                 for ns in candidates:
+                    hits.add((ns, raw, line, str(rel)))
+
+        for m in TRANS_I18NKEY.finditer(text):
+            raw = m.group(1)
+            line = text[: m.start()].count("\n") + 1
+            if ":" in raw:
+                ns, key = raw.split(":", 1)
+                hits.add((ns, key, line, str(rel)))
+            else:
+                # <Trans> has no alias of its own; it resolves against the
+                # namespaces the file binds, same superset the bare `t` uses.
+                for ns in alias_to_namespaces.get("t", {"common"}):
                     hits.add((ns, raw, line, str(rel)))
     return hits
 
@@ -290,7 +312,7 @@ def main() -> int:
             print(f"  {file}:{line}: t('{ns}:{key}') — not in {ns}.json")
         if len(missing) > 30:
             print(f"  … and {len(missing) - 30} more")
-            code = 1
+        code = 1
     else:
         print("✓ every t() call has a matching EN locale key")
 
@@ -306,7 +328,7 @@ def main() -> int:
             print(f"  {ns}.json: {key}")
         if len(unused) > 30:
             print(f"  … and {len(unused) - 30} more")
-            code = 1
+        code = 1
     else:
         print("✓ every EN locale key is referenced by at least one t() call")
 

--- a/scripts/i18n/test-check-keys.py
+++ b/scripts/i18n/test-check-keys.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Self-tests for the i18n key cross-reference gate.
+
+The gate reported findings as `::error::` annotations while returning 0
+whenever there were 30 or fewer of them, because `code = 1` sat inside the
+`if len(...) > 30:` branch that prints the "… and N more" line. A GitHub
+Actions annotation does not fail a job, so a repo could report unreferenced
+keys on every run and stay green. Nothing tested the exit code, so nothing
+caught it.
+
+check-keys.py derives its ROOT from __file__ and reads the allowlist relative
+to the working directory, so each case builds a throwaway repo tree with the
+checker copied to the same relative path and runs it there.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+CHECKER = Path(__file__).with_name("check-keys.py")
+
+
+class CheckKeysTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        (self.root / "scripts" / "i18n").mkdir(parents=True)
+        shutil.copy(CHECKER, self.root / "scripts" / "i18n" / "check-keys.py")
+        (self.root / "ui" / "src").mkdir(parents=True)
+        (self.root / "internal" / "i18n" / "locales" / "en").mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def locale(self, namespace: str, payload: dict) -> None:
+        path = self.root / "internal" / "i18n" / "locales" / "en" / f"{namespace}.json"
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    def source(self, name: str, content: str) -> None:
+        (self.root / "ui" / "src" / name).write_text(content, encoding="utf-8")
+
+    def run_checker(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "scripts/i18n/check-keys.py"],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_clean_tree_passes(self) -> None:
+        self.locale("common", {"greeting": {"hello": "Hello"}})
+        self.source(
+            "Greeting.tsx",
+            "const { t } = useTranslation('common');\n"
+            "export const G = () => <p>{t('greeting.hello')}</p>;\n",
+        )
+        self.assertEqual(self.run_checker().returncode, 0)
+
+    def test_single_unused_key_fails(self) -> None:
+        """One unreferenced key must fail. This is the regression: it exited 0."""
+        self.locale(
+            "common",
+            {"greeting": {"hello": "Hello", "abandoned": "Nothing references me"}},
+        )
+        self.source(
+            "Greeting.tsx",
+            "const { t } = useTranslation('common');\n"
+            "export const G = () => <p>{t('greeting.hello')}</p>;\n",
+        )
+        result = self.run_checker()
+        self.assertIn("greeting.abandoned", result.stdout)
+        self.assertEqual(result.returncode, 1, "one unused key must fail the gate")
+
+    def test_single_missing_key_fails(self) -> None:
+        """One t() call with no locale entry must fail, for the same reason."""
+        self.locale("common", {"greeting": {"hello": "Hello"}})
+        self.source(
+            "Greeting.tsx",
+            "const { t } = useTranslation('common');\n"
+            "export const G = () => <p>{t('greeting.absent')}</p>;\n",
+        )
+        result = self.run_checker()
+        self.assertIn("greeting.absent", result.stdout)
+        self.assertEqual(result.returncode, 1, "one missing key must fail the gate")
+
+    def test_trans_i18nkey_counts_as_a_reference(self) -> None:
+        """<Trans i18nKey> is a reference; it used to read as an unused key."""
+        self.locale("common", {"greeting": {"rich": "Hello <strong>you</strong>"}})
+        self.source(
+            "Greeting.tsx",
+            "const { t } = useTranslation('common');\n"
+            'export const G = () => <Trans i18nKey="greeting.rich" '
+            "components={{ strong: <strong /> }} />;\n",
+        )
+        result = self.run_checker()
+        self.assertEqual(
+            result.returncode, 0, f"<Trans> key reported unused:\n{result.stdout}"
+        )
+
+    def test_trans_i18nkey_missing_from_locale_fails(self) -> None:
+        """A <Trans> pointing at a key that does not exist is now caught."""
+        self.locale("common", {"greeting": {"rich": "Hello"}})
+        self.source(
+            "Greeting.tsx",
+            "const { t } = useTranslation('common');\n"
+            'export const G = () => <Trans i18nKey="greeting.typo" />;\n',
+        )
+        result = self.run_checker()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("greeting.typo", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Ports the seed fix (MustardSeedNetworks/seed#2086) so the two copies stay
byte-identical — verified by hash after the change.

`check-keys.py` printed findings as `::error::` annotations and returned **0
unless there were more than 30** — `code = 1` sat inside the
`if len(...) > 30:` branch. An annotation does not fail a job.

**Latent here, not live:** niac reports 0 findings today, so nothing was being
hidden. In seed the same code has been reporting three unreferenced keys on
every run while the job passed.

The `<Trans i18nKey>` blind spot *is* real in this repo. `check-keys.py` scans
`t()` calls only, so keys rendered solely through `<Trans>` read as
unreferenced — 13 sites here, 10 of them added by #1528. They report clean only
because `dynamic-prefixes.txt` allowlists their prefixes
(`common:errorBoundary.`, `pages:walkAnalyzer.`, `pages:walkValidator.`,
`pages:configDiff.`). Teaching the checker `<Trans>` resolves them properly
instead of relying on the allowlist to hide them.

Pruning those now-redundant allowlist entries is deliberately **not** in this
PR — it changes what the gate covers and deserves its own verification.

stem is unaffected on both counts: its copy already has the correct
indentation and it has zero `<Trans i18nKey>` sites.

## Linked Issue

Closes #1531

## Type of Change

- [x] Defect fix
- [ ] Feature
- [ ] Chore / refactor / dependency update
- [ ] Documentation
- [ ] CI / release / packaging
- [ ] Security hardening

## Risk

- [x] Low
- [ ] Medium
- [ ] High

The gate gets stricter; no locale values and no product code change.

## Testing Evidence

The defect on unmodified `origin/main` — `code = 1` nested in the `> 30` branch:

```text
$ grep -n -B2 -A1 'code = 1' scripts/i18n/check-keys.py
291-        if len(missing) > 30:
292-            print(f"  … and {len(missing) - 30} more")
293:            code = 1
307-        if len(unused) > 30:
308-            print(f"  … and {len(unused) - 30} more")
309:            code = 1
```

New tests fail against the pre-fix checker and pass against the fixed one:

```text
$ # against pre-fix check-keys.py
AssertionError: 0 != 1 : one unused key must fail the gate
Ran 5 tests — FAILED (failures=3)

$ # against fixed check-keys.py
Ran 5 tests in 0.164s
OK
```

Repo gates after the change:

```text
$ python3 scripts/i18n/check-keys.py
✓ every t() call has a matching EN locale key
✓ every EN locale key is referenced by at least one t() call
$ echo $?
0

$ ./scripts/i18n/validate.sh
OK — all checks passed

$ actionlint -ignore 'SC2129' .github/workflows/ci.yml   # clean
```

Byte-identity with seed confirmed after the edit:

```text
$ shasum -a 256 {seed,niac}/scripts/i18n/check-keys.py
  check-keys.py: identical
  test-check-keys.py: identical
```

## Security and Release Checklist

- [x] No secrets, tokens, credentials, or customer data are included.
- [x] Mutating routes, auth surfaces, permission checks, and output encoding were reviewed if touched. — build tooling only.
- [x] Dependencies are pinned and justified if changed. — none changed.
- [x] Documentation, screenshots, or operator notes were updated if behavior changed. — no user-visible change.