### PR TITLE
ci: make .nvmrc the only source for the Node version

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,10 +1,6 @@
 name: 'Setup Node.js'
 description: 'Set up Node.js with npm caching'
 inputs:
-  node-version:
-    description: 'Node.js version'
-    required: false
-    default: '26.7.0'
   working-directory:
     description: 'Working directory for npm'
     required: false
@@ -25,7 +21,15 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
-        node-version: ${{ inputs.node-version }}
+        # .nvmrc is the single source of truth for the Node version. This
+        # used to be a `node-version` input defaulting to a literal, which is
+        # a second copy of a value that already lives in .nvmrc and
+        # package.json engines — and it drifted: Renovate bumps the manifests
+        # it can see and cannot see a default buried in a composite, so CI ran
+        # 26.7.0 against manifests demanding 26.8.1 and logged EBADENGINE on
+        # every job. The input is deleted rather than corrected, so no caller
+        # can reintroduce the divergence.
+        node-version-file: '.nvmrc'
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
         # An empty `cache` alone is not enough: setup-node falls through to

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -83,11 +83,26 @@ opts out by passing `cache: ""` to the `setup-node` composite action.
 
 ## The Node.js pin lives in one file
 
-Every workflow that needs Node uses `./.github/actions/setup-node`; none pin a
-`node-version:` literal. The composite is the single place the Node and npm
-versions are declared, and it must stay in step with `.nvmrc` and the `engines` /
-`packageManager` fields in `package.json`. Release and CI therefore build on the
-same Node version by construction rather than by convention.
+`.nvmrc` is the single source of truth for the Node version. Every workflow that
+needs Node uses `./.github/actions/setup-node`, and that composite reads
+`.nvmrc` via `node-version-file` — it has **no `node-version` input**, so no
+caller can override it and no second copy of the version can exist.
+
+That input used to default to a literal, and it drifted: Renovate bumps the
+manifests it can see and cannot see a default buried inside a composite, so CI
+ran 26.7.0 against manifests demanding 26.8.1 and logged EBADENGINE on every
+job for weeks. "Must stay in step" was the previous rule here, and a rule that
+depends on someone remembering is not a mechanism.
+
+The remaining pair that can disagree is `.nvmrc` and the `engines` field in
+`package.json`. Making that a hard failure (`engine-strict=true`) is the obvious
+next step and is deliberately **not** taken yet: Homebrew's newest `node` is
+26.7.0, so 26.8.1 is not installable through the fleet's normal channel, and
+turning the mismatch fatal would block local development in all four repos. See
+the linked issue.
+
+The npm version is still declared in the composite; `packageManager` in
+`package.json` is what `engines` checks it against.
 
 ## CI Must Pass Before Merge
 

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -19,4 +19,3 @@
 # Remove this when tailwind stops shipping that package this way, or when npm
 # supports a per-package allowlist that actually applies.
 allow-remote=all
-

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -19,3 +19,4 @@
 # Remove this when tailwind stops shipping that package this way, or when npm
 # supports a per-package allowlist that actually applies.
 allow-remote=all
+


### PR DESCRIPTION
## Summary

Makes `.nvmrc` the single source of truth for the Node version and **deletes** the `node-version` input from `.github/actions/setup-node`.

The composite hardcoded a default of `26.7.0` while `.nvmrc` and `ui/package.json` `engines` both require **26.8.1**, so CI ran the wrong Node and logged `EBADENGINE` on every job.

The cause is structural, not a stale value: Renovate bumps the manifests it can see and cannot see a default buried inside a composite action. Correcting the literal would drift again on the next bump — that is exactly how it drifted this week. So the input is deleted rather than corrected, and no caller can reintroduce a second copy. Nothing overrides it today (verified: the only `node-version:` references outside the composite are in `CI.md` prose).

`CI.md` said the composite "must stay in step with `.nvmrc`". A rule that depends on someone remembering is not a mechanism; that section is rewritten to describe the one that replaced it.

### What this PR deliberately does *not* do

`engine-strict=true` was written, tested, and then **backed out**. It is the obvious guard for the remaining `.nvmrc` vs `engines` pair, but **Homebrew's newest `node` is 26.7.0** — 26.8.1 is only installable via nvm or a direct download. Turning the mismatch fatal today would block `npm ci` for every developer in all four repos, which is a worse failure than the warning it replaces. Tracked on the issue.

This is not hypothetical: niac-go's own pre-commit hook already enforces 26.8.1 and refuses to commit on 26.7.0.

## Linked Issue

Closes #1564

## Testing Evidence

```
$ brew info node --json=v2 | jq -r '.formulae[0].versions.stable'
26.7.0                     # <- 26.8.1 not yet available from Homebrew

$ nvm install 26.8.1 && node --version
Checksums matched!
v26.8.1                    # <- installable from nodejs.org

$ grep -rn "node-version:" .github/workflows/ | grep -v CI.md
                           # <- no workflow overrides the deleted input

$ actionlint -ignore 'SC2129' .github/workflows/ci.yml; echo "exit=$?"
exit=0
```

## Security and Release Checklist

- [x] No product code touched — CI configuration and docs only.
- [x] No new dependencies, actions or permissions.
- [x] Removes an input rather than adding one; strictly reduces the ways the version can diverge.
- [x] Release workflows use the same composite, so release builds move to 26.8.1 in step with CI — no split between them.
- [x] No secrets or credentials involved.
