### PR TITLE
ci(dead-code): make one step actually gate, on reachability

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -15,6 +15,17 @@
 # - Files: orphaned files not imported anywhere
 # =============================================================================
 
+# Dead-code analysis.
+#
+# One step gates: "Check package reachability" fails the job when an internal
+# package is reachable from no binary and is not recorded in
+# scripts/package-reachability-baseline.txt.
+#
+# Every other step in this workflow is advisory by design — staticcheck's
+# unused checks and ts-prune both produce false positives on interfaces,
+# generated code and platform-gated files, so they write to the step summary
+# and do not fail. A green run on this workflow therefore means "no NEW
+# unreachable packages", not "no dead code".
 name: Dead Code Detection
 
 on:
@@ -49,6 +60,20 @@ jobs:
         # waits, then retries the transient case.
         with:
           packages: libpcap-dev
+
+      # The one step in this workflow that can fail. Everything below reports
+      # into the step summary and returns success regardless, which is
+      # defensible for a fuzzy signal like "possibly unused export" but meant
+      # this job reported success weekly while two packages totalling 2,800
+      # lines sat unreachable in stem (stem#798).
+      #
+      # Reachability is not a fuzzy signal. Either a binary can reach a package
+      # or it cannot, `go list -deps` says which in about a second, and
+      # staticcheck's unused checks structurally cannot: they find unused
+      # identifiers inside a package being compiled, and a package nobody
+      # imports still looks used from within its own tests.
+      - name: Check package reachability
+        run: ./scripts/check-package-reachability.sh
 
       - name: Run staticcheck for unused code
         run: |

--- a/scripts/check-package-reachability.sh
+++ b/scripts/check-package-reachability.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# scripts/check-package-reachability.sh
+# Fails when an internal package is reachable from no binary.
+#
+# staticcheck's unused checks (U1000 and friends) cannot answer this. They find
+# unused identifiers *within* a package that is being compiled; a package
+# nobody imports still looks fully used from inside its own tests. That gap is
+# not theoretical — stem carried 2,800 lines across two packages that no binary
+# reached, past a weekly dead-code job that reported success every time.
+#
+# `go list -deps` over every main package answers it directly, in a second.
+#
+# Packages already unreachable when this gate was adopted are recorded in
+# scripts/package-reachability-baseline.txt with a note. They are debt, not
+# permission: the list may shrink and must not grow.
+
+set -euo pipefail
+
+BASELINE_FILE=${BASELINE_FILE:-scripts/package-reachability-baseline.txt}
+MODULE=$(go list -m)
+
+# Packages reached from any binary's import graph, on every platform seed
+# ships to. A single-platform check would report a package wired only under
+# //go:build linux as dead when run on a developer's Mac, which is the fastest
+# way to make a gate untrustworthy.
+reachable=$(
+    for goos in linux darwin windows; do
+        # Every main package, not just ./cmd/... — niac reaches one of its
+        # packages only from ./tools/, and hardcoding ./cmd would report that
+        # as dead.
+        mains=$(GOOS=$goos go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./... 2>/dev/null)
+        [ -z "$mains" ] && continue
+        # shellcheck disable=SC2086 # deliberate word splitting of the package list
+        GOOS=$goos go list -deps $mains 2>/dev/null
+    done | sort -u
+)
+
+# Every internal package in the module.
+all_internal=$(go list ./... 2>/dev/null | grep "/internal/" | sort -u)
+
+baselined() {
+    local pkg=$1
+    # Comment and blank lines are ignored; the package path is the first field.
+    awk -v target="$pkg" '
+        /^[[:space:]]*(#|$)/ { next }
+        $1 == target { found = 1; exit }
+        END { exit !found }
+    ' "$BASELINE_FILE"
+}
+
+new_unreachable=()
+still_unreachable=0
+
+while read -r pkg; do
+    [ -z "$pkg" ] && continue
+    if grep -qxF "$pkg" <<<"$reachable"; then
+        continue
+    fi
+    short=${pkg#"$MODULE/"}
+    if baselined "$short"; then
+        still_unreachable=$((still_unreachable + 1))
+        continue
+    fi
+    new_unreachable+=("$short")
+done <<<"$all_internal"
+
+if [ ${#new_unreachable[@]} -eq 0 ]; then
+    echo "✓ no new unreachable packages ($still_unreachable baselined)"
+    exit 0
+fi
+
+echo "::error::${#new_unreachable[@]} internal package(s) are reachable from no binary"
+echo
+for pkg in "${new_unreachable[@]}"; do
+    echo "  $pkg"
+done
+echo
+echo "No main package can reach these, so they are not in any shipped"
+echo "binary. Either wire them up, delete them, or — if a package is"
+echo "deliberately test-only or platform-gated — add it to $BASELINE_FILE"
+echo "with a line saying which."
+echo
+echo "Before deleting: check for consumers Go tooling cannot see. A frontend"
+echo "importing a directory inside a Go package is invisible to go build, and"
+echo "stem's locales sat inside a dead package for exactly that reason."
+exit 1

--- a/scripts/package-reachability-baseline.txt
+++ b/scripts/package-reachability-baseline.txt
@@ -1,0 +1,2 @@
+
+internal/device                      # unwired — nothing imports it


### PR DESCRIPTION
## Summary

`dead-code.yml` has run weekly and reported success every time. It cannot do otherwise —
every step ends in `|| true` and writes findings to the step summary, so **it has no failing
path at all**.

That is defensible for the checks it runs. staticcheck's unused checks and `ts-prune` both
false-positive on interfaces, generated code and platform-gated files, so failing on them would
produce a permanently red job that everyone learns to ignore.

But it means a green run says nothing. Two packages totalling **2,800 lines** sat unreachable in
stem for months behind exactly this job (stem#798).

## Linked Issue

Related to #1550

## What changes

One step now gates, on the one signal here that is not fuzzy.

Either a binary can reach a package or it cannot. `go list -deps` answers it in about a
second, and **staticcheck structurally cannot**: its unused checks find unused identifiers
inside a package being compiled, and a package nobody imports still looks fully used from
within its own tests.

`scripts/check-package-reachability.sh`:

- takes the **union of the reachable set across linux, darwin and windows**, so a package wired
  only under one `//go:build` tag is not called dead when the check runs elsewhere
- enumerates **every main package** rather than assuming `./cmd/...` — niac reaches one of its
  packages only from `./tools/`, and a check rooted at `./cmd` reported it dead until I fixed that

Everything else in the workflow stays advisory, and the header now says so plainly, so a green
run is not read as "no dead code".

## Baseline

**One package**: `internal/device`, which nothing imports.

Worth noting what this check found and then un-found here. Rooted at `./cmd/...` it also reported `internal/acceptance/linklive` (1,389 lines) as dead — but that is reached from `./tools/linklive-acceptance`, a main package outside `./cmd`. Enumerating every main package removes that false positive, and niac is the repo that surfaced it.

Recorded in `scripts/package-reachability-baseline.txt` with the reason for each, following the
existing `scripts/file-size-baseline.txt` precedent. **The list may shrink and must not grow.**

The file also carries the warning that cost me an hour on stem: before deleting any of these,
check for consumers Go tooling cannot see. A frontend importing a directory inside a Go package
is invisible to `go build`.

## Testing Evidence

Verified in both directions — a gate that only ever passes is what this PR exists to fix:

```
# with a package nobody imports
$ ./scripts/check-package-reachability.sh; echo "exit=$?"
::error::1 internal package(s) are reachable from no binary
  internal/deliberatelydead
exit=1

# with the baseline in place
$ ./scripts/check-package-reachability.sh; echo "exit=$?"
✓ no new unreachable packages
exit=0
```

`shellcheck` and `actionlint` both clean.

## Security and Release Checklist

- [x] No routes, auth surfaces or destructive operations touched
- [x] No credentials or secrets touched
- [x] CI-only; nothing added to the product binary
- [x] **Turns a reporting-only job into one with a real failing path**, on the signal that can
      support one
- [x] The advisory steps are unchanged and now labelled as advisory
- [x] `shellcheck` clean; `actionlint` clean


