### PR TITLE
ci: adopt shared-workflow v1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,9 +564,13 @@ jobs:
   # Defined once in MustardSeedNetworks/.github (fleet-shared); ci-complete
   # still needs: [semgrep]. Edit the pinned version / config policy there.
   semgrep:
-    uses: MustardSeedNetworks/.github/.github/workflows/semgrep.yml@37513d7fbaacf4a7adaab1ac1514f021115868d1 # v1.4.0
+    uses: MustardSeedNetworks/.github/.github/workflows/semgrep.yml@3c9b3aadab847d2faab5116c6af07eb05d978d62 # v1.8.0
     permissions:
       contents: read
+      # v1.8.0 publishes the all-severity SARIF to code scanning. The
+      # upload is deliberately not continue-on-error, so this scope is
+      # required, not optional.
+      security-events: write
 
   # Asserts this repo's own gates are wired to gate: every job below is either
   # in ci-complete's needs or documented in .github/ci-advisory-jobs.txt, the
@@ -576,7 +580,7 @@ jobs:
   # Defined once in MustardSeedNetworks/.github (fleet-shared); ci-complete
   # still needs: [ci-conformance].
   ci-conformance:
-    uses: MustardSeedNetworks/.github/.github/workflows/ci-conformance.yml@37513d7fbaacf4a7adaab1ac1514f021115868d1 # v1.4.0
+    uses: MustardSeedNetworks/.github/.github/workflows/ci-conformance.yml@3c9b3aadab847d2faab5116c6af07eb05d978d62 # v1.8.0
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

Adopts `MustardSeedNetworks/.github` **v1.8.0**, which fixes two fleet-policy defects found by the 2026-08-27 CI audit.

**The conformance pin was illusory.** This repo pinned `ci-conformance.yml` at a SHA, but that workflow checked out the policy repo with **no `ref:`** — so the scripts that actually decide the verdict came from its default branch at run time. The pin bought nothing, and two runs of an identical commit could disagree. It also hardcoded `GOLANGCI_VERSION: v2.12.2` while this repo lints with **v2.13.1**, so the linter floor was read through a binary that did not know about `embedlit`. Upstream now pins the checkout to `github.job_workflow_sha` and derives the version from this repo's own `ci.yml`, failing closed if no pin is found.

**Semgrep reported nothing below ERROR.** It ran with `--severity ERROR`, so WARNING and MEDIUM findings went nowhere at all — contradicting the documented behaviour that non-blocking findings stay visible. It now scans once at every severity, publishes the SARIF to code scanning, and gates on ERROR read back from that SARIF: the same shape as the Trivy gate already in this file.

That upload needs `security-events: write`, granted here. Upstream deliberately does **not** mark it `continue-on-error` — an upload that fails silently is how a security feed goes stale unnoticed, which is the defect being fixed.

`apt-install` and `i18n-validate` keep their existing pins; neither changed in v1.8.0.

## Linked Issue

Closes #1562

## Testing Evidence

```
$ actionlint -ignore 'SC2129' .github/workflows/ci.yml; echo "exit=$?"
exit=0

$ grep -oE 'workflows/(ci-conformance|semgrep)[.]yml@[0-9a-f]+ # v[0-9.]+' .github/workflows/ci.yml
workflows/ci-conformance.yml@3c9b3aa... # v1.8.0
workflows/semgrep.yml@3c9b3aa... # v1.8.0
```

The upstream SARIF gate was proved against three fixtures before v1.8.0 was tagged — a result-level `error`, a level inherited from the rule's `defaultConfiguration`, and a clean scan — returning 1, 1 and 0 respectively.

## Security and Release Checklist

- [x] No product code touched — CI configuration only.
- [x] Grants `security-events: write` to the semgrep job **only**. The scope is required by the SARIF upload, not incidental.
- [x] Both new pins are full SHAs with the tag in a trailing comment, matching fleet convention.
- [x] Strictly *tightening*: the conformance scripts become immutable per-run, and Semgrep gains visibility without losing its ERROR gate.
- [x] `release.yml` untouched. Not release-affecting.
