### PR TITLE
ci: refuse to release a tag whose commit never passed CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,46 @@ env:
   NPCAP_SDK_SHA256: "f0a8be7778ee3ae1b99bbbecb27a3ff0f6c111a4093f1c78c5c5a099607184db"
 
 jobs:
+  # A v* tag is enough to start a release: no ruleset restricts tag creation in
+  # any fleet repo (verified 2026-08-27 — the only ruleset present is
+  # merge-queue, and it targets branches). Until tag protection lands, this is
+  # the gate. It refuses to build a tag whose commit never passed CI, so an
+  # accidental or unauthorised tag fails here instead of producing signed,
+  # published artifacts.
+  #
+  # The assertion is skipped for workflow_dispatch, which is the deliberate
+  # dry-run path and carries no tag — but the job itself still runs and
+  # succeeds, so nothing downstream is skipped.
+  verify-tag:
+    name: Verify tagged commit passed CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      contents: read
+    steps:
+      # The condition is on the step, not the job. A job-level `if:` that
+      # evaluated false would leave this SKIPPED, and a skipped `needs:` entry
+      # skips everything downstream through the implicit success() — the whole
+      # dry-run path would silently do nothing. As a step, the job still
+      # reports success and dependents run normally.
+      - name: Assert CI Complete succeeded for this commit
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # index() returns 0 for a first-element match, and jq's // only fires
+          # on null/false — so a match at position 0 still prints 0 and passes.
+          found=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name == "CI Complete") | .conclusion] | index("success") // empty')
+          if [ -z "$found" ]; then
+            echo "::error::No successful 'CI Complete' check run for ${GITHUB_SHA}. Refusing to release an unvalidated commit."
+            exit 1
+          fi
+          echo "CI Complete succeeded for ${GITHUB_SHA}"
+
   # =========================================================================
   # UI build — done outside the goreleaser-cross container because that
   # image is Go-focused and doesn't ship Node. Vite writes directly into
@@ -76,6 +116,7 @@ jobs:
   build-ui:
     name: Build UI
     if: ${{ !inputs.provenance_only }}
+    needs: [verify-tag]
     runs-on: ubuntu-latest
     outputs:
       ui_hash: ${{ steps.ui-hash.outputs.hash }}
@@ -121,6 +162,7 @@ jobs:
   prepare-npcap-sdk:
     name: Prepare Npcap SDK
     if: ${{ !inputs.provenance_only }}
+    needs: [verify-tag]
     runs-on: ubuntu-latest
     steps:
       - name: Restore checksum-keyed Npcap SDK cache


### PR DESCRIPTION
## Summary

Adds `verify-tag` as the entry point of `release.yml`: it refuses to build a tag whose commit has no successful `CI Complete` check run.

**Any `v*` tag can publish today.** Verified via `gh api repos/.../rulesets` — the only ruleset in this repo, or any of the four fleet repos, is `merge-queue`, and it targets *branches*. **No repo has a tag ruleset.** Anyone who can push a tag can start a signed, published release from an arbitrary commit, bypassing release-please entirely.

This is not a substitute for tag protection. It means an accidental or unauthorised tag fails in seconds instead of producing published artifacts — and it lands **before** any ruleset is created, deliberately: the only way to test a misconfigured tag ruleset is to push a tag, and if it is wrong, that test publishes a release.

### One detail worth reviewing

The condition is on the **step**, not the job. A job-level `if:` evaluating false would leave `verify-tag` SKIPPED, and a skipped `needs:` entry skips everything downstream through the implicit `success()` — the `workflow_dispatch` dry-run path would have silently done nothing. As a step, the job still reports success and dependents run normally.
## Linked Issue

Closes #1566

## Testing Evidence

Logic verified against real commits before opening, rather than by inspection:

```
$ SHA=$(gh api repos/MustardSeedNetworks/stem/git/ref/tags/v0.24.40 --jq .object.sha)   # today's release
$ gh api "repos/.../commits/$SHA/check-runs?per_page=100" \
    --jq '[.check_runs[]|select(.name=="CI Complete")|.conclusion]|index("success") // empty'
0                          -> WOULD ALLOW

$ # same query for a check name that does not exist on the commit
''                         -> WOULD BLOCK
```

`found='0'` is the important one: `index()` returns 0 for a first-element match, and jq's `//` only fires on null/false, so a match at position 0 still prints `0` and passes. That is the classic trap with this idiom and it is handled.

```
$ actionlint -ignore 'SC2129' .github/workflows/release.yml; echo "exit=$?"
exit=0
```
## Security and Release Checklist

- [x] No product code touched — release pipeline only.
- [x] New job takes `checks: read` + `contents: read` only; it holds no write scope and touches no artifact.
- [x] Dry-run path (`workflow_dispatch`) explicitly preserved and reasoned about above.
- [x] Adds a gate; relaxes nothing.
- [x] No secrets or credentials read or written by the new job.
