### PR TITLE
ci: save the Go cache after compiling, cancel superseded runs, pin the macOS target

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -5,6 +5,16 @@ inputs:
     description: 'Path to go.mod file'
     required: false
     default: 'go.mod'
+outputs:
+  cache-build:
+    description: 'Resolved GOCACHE path'
+    value: ${{ steps.go-cache-paths.outputs.build }}
+  cache-mod:
+    description: 'Resolved GOMODCACHE path'
+    value: ${{ steps.go-cache-paths.outputs.mod }}
+  cache-key:
+    description: 'Cache key matching the restore performed here'
+    value: ${{ runner.os }}-go-${{ steps.go-cache-paths.outputs.tag }}-${{ hashFiles('**/go.sum') }}
 runs:
   using: composite
   steps:
@@ -56,16 +66,12 @@ runs:
       shell: bash
       run: go mod download
 
-    # Save only from the default branch. GitHub scopes caches per ref, so a PR
-    # that saves writes its OWN copy that is useless the moment it merges —
-    # this pushed niac past the 10GB cache ceiling where entries evict each
-    # other and restores fail with `tar` exit 2. PRs still READ main's cache;
-    # they simply stop littering.
-    - name: Save Go cache (default branch only)
-      if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          ${{ steps.go-cache-paths.outputs.build }}
-          ${{ steps.go-cache-paths.outputs.mod }}
-        key: ${{ runner.os }}-go-${{ steps.go-cache-paths.outputs.tag }}-${{ hashFiles('**/go.sum') }}
+# NOTE: there is deliberately no save step here. This composite runs at the
+# START of a job, so anything saved from inside it captures the build cache as
+# it was BEFORE the caller compiled anything — which is the empty cache the
+# restore just produced on a miss. The save has to be the last step of a job
+# that actually compiled, so it lives in ci.yml; the outputs above exist to let
+# that step reuse this exact path/key pair.
+#
+# It also cannot be a separate job: caches are populated per runner, and a
+# fresh runner has nothing to save.

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -14,7 +14,7 @@ outputs:
     value: ${{ steps.go-cache-paths.outputs.mod }}
   cache-key:
     description: 'Cache key matching the restore performed here'
-    value: ${{ runner.os }}-go-${{ steps.go-cache-paths.outputs.tag }}-${{ hashFiles('**/go.sum') }}
+    value: ${{ steps.go-cache-paths.outputs.key }}
 runs:
   using: composite
   steps:
@@ -39,10 +39,17 @@ runs:
         # cache key with default-path jobs (actions/cache restores to the saved
         # path, so a path mismatch leaves the job cold). Discriminate by path.
         tag="$(printf '%s|%s' "$build" "$mod" | sha256sum | cut -c1-12)"
+        # hashFiles() is not available in a composite action's `outputs:` block,
+        # so the key is assembled here and exported whole. That is also why the
+        # restore below reads the same output rather than repeating the
+        # expression: two hand-copied keys are what drift apart, and a restore
+        # that no longer matches its save is a silently cold cache.
+        sums="$(git ls-files '*go.sum' | sort | xargs -r sha256sum | sha256sum | cut -c1-64)"
         {
           echo "build=$build"
           echo "mod=$mod"
           echo "tag=$tag"
+          echo "key=${RUNNER_OS}-go-${tag}-${sums}"
         } >> "$GITHUB_OUTPUT"
 
     # Persist the build + module caches across runs (official actions/cache Go
@@ -58,7 +65,7 @@ runs:
         path: |
           ${{ steps.go-cache-paths.outputs.build }}
           ${{ steps.go-cache-paths.outputs.mod }}
-        key: ${{ runner.os }}-go-${{ steps.go-cache-paths.outputs.tag }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ steps.go-cache-paths.outputs.key }}
         restore-keys: |
           ${{ runner.os }}-go-${{ steps.go-cache-paths.outputs.tag }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Include the commit so a wedged run cannot block validation of a newer
-  # commit on the same pull request.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
+  # Keyed by PR (or ref), NOT by commit. The commit used to be in the key to
+  # stop "a wedged run blocking validation of a newer commit" — but
+  # cancel-in-progress CANCELS the older run; it never blocks the newer one.
+  # That is a description of a queue, which this is not. Including the SHA gave
+  # every commit its own group, so cancel-in-progress could never fire and
+  # superseded runs burned runners to completion.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Least-privilege default: read-only for every job. No job in this workflow
@@ -149,6 +153,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
+        id: go
         uses: ./.github/actions/setup-go
 
       - name: Install libpcap-dev
@@ -248,6 +253,20 @@ jobs:
             echo "ERROR: Coverage ${COVERAGE}% is below minimum threshold of ${MIN_COVERAGE}%"
             exit 1
           fi
+
+      # The one designated writer for the Go cache, and the last step of the
+      # job that filled it. Saving from inside setup-go stored a build cache
+      # that was empty because nothing had compiled yet; several default-branch
+      # jobs also raced the same key, which is the cache-reservation contention
+      # in the logs. One writer, after the work.
+      - name: Save Go cache (default branch only)
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.go.outputs.cache-build }}
+            ${{ steps.go.outputs.cache-mod }}
+          key: ${{ steps.go.outputs.cache-key }}
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,6 +98,12 @@ builds:
         goarch: arm64
         env:
           - CC=oa64-clang
+          # osxcross's clang and its linker were defaulting differently, so the
+          # release log read "object file was built for newer macOS version
+          # (13.0) than being linked (11.0)". Setting it once makes both agree.
+          # 13.0 is what the objects were already compiled for, so this records
+          # the existing floor rather than changing what the binary supports.
+          - MACOSX_DEPLOYMENT_TARGET=13.0
           - CXX=oa64-clang++
 
   # Windows is intentionally NOT built here. gopacket/pcap needs real cgo

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "format": "biome format --write src/",
-    "test": "node --disable-warning=DEP0205 ./node_modules/vitest/vitest.mjs run --reporter=verbose --passWithNoTests",
+    "test": "node --disable-warning=DEP0205 ./node_modules/vitest/vitest.mjs run --reporter=verbose",
     "test:watch": "node --disable-warning=DEP0205 ./node_modules/vitest/vitest.mjs --reporter=dot",
     "test:coverage": "node --disable-warning=DEP0205 ./node_modules/vitest/vitest.mjs run --coverage --reporter=verbose",
     "test:e2e": "NO_COLOR= node --disable-warning=DEP0205 ./node_modules/playwright/cli.js test --reporter=list",


### PR DESCRIPTION
## Summary

Four independent defects from the 2026-08-27 audit.

**The Go cache was saved before anything compiled.** `setup-go` runs at the *start* of a job, so the save inside it stored the build cache as it existed beforehand — the empty cache the restore had just produced on a miss. It now happens as the **last step of `backend`**, the job that actually fills it, and the composite exports its path/key pair so the save and the restore cannot drift apart.

It could not become a separate job: caches are populated per runner, and a fresh runner has nothing to save. That is why this touches the composite *and* `ci.yml` rather than just moving a job.

**`cancel-in-progress` could never fire.** The concurrency group contained the commit SHA, so every commit formed its own group. The comment justified this as stopping "a wedged run blocking validation of a newer commit" — but `cancel-in-progress` *cancels* the older run; it never blocks the newer one. That describes a queue, which this is not. Keyed by PR now, and **the comment is corrected too**, because the wrong rationale is why the wrong key survived review.

**macOS target mismatch.** Release logs reported objects built for 13.0 linked for 11.0. `MACOSX_DEPLOYMENT_TARGET=13.0` makes both agree; 13.0 is what the objects were already compiled for, so this records the existing floor rather than changing what the binary supports. Worth a second opinion if 13.0 is not the intended support floor.

**`--passWithNoTests`** removed — it turned "the suite did not run" into a pass.

## Linked Issue

Closes #1568

## Testing Evidence

```
$ actionlint -ignore 'SC2129' .github/workflows/ci.yml; echo "exit=$?"
exit=0

$ goreleaser check
  • 1 configuration file(s) validated

$ # the id and the save must be in the SAME job, or the outputs resolve empty
'id: go' is in job: backend (line 156)
save step is in job: backend (line 262)
```

The cache behaviour itself is only observable on `main` — a PR run does not save. Post-merge check: the next default-branch `backend` run should save a populated build cache, and subsequent runs should restore warm.

## Security and Release Checklist

- [x] No product code touched.
- [x] No new actions; `actions/cache/save` moved, still the same pinned SHA.
- [x] Save remains gated to the default branch, so PRs still cannot write cache entries.
- [x] `MACOSX_DEPLOYMENT_TARGET` records the existing floor; it does not widen or narrow platform support.
- [x] Removing `--passWithNoTests` is strictly tightening.
