### PR TITLE
fix(ci): request the workflows scope for the release-please token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,6 +104,14 @@ jobs:
           # real issues, which release-please never does.
           permission-contents: write
           permission-pull-requests: write
+          # release-please creates the release branch and the version tag. When a
+          # workflow file has changed since the last release those refs carry a
+          # .github/workflows/** diff, and GitHub refuses the ref write without
+          # this scope — every release stalled fleet-wide until it was added.
+          # create-github-app-token scopes the minted token to exactly these
+          # inputs, so granting the installation the permission is necessary but
+          # not sufficient; it has to be requested here too.
+          permission-workflows: write
 
       - name: Run Release Please
         id: release


### PR DESCRIPTION
## Summary

Releases stalled fleet-wide from 2026-08-24. `niac-go`, `seed` and `stem` all failed with `Resource not accessible by integration` while creating the release branch ref or the version tag; `trellis` kept working the whole time.

release-please creates a branch and a tag. When a workflow file has changed since the last release, those refs carry a `.github/workflows/**` diff, and GitHub refuses the ref write without the **workflows** scope. That is exactly why trellis was unaffected — nothing had touched its workflows, so its refs carried no such diff.

Workflow files changed since each repo`s last tag, against outcome:

| repo | workflow files changed since tag | release-please |
| --- | --- | --- |
| seed | 2 | failed |
| niac-go | 1 | failed |
| stem | 1 | failed |
| trellis | **0** | worked |

## Two things were needed, in order

1. **The installation grant.** `msn-ci-bot` had `Workflows: Read and write` declared on the App, but the org installation had never accepted the change — so it was absent from the granted set entirely:

   ```
   before: administration=read, contents=write, metadata=read,
           organization_administration=read, pull_requests=write, statuses=read
   after:  ... , workflows=write
   ```

   Approved via the pending "Permission updates requested" review on the installation.

2. **This change.** `create-github-app-token` scopes the minted token to exactly the `permission-*` inputs it is given. The grant alone is therefore necessary but not sufficient — re-running release-please after the grant still failed identically, because the workflow was still minting a contents+pull-requests-only token.

The order is load-bearing and is recorded in the comment: the action **hard-fails when it requests a permission the installation does not grant**, so landing this before the grant would have turned a silent failure into a total one.

## Testing Evidence

The diagnosis was confirmed by elimination rather than assumed:

```
config          byte-identical to trellis`s, unchanged since 2026-08-22
rulesets        identical across all four repos (merge-queue on refs/heads/main only)
org rulesets    none (free plan)
tag protection  none (endpoint 404s)
contents:write  granted, and demonstrably working — trellis created a branch,
                tree, commit and ref successfully throughout
```

Re-running the failed run in each repo after the grant, and observing it still fail with the same error, is what isolated the token-scoping half:

```
niac-go run 32913603020 (re-run 01:23Z, after the grant)
  ✔ Creating 1 releases for pull #1524
  ##[error] Resource not accessible by integration - .../git/refs#create-a-reference
```

Verification after this merges is the next release-please run cutting the pending tags. Three release commits are merged but untagged and waiting: niac `ef14ab65` → v0.94.74, seed `f39b3e42` → v0.213.28, stem `4bf01e5` → v0.24.36.

## Security and Release Checklist

- [x] Scope is granted to the release-please token only, not to CI generally
- [x] The App already declared this permission; this requests it on the minted token
- [x] Worth naming plainly: an App with `workflows: write` can rewrite CI. Renovate already holds it in this org, so it is not a new class of trust, but it is a real grant rather than a formality
- [x] No product code touched — one workflow file per repo
- [x] No suppressions added

## Linked Issue

Closes #1540